### PR TITLE
docs: improve doxygen comments

### DIFF
--- a/include/mdbx_containers/common/Config.hpp
+++ b/include/mdbx_containers/common/Config.hpp
@@ -7,7 +7,7 @@
 
 namespace mdbxc {
 
-    /// \class MDBXConfig
+    /// \class Config
     /// \brief Configuration for MDBX databases.
     class Config {
     public:

--- a/include/mdbx_containers/common/Connection.hpp
+++ b/include/mdbx_containers/common/Connection.hpp
@@ -23,8 +23,10 @@ namespace mdbxc {
         /// \brief Destructor. Closes the MDBX environment and aborts any open transactions.
         ~Connection();
 		
-		/// \brief
-		static std::shared_ptr<Connection> create(const Config& config);
+                /// \brief Creates and connects a new shared Connection instance.
+                /// \param config Configuration to use for initialization.
+                /// \return Shared pointer to the created Connection.
+                static std::shared_ptr<Connection> create(const Config& config);
 
         /// \brief Sets the MDBX configuration (must be called before connect()).
         /// \param config New configuration to apply.
@@ -46,10 +48,11 @@ namespace mdbxc {
         /// \return true if connected, false otherwise.
         bool is_connected() const;
 
-		/// \brief
-		/// \param mode The transaction mode (default: WRITABLE).
-		/// \throws 
-		Transaction transaction(TransactionMode mode = TransactionMode::WRITABLE);
+                /// \brief Creates a RAII transaction object.
+                /// \param mode Transaction mode to open (default: WRITABLE).
+                /// \throws MdbxException on MDBX errors.
+                /// \return Transaction guard managing the MDBX_txn handle.
+                Transaction transaction(TransactionMode mode = TransactionMode::WRITABLE);
 		
 		/// \brief Begins a manual transaction (must be committed or rolled back later).
         /// \param mode The transaction mode (default: WRITABLE).
@@ -65,7 +68,9 @@ namespace mdbxc {
         /// \throws MdbxException if no transaction is active or rollback/reset fails.
         void rollback();
 		
-		std::shared_ptr<Transaction> current_txn() const;
+                /// \brief Returns the transaction associated with the current thread.
+                /// \return Shared pointer to the active Transaction or nullptr.
+                std::shared_ptr<Transaction> current_txn() const;
 
         /// \brief Returns the environment handle.
         /// \return MDBX environment pointer.
@@ -83,6 +88,7 @@ namespace mdbxc {
         void initialize();
 		
         /// \brief Safely closes the environment and aborts transaction if needed.
+        /// \param use_throw If true, throw on error; otherwise suppress exceptions.
         void cleanup(bool use_throw = true);
 
 		/// \brief Creates the parent directory for the database if it doesn't exist.

--- a/include/mdbx_containers/common/Transaction.hpp
+++ b/include/mdbx_containers/common/Transaction.hpp
@@ -36,7 +36,7 @@ namespace mdbxc {
         /// For read-only transactions, uses a shared reusable handle and attempts renewal.
         /// For writable transactions, begins a new transaction using the MDBX environment.
         ///
-        /// \throws Exception if the transaction is already started or if beginning fails.
+        /// \throws MdbxException if the transaction is already started or if beginning fails.
         void begin();
 
         /// \brief Commits the transaction.
@@ -44,7 +44,7 @@ namespace mdbxc {
         /// For read-only transactions, resets the handle for reuse.
         /// For writable transactions, commits the changes and closes the handle.
         ///
-        /// \throws Exception if no transaction is active or commit/reset fails.
+        /// \throws MdbxException if no transaction is active or commit/reset fails.
         void commit();
 
         /// \brief Rolls back the transaction.
@@ -52,7 +52,7 @@ namespace mdbxc {
         /// For read-only transactions, resets the handle.
         /// For writable transactions, aborts the transaction.
         ///
-        /// \throws Exception if no transaction is active or rollback/reset fails.
+        /// \throws MdbxException if no transaction is active or rollback/reset fails.
         void rollback();
 
         /// \brief Returns the internal MDBX transaction handle.

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -86,9 +86,11 @@ namespace mdbxc {
         std::shared_ptr<Connection>  m_connection;   ///< Shared connection to MDBX environment.
         MDBX_dbi                     m_dbi{};         ///< DBI handle for the opened table.
 
+        /// \brief Returns the transaction bound to the current thread, if any.
+        /// \return Pointer to the MDBX transaction or nullptr.
         MDBX_txn* thread_txn() const {
-			return m_connection->thread_txn();
-		}
+                        return m_connection->thread_txn();
+                }
 		
 		/// \brief Gets the raw DBI handle.
         MDBX_dbi handle() const { return m_dbi; }


### PR DESCRIPTION
## Summary
- fix wording about MDBX vs SQLite
- document public helper methods and members
- clarify thrown exceptions in comments

## Testing
- `cmake -B build` *(fails: Could not find a package configuration file provided by "mdbx")*

------
https://chatgpt.com/codex/tasks/task_e_68880fa367f8832cbc5a753a141b2f59