### PR TITLE
Add Doxygen group descriptions

### DIFF
--- a/docs/groups.dox
+++ b/docs/groups.dox
@@ -1,0 +1,17 @@
+/*! \defgroup mdbxc_core Core Components
+ *  Classes for connection management, configuration, transaction handling,
+ *  and the common base classes shared across containers.
+ */
+
+/*! \defgroup mdbxc_tables Persistent Containers
+ *  STL-like containers backed by MDBX such as \c KeyValueTable, \c KeyTable
+ *  and related types providing durable storage.
+ */
+
+/*! \defgroup mdbxc_utils Utility Functions
+ *  Helper traits and serialization routines used throughout the library.
+ */
+
+/*! \defgroup mdbxc_examples Examples
+ *  Example programs demonstrating how to use the mdbx-containers library.
+ */


### PR DESCRIPTION
## Summary
- document groups for core, table, utils, and example modules

## Testing
- `cmake -S . -B build -DBUILD_DEPS=ON -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON -DBUILD_STATIC_LIB=ON` *(fails: missing libmdbx)*
- `cmake -S . -B build -DBUILD_DEPS=OFF -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON -DBUILD_STATIC_LIB=ON` *(fails: missing mdbx package)*
- `ctest --output-on-failure` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6889b7d396ec832cb6d56ede81ed33b2