### PR TITLE
Add ValueTable and AnyValueTable type tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@
 
 ### 🧱 Table APIs
 - `KeyValueTable<K, V>` is the main implemented table: one value per key with `insert`, `insert_or_assign`, `find`, `erase`, `clear`, `load`, `reconcile`, `operator[]`, and related helpers.
+- `ValueTable<V>` stores one strongly typed singleton value per named table for metadata, module state, snapshots, and single-object configuration records.
 - `AnyValueTable<K>` stores heterogeneous values by caller-selected type and supports typed `set`, `insert`, `get`, `find`, `get_or`, `update`, `contains`, `erase`, and `keys`.
 - `KeyTable<K>` stores unique keys with a `std::set`-like API: `insert`, `contains`, `erase`, `clear`, `load`, `reconcile`, and related helpers.
 - `KeyMultiValueTable<K, V>` stores multiple values per key with a `std::multimap`-like API and preserves repeated identical `(key, value)` pairs.
-- `AnyValueTable` type-tag prefix verification is not fully implemented yet, so do not rely on it for complete runtime type safety.
+- `AnyValueTable` type-tag prefix verification is opt-in via `set_type_tag_check(true)` and is disabled by default for compatibility with existing raw records.
 
 ### 🔁 Serialization
 - Automatic serialization of trivially copyable types.
@@ -106,6 +107,25 @@ keys.insert("active");
 keys.insert("archived");
 
 std::set<std::string> restored = keys.retrieve_all();
+```
+
+### Single-value table
+
+```cpp
+#include <mdbx_containers/ValueTable.hpp>
+
+struct AppState {
+    int schema_version = 1;
+    int active_profiles = 0;
+
+    std::vector<uint8_t> to_bytes() const;
+    static AppState from_bytes(const void* data, size_t size);
+};
+
+mdbxc::ValueTable<AppState> state(conn, "app_state");
+state.set(AppState{});
+
+AppState loaded = state.get_or(AppState{});
 ```
 
 ### Multi-value table

--- a/agents/codebase-orientation.md
+++ b/agents/codebase-orientation.md
@@ -32,6 +32,7 @@ Primary entry points:
   `include/mdbx_containers/KeyValueTable.hpp`,
   `include/mdbx_containers/HashedKeyValueStore.hpp`,
   `include/mdbx_containers/Hash.hpp`,
+  `include/mdbx_containers/ValueTable.hpp`,
   `include/mdbx_containers/AnyValueTable.hpp`,
   `include/mdbx_containers/KeyTable.hpp`,
   `include/mdbx_containers/KeyMultiValueTable.hpp`.
@@ -51,8 +52,8 @@ library over libmdbx.
 Real subdomains:
 
 - **Persistent tables**: active `KeyValueTable`, active
-  `HashedKeyValueStore`, active `AnyValueTable`, active `KeyTable`, active
-  `KeyMultiValueTable`.
+  `HashedKeyValueStore`, active `ValueTable`, active `AnyValueTable`, active
+  `KeyTable`, active `KeyMultiValueTable`.
 - **MDBX environment and transactions**: `Connection`, `Transaction`,
   `TransactionTracker`, `BaseTable`.
 - **Serialization**: `serialize_key`, `serialize_value`,
@@ -107,8 +108,8 @@ Avoid:
   in `commit()`, `rollback()`, or the destructor.
 - **Factory method**: `Connection::create(const Config&)` returns
   `std::shared_ptr<Connection>` and opens the environment.
-- **Table Gateway / repository-like API**: `KeyValueTable` and `AnyValueTable`
-  hide MDBX DBI/cursor handling behind STL-like methods.
+- **Table Gateway / repository-like API**: `KeyValueTable`, `ValueTable`, and
+  `AnyValueTable` hide MDBX DBI/cursor handling behind typed methods.
 - **Adapter over MDBX C API**: `check_mdbx`, `BaseTable`, `Connection`, and
   private `db_*` methods translate raw MDBX calls into C++ APIs.
 - **Template strategy / SFINAE**: `serialize_key`, `serialize_value`, and
@@ -135,9 +136,9 @@ Prefer for new table code:
 
 Do not copy without review:
 
-- `AnyValueTable::wrap_with_type_tag()` and
-  `unwrap_and_check_type_tag()` still contain TODOs and do not implement the
-  type-tag prefix yet.
+- `AnyValueTable` type-tag checks are opt-in. Raw records remain the default
+  storage format unless `set_type_tag_check(true)` is enabled on the table
+  instance.
 - `KeyMultiValueTable` hidden duplicate sequence-prefix storage; do not change
   it without migration notes and compatibility tests.
 - `tests/mdbx_test.cpp` is a raw MDBX smoke test, not the library API style.
@@ -370,8 +371,9 @@ Do not add an HTTP/WebSocket framework to persistence-library headers.
   `m_mdbx_mutex`, `m_transactions`, `TransactionTracker::m_thread_txns`.
 - Cursor cleanup must be explicit. If early returns/exceptions are added around
   cursor logic, make sure the cursor is closed.
-- `AnyValueTable` type-tag checking is not fully implemented yet; do not
-  promise runtime type safety until the TODO is implemented.
+- `AnyValueTable` type-tag checking is opt-in and default tags are
+  implementation-defined. Durable schemas should specialize
+  `AnyValueTypeTag<T>`.
 
 ## Usually Do Not Change
 

--- a/agents/coding-agent-workflow.md
+++ b/agents/coding-agent-workflow.md
@@ -51,7 +51,9 @@ behavior. Small, well-verified edits matter more than broad rewrites.
 - Serialization changes: run `kv_container_all_types_test` and any affected
   table tests.
 - Transaction/concurrency changes: run `mdbx_test` and related examples/tests.
-- AnyValueTable changes: run `any_value_table_test` and the example build.
+- `ValueTable` changes: run `value_table_test` and build
+  `value_table_example`.
+- `AnyValueTable` changes: run `any_value_table_test` and the example build.
 
 ## Context Hygiene
 

--- a/agents/implementation-notes.md
+++ b/agents/implementation-notes.md
@@ -59,8 +59,8 @@ mdbxc::KeyValueTable<std::string, int> orders(conn, "orders");
 Set `Config::max_dbs` high enough for tests and examples that open several
 tables in one environment.
 
-For choosing between `KeyValueTable`, `KeyTable`, `KeyMultiValueTable`, and
-`AnyValueTable`, and for their bulk-operation semantics, see
+For choosing between `KeyValueTable`, `ValueTable`, `KeyTable`,
+`KeyMultiValueTable`, and `AnyValueTable`, and for their operation semantics, see
 `agents/table-api-guide.md`.
 
 ## Configuration

--- a/agents/project-overview.md
+++ b/agents/project-overview.md
@@ -24,7 +24,8 @@ and compiles in the consumer's translation units.
 | --- | --- | --- |
 | `KeyValueTable<K, V>` | Active | One value per key, similar to `std::map`. |
 | `HashedKeyValueStore<K, V, H, Layout>` | Active | One value per string/byte key with a hash lookup index. |
-| `AnyValueTable<K>` | Active | Heterogeneous values by caller-specified type; type-tag prefix checks are not fully implemented yet. |
+| `ValueTable<V>` | Active | One strongly typed singleton value per named table. |
+| `AnyValueTable<K>` | Active | Heterogeneous values by caller-specified type with optional type-tag prefix checks. |
 | `KeyTable<K>` | Active | Key-only table with `std::set`-like membership semantics. |
 | `KeyMultiValueTable<K, V>` | Active | Multimap-like table with multiple values per key, including repeated identical pairs. |
 
@@ -82,7 +83,8 @@ keys.
 - MDBX errors are checked with `check_mdbx()` and reported as `MdbxException`.
 - Serialization and type validation errors use standard exceptions such as
   `std::runtime_error`.
-- `AnyValueTable` should not be documented as providing full runtime type
-  safety until its type-tag TODO is implemented.
+- `AnyValueTable` type-tag checks are opt-in via `set_type_tag_check(true)`.
+  They are disabled by default for raw-record compatibility; durable schemas
+  should specialize `AnyValueTypeTag<T>`.
 - In C++17 builds, lookup APIs can return `std::optional`. C++11 fallback APIs
   use explicit success flags such as `std::pair<bool, ValueT>`.

--- a/agents/table-api-guide.md
+++ b/agents/table-api-guide.md
@@ -16,6 +16,7 @@ source of truth.
 | --- | --- | --- | --- |
 | One value per key | `KeyValueTable<K, V>` | `std::map` | Default choice for durable key-value storage. |
 | One value per string/byte key with hash lookup | `HashedKeyValueStore<K, V, H, Layout>` | `std::map` | Uses a hash bucket index and verifies original key bytes. |
+| One true singleton object in a named table | `ValueTable<V>` | persistent variable | Best for metadata, config snapshots, module state, schema/version records, and checkpoints. |
 | Unique keys only | `KeyTable<K>` | `std::set` | Stores serialized keys with empty values. |
 | Multiple values per key | `KeyMultiValueTable<K, V>` | `std::multimap` | Preserves repeated identical `(key, value)` pairs. |
 | Different value types by key | `AnyValueTable<K>` | Heterogeneous key-value store | Caller names value type on each access. |
@@ -25,12 +26,16 @@ Choose the narrowest table that represents the data:
 - Use `KeyTable` for membership, tags, IDs, indexes, and "seen" sets.
 - Use `KeyValueTable` for configuration, object snapshots, latest state, and
   any model where a key has one current value.
+- Use `ValueTable` for a true singleton object scoped by table name, such as
+  storage metadata, app/config snapshots, module state, scheduler state,
+  schema/version records, and durable checkpoints.
 - Use `HashedKeyValueStore` when keys are strings or byte vectors and a compact
   hash-index lookup path is preferable to ordering by full original key bytes.
 - Use `KeyMultiValueTable` for event lists, secondary indexes, histories, and
   any model where repeated values for the same key must remain visible.
-- Use `AnyValueTable` only when values under one key domain genuinely need
-  different C++ types. It is not a replacement for schema design.
+- Use `AnyValueTable` only for small heterogeneous keyed settings where values
+  under one stable key domain genuinely need different C++ types. It is not a
+  replacement for schema design or a typed singleton object.
 
 ## Common Table Contract
 
@@ -210,6 +215,57 @@ Avoid it when:
 - A key needs a payload. Use `KeyValueTable`.
 - A key needs multiple payloads. Use `KeyMultiValueTable`.
 
+## ValueTable
+
+`ValueTable<V>` stores one strongly typed value in a named MDBX table. It is the
+right shape for a real singleton object: the table name identifies the object,
+and there is no caller-visible key. It uses a fixed internal key and exposes
+value-oriented operations instead of asking the caller to remember a sentinel
+key.
+
+Write methods:
+
+- `set(value)` upserts the singleton value.
+- `insert(value)` writes only when the singleton is absent.
+- `update(fn)` reads the value, applies `fn(ValueT&)`, writes it back, and
+  returns whether a value existed.
+- `erase()` removes the singleton value.
+- `clear()` removes all physical rows from the DBI.
+
+Read/meta methods:
+
+- `get()` returns the value or throws `std::out_of_range`.
+- `try_get(out)` returns a success flag.
+- `find()` returns `std::optional<ValueT>` in C++17 and a pair in C++11.
+- `find_compat()` is the pair-based compatibility form.
+- `get_or(fallback)`, `has_value()`, `count()`, and `empty()` expose singleton
+  state.
+
+Restrictions and common mistakes:
+
+- `count()` is logical and returns `0` or `1`.
+- The singleton invariant is guaranteed only when using `ValueTable`; opening
+  the same DBI through another table type can intentionally add extra rows.
+- Use `clear()` if you need to remove extra physical rows from a DBI that was
+  previously misused through another table type.
+
+Use it for:
+
+- `StorageMetadata`, schema version records, migration state, and other
+  database metadata.
+- `AppConfigSnapshot`, `ModuleState`, `SchedulerState`, and other coherent
+  single-object state.
+- Durable checkpoints, last-run summaries, cache manifests, and snapshots that
+  should have exactly one current value.
+
+Avoid it when:
+
+- Multiple records share one schema, for example profiles by ID or state by
+  account. Use `KeyValueTable<K,V>`.
+- The data is a set of IDs or flags without payload. Use `KeyTable`.
+- Values need different C++ types under user keys and are not one coherent
+  object. Use `AnyValueTable`.
+
 ## KeyMultiValueTable
 
 `KeyMultiValueTable<K, V>` is the multimap-like table. It stores multiple values
@@ -266,7 +322,9 @@ Avoid it when:
 ## AnyValueTable
 
 `AnyValueTable<K>` stores one value per key, but the value type is selected by
-the caller for each operation.
+the caller for each operation. It is best treated as a small heterogeneous
+keyed store for settings and options, not as a replacement for a typed table or
+a typed singleton record.
 
 Write methods:
 
@@ -284,27 +342,35 @@ Read/meta methods:
 - `get_or<T>(key, fallback)` returns a fallback when missing.
 - `contains(key)` checks key existence.
 - `keys()` returns stored keys only.
-- `set_type_tag_check(enabled)` toggles the reserved type-tag flag.
+- `set_type_tag_check(enabled)` toggles opt-in type-tag prefix validation.
 
 Restrictions and common mistakes:
 
 - Each key stores one value. Setting a new type under the same key replaces the
   old value bytes.
 - There is no type-erased value enumeration API.
-- Type-tag prefix checking is not fully implemented. Do not promise complete
-  runtime type safety.
-- Callers must read with the same type and serialization contract used to write.
+- Type-tag prefix checking is opt-in through `set_type_tag_check(true)` and is
+  disabled by default for compatibility with existing raw records.
+- Default type tags are implementation-defined. Durable schemas should
+  specialize `AnyValueTypeTag<T>`.
+- Raw records behave as type mismatches while tag checking is enabled.
 
 Use it for:
 
-- Small heterogeneous settings keyed by stable IDs.
-- Cases where the key domain is shared but values naturally differ by type.
+- Small heterogeneous settings keyed by stable IDs, such as `"host"` as
+  `std::string`, `"port"` as `int`, and `"enabled"` as `bool`.
+- Feature flags, plugin/module options, and local preferences where a shared
+  key namespace naturally contains different value types.
+- Transitional or extensible option bags where adding a new key should not
+  require changing a single aggregate type.
 
 Avoid it when:
 
-- The value schema is known and uniform. Use `KeyValueTable`.
-- Runtime type safety is required. Implement type-tag support first or store an
-  explicit tagged value type in `KeyValueTable`.
+- The value schema is known and uniform. Use `KeyValueTable<K,V>`.
+- The values together form one coherent config/state object. Use
+  `ValueTable<AppConfig>` or another explicit aggregate type.
+- Runtime type safety is required for an existing raw table. Enable type-tag
+  checks only after planning how old raw records should be rewritten or handled.
 
 ## Method Stack For Implementers
 

--- a/docs/groups.dox
+++ b/docs/groups.dox
@@ -5,7 +5,7 @@ and the common base classes shared across containers.
 
 /*! \defgroup mdbxc_tables Persistent Containers
 STL-like containers backed by MDBX: \c KeyValueTable, \c HashedKeyValueStore,
-\c AnyValueTable, \c KeyTable, and \c KeyMultiValueTable.
+\c ValueTable, \c AnyValueTable, \c KeyTable, and \c KeyMultiValueTable.
  */
 
 /*! \defgroup mdbxc_utils Utility Functions

--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -10,6 +10,8 @@ Key features:
 - Implemented `KeyValueTable` API for map-like key-value storage.
 - Implemented `HashedKeyValueStore` API for string and byte-vector keys with a
   hash lookup index.
+- Implemented `ValueTable` API for singleton metadata, state, snapshots, and
+  single-object configuration records.
 - Implemented `AnyValueTable` API for heterogeneous values by caller-selected type.
 - Implemented `KeyTable` API for set-like key storage.
 - Implemented `KeyMultiValueTable` API for multimap-like storage with repeated
@@ -76,6 +78,15 @@ a.insert_or_assign(100, "hundred");
 b.insert_or_assign("a", "b");
 ```
 
+\subsection ex_value Singleton value table
+```cpp
+mdbxc::Config cfg; cfg.pathname = "state.mdbx";
+auto conn = mdbxc::Connection::create(cfg);
+mdbxc::ValueTable<int> schema_version(conn, "schema_version");
+schema_version.set(1);
+int version = schema_version.get_or(0);
+```
+
 \section build_sec Building
 Use CMake or simply include the headers and link with libmdbx.
 ```bash
@@ -86,8 +97,11 @@ cmake --build build
 
 For more details on container usage and C++ version differences see \subpage tables_page.
 
-\warning `AnyValueTable` type-tag prefix verification is not fully implemented
-yet and should not be treated as complete runtime type safety.
+\note `AnyValueTable` type-tag prefix verification is opt-in through
+`set_type_tag_check(true)`. It is disabled by default for compatibility with
+existing raw records, and durable application schemas should specialize
+`AnyValueTypeTag<T>` rather than relying on the default implementation-defined
+tag.
 
 \section config_sec Configuration Guide
 Details on tuning the MDBX environment are available on \subpage config_page.

--- a/docs/tables.dox
+++ b/docs/tables.dox
@@ -3,8 +3,9 @@
 
 This page describes how to work with persistent container classes. The
 implemented table APIs are \ref mdbxc::KeyValueTable,
-\ref mdbxc::HashedKeyValueStore, \ref mdbxc::AnyValueTable,
-\ref mdbxc::KeyTable, and \ref mdbxc::KeyMultiValueTable.
+\ref mdbxc::HashedKeyValueStore, \ref mdbxc::ValueTable,
+\ref mdbxc::AnyValueTable, \ref mdbxc::KeyTable, and
+\ref mdbxc::KeyMultiValueTable.
 
 ## Creating a connection
 
@@ -55,6 +56,32 @@ table = src;                     // reconcile with database keys
 auto restored = table.operator()<std::map>();
 for (std::map<int, std::string>::const_iterator it = restored.begin();
      it != restored.end(); ++it) {/* ... */}
+```
+
+## Singleton value tables
+
+\ref mdbxc::ValueTable stores one strongly typed value in a named MDBX table.
+Use it for true singleton objects where the table name identifies the object:
+storage metadata, schema/version records, config snapshots, module state,
+scheduler state, durable checkpoints, and other single-object records where an
+artificial user key would obscure the data model. Operations such as \c set(),
+\c insert(), \c get(), \c find(), \c get_or(), \c update(), \c has_value(),
+\c erase(), and \c clear() operate on the singleton value directly.
+
+\note If the data contains many records with the same schema, use
+      \ref mdbxc::KeyValueTable instead. If the values are independent keys with
+      genuinely different C++ types, use \ref mdbxc::AnyValueTable.
+
+\note The one-value invariant is guaranteed for operations performed through
+      \ref mdbxc::ValueTable. Opening the same DBI through another table type can
+      intentionally create extra physical rows; \c clear() removes all rows in
+      the DBI.
+
+```cpp
+mdbxc::ValueTable<int> schema_version(conn, "schema_version");
+schema_version.set(1);
+schema_version.update([](int& value){ value += 1; });
+int version = schema_version.get_or(0);
 ```
 
 ## Hashed key-value stores
@@ -156,15 +183,23 @@ std::vector<std::string> values = events.find(7);
 ## Heterogeneous values
 
 \ref mdbxc::AnyValueTable stores values of arbitrary caller-selected types.
+Use it for small heterogeneous keyed settings and option bags: mixed primitive
+settings, feature flags, plugin/module options, and local preferences where one
+stable key namespace naturally contains different C++ value types. It is not a
+substitute for a typed schema: use \ref mdbxc::ValueTable for one coherent
+config/state object, and \ref mdbxc::KeyValueTable for many uniform records.
 \c set<T>(), \c insert<T>(), and \c get<T>() operate on typed values, and
 \c update<T>() modifies them in place with a functor. Each key stores at most one
 value: \c set<T>() replaces any existing value, while \c insert<T>() succeeds
 only when the key is absent. \c keys() lists stored keys, but the class does not
 provide type-erased enumeration of all values.
 
-\warning Type-tag prefix verification is currently a reserved switch and should
-         not be treated as complete runtime type safety. Read values with the
-         same type and serialization contract used to store them.
+\note Type-tag prefix verification is opt-in through
+      \c set_type_tag_check(true). When enabled, newly written values get a
+      type-tag prefix and reads validate that prefix before deserialization.
+      Existing raw records behave as type mismatches while checking is enabled.
+      For durable schemas, specialize \ref mdbxc::AnyValueTypeTag instead of
+      relying on the default implementation-defined tag.
 
 ```cpp
 mdbxc::AnyValueTable<int> any(conn);

--- a/examples/any_value_table_example.cpp
+++ b/examples/any_value_table_example.cpp
@@ -31,6 +31,35 @@ struct MyStruct {
     }
 };
 
+/// \brief Small value type with an application-defined stable tag.
+struct TaggedCounter {
+    int value;
+
+    std::vector<uint8_t> to_bytes() const {
+        std::vector<uint8_t> bytes(sizeof(value));
+        std::memcpy(bytes.data(), &value, sizeof(value));
+        return bytes;
+    }
+
+    static TaggedCounter from_bytes(const void* data, size_t size) {
+        if (size != sizeof(int)) {
+            throw std::runtime_error("Invalid data size for TaggedCounter");
+        }
+        TaggedCounter out{};
+        std::memcpy(&out.value, data, sizeof(out.value));
+        return out;
+    }
+};
+
+namespace mdbxc {
+    template<>
+    struct AnyValueTypeTag<TaggedCounter> {
+        static const char* value() noexcept {
+            return "example.TaggedCounter.v1";
+        }
+    };
+} // namespace mdbxc
+
 /// \brief Entry point demonstrating AnyValueTable.
 int main() {
     mdbxc::Config cfg;
@@ -56,6 +85,42 @@ int main() {
 
     for (auto& key : table.keys()) {
         std::cout << "key: " << key << '\n';
+    }
+
+    mdbxc::AnyValueTable<std::string> checked(conn, "checked_settings");
+    checked.erase("counter");
+    checked.erase("legacy_raw");
+
+    checked.set_type_tag_check(true);
+    TaggedCounter counter{10};
+    checked.set<TaggedCounter>("counter", counter);
+
+    TaggedCounter restored = checked.get<TaggedCounter>("counter");
+    std::cout << "tagged counter: " << restored.value << '\n';
+    std::cout << "stable tag: " << mdbxc::AnyValueTypeTag<TaggedCounter>::value() << '\n';
+
+    try {
+        (void)checked.get<int>("counter");
+    } catch (const std::bad_cast&) {
+        std::cout << "wrong tagged type rejected by get<T>()\n";
+    }
+
+#if __cplusplus >= 201703L
+    if (!checked.find<int>("counter")) {
+        std::cout << "wrong tagged type is missing for find<T>()\n";
+    }
+#else
+    auto wrong_type = checked.find_compat<int>("counter");
+    if (!wrong_type.first) {
+        std::cout << "wrong tagged type is missing for find_compat<T>()\n";
+    }
+#endif
+
+    checked.set_type_tag_check(false);
+    checked.set<int>("legacy_raw", 5);
+    checked.set_type_tag_check(true);
+    if (checked.get_or<int>("legacy_raw", -1) == -1) {
+        std::cout << "raw legacy value is hidden while tag checking is enabled\n";
     }
 
     std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');

--- a/examples/value_table_example.cpp
+++ b/examples/value_table_example.cpp
@@ -1,0 +1,61 @@
+/**
+ * \ingroup mdbxc_examples
+ * Demonstrates a singleton value table for application state.
+ */
+
+#include <mdbx_containers/ValueTable.hpp>
+
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+struct AppState {
+    int schema_version;
+    int active_profiles;
+
+    std::vector<uint8_t> to_bytes() const {
+        std::vector<uint8_t> bytes(sizeof(schema_version) + sizeof(active_profiles));
+        std::memcpy(bytes.data(), &schema_version, sizeof(schema_version));
+        std::memcpy(bytes.data() + sizeof(schema_version),
+                    &active_profiles,
+                    sizeof(active_profiles));
+        return bytes;
+    }
+
+    static AppState from_bytes(const void* data, size_t size) {
+        if (size != sizeof(int) + sizeof(int)) {
+            throw std::runtime_error("Invalid data size for AppState");
+        }
+        AppState out{};
+        const uint8_t* ptr = static_cast<const uint8_t*>(data);
+        std::memcpy(&out.schema_version, ptr, sizeof(out.schema_version));
+        std::memcpy(&out.active_profiles, ptr + sizeof(out.schema_version), sizeof(out.active_profiles));
+        return out;
+    }
+};
+
+int main() {
+    mdbxc::Config config;
+    config.pathname = "value_table_example_db";
+    config.max_dbs = 1;
+
+    auto conn = mdbxc::Connection::create(config);
+    mdbxc::ValueTable<AppState> state(conn, "app_state");
+
+    if (!state.has_value()) {
+        AppState initial{};
+        initial.schema_version = 1;
+        initial.active_profiles = 0;
+        state.set(initial);
+    }
+
+    state.update([](AppState& value) {
+        value.active_profiles += 1;
+    });
+
+    AppState loaded = state.get();
+    std::cout << "schema version: " << loaded.schema_version << '\n';
+    std::cout << "active profiles: " << loaded.active_profiles << '\n';
+
+    return 0;
+}

--- a/include/mdbx_containers.hpp
+++ b/include/mdbx_containers.hpp
@@ -14,5 +14,6 @@
 #include "mdbx_containers/KeyMultiValueTable.hpp"
 #include "mdbx_containers/KeyTable.hpp"
 #include "mdbx_containers/KeyValueTable.hpp"
+#include "mdbx_containers/ValueTable.hpp"
 
 #endif // _MDBX_CONTAINERS_HPP_INCLUDED

--- a/include/mdbx_containers/AnyValueTable.hpp
+++ b/include/mdbx_containers/AnyValueTable.hpp
@@ -9,8 +9,26 @@
 /// serialized value chosen by the caller at the access site.
 
 #include "common.hpp"
+#include <limits>
+#include <typeinfo>
 
 namespace mdbxc {
+
+    /// \struct AnyValueTypeTag
+    /// \ingroup mdbxc_tables
+    /// \brief Provides the runtime type tag used by \ref AnyValueTable.
+    /// \tparam T Value type.
+    /// \details
+    /// Specialize this trait for durable, application-defined type tags. The
+    /// default tag is implementation-defined and may differ across compilers.
+    template<class T>
+    struct AnyValueTypeTag {
+        /// \brief Returns the type tag for \c T.
+        /// \return Implementation-defined default tag.
+        static const char* value() noexcept {
+            return typeid(T).name();
+        }
+    };
 
     /// \class AnyValueTable
     /// \ingroup mdbxc_tables
@@ -31,9 +49,9 @@ namespace mdbxc {
     ///
     /// \note \c keys() lists stored keys only; this table does not expose a
     ///       type-erased value enumeration API.
-    /// \warning Type-tag prefix verification is currently a reserved switch, not
-    ///          complete runtime type safety. Callers must request values with
-    ///          the same type and serialization contract used to store them.
+    /// \note Type-tag prefix verification is opt-in through
+    ///       \c set_type_tag_check(true). It is disabled by default to preserve
+    ///       compatibility with existing raw records.
     template <class KeyT, class Options = DefaultTableOptions>
     class AnyValueTable final : public BaseTable {
     public:
@@ -165,9 +183,7 @@ namespace mdbxc {
         /// \param txn Optional transaction handle.
         /// \return Optional with value or std::nullopt.
         /// \note If type-tag verification reports a mismatch, the value is
-        ///       treated as missing. The current type-tag implementation does
-        ///       not provide full runtime type safety; use the same \c T that
-        ///       was used to store the value.
+        ///       treated as missing.
 #if __cplusplus >= 201703L
         template <class T>
         std::optional<T> find(const KeyT& key, MDBX_txn* txn = nullptr) const {
@@ -220,9 +236,7 @@ namespace mdbxc {
         /// \param txn Optional transaction handle.
         /// \return Pair of success flag and retrieved value.
         /// \note If type-tag verification reports a mismatch, the value is
-        ///       treated as missing. The current type-tag implementation does
-        ///       not provide full runtime type safety; use the same \c T that
-        ///       was used to store the value.
+        ///       treated as missing.
         template <class T>
         std::pair<bool, T> find_compat(const KeyT& key, MDBX_txn* txn = nullptr) const {
             std::pair<bool, T> result{false, T{}};
@@ -334,8 +348,10 @@ namespace mdbxc {
 
         /// \brief Enable or disable type-tag checking.
         /// \param enabled Enables check when set to true.
-        /// \warning Reserved for future type-tag prefix verification; currently
-        ///          toggling this flag does not add or validate type metadata.
+        /// \note When enabled, newly written values are stored with a type-tag
+        ///       prefix and reads validate that prefix before deserialization.
+        ///       Existing raw records behave as type mismatches while this flag
+        ///       is enabled.
         void set_type_tag_check(bool enabled) noexcept { m_check_type_tag = enabled; }
 
     private:
@@ -366,9 +382,10 @@ namespace mdbxc {
         bool put_typed(const KeyT& key, const T& value, bool upsert, MDBX_txn* txn) {
             SerializeScratch sc_key;
             SerializeScratch sc_value;
+            SerializeScratch sc_tagged_value;
             MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
             MDBX_val raw_val = serialize_value(value, sc_value);
-            MDBX_val db_val = wrap_with_type_tag<T>(raw_val);
+            MDBX_val db_val = wrap_with_type_tag<T>(raw_val, sc_tagged_value);
             MDBX_put_flags_t flags = upsert ? MDBX_UPSERT : MDBX_NOOVERWRITE;
             int rc = mdbx_put(txn, m_dbi, &db_key, &db_val, flags);
             if (!upsert && rc == MDBX_KEYEXIST) {
@@ -394,7 +411,8 @@ namespace mdbxc {
         bool db_contains(const KeyT& key, MDBX_txn* txn) const {
             SerializeScratch sc_key;
             MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
-            int rc = mdbx_get(txn, m_dbi, &db_key, nullptr);
+            MDBX_val db_val;
+            int rc = mdbx_get(txn, m_dbi, &db_key, &db_val);
             if (rc == MDBX_SUCCESS) return true;
             if (rc == MDBX_NOTFOUND) return false;
             check_mdbx(rc, "Failed to check key presence");
@@ -422,15 +440,93 @@ namespace mdbxc {
         }
 
         template <class T>
-        MDBX_val wrap_with_type_tag(const MDBX_val& raw) const {
+        MDBX_val wrap_with_type_tag(const MDBX_val& raw, SerializeScratch& sc) const {
             if (!m_check_type_tag) return raw;
-            return raw; // TODO: implement type-tag prefix
+
+            const std::string tag = type_tag<T>();
+            if (tag.size() > static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max())) {
+                throw std::length_error("AnyValueTable type tag is too large");
+            }
+
+            sc.bytes.clear();
+            sc.bytes.reserve(type_tag_header_size() + tag.size() + raw.iov_len);
+            append_magic(sc.bytes);
+            append_le32(sc.bytes, static_cast<std::uint32_t>(tag.size()));
+            sc.bytes.insert(sc.bytes.end(), tag.begin(), tag.end());
+            if (raw.iov_len) {
+                const std::uint8_t* payload = static_cast<const std::uint8_t*>(raw.iov_base);
+                sc.bytes.insert(sc.bytes.end(), payload, payload + raw.iov_len);
+            }
+            return sc.view_bytes();
         }
 
         template <class T>
         MDBX_val unwrap_and_check_type_tag(const MDBX_val& raw) const {
             if (!m_check_type_tag) return raw;
-            return raw; // TODO: verify type-tag
+
+            if (raw.iov_len < type_tag_header_size() || !raw.iov_base) {
+                throw std::bad_cast();
+            }
+
+            const std::uint8_t* data = static_cast<const std::uint8_t*>(raw.iov_base);
+            if (std::memcmp(data, type_tag_magic(), type_tag_magic_size()) != 0) {
+                throw std::bad_cast();
+            }
+
+            const std::uint32_t tag_size = read_le32(data + type_tag_magic_size());
+            const std::size_t payload_offset = type_tag_header_size() + tag_size;
+            if (tag_size > raw.iov_len - type_tag_header_size()) {
+                throw std::bad_cast();
+            }
+
+            const std::string expected = type_tag<T>();
+            if (expected.size() != tag_size ||
+                std::memcmp(data + type_tag_header_size(), expected.data(), tag_size) != 0) {
+                throw std::bad_cast();
+            }
+
+            MDBX_val payload;
+            payload.iov_len = raw.iov_len - payload_offset;
+            payload.iov_base = payload.iov_len
+                ? const_cast<std::uint8_t*>(data + payload_offset)
+                : nullptr;
+            return payload;
+        }
+
+        static const char* type_tag_magic() {
+            return "MDBXCAV1";
+        }
+
+        static std::size_t type_tag_magic_size() {
+            return 8u;
+        }
+
+        static std::size_t type_tag_header_size() {
+            return type_tag_magic_size() + 4u;
+        }
+
+        static void append_magic(std::vector<std::uint8_t>& out) {
+            const char* magic = type_tag_magic();
+            out.insert(out.end(), magic, magic + type_tag_magic_size());
+        }
+
+        static void append_le32(std::vector<std::uint8_t>& out, std::uint32_t value) {
+            out.push_back(static_cast<std::uint8_t>(value & 0xffu));
+            out.push_back(static_cast<std::uint8_t>((value >> 8) & 0xffu));
+            out.push_back(static_cast<std::uint8_t>((value >> 16) & 0xffu));
+            out.push_back(static_cast<std::uint8_t>((value >> 24) & 0xffu));
+        }
+
+        static std::uint32_t read_le32(const std::uint8_t* data) {
+            return static_cast<std::uint32_t>(data[0]) |
+                   (static_cast<std::uint32_t>(data[1]) << 8) |
+                   (static_cast<std::uint32_t>(data[2]) << 16) |
+                   (static_cast<std::uint32_t>(data[3]) << 24);
+        }
+
+        template <class T>
+        static std::string type_tag() {
+            return std::string(AnyValueTypeTag<T>::value());
         }
     };
 

--- a/include/mdbx_containers/ValueTable.hpp
+++ b/include/mdbx_containers/ValueTable.hpp
@@ -1,0 +1,413 @@
+#pragma once
+#ifndef _MDBX_CONTAINERS_VALUE_TABLE_HPP_INCLUDED
+#define _MDBX_CONTAINERS_VALUE_TABLE_HPP_INCLUDED
+
+/// \file ValueTable.hpp
+/// \brief Singleton-value table persisted in MDBX.
+/// \details
+/// Provides a strongly typed persistent variable: one named MDBX table stores
+/// at most one user value.
+
+#include "common.hpp"
+#include <utility>
+
+namespace mdbxc {
+
+    /// \class ValueTable
+    /// \ingroup mdbxc_tables
+    /// \brief Persistent table that stores at most one value.
+    /// \tparam ValueT Type of the stored value.
+    /// \details
+    /// ValueTable is useful for metadata, module state, snapshots, and
+    /// single-object configuration records. All ValueTable operations use one
+    /// fixed internal key, so the public API exposes value semantics rather
+    /// than key-value semantics.
+    ///
+    /// \note The singleton invariant is guaranteed for operations performed
+    ///       through ValueTable. Opening the same MDBX DBI through another table
+    ///       type can intentionally create extra physical rows; \c clear()
+    ///       removes all rows in the DBI.
+    template<class ValueT>
+    class ValueTable final : public BaseTable {
+    public:
+        /// \brief Constructs table using existing connection.
+        /// \param connection Existing connection.
+        /// \param name Name of the table within the MDBX environment.
+        /// \param flags Additional MDBX database flags.
+        ValueTable(std::shared_ptr<Connection> connection,
+                   std::string name = "value_store",
+                   MDBX_db_flags_t flags = MDBX_DB_DEFAULTS | MDBX_CREATE)
+            : BaseTable(std::move(connection),
+                        std::move(name),
+                        flags | get_mdbx_flags<std::uint32_t>()) {}
+
+        /// \brief Constructs table using configuration.
+        /// \param config Configuration settings.
+        /// \param name Name of the table within the MDBX environment.
+        /// \param flags Additional MDBX database flags.
+        explicit ValueTable(const Config& config,
+                            std::string name = "value_store",
+                            MDBX_db_flags_t flags = MDBX_DB_DEFAULTS | MDBX_CREATE)
+            : BaseTable(Connection::create(config),
+                        std::move(name),
+                        flags | get_mdbx_flags<std::uint32_t>()) {}
+
+        /// \brief Destructor.
+        ~ValueTable() override = default;
+
+        /// \brief Sets the singleton value, replacing any existing value.
+        /// \param value Value to store.
+        /// \param txn Optional transaction handle.
+        void set(const ValueT& value, MDBX_txn* txn = nullptr) {
+            with_transaction([this, &value](MDBX_txn* t) {
+                db_set(value, t);
+            }, TransactionMode::WRITABLE, txn);
+        }
+
+        /// \brief Sets the singleton value using an external transaction.
+        /// \param value Value to store.
+        /// \param txn Active transaction wrapper.
+        void set(const ValueT& value, const Transaction& txn) {
+            set(value, txn.handle());
+        }
+
+        /// \brief Inserts the singleton value if absent.
+        /// \param value Value to store.
+        /// \param txn Optional transaction handle.
+        /// \return \c true if inserted, \c false if the value already exists.
+        bool insert(const ValueT& value, MDBX_txn* txn = nullptr) {
+            bool res = false;
+            with_transaction([this, &value, &res](MDBX_txn* t) {
+                res = db_insert(value, t);
+            }, TransactionMode::WRITABLE, txn);
+            return res;
+        }
+
+        /// \brief Inserts the singleton value if absent using an external transaction.
+        /// \param value Value to store.
+        /// \param txn Active transaction wrapper.
+        /// \return \c true if inserted, \c false if the value already exists.
+        bool insert(const ValueT& value, const Transaction& txn) {
+            return insert(value, txn.handle());
+        }
+
+        /// \brief Retrieves the singleton value or throws if absent.
+        /// \param txn Optional transaction handle.
+        /// \return Stored value.
+        /// \throws std::out_of_range if the value is absent.
+        ValueT get(MDBX_txn* txn = nullptr) const {
+            ValueT value;
+            with_transaction([this, &value](MDBX_txn* t) {
+                if (!db_get(value, t)) {
+                    throw std::out_of_range("Value not found");
+                }
+            }, TransactionMode::READ_ONLY, txn);
+            return value;
+        }
+
+        /// \brief Retrieves the singleton value using an external transaction.
+        /// \param txn Active transaction wrapper.
+        /// \return Stored value.
+        /// \throws std::out_of_range if the value is absent.
+        ValueT get(const Transaction& txn) const {
+            return get(txn.handle());
+        }
+
+        /// \brief Tries to retrieve the singleton value.
+        /// \param out Output value.
+        /// \param txn Optional transaction handle.
+        /// \return \c true if the value exists.
+        bool try_get(ValueT& out, MDBX_txn* txn = nullptr) const {
+            bool res = false;
+            with_transaction([this, &out, &res](MDBX_txn* t) {
+                res = db_get(out, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return res;
+        }
+
+        /// \brief Tries to retrieve the singleton value using an external transaction.
+        /// \param out Output value.
+        /// \param txn Active transaction wrapper.
+        /// \return \c true if the value exists.
+        bool try_get(ValueT& out, const Transaction& txn) const {
+            return try_get(out, txn.handle());
+        }
+
+#if __cplusplus >= 201703L
+        /// \brief Finds the singleton value.
+        /// \param txn Optional transaction handle.
+        /// \return Optional containing the value when present.
+        std::optional<ValueT> find(MDBX_txn* txn = nullptr) const {
+            std::optional<ValueT> result;
+            with_transaction([this, &result](MDBX_txn* t) {
+                ValueT tmp;
+                if (db_get(tmp, t)) {
+                    result = std::move(tmp);
+                }
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Finds the singleton value using an external transaction.
+        /// \param txn Active transaction wrapper.
+        /// \return Optional containing the value when present.
+        std::optional<ValueT> find(const Transaction& txn) const {
+            return find(txn.handle());
+        }
+#else
+        /// \brief Finds the singleton value.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and value.
+        std::pair<bool, ValueT> find(MDBX_txn* txn = nullptr) const {
+            return find_compat(txn);
+        }
+
+        /// \brief Finds the singleton value using an external transaction.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and value.
+        std::pair<bool, ValueT> find(const Transaction& txn) const {
+            return find(txn.handle());
+        }
+#endif
+
+        /// \brief Finds the singleton value in a C++11-compatible form.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and value.
+        std::pair<bool, ValueT> find_compat(MDBX_txn* txn = nullptr) const {
+            std::pair<bool, ValueT> result(false, ValueT());
+            with_transaction([this, &result](MDBX_txn* t) {
+                if (db_get(result.second, t)) {
+                    result.first = true;
+                }
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Finds the singleton value in a C++11-compatible form.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and value.
+        std::pair<bool, ValueT> find_compat(const Transaction& txn) const {
+            return find_compat(txn.handle());
+        }
+
+        /// \brief Returns the stored value or the supplied default.
+        /// \param default_value Value returned when the singleton is absent.
+        /// \param txn Optional transaction handle.
+        /// \return Stored value or \p default_value.
+        ValueT get_or(ValueT default_value, MDBX_txn* txn = nullptr) const {
+            std::pair<bool, ValueT> found = find_compat(txn);
+            if (found.first) {
+                return std::move(found.second);
+            }
+            return default_value;
+        }
+
+        /// \brief Returns the stored value or the supplied default.
+        /// \param default_value Value returned when the singleton is absent.
+        /// \param txn Active transaction wrapper.
+        /// \return Stored value or \p default_value.
+        ValueT get_or(ValueT default_value, const Transaction& txn) const {
+            return get_or(std::move(default_value), txn.handle());
+        }
+
+        /// \brief Updates the stored value in place.
+        /// \tparam Fn Functor accepting \c ValueT&.
+        /// \param fn Function applied to the stored value.
+        /// \param txn Optional transaction handle.
+        /// \return \c true if the value existed and was updated.
+        template<class Fn>
+        bool update(Fn&& fn, MDBX_txn* txn = nullptr) {
+            bool res = false;
+            with_transaction([this, &fn, &res](MDBX_txn* t) {
+                ValueT tmp;
+                if (!db_get(tmp, t)) {
+                    return;
+                }
+                fn(tmp);
+                db_set(tmp, t);
+                res = true;
+            }, TransactionMode::WRITABLE, txn);
+            return res;
+        }
+
+        /// \brief Updates the stored value in place using an external transaction.
+        /// \tparam Fn Functor accepting \c ValueT&.
+        /// \param fn Function applied to the stored value.
+        /// \param txn Active transaction wrapper.
+        /// \return \c true if the value existed and was updated.
+        template<class Fn>
+        bool update(Fn&& fn, const Transaction& txn) {
+            return update(std::forward<Fn>(fn), txn.handle());
+        }
+
+        /// \brief Checks whether the singleton value exists.
+        /// \param txn Optional transaction handle.
+        /// \return \c true if the value exists.
+        bool has_value(MDBX_txn* txn = nullptr) const {
+            bool res = false;
+            with_transaction([this, &res](MDBX_txn* t) {
+                res = db_has_value(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return res;
+        }
+
+        /// \brief Checks whether the singleton value exists.
+        /// \param txn Active transaction wrapper.
+        /// \return \c true if the value exists.
+        bool has_value(const Transaction& txn) const {
+            return has_value(txn.handle());
+        }
+
+        /// \brief Counts the logical singleton value.
+        /// \param txn Optional transaction handle.
+        /// \return \c 1 when the singleton exists, otherwise \c 0.
+        std::size_t count(MDBX_txn* txn = nullptr) const {
+            return has_value(txn) ? 1u : 0u;
+        }
+
+        /// \brief Counts the logical singleton value.
+        /// \param txn Active transaction wrapper.
+        /// \return \c 1 when the singleton exists, otherwise \c 0.
+        std::size_t count(const Transaction& txn) const {
+            return count(txn.handle());
+        }
+
+        /// \brief Checks whether the singleton value is absent.
+        /// \param txn Optional transaction handle.
+        /// \return \c true if the singleton is absent.
+        bool empty(MDBX_txn* txn = nullptr) const {
+            return !has_value(txn);
+        }
+
+        /// \brief Checks whether the singleton value is absent.
+        /// \param txn Active transaction wrapper.
+        /// \return \c true if the singleton is absent.
+        bool empty(const Transaction& txn) const {
+            return empty(txn.handle());
+        }
+
+        /// \brief Erases the singleton value.
+        /// \param txn Optional transaction handle.
+        /// \return \c true if the value was removed.
+        bool erase(MDBX_txn* txn = nullptr) {
+            bool res = false;
+            with_transaction([this, &res](MDBX_txn* t) {
+                res = db_erase(t);
+            }, TransactionMode::WRITABLE, txn);
+            return res;
+        }
+
+        /// \brief Erases the singleton value.
+        /// \param txn Active transaction wrapper.
+        /// \return \c true if the value was removed.
+        bool erase(const Transaction& txn) {
+            return erase(txn.handle());
+        }
+
+        /// \brief Removes all physical rows from the DBI.
+        /// \param txn Optional transaction handle.
+        void clear(MDBX_txn* txn = nullptr) {
+            with_transaction([this](MDBX_txn* t) {
+                db_clear(t);
+            }, TransactionMode::WRITABLE, txn);
+        }
+
+        /// \brief Removes all physical rows from the DBI.
+        /// \param txn Active transaction wrapper.
+        void clear(const Transaction& txn) {
+            clear(txn.handle());
+        }
+
+    private:
+        template<typename F>
+        void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
+            if (txn) {
+                action(txn);
+                return;
+            }
+            txn = thread_txn();
+            if (txn) {
+                action(txn);
+                return;
+            }
+
+            auto txn_guard = m_connection->transaction(mode);
+            try {
+                action(txn_guard.handle());
+                txn_guard.commit();
+            } catch (...) {
+                try { txn_guard.rollback(); } catch (...) {}
+                throw;
+            }
+        }
+
+        static std::uint32_t singleton_key() {
+            return 0u;
+        }
+
+        static MDBX_val make_key(SerializeScratch& sc) {
+            const std::uint32_t key = singleton_key();
+            return serialize_key<true>(key, sc);
+        }
+
+        void db_set(const ValueT& value, MDBX_txn* txn) {
+            SerializeScratch sc_key;
+            SerializeScratch sc_value;
+            MDBX_val db_key = make_key(sc_key);
+            MDBX_val db_val = serialize_value(value, sc_value);
+            check_mdbx(mdbx_put(txn, m_dbi, &db_key, &db_val, MDBX_UPSERT),
+                       "Failed to set value");
+        }
+
+        bool db_insert(const ValueT& value, MDBX_txn* txn) {
+            SerializeScratch sc_key;
+            SerializeScratch sc_value;
+            MDBX_val db_key = make_key(sc_key);
+            MDBX_val db_val = serialize_value(value, sc_value);
+            int rc = mdbx_put(txn, m_dbi, &db_key, &db_val, MDBX_NOOVERWRITE);
+            if (rc == MDBX_SUCCESS) return true;
+            if (rc == MDBX_KEYEXIST) return false;
+            check_mdbx(rc, "Failed to insert value");
+            return false;
+        }
+
+        bool db_get(ValueT& out, MDBX_txn* txn) const {
+            SerializeScratch sc_key;
+            MDBX_val db_key = make_key(sc_key);
+            MDBX_val db_val;
+            int rc = mdbx_get(txn, m_dbi, &db_key, &db_val);
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "Failed to retrieve value");
+            out = deserialize_value<ValueT>(db_val);
+            return true;
+        }
+
+        bool db_has_value(MDBX_txn* txn) const {
+            SerializeScratch sc_key;
+            MDBX_val db_key = make_key(sc_key);
+            MDBX_val db_val;
+            int rc = mdbx_get(txn, m_dbi, &db_key, &db_val);
+            if (rc == MDBX_SUCCESS) return true;
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "Failed to check value presence");
+            return false;
+        }
+
+        bool db_erase(MDBX_txn* txn) {
+            SerializeScratch sc_key;
+            MDBX_val db_key = make_key(sc_key);
+            int rc = mdbx_del(txn, m_dbi, &db_key, nullptr);
+            if (rc == MDBX_SUCCESS) return true;
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "Failed to erase value");
+            return false;
+        }
+
+        void db_clear(MDBX_txn* txn) {
+            check_mdbx(mdbx_drop(txn, m_dbi, 0), "Failed to clear value table");
+        }
+    };
+
+} // namespace mdbxc
+
+#endif // _MDBX_CONTAINERS_VALUE_TABLE_HPP_INCLUDED

--- a/tests/any_value_table_test.cpp
+++ b/tests/any_value_table_test.cpp
@@ -30,6 +30,62 @@ struct MyStruct {
     }
 };
 
+/// \brief Custom value with a stable AnyValueTable tag specialization.
+struct StableTagged {
+    int value;
+
+    std::vector<uint8_t> to_bytes() const {
+        std::vector<uint8_t> bytes(sizeof(value));
+        std::memcpy(bytes.data(), &value, sizeof(value));
+        return bytes;
+    }
+
+    static StableTagged from_bytes(const void* data, size_t size) {
+        if (size != sizeof(int)) {
+            throw std::runtime_error("Invalid data size for StableTagged");
+        }
+        StableTagged out{};
+        std::memcpy(&out.value, data, sizeof(out.value));
+        return out;
+    }
+};
+
+/// \brief Compatible value using the same stable AnyValueTable tag.
+struct StableTaggedAlias {
+    int value;
+
+    std::vector<uint8_t> to_bytes() const {
+        std::vector<uint8_t> bytes(sizeof(value));
+        std::memcpy(bytes.data(), &value, sizeof(value));
+        return bytes;
+    }
+
+    static StableTaggedAlias from_bytes(const void* data, size_t size) {
+        if (size != sizeof(int)) {
+            throw std::runtime_error("Invalid data size for StableTaggedAlias");
+        }
+        StableTaggedAlias out{};
+        std::memcpy(&out.value, data, sizeof(out.value));
+        return out;
+    }
+};
+
+namespace mdbxc {
+    template<>
+    struct AnyValueTypeTag<StableTagged> {
+        static const char* value() noexcept {
+            return "tests.StableTagged.v1";
+        }
+    };
+
+    template<>
+    struct AnyValueTypeTag<StableTaggedAlias> {
+        static const char* value() noexcept {
+            return "tests.StableTagged.v1";
+        }
+    };
+} // namespace mdbxc
+
 int main() {
     mdbxc::Config cfg;
     cfg.pathname = "data/any_value_table.mdbx";
@@ -54,6 +110,8 @@ int main() {
     }
 #endif
     assert(table.get<MyStruct>("object") == expected);
+    assert(table.contains("answer"));
+    assert(!table.contains("missing"));
 
     auto ks = table.keys();
     assert(ks.size() == 3);
@@ -64,6 +122,66 @@ int main() {
     fast_int_table.set<int>(12, 99);
     assert(fast_int_table.get<std::string>(11) == "safe");
     assert(safe_int_table.get<int>(12) == 99);
+
+    mdbxc::AnyValueTable<std::string> tagged(conn, "test_any_tagged");
+    tagged.erase("answer");
+    tagged.erase("stable");
+    tagged.set_type_tag_check(true);
+    tagged.set<int>("answer", 42);
+    assert(tagged.get<int>("answer") == 42);
+    assert(tagged.contains("answer"));
+
+    tagged.update<int>("answer", [](int& value) {
+        value += 1;
+    });
+    assert(tagged.get<int>("answer") == 43);
+
+    bool bad_cast_thrown = false;
+    try {
+        (void)tagged.get<std::string>("answer");
+    } catch (const std::bad_cast&) {
+        bad_cast_thrown = true;
+    }
+    assert(bad_cast_thrown);
+
+#if __cplusplus >= 201703L
+    assert(!tagged.find<std::string>("answer").has_value());
+#else
+    {
+        auto mismatch = tagged.find_compat<std::string>("answer");
+        assert(!mismatch.first);
+    }
+#endif
+    assert(tagged.get_or<std::string>("answer", std::string("fallback")) == "fallback");
+
+    StableTagged stable{};
+    stable.value = 77;
+    tagged.set<StableTagged>("stable", stable);
+    StableTaggedAlias alias = tagged.get<StableTaggedAlias>("stable");
+    assert(alias.value == stable.value);
+    assert(std::string(mdbxc::AnyValueTypeTag<StableTagged>::value()) == "tests.StableTagged.v1");
+
+    mdbxc::AnyValueTable<std::string> legacy(conn, "test_any_legacy_raw");
+    legacy.erase("legacy");
+    legacy.set<int>("legacy", 7);
+    assert(legacy.get<int>("legacy") == 7);
+    legacy.set_type_tag_check(true);
+    bool legacy_bad_cast = false;
+    try {
+        (void)legacy.get<int>("legacy");
+    } catch (const std::bad_cast&) {
+        legacy_bad_cast = true;
+    }
+    assert(legacy_bad_cast);
+
+#if __cplusplus >= 201703L
+    assert(!legacy.find<int>("legacy").has_value());
+#else
+    {
+        auto legacy_lookup = legacy.find_compat<int>("legacy");
+        assert(!legacy_lookup.first);
+    }
+#endif
 
     std::cout << "AnyValueTable test passed.\n";
     return 0;

--- a/tests/value_table_test.cpp
+++ b/tests/value_table_test.cpp
@@ -1,0 +1,167 @@
+#include <cassert>
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mdbx_containers/ValueTable.hpp>
+
+/// \brief Custom serializable state used by ValueTable tests.
+struct StoredState {
+    int id;
+    double score;
+
+    std::vector<uint8_t> to_bytes() const {
+        std::vector<uint8_t> bytes(sizeof(id) + sizeof(score));
+        std::memcpy(bytes.data(), &id, sizeof(id));
+        std::memcpy(bytes.data() + sizeof(id), &score, sizeof(score));
+        return bytes;
+    }
+
+    static StoredState from_bytes(const void* data, size_t size) {
+        if (size != sizeof(int) + sizeof(double)) {
+            throw std::runtime_error("Invalid data size for StoredState");
+        }
+        StoredState out;
+        const uint8_t* ptr = static_cast<const uint8_t*>(data);
+        std::memcpy(&out.id, ptr, sizeof(out.id));
+        std::memcpy(&out.score, ptr + sizeof(out.id), sizeof(out.score));
+        return out;
+    }
+
+    bool operator==(const StoredState& other) const {
+        return id == other.id && score == other.score;
+    }
+};
+
+int main() {
+    mdbxc::Config cfg;
+    cfg.pathname = "data/value_table_test.mdbx";
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    cfg.relative_to_exe = true;
+
+    auto conn = mdbxc::Connection::create(cfg);
+
+    {
+        mdbxc::ValueTable<int> table(conn, "integer_state");
+        table.clear();
+
+        assert(table.empty());
+        assert(!table.has_value());
+        assert(table.count() == 0);
+        assert(table.get_or(7) == 7);
+
+        int out = 0;
+        assert(!table.try_get(out));
+        assert(!table.erase());
+
+        bool threw = false;
+        try {
+            (void)table.get();
+        } catch (const std::out_of_range&) {
+            threw = true;
+        }
+        assert(threw);
+
+        assert(table.insert(10));
+        assert(!table.insert(20));
+        assert(table.has_value());
+        assert(!table.empty());
+        assert(table.count() == 1);
+        assert(table.get() == 10);
+        assert(table.try_get(out) && out == 10);
+
+        table.set(30);
+        assert(table.get() == 30);
+
+        bool updated = table.update([](int& value) {
+            value += 1;
+        });
+        assert(updated);
+        assert(table.get() == 31);
+
+#if __cplusplus >= 201703L
+        auto found = table.find();
+        assert(found && *found == 31);
+#else
+        auto found = table.find();
+        assert(found.first && found.second == 31);
+#endif
+
+        std::pair<bool, int> compat = table.find_compat();
+        assert(compat.first && compat.second == 31);
+
+        assert(table.erase());
+        assert(!table.erase());
+        assert(!table.update([](int& value) {
+            value += 1;
+        }));
+        assert(table.count() == 0);
+    }
+
+    {
+        mdbxc::ValueTable<StoredState> table(conn, "custom_state");
+        table.clear();
+
+        StoredState expected;
+        expected.id = 42;
+        expected.score = 3.5;
+        table.set(expected);
+
+        StoredState loaded = table.get();
+        assert(loaded == expected);
+
+        assert(table.update([](StoredState& value) {
+            value.id += 1;
+            value.score += 0.5;
+        }));
+
+        StoredState changed = table.get();
+        assert(changed.id == 43);
+        assert(changed.score == 4.0);
+
+        table.clear();
+        assert(!table.has_value());
+    }
+
+    {
+        mdbxc::ValueTable<int> table(conn, "manual_value_txn");
+        table.clear();
+
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        assert(table.insert(5, txn));
+        txn.commit();
+
+        auto read_txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        assert(table.has_value(read_txn));
+        assert(table.count(read_txn) == 1);
+        assert(table.get(read_txn) == 5);
+        read_txn.commit();
+
+        auto update_txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        assert(table.update([](int& value) {
+            value *= 2;
+        }, update_txn));
+        update_txn.commit();
+
+        assert(table.get() == 10);
+    }
+
+    {
+        mdbxc::Config standalone_cfg;
+        standalone_cfg.pathname = "data/value_table_config_test.mdbx";
+        standalone_cfg.max_dbs = 2;
+        standalone_cfg.no_subdir = true;
+        standalone_cfg.relative_to_exe = true;
+
+        mdbxc::ValueTable<std::string> table(standalone_cfg, "config_value");
+        table.clear();
+        table.set("ready");
+        assert(table.get() == "ready");
+    }
+
+    std::cout << "ValueTable test passed.\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add `mdbxc::ValueTable<V>` for strongly typed singleton records stored in a dedicated MDBX table.
- Add opt-in `AnyValueTable` type-tag prefix validation via `set_type_tag_check(true)` and public `AnyValueTypeTag<T>` customization.
- Add tests, examples, README/Doxygen updates, and agent guidance for choosing `ValueTable` vs `AnyValueTable`.

## Verification
- `cmake -S . -B tmp/build-cpp17-mingw -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=17`
- `cmake --build tmp/build-cpp17-mingw`
- `ctest --test-dir tmp/build-cpp17-mingw --output-on-failure`
- `cmake -S . -B tmp/build-cpp11-mingw -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=11`
- `cmake --build tmp/build-cpp11-mingw`
- `ctest --test-dir tmp/build-cpp11-mingw --output-on-failure`
- `cmake --build tmp/build-cpp17-mingw --target any_value_table_example`
- `cmake --build tmp/build-cpp11-mingw --target any_value_table_example`
- `git diff --check`