### PR TITLE
Fix Doxygen docs

### DIFF
--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -64,7 +64,8 @@ Use CMake or simply include the headers and link with libmdbx.
 cmake -S . -B build -DBUILD_DEPS=ON -DBUILD_STATIC_LIB=ON
 cmake --build build
 ```
-The library supports both C++11 and C++17. When built with C++17, functions such as `find()` return `std::optional`; with C++11 use the `*_compat` variants returning `std::pair<bool, T>`.
+
+For more details on container usage and C++ version differences see \ref tables_page.
 
 \section config_sec Configuration Guide
 Details on tuning the MDBX environment are available on \ref config_page.

--- a/docs/tables.dox
+++ b/docs/tables.dox
@@ -1,0 +1,28 @@
+/*! \page tables_page Persistent Containers Usage
+\ingroup mdbxc_tables
+\tableofcontents
+
+This page describes how to work with the persistent container classes such as
+\ref mdbxc::KeyValueTable. These containers expose familiar STL-like interfaces
+while storing data durably in an MDBX database.
+
+## Basic Operations
+
+`KeyValueTable` behaves similarly to `std::map`. You can insert or assign
+key-value pairs, look them up, and remove them. All modifying operations run
+inside a transaction which is automatically created when needed.
+
+```cpp
+mdbxc::Config cfg; cfg.pathname = "example.mdbx";
+auto conn = mdbxc::Connection::create(cfg);
+mdbxc::KeyValueTable<int, std::string> table(conn, "demo");
+
+table.insert_or_assign(1, "one");
+```
+
+## C++ Compatibility
+
+The library supports both C++11 and C++17. When built with C++17, functions
+such as `find()` return `std::optional`. With C++11 use the `*_compat`
+variants returning `std::pair<bool, T>`.
+*/

--- a/include/mdbx_containers/KeyValueTable.hpp
+++ b/include/mdbx_containers/KeyValueTable.hpp
@@ -28,18 +28,26 @@ namespace mdbxc {
     public:
 
         /// \brief Default constructor.
+        /// \param connection Existing \ref Connection instance.
+        /// \param name Name of the table within the MDBX environment.
+        /// \param flags Additional MDBX database flags.
         KeyValueTable(std::shared_ptr<Connection> connection,
                       std::string name = "kv_store",
-                      MDBX_db_flags_t flags = MDBX_DB_DEFAULTS | MDBX_CREATE) 
-            : BaseTable(std::move(connection), std::move(name), flags | get_mdbx_flags<KeyT>())  {}
+                      MDBX_db_flags_t flags = MDBX_DB_DEFAULTS | MDBX_CREATE)
+            : BaseTable(std::move(connection),
+                        std::move(name),
+                        flags | get_mdbx_flags<KeyT>()) {}
 
         /// \brief Constructor with configuration.
         /// \param config Configuration settings for the database.
-        explicit KeyValueTable(const Config& config, 
+        /// \param name Name of the table within the MDBX environment.
+        /// \param flags Additional MDBX database flags.
+        explicit KeyValueTable(const Config& config,
                                std::string name = "kv_store",
-                               MDBX_db_flags_t flags = MDBX_DB_DEFAULTS | MDBX_CREATE) 
-            : BaseTable(Connection::create(config), std::move(name), flags | get_mdbx_flags<KeyT>()) {
-        }
+                               MDBX_db_flags_t flags = MDBX_DB_DEFAULTS | MDBX_CREATE)
+            : BaseTable(Connection::create(config),
+                        std::move(name),
+                        flags | get_mdbx_flags<KeyT>()) {}
 
         /// \brief Destructor.
         ~KeyValueTable() override final = default;
@@ -720,6 +728,7 @@ namespace mdbxc {
         /// Clears old data, inserts new data, and updates existing records in the main table.
         /// \tparam ContainerT Template for the container type (map or unordered_map).
         /// \param container Container with key-value pairs to be reconciled with the database.
+        /// \param txn_handle Active MDBX transaction.
         /// \throws MdbxException if a database error occurs.
         template<template <class...> class ContainerT>
         void db_reconcile(const ContainerT<KeyT, ValueT>& container, MDBX_txn* txn_handle) {

--- a/include/mdbx_containers/common/Transaction.hpp
+++ b/include/mdbx_containers/common/Transaction.hpp
@@ -61,9 +61,13 @@ namespace mdbxc {
         MDBX_txn *handle() const noexcept;
         
         /// \brief Constructs a new transaction object.
+        /// \param registry Transaction tracker used to associate the
+        ///        transaction with the current thread.
         /// \param env Pointer to the MDBX environment handle.
         /// \param mode Access mode of the transaction.
-        Transaction(TransactionTracker* registry, MDBX_env* env, TransactionMode mode);
+        Transaction(TransactionTracker* registry,
+                    MDBX_env* env,
+                    TransactionMode mode);
         
         Transaction(Transaction&&) noexcept = default;
         Transaction& operator=(Transaction&&) noexcept = default;


### PR DESCRIPTION
## Summary
- document container usage and move compatibility note

## Testing
- `cmake -S . -B build -DBUILD_DEPS=ON -DBUILD_STATIC_LIB=ON -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON` *(fails: libs/libmdbx lacks CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_688a484c02b0832c9c2b0f1afb781c37