### PR TITLE
fix(detail): inline path utils for cross-platform builds

### DIFF
--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -182,7 +182,11 @@ namespace mdbxc {
         std::string pathname = m_config->pathname;
         if (m_config->relative_to_exe && !is_absolute_path(pathname)) {
 #if __cplusplus >= 201703L
+#if __cplusplus >= 202002L
+            pathname = u8string_to_string((fs::u8path(get_exec_dir()) / fs::u8path(pathname)).u8string());
+#else
             pathname = (fs::u8path(get_exec_dir()) / fs::u8path(pathname)).u8string();
+#endif
 #else
 #   ifdef _WIN32
             pathname = get_exec_dir() + "\\" + pathname;


### PR DESCRIPTION
## Summary
- make path utilities inline and guard Windows-specific UTF-8 to ANSI conversion
- add helper for C++20 `u8string` and update Connection path handling

## Testing
- `g++ -std=c++11 -Iinclude -Ilibs/libmdbx -c /tmp/test.cpp`
- `g++ -std=c++14 -Iinclude -Ilibs/libmdbx -c /tmp/test.cpp && echo OK`
- `g++ -std=c++17 -Iinclude -Ilibs/libmdbx -c /tmp/test.cpp && echo OK`
- `g++ -std=c++20 -Iinclude -Ilibs/libmdbx -c /tmp/test.cpp && echo OK`
- `g++ -std=c++11 -Iinclude -Ilibs/libmdbx /tmp/pu1.cpp /tmp/pu2.cpp -o /tmp/pu && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68a5022da0a4832c8106947513cde8c5