### PR TITLE
docs(config): expand configuration guide

### DIFF
--- a/docs/configuration.dox
+++ b/docs/configuration.dox
@@ -1,0 +1,41 @@
+/*! \page config_page Database Configuration
+\tableofcontents
+
+This page describes each option of the \ref mdbxc::Config class and how it
+affects the resulting MDBX environment. These settings are passed to
+\ref mdbxc::Connection when opening the database and translate directly to
+MDBX API calls or flags.
+
+- **pathname**: Location of the database files. If `relative_to_exe` is true
+  and the path is relative, it is resolved against the directory of the running
+  executable.
+- **size_lower**, **size_now**, **size_upper**, **growth_step**,
+  **shrink_threshold**, **page_size**: Parameters of
+  \ref mdbx_env_set_geometry that control the file size limits, growth step and
+  page size. Use them to preallocate space or restrict database growth. See the
+  MDBX manual for details:
+  https://libmdbx.dqdkfa.ru/group__c__settings.html#ga79065e4f3c5fb2ad37a52b59224d583e
+- **max_readers**: Maximum number of concurrent readers set via
+  \ref mdbx_env_set_maxreaders. Increase this if many threads or processes need
+  parallel read transactions.
+- **max_dbs**: Upper bound for the number of named sub-databases configured via
+  \ref mdbx_env_set_maxdbs. Set this to the total tables you expect.
+- **read_only**: When true adds `MDBX_RDONLY` so the environment is opened in
+  read-only mode.
+- **readahead**: If false adds `MDBX_NORDAHEAD`, disabling OS readahead and
+  potentially improving random I/O performance.
+- **no_subdir**: Adds `MDBX_NOSUBDIR` so the data and lock files are stored next
+  to each other rather than inside a directory.
+- **sync_durable**: Adds `MDBX_SYNC_DURABLE` forcing an fsync after each commit
+  for maximum durability at the cost of latency.
+- **writemap_mode**: Adds `MDBX_WRITEMAP` to map pages writable. This can speed
+  up modifications but may increase virtual memory usage and requires reliable
+  syncing.
+- **relative_to_exe**: When set, resolves relative paths as described for
+  `pathname`.
+
+Tune these options to balance performance and durability. Combining
+`writemap_mode` with `sync_durable` mimics MDBX's default safe mode, while
+disabling `sync_durable` trades safety for throughput. For more guidance see
+the official MDBX documentation: https://libmdbx.dqdkfa.ru/.
+*/

--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -8,6 +8,9 @@ Version: VERSION_PLACEHOLDER
 The LogIt++ library is open-source and hosted on GitHub:
 [LogIt++ GitHub Repository](https://github.com/NewYaroslav/mdbx-containers).
 
+\section config_sec Configuration Guide
+For details on tuning the MDBX environment see \ref config_page.
+
 \section license_sec License
 
 This library is licensed under the **MIT License**. See the [LICENSE](https://github.com/NewYaroslav/log-it-cpp/blob/main/LICENSE) file in the repository for more details.

--- a/include/mdbx_containers/common/Config.hpp
+++ b/include/mdbx_containers/common/Config.hpp
@@ -3,29 +3,33 @@
 #define _MDBX_CONTAINERS_CONFIG_HPP_INCLUDED
 
 /// \file Config.hpp
-/// \brief Configuration class for MDBX database.
+/// \brief Configuration options used when opening an MDBX environment.
 
 namespace mdbxc {
 
     /// \class Config
-    /// \brief Configuration for MDBX databases.
+    /// \brief Parameters used by \ref Connection to create the MDBX environment.
+    ///
+    /// Each option corresponds to an MDBX flag or setting. See
+    /// \ref config_page for a detailed description of how these values
+    /// influence the database.
     class Config {
     public:
-        std::string pathname;                   ///< Pathname for the database or directory in which the database files reside.
+        std::string pathname;                   ///< Path to the database file or directory containing the database.
         int64_t size_lower  = -1;               ///< Lower bound for database size.
         int64_t size_now    = -1;               ///< Current size of the database.
         int64_t size_upper  = -1;               ///< Upper bound for database size.
         int64_t growth_step = 16 * 1024 * 1024; ///< Step size for database growth.
         int64_t shrink_threshold = 16 * 1024 * 1024; ///< Threshold for database shrinking.
-        int64_t page_size   = 0;                ///< Page size; should be a power of two.
-        int64_t max_readers = 0;                ///< Maximum number of reader slots; 0 uses the default (twice the number of CPU cores).
-        int64_t max_dbs = 10;                   ///< Maximum number of named databases (DBI) within the environment.
-        bool read_only = false;                 ///< Enables or disables read-only mode.
-        bool readahead = true;                  ///< Enables or disables readahead for sequential data access.
-        bool no_subdir = true;      			///< If true, uses a single file instead of a directory for the database.
-		bool sync_durable = true;   			///< If true, enforces synchronous/durable writes (MDBX_SYNC_DURABLE).
-		bool writemap_mode = false;             ///< Enables or disables the `MDBX_WRITEMAP` mode, which maps the database into memory for direct modification.
-        bool relative_to_exe = false;           ///< If true and pathname is relative, interpret it as relative to executable directory.
+        int64_t page_size   = 0;                ///< Page size (must be a power of two).
+        int64_t max_readers = 0;                ///< Maximum reader slots; use 0 for the default (twice the CPU count).
+        int64_t max_dbs = 10;                   ///< Maximum number of named databases (DBI) in the environment.
+        bool read_only = false;                 ///< Whether to open the environment in read-only mode.
+        bool readahead = true;                  ///< Whether to enable OS readahead for sequential access.
+        bool no_subdir = true;                  ///< Whether to store the database in a single file instead of a directory.
+        bool sync_durable = true;               ///< Whether to enforce synchronous durable writes (MDBX_SYNC_DURABLE).
+        bool writemap_mode = false;             ///< Whether to map the database with MDBX_WRITEMAP for direct modification.
+        bool relative_to_exe = false;           ///< Whether to resolve a relative path relative to the executable directory.
         
         /// \brief Validate the MDBX configuration.
         /// \return True if the configuration is valid, false otherwise.


### PR DESCRIPTION
## Summary
- expand description of Config variables and their effect on MDBX

## Testing
- `cmake -S . -B build -DBUILD_DEPS=ON -DBUILD_TESTS=ON -DBUILD_EXAMPLES=OFF`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68899487a970832cbac3a81833b7afd0