### PR TITLE
Define doxygen groups

### DIFF
--- a/docs/groups.dox
+++ b/docs/groups.dox
@@ -1,0 +1,8 @@
+/*! \defgroup mdbxc_core Core API
+    Classes managing connections, configuration, and transactions.
+*/
+
+/*! \defgroup mdbxc_tables Table Containers
+    STL-like containers backed by MDBX.
+*/
+

--- a/include/mdbx_containers/KeyValueTable.hpp
+++ b/include/mdbx_containers/KeyValueTable.hpp
@@ -12,6 +12,7 @@
 namespace mdbxc {
 
     /// \class KeyValueTable
+    /// \ingroup mdbxc_tables
     /// \brief Template class for managing key-value pairs in an MDBX database.
     /// \tparam KeyT Type of the keys.
     /// \tparam ValueT Type of the values.

--- a/include/mdbx_containers/common/Config.hpp
+++ b/include/mdbx_containers/common/Config.hpp
@@ -8,6 +8,7 @@
 namespace mdbxc {
 
     /// \class Config
+    /// \ingroup mdbxc_core
     /// \brief Parameters used by \ref Connection to create the MDBX environment.
     ///
     /// Each option corresponds to an MDBX flag or setting. See

--- a/include/mdbx_containers/common/Connection.hpp
+++ b/include/mdbx_containers/common/Connection.hpp
@@ -8,6 +8,7 @@
 namespace mdbxc {
 
     /// \class Connection
+    /// \ingroup mdbxc_core
     /// \brief Manages a single MDBX environment and an optional read-only transaction.
     class Connection : private TransactionTracker {
         friend class BaseTable;

--- a/include/mdbx_containers/common/MdbxException.hpp
+++ b/include/mdbx_containers/common/MdbxException.hpp
@@ -8,6 +8,7 @@
 namespace mdbxc {
 
     /// \class MdbxException
+    /// \ingroup mdbxc_core
     /// \brief Represents a specific exception for MDBX-related errors.
     ///
     /// This exception is used to handle errors that occur during MDBX operations.

--- a/include/mdbx_containers/common/Transaction.hpp
+++ b/include/mdbx_containers/common/Transaction.hpp
@@ -17,6 +17,7 @@ namespace mdbxc {
     };
 
     /// \class Transaction
+    /// \ingroup mdbxc_core
     /// \brief Manages MDBX transactions with automatic cleanup and error handling.
     ///
     /// Supports both read-only and writable modes. Provides methods for beginning,

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -8,6 +8,7 @@
 namespace mdbxc {
     
     /// \class BaseTable
+    /// \ingroup mdbxc_core
     /// \brief Base class providing common functionality for MDBX database access.
     ///
     /// Opens or creates a table (DBI handle) and offers basic transaction management.

--- a/include/mdbx_containers/detail/TransactionTracker.hpp
+++ b/include/mdbx_containers/detail/TransactionTracker.hpp
@@ -8,6 +8,7 @@
 namespace mdbxc {
 
     /// \class TransactionTracker
+    /// \ingroup mdbxc_core
     /// \brief Associates MDBX transactions with threads.
     ///
     /// Manages a map from thread IDs to MDBX transaction pointers,

--- a/include/mdbx_containers/detail/path_utils.hpp
+++ b/include/mdbx_containers/detail/path_utils.hpp
@@ -3,6 +3,7 @@
 #define _MDBX_CONTAINERS_PATH_UTILS_HPP_INCLUDED
 
 /// \file path_utils.hpp
+/// \ingroup mdbxc_utils
 /// \brief Utility functions for path manipulation, including relative path computation.
 
 #include <string>


### PR DESCRIPTION
## Summary
- document Doxygen groups for the project
- mark Config, Connection and other classes as members of `mdbxc_core`
- mark `KeyValueTable` as a member of `mdbxc_tables`
- reference utility code in `mdbxc_utils`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6889b4551c50832cbae2ba002c01097b