### PR TITLE
docs(cmake): translate comments to English

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,15 +32,15 @@ message(STATUS "MDBXC_USE_ASAN          = ${MDBXC_USE_ASAN}")
 set(MDBXC_HAS_ASAN OFF CACHE BOOL "Compiler+linker support -fsanitize=address")
 
 if (MDBXC_USE_ASAN AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang") AND NOT MSVC)
-    # Проверяем, понимает ли компилятор флаг
+    # Check whether the compiler supports the flag
     check_cxx_compiler_flag("-fsanitize=address" MDBXC_ASAN_CFLAG_OK)
-    # И умеет ли линкер
+    # Check whether the linker supports the flag
     check_linker_flag(CXX "-fsanitize=address" MDBXC_ASAN_LDFLAG_OK)
 
     if (MDBXC_ASAN_CFLAG_OK AND MDBXC_ASAN_LDFLAG_OK)
         set(MDBXC_HAS_ASAN ON CACHE BOOL "" FORCE)
     else()
-        message(WARNING "ASan недоступен у текущего toolchain (compiler: ${MDBXC_ASAN_CFLAG_OK}, linker: ${MDBXC_ASAN_LDFLAG_OK}). Отключаю MDBXC_USE_ASAN.")
+        message(WARNING "ASan is unavailable for the current toolchain (compiler: ${MDBXC_ASAN_CFLAG_OK}, linker: ${MDBXC_ASAN_LDFLAG_OK}). Disabling MDBXC_USE_ASAN.")
         set(MDBXC_HAS_ASAN OFF CACHE BOOL "" FORCE)
     endif()
 endif()

--- a/libs/cmake/install-headers.cmake
+++ b/libs/cmake/install-headers.cmake
@@ -1,12 +1,12 @@
 # install-headers.cmake
 #
-# Утилита для копирования заголовков в build-libs/include/<target_name>/
+# Utility for copying headers to ${CMAKE_BINARY_DIR}/include/<target_name>/
 
 function(install_headers_to_include target_name include_dir)
     file(GLOB_RECURSE headers
         "${include_dir}/*.h"
         "${include_dir}/*.hpp"
-		"${include_dir}/*.ipp"
+        "${include_dir}/*.ipp"
         "${include_dir}/*.inl"
     )
 


### PR DESCRIPTION
## Summary
- translate ASan configuration comments to English
- update header install helper comment and formatting

## Testing
- `cmake -S . -B build -DMDBXC_BUILD_TESTS=OFF -DMDBXC_BUILD_EXAMPLES=OFF`
- `cmake --build build --target copy_headers_to_build`


------
https://chatgpt.com/codex/tasks/task_e_68a66bb91164832c80159c8f1e138046