### PR TITLE
docs: clarify unimplemented KeyTable and KeyMultiValueTable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 
 **mdbx-containers** is a lightweight header-only C++11/17 library that bridges [libmdbx](https://github.com/erthink/libmdbx) with familiar STL containers such as `std::map` and `std::set`. It transparently persists your in-memory data in MDBX while providing high performance and thread-safe transactions.
 
+> **Note:** `KeyTable` and `KeyMultiValueTable` are not implemented yet.
+
 ## Features
 
 ### Unified API
 - Identical interface for all table types: `insert`, `insert_or_assign`, `find`, `erase`, `clear`, `load`, `reconcile`, `operator[]` and more.
 - Four container flavours:
-  - `KeyTable<K>` – keys only;
+  - `KeyTable<K>` – keys only (not implemented yet);
   - `KeyValueTable<K, V>` – one value per key;
-  - `KeyMultiValueTable<K, V>` – multiple values per key (`std::multimap`);
+  - `KeyMultiValueTable<K, V>` – multiple values per key (`std::multimap`) (not implemented yet);
   - `AnyValueTable<K>` – heterogeneous values with runtime type checks.
 
 ### Serialization


### PR DESCRIPTION
## Summary
- note that KeyTable and KeyMultiValueTable are not implemented yet

## Testing
- `cmake -S . -B build -DBUILD_DEPS=ON -DBUILD_STATIC_LIB=ON -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON` *(warning: API version mismatch for libmdbx)*
- `cmake --build build` *(failed: API version mismatch, missing git tags for libmdbx)*
- `cd build && ctest --output-on-failure` *(failed: tests binaries not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a63b88d1b4832c9ec9c8506dd5a15d