### PR TITLE
Update Doxygen main page

### DIFF
--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -1,19 +1,77 @@
-/*!
-\mainpage MDBX-Containers Library
+/*!\mainpage MDBX-Containers Library
 
 Version: VERSION_PLACEHOLDER
 
-\section repo_sec Repository
+\section intro_sec Introduction
+mdbx-containers bridges standard STL containers with high-performance [libmdbx](https://github.com/erthink/libmdbx) storage. It transparently persists data in a transactional database while exposing familiar container-like interfaces.
 
-The LogIt++ library is open-source and hosted on GitHub:
-[LogIt++ GitHub Repository](https://github.com/NewYaroslav/mdbx-containers).
+Key features:
+- Header-only usage or optional static library.
+- Unified API for `KeyTable`, `KeyValueTable`, and `KeyMultiValueTable`.
+- Automatic serialization of trivially copyable types and custom `to_bytes()`/`from_bytes()` support.
+- Multiple logical tables inside one MDBX environment.
+- Thread-safe operations with per-thread transactions.
+
+\section transaction_sec Transactions
+Every modifying operation runs inside a transaction. There are two ways to manage them:
+- **RAII transactions** created via `Connection::transaction()`. A transaction object commits on `commit()` or rolls back on destruction. Convenient for scoped writes.
+- **Manual transactions** started with `Connection::begin()` and finished with `commit()` or `rollback()`. This approach reduces overhead when grouping many operations.
+
+Read transactions are reused per thread. Nested transactions are not supported.
+
+\section examples_sec Examples
+\subsection ex_basic Basic usage
+```cpp
+mdbxc::Config cfg;            // minimal config
+cfg.pathname = "example.mdbx";
+auto conn = mdbxc::Connection::create(cfg);
+mdbxc::KeyValueTable<int, std::string> table(conn, "demo");
+
+table.insert_or_assign(1, "one");
+#if __cplusplus >= 201703L
+std::optional<std::string> val = table.find(1);
+if (val) std::cout << *val << std::endl;
+#else
+auto res = table.find_compat(1);
+if (res.first) std::cout << res.second << std::endl;
+#endif
+```
+
+\subsection ex_manual Manual transaction
+```cpp
+mdbxc::Config cfg; cfg.pathname = "manual_txn.mdbx";
+auto conn = mdbxc::Connection::create(cfg);
+conn->begin(mdbxc::TransactionMode::WRITABLE);
+
+mdbxc::KeyValueTable<int, std::string> tbl(conn, "data");
+tbl.insert_or_assign(10, "ten");
+conn->commit();
+```
+
+\subsection ex_multitable Multiple tables
+```cpp
+mdbxc::Config cfg; cfg.pathname = "multi.mdbx"; cfg.max_dbs = 2;
+auto conn = mdbxc::Connection::create(cfg);
+mdbxc::KeyValueTable<int, std::string> a(conn, "numbers");
+mdbxc::KeyValueTable<std::string, std::string> b(conn, "strings");
+a.insert_or_assign(100, "hundred");
+b.insert_or_assign("a", "b");
+```
+
+\section build_sec Building
+Use CMake or simply include the headers and link with libmdbx.
+```bash
+cmake -S . -B build -DBUILD_DEPS=ON -DBUILD_STATIC_LIB=ON
+cmake --build build
+```
+The library supports both C++11 and C++17. When built with C++17, functions such as `find()` return `std::optional`; with C++11 use the `*_compat` variants returning `std::pair<bool, T>`.
 
 \section config_sec Configuration Guide
-For details on tuning the MDBX environment see \ref config_page.
+Details on tuning the MDBX environment are available on \ref config_page.
+
+\section repo_sec Repository
+Sources: [GitHub repository](https://github.com/NewYaroslav/mdbx-containers).
 
 \section license_sec License
-
-This library is licensed under the **MIT License**. See the [LICENSE](../LICENSE) file for more details.
-
-It bundles [libmdbx](https://github.com/erthink/libmdbx) which is distributed under the Apache License 2.0. The license text can be found in `docs/libmdbx.LICENSE`.
+This project is licensed under the MIT License. It bundles libmdbx under the Apache License 2.0. See files in the repository for full texts.
 */


### PR DESCRIPTION
## Summary
- expand `mainpage.dox` with introductory material
- describe transactions and provide usage examples
- document build instructions and C++11/C++17 differences

## Testing
- `cmake -S . -B build -DBUILD_DEPS=ON -DBUILD_TESTS=OFF`
- `cmake --build build`
- `cmake -S . -B build_test -DBUILD_DEPS=ON -DBUILD_TESTS=ON -DBUILD_EXAMPLES=OFF`
- `cmake --build build_test`
- `ctest --test-dir build_test --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6889ab4ad028832c9aef43c32674b791