### PR TITLE
fix: unify error messages

### DIFF
--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -141,23 +141,36 @@ namespace mdbxc {
 #endif
 
         int rc = 0;
-        check_mdbx(mdbx_env_create(&m_env), "mdbx_env_create");
+        check_mdbx(
+            mdbx_env_create(&m_env),
+            "Failed to create environment"
+        );
 
-        check_mdbx(mdbx_env_set_geometry(
-            m_env,
-            m_config->size_lower,
-            m_config->size_now,
-            m_config->size_upper,
-            m_config->growth_step,
-            m_config->shrink_threshold,
-            m_config->page_size), "mdbx_env_set_geometry");
+        check_mdbx(
+            mdbx_env_set_geometry(
+                m_env,
+                m_config->size_lower,
+                m_config->size_now,
+                m_config->size_upper,
+                m_config->growth_step,
+                m_config->shrink_threshold,
+                m_config->page_size
+            ),
+            "Failed to set environment geometry"
+        );
 
-        check_mdbx(mdbx_env_set_maxdbs(m_env, m_config->max_dbs), "mdbx_env_set_maxdbs");
+        check_mdbx(
+            mdbx_env_set_maxdbs(m_env, m_config->max_dbs),
+            "Failed to set max databases"
+        );
 
         int readers = m_config->max_readers > 0
             ? static_cast<int>(m_config->max_readers)
             : static_cast<int>(std::thread::hardware_concurrency()) * 2;
-        check_mdbx(mdbx_env_set_maxreaders(m_env, readers), "mdbx_env_set_maxreaders");
+        check_mdbx(
+            mdbx_env_set_maxreaders(m_env, readers),
+            "Failed to set max readers"
+        );
 
         MDBX_env_flags_t env_flags = MDBX_ACCEDE;
         if (m_config->no_subdir)     env_flags |= MDBX_NOSUBDIR;
@@ -188,15 +201,24 @@ namespace mdbxc {
         std::wstring wide_path = converter.from_bytes(pathname);
         fs::path file_path = fs::path(wide_path);
 #       endif
-        check_mdbx(mdbx_env_openW(m_env, file_path.c_str(), env_flags, 0664), "mdbx_env_openW");
+        check_mdbx(
+            mdbx_env_openW(m_env, file_path.c_str(), env_flags, 0664),
+            "Failed to open environment"
+        );
 #   else
         std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
         std::wstring wide_path = converter.from_bytes(pathname);
-        check_mdbx(mdbx_env_openW(m_env, wide_path.c_str(), env_flags, 0664), "mdbx_env_openW");
+        check_mdbx(
+            mdbx_env_openW(m_env, wide_path.c_str(), env_flags, 0664),
+            "Failed to open environment"
+        );
 #   endif
 
 #else
-        check_mdbx(mdbx_env_open(m_env, pathname.c_str(), env_flags, 0664), "mdbx_env_open");
+        check_mdbx(
+            mdbx_env_open(m_env, pathname.c_str(), env_flags, 0664),
+            "Failed to open environment"
+        );
 #endif
     }
 

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -23,8 +23,10 @@ namespace mdbxc {
                         MDBX_db_flags_t flags)
             : m_connection(std::move(connection)) {
             auto txn = m_connection->transaction();
-            check_mdbx(mdbx_dbi_open(txn.handle(), name.c_str(), flags, &m_dbi),
-                       "mdbx_dbi_open");
+            check_mdbx(
+                mdbx_dbi_open(txn.handle(), name.c_str(), flags, &m_dbi),
+                "Failed to open table"
+            );
             txn.commit();
         }
         


### PR DESCRIPTION
## Summary
- improve check_mdbx context messages in `BaseTable` and `Connection`

## Testing
- `cmake -S . -B build -DBUILD_DEPS=ON -DBUILD_TESTS=ON`
- `cmake --build build`
- `./tests/mdbx_test`
- `./tests/utils_test`
- *(failed: `./tests/kv_container_all_types_test`)*

------
https://chatgpt.com/codex/tasks/task_e_688990ed0d40832ca36c63054f3c61a4