### PR TITLE
docs(detail): clarify path utility Doxygen comments

### DIFF
--- a/include/mdbx_containers/detail/path_utils.hpp
+++ b/include/mdbx_containers/detail/path_utils.hpp
@@ -45,7 +45,9 @@ namespace mdbxc {
     }
 #endif
 
-    /// \brief
+    /// \brief Check if path starts with explicit relative prefix.
+    /// \param s Path string to inspect.
+    /// \return true if path starts with "./", "../", ".\\", or "..\\".
     inline bool is_explicitly_relative(const std::string& s) noexcept {
         auto sw = [&](const char* p){ return s.rfind(p, 0) == 0; };
         return sw("./") || sw("../") || sw(".\\") || sw("..\\");
@@ -244,10 +246,16 @@ namespace mdbxc {
 #else
     // С++11/14
 
-    inline bool is_path_sep(char c) { 
-        return c == '/' || c == '\\'; 
+    /// \brief Check if character is a path separator.
+    /// \param c Character to check.
+    /// \return true if \a c is '/' or '\\'.
+    inline bool is_path_sep(char c) {
+        return c == '/' || c == '\\';
     }
 
+    /// \brief Normalize path removing '.' and '..' components.
+    /// \param in Path to normalize.
+    /// \return Normalized path.
     inline std::string lexically_normal_compat(const std::string& in) {
 #       ifdef _WIN32
         const char SEP = '\\';


### PR DESCRIPTION
## Summary
- document relative path check helper
- describe path separator check and normalization helpers

## Testing
- `cmake -S . -B build -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=OFF -DCMAKE_CXX_STANDARD=17` *(fails: API version mismatch)*
- `cmake --build build -j 2` *(fails: API version mismatch)*
- `cmake -S . -B build11 -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=OFF -DCMAKE_CXX_STANDARD=11` *(fails: API version mismatch)*
- `cmake --build build11 -j 2` *(fails: API version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68a675dfed2c832c8f07748ad320d732