### PR TITLE
docs: pluralize README titles and add Russian link

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -1,4 +1,4 @@
-# mdbx-containers
+# MDBX-Containers
 
 **mdbx-containers** — это лёгкая заголовочная библиотека на C++11/C++17, предоставляющая удобный интерфейс для работы с базой данных [libmdbx](https://github.com/erthink/libmdbx) через стандартные контейнеры STL: `std::map`, `std::set`, `std::unordered_map`, `std::vector` и др.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# mdbx-containers
+# MDBX-Containers
+
+[Русская версия](README-RU.md)
 
 **mdbx-containers** is a lightweight header-only C++11/17 library that bridges [libmdbx](https://github.com/erthink/libmdbx) with familiar STL containers such as `std::map` and `std::set`. It transparently persists your in-memory data in MDBX while providing high performance and thread-safe transactions.
 


### PR DESCRIPTION
## Summary
- rename top-level headings in English and Russian READMEs to `MDBX-Containers`
- link to the Russian README directly beneath the English title

## Testing
- `cmake -S . -B build -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=OFF -DMDBXC_BUILD_STATIC_LIB=ON -DCMAKE_CXX_STANDARD=17`
- `cmake --build build` *(fails: fatal error: mdbx.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a106e17c832cb80e0186cea8e73f