### PR TITLE
Refactor KeyValueContainer to KeyValueTable

### DIFF
--- a/include/mdbx_containers.hpp
+++ b/include/mdbx_containers.hpp
@@ -8,6 +8,6 @@
 /// Provides integration between MDBX and STL-style containers with support
 /// for transactions, persistence, and thread-safe operations.
 
-#include "mdbx_containers/KeyValueContainer.hpp"
+#include "mdbx_containers/KeyValueTable.hpp"
 
 #endif // _MDBX_CONTAINERS_HPP_INCLUDED

--- a/include/mdbx_containers/KeyValueTable.hpp
+++ b/include/mdbx_containers/KeyValueTable.hpp
@@ -1,9 +1,9 @@
 #pragma once
-#ifndef _MDBX_CONTAINERS_KEY_VALUE_CONTAINER_HPP_INCLUDED
-#define _MDBX_CONTAINERS_KEY_VALUE_CONTAINER_HPP_INCLUDED
+#ifndef _MDBX_CONTAINERS_KEY_VALUE_TABLE_HPP_INCLUDED
+#define _MDBX_CONTAINERS_KEY_VALUE_TABLE_HPP_INCLUDED
 
-/// \file KeyValueContainer.hpp
-/// \brief Declaration of the KeyValueContainer class for managing key-value pairs in a SQLite database.
+/// \file KeyValueTable.hpp
+/// \brief Declaration of the KeyValueTable class for managing key-value pairs in a SQLite database.
 
 #include "common.hpp"
 #include <map>
@@ -11,7 +11,7 @@
 
 namespace mdbxc {
 
-    /// \class KeyValueContainer
+    /// \class KeyValueTable
     /// \brief Template class for managing key-value pairs in a SQLite database.
     /// \tparam KeyT Type of the keys.
     /// \tparam ValueT Type of the values.
@@ -23,35 +23,35 @@ namespace mdbxc {
     /// synchronization. This class also provides methods for checking the count and emptiness of the database, and efficiently
     /// handles database errors with detailed exception handling.
     template<class KeyT, class ValueT>
-    class KeyValueContainer final : public BaseTable {
+    class KeyValueTable final : public BaseTable {
     public:
 
         /// \brief Default constructor.
-        KeyValueContainer(std::shared_ptr<Connection> connection,
+        KeyValueTable(std::shared_ptr<Connection> connection,
                           std::string name = "kv_store",
                           MDBX_db_flags_t flags = MDBX_DB_DEFAULTS | MDBX_CREATE) 
             : BaseTable(std::move(connection), std::move(name), flags | get_mdbx_flags<KeyT>())  {}
 
         /// \brief Constructor with configuration.
         /// \param config Configuration settings for the database.
-        explicit KeyValueContainer(const Config& config, 
+        explicit KeyValueTable(const Config& config, 
                                    std::string name = "kv_store",
                                    MDBX_db_flags_t flags = MDBX_DB_DEFAULTS | MDBX_CREATE) 
             : BaseTable(Connection::create(config), std::move(name), flags | get_mdbx_flags<KeyT>()) {
         }
 
         /// \brief Destructor.
-        ~KeyValueContainer() override final = default;
+        ~KeyValueTable() override final = default;
 
         // --- Operators ---
 
         /// \brief Assigns a container (e.g., std::map or std::unordered_map) to the database.
         /// \param container The container with key-value pairs.
-        /// \return Reference to this KeyValueContainer.
+        /// \return Reference to this KeyValueTable.
         /// \throws 
         /// \note The transaction mode is taken from the database configuration.
         template<template <class...> class ContainerT>
-        KeyValueContainer& operator=(const ContainerT<KeyT, ValueT>& container) {
+        KeyValueTable& operator=(const ContainerT<KeyT, ValueT>& container) {
             with_transaction([this, &container](MDBX_txn* txn) {
                 db_reconcile(container, txn);
             }, TransactionMode::WRITABLE);
@@ -74,7 +74,7 @@ namespace mdbxc {
 
         class AssignmentProxy {
         public:
-            AssignmentProxy(KeyValueContainer& db, KeyT key)
+            AssignmentProxy(KeyValueTable& db, KeyT key)
                 : m_db(db), m_key(std::move(key)) {}
 
             AssignmentProxy& operator=(const ValueT& value) {
@@ -91,7 +91,7 @@ namespace mdbxc {
             }
 
         private:
-            KeyValueContainer& m_db;
+            KeyValueTable& m_db;
             KeyT m_key;
         };
         
@@ -469,8 +469,8 @@ namespace mdbxc {
             check_mdbx(mdbx_drop(txn_handle, m_dbi, 0), "mdbx_drop");
         }
 
-    }; // KeyValueContainer
+    }; // KeyValueTable
 
 }; // namespace mdbxc
 
-#endif // _MDBX_CONTAINERS_KEY_VALUE_CONTAINER_HPP_INCLUDED
+#endif // _MDBX_CONTAINERS_KEY_VALUE_TABLE_HPP_INCLUDED

--- a/tests/kv_container_all_types_test.cpp
+++ b/tests/kv_container_all_types_test.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <cassert>
-#include <mdbx_containers/KeyValueContainer.hpp>
+#include <mdbx_containers/KeyValueTable.hpp>
 
 struct SimpleStruct {
     int x;
@@ -42,7 +42,7 @@ int main() {
     // int8 -> int8
     std::cout << "int8 -> int8\n";
     {
-        mdbxc::KeyValueContainer<int8_t, int8_t> kv(conn, "i8_i8");
+        mdbxc::KeyValueTable<int8_t, int8_t> kv(conn, "i8_i8");
         kv.insert_or_assign(1, 100);
         assert(kv.find(1).value() == 100);
     }
@@ -50,7 +50,7 @@ int main() {
     // int8 -> int64
     std::cout << "int8 -> int64\n";
     {
-        mdbxc::KeyValueContainer<int8_t, int64_t> kv(conn, "i8_i64");
+        mdbxc::KeyValueTable<int8_t, int64_t> kv(conn, "i8_i64");
         kv.insert_or_assign(2, 1234567890123456LL);
         assert(kv.find(2).value() == 1234567890123456LL);
     }
@@ -58,7 +58,7 @@ int main() {
     // int32 -> string
     std::cout << "int32 -> string\n";
     {
-        mdbxc::KeyValueContainer<int32_t, std::string> kv(conn, "i32_str");
+        mdbxc::KeyValueTable<int32_t, std::string> kv(conn, "i32_str");
         kv.insert_or_assign(3, "hello");
         assert(kv.find(3).value() == "hello");
     }
@@ -66,7 +66,7 @@ int main() {
     // string -> string
     std::cout << "string -> string\n";
     {
-        mdbxc::KeyValueContainer<std::string, std::string> kv(conn, "str_str");
+        mdbxc::KeyValueTable<std::string, std::string> kv(conn, "str_str");
         kv.insert_or_assign("key", "value");
         assert(kv.find("key").value() == "value");
     }
@@ -74,7 +74,7 @@ int main() {
     // string -> POD
     std::cout << "string -> POD\n";
     {
-        mdbxc::KeyValueContainer<std::string, SimpleStruct> kv(conn, "str_struct");
+        mdbxc::KeyValueTable<std::string, SimpleStruct> kv(conn, "str_struct");
         SimpleStruct s{42, 3.14f};
         kv.insert_or_assign("obj", s);
         assert(kv.find("obj").value() == s);
@@ -83,7 +83,7 @@ int main() {
     // int64 -> vector<byte>
     std::cout << "int64 -> vector<byte>\n";
     {
-        mdbxc::KeyValueContainer<int64_t, std::vector<uint8_t>> kv(conn, "i64_vec");
+        mdbxc::KeyValueTable<int64_t, std::vector<uint8_t>> kv(conn, "i64_vec");
         std::vector<uint8_t> data{1, 2, 3, 4};
         kv.insert_or_assign(9, data);
         assert(kv.find(9).value() == data);
@@ -92,7 +92,7 @@ int main() {
     // string -> vector<SimpleStruct>
     std::cout << "string -> vector<SimpleStruct>\n";
     {
-        mdbxc::KeyValueContainer<std::string, std::vector<SimpleStruct>> kv(conn, "str_vec_struct");
+        mdbxc::KeyValueTable<std::string, std::vector<SimpleStruct>> kv(conn, "str_vec_struct");
         std::vector<SimpleStruct> vec{{1, 1.0f}, {2, 2.0f}};
         kv.insert_or_assign("many", vec);
         assert(kv.find("many").value() == vec);
@@ -101,7 +101,7 @@ int main() {
     // string -> list<string>
     std::cout << "string -> list<string>\n";
     {
-        mdbxc::KeyValueContainer<std::string, std::list<std::string>> kv(conn, "str_list_str");
+        mdbxc::KeyValueTable<std::string, std::list<std::string>> kv(conn, "str_list_str");
         std::list<std::string> lst{"a", "b", "c"};
         kv.insert_or_assign("letters", lst);
         assert(kv.find("letters").value() == lst);
@@ -110,7 +110,7 @@ int main() {
     // string -> vector<string>
     std::cout << "string -> vector<string>\n";
     {
-        mdbxc::KeyValueContainer<std::string, std::vector<std::string>> kv(conn, "str_vector_str");
+        mdbxc::KeyValueTable<std::string, std::vector<std::string>> kv(conn, "str_vector_str");
         std::vector<std::string> lst{"a", "b", "c"};
         kv.insert_or_assign("letters", lst);
         assert(kv.find("letters").value() == lst);
@@ -119,7 +119,7 @@ int main() {
     // string -> set<string>
     std::cout << "string -> set<string>\n";
     {
-        mdbxc::KeyValueContainer<std::string, std::set<std::string>> kv(conn, "str_set_str");
+        mdbxc::KeyValueTable<std::string, std::set<std::string>> kv(conn, "str_set_str");
         std::set<std::string> s{"a", "b", "c"};
         kv.insert_or_assign("letters", s);
         assert(kv.find("letters").value() == s);
@@ -128,7 +128,7 @@ int main() {
 	// string -> set<int>
     std::cout << "string -> set<int>\n";
     {
-        mdbxc::KeyValueContainer<std::string, std::set<std::int>> kv(conn, "str_set_int");
+        mdbxc::KeyValueTable<std::string, std::set<std::int>> kv(conn, "str_set_int");
         std::set<int> s{1, 2, 3};
         kv.insert_or_assign("digits", s);
         assert(kv.find(digits).value() == s);
@@ -163,7 +163,7 @@ int main() {
             }
         };
 
-        mdbxc::KeyValueContainer<std::string, Serializable> kv(conn, "str_serializable");
+        mdbxc::KeyValueTable<std::string, Serializable> kv(conn, "str_serializable");
         Serializable s{7, "seven"};
         kv.insert_or_assign("ser", s);
         assert(kv.find("ser").value() == s);

--- a/tests/kv_container_test.cpp
+++ b/tests/kv_container_test.cpp
@@ -1,12 +1,12 @@
 #include <iostream>
-#include <mdbx_containers/KeyValueContainer.hpp>
+#include <mdbx_containers/KeyValueTable.hpp>
 
 int main() {
     // Конфиг и подключение к БД
     mdbxc::Config config;
     config.pathname = "example_db.mdbx";
 
-    mdbxc::KeyValueContainer<std::string, int> kv(config);
+    mdbxc::KeyValueTable<std::string, int> kv(config);
     
 	std::cout << "-1" << std::endl;
     kv.clear();


### PR DESCRIPTION
## Summary
- rename `KeyValueContainer` to `KeyValueTable`
- update includes and tests

## Testing
- `cmake -S . -B build -DBUILD_DEPS=ON -DBUILD_TESTS=ON -DBUILD_EXAMPLES=OFF` *(fails: The source directory libs/libmdbx does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_6888073c272c832ca5172abfdd70f593