### PR TITLE
test: remove waits and add C++11 support

### DIFF
--- a/examples/any_value_table_example.cpp
+++ b/examples/any_value_table_example.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <string>
 #include <cstring>
+#include <limits>
 
 /// \brief Simple struct for demonstration.
 struct MyStruct {
@@ -44,7 +45,12 @@ int main() {
     table.set<MyStruct>("struct", MyStruct{42, 0.5f});
 
     auto retries = table.get_or<int>("retries", 1);
+#if __cplusplus >= 201703L
     auto url = table.find<std::string>("url").value_or("none");
+#else
+    auto url_pair = table.find_compat<std::string>("url");
+    std::string url = url_pair.first ? url_pair.second : "none";
+#endif
 
     std::cout << "retries: " << retries << "\nurl: " << url << '\n';
 
@@ -52,5 +58,7 @@ int main() {
         std::cout << "key: " << key << '\n';
     }
 
+    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    std::cin.get();
     return 0;
 }

--- a/examples/config_initialized_table.cpp
+++ b/examples/config_initialized_table.cpp
@@ -5,6 +5,7 @@
 
 #include <mdbx_containers/KeyValueTable.hpp>
 #include <iostream>
+#include <limits>
 
 int main() {
     mdbxc::Config config;
@@ -21,4 +22,7 @@ int main() {
     auto val = table.find_compat(1);
     std::cout << "Found: " << (val.first ? val.second : "not found") << std::endl;
 #   endif
+
+    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    std::cin.get();
 }

--- a/examples/custom_struct_example.cpp
+++ b/examples/custom_struct_example.cpp
@@ -6,6 +6,7 @@
 #include <mdbx_containers/KeyValueTable.hpp>
 #include <iostream>
 #include <vector>
+#include <limits>
 
 struct MyData {
     int id;
@@ -44,4 +45,7 @@ int main() {
     if (result.first)
         std::cout << "id: " << result.second.id << ", value: " << result.second.value << std::endl;
 #   endif
+
+    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    std::cin.get();
 }

--- a/examples/manual_transaction_example.cpp
+++ b/examples/manual_transaction_example.cpp
@@ -5,6 +5,7 @@
 
 #include <mdbx_containers/KeyValueTable.hpp>
 #include <iostream>
+#include <limits>
 
 int main() {
     mdbxc::Config config;
@@ -47,5 +48,8 @@ int main() {
 
     // Commit transaction
     conn->commit();
+
+    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    std::cin.get();
     return 0;
 }

--- a/examples/multi_table_demo.cpp
+++ b/examples/multi_table_demo.cpp
@@ -6,6 +6,7 @@
 #include <mdbx_containers/KeyValueTable.hpp>
 #include <mdbx_containers/KeyTable.hpp>
 #include <iostream>
+#include <limits>
 
 int main() {
     mdbxc::Config config;
@@ -49,5 +50,7 @@ int main() {
         std::cout << "kv_table2[\"a\"]: not found" << std::endl;
 #   endif
 
+    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    std::cin.get();
     return 0;
 }

--- a/examples/single_transaction_demo.cpp
+++ b/examples/single_transaction_demo.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <vector>
 #include <cstring>
+#include <limits>
 
 struct MyStruct {
     int a;
@@ -50,5 +51,8 @@ int main() {
 #   endif
 
     txn.commit();
+
+    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    std::cin.get();
     return 0;
 }

--- a/examples/table_methods_showcase.cpp
+++ b/examples/table_methods_showcase.cpp
@@ -6,6 +6,7 @@
 #include <mdbx_containers/KeyValueTable.hpp>
 #include <iostream>
 #include <string>
+#include <limits>
 
 int main() {
     mdbxc::Config config;
@@ -37,8 +38,8 @@ int main() {
     // operator()
     std::map<int, std::string> snapshot = table();
     std::cout << "Snapshot:\n";
-    for (const auto& [k, v] : snapshot)
-        std::cout << k << ": " << v << std::endl;
+    for (std::map<int, std::string>::const_iterator it = snapshot.begin(); it != snapshot.end(); ++it)
+        std::cout << it->first << ": " << it->second << std::endl;
     
     // operator=
     std::unordered_map<int, std::string> temp_data = {
@@ -80,5 +81,7 @@ int main() {
     table.clear();
     std::cout << "After clear, size = " << table.count() << std::endl;
 
+    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    std::cin.get();
     return 0;
 }

--- a/tests/any_value_table_test.cpp
+++ b/tests/any_value_table_test.cpp
@@ -45,7 +45,14 @@ int main() {
     table.set<MyStruct>("object", expected);
 
     assert(table.get<int>("answer") == 42);
+#if __cplusplus >= 201703L
     assert(table.find<std::string>("greeting").value() == "hello");
+#else
+    {
+        auto res = table.find_compat<std::string>("greeting");
+        assert(res.first && res.second == "hello");
+    }
+#endif
     assert(table.get<MyStruct>("object") == expected);
 
     auto ks = table.keys();


### PR DESCRIPTION
## Summary
- drop interactive stdin waits from tests
- add pauses and C++11-friendly branches to examples
- ensure tests support C++11 via `find_compat` helper

## Testing
- `cmake -S . -B build -DBUILD_DEPS=ON -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=11` *(fails: KeyValueTable.hpp uses C++14/17 features)*
- `cmake -S . -B build -DBUILD_DEPS=ON -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=17`
- `cmake --build build`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68a50569f738832c857d7f46192de66f