### PR TITLE
docs(detail): expand BaseTable documentation

### DIFF
--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -34,16 +34,19 @@ namespace mdbxc {
         virtual ~BaseTable() = default;
         
         /// \brief Checks if the connection is currently active.
+        /// \return true if connected, false otherwise.
         bool is_connected() const {
             return m_connection->is_connected();
         }
-        
+
         /// \brief Connects to the MDBX environment if not already connected.
+        /// \throws MdbxException if connection fails.
         void connect() {
             m_connection->connect();
         }
-        
+
         /// \brief Disconnects the MDBX environment.
+        /// \throws MdbxException if closing the environment fails.
         void disconnect() {
             m_connection->disconnect();
         }
@@ -96,6 +99,7 @@ namespace mdbxc {
         }
         
         /// \brief Gets the raw DBI handle.
+        /// \return DBI handle for the opened table.
         MDBX_dbi handle() const { return m_dbi; }
     };
     


### PR DESCRIPTION
## Summary
- document BaseTable connection helpers and handle

## Testing
- `cmake -S . -B build -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=OFF -DMDBXC_DEPS_MODE=BUNDLED -DCMAKE_CXX_STANDARD=17`
- `cmake --build build` *(fails: API version mismatch)*
- `cd build && ctest --output-on-failure` *(fails: executables not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a67ba81bf8832c828584aeca23068c