### PR TITLE
docs(agents): require PR workflow for all code changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,8 @@ Determine the task type and apply the corresponding format:
 - Do not introduce `thread_local` STL scratch buffers in serialization paths.
 - For code changes, verify with the narrowest relevant tests, and use both C++11
   and C++17 when the change touches shared headers or template behavior.
+- All changes reach `main` through PRs; do not push directly to `main` unless
+  the user explicitly overrides this rule.
 
 ## Provenance and Honesty
 

--- a/guides/coding-agent-workflow.md
+++ b/guides/coding-agent-workflow.md
@@ -22,6 +22,18 @@ behavior. Small, well-verified edits matter more than broad rewrites.
 10. In the final response, separate what changed, what was verified, and any
     remaining limitation.
 
+## Git Workflow
+
+All code changes must reach `main` through pull requests. Never push directly
+to `main`.
+
+- Create a feature or fix branch from `main` for any non-trivial work.
+- Keep the branch focused: one logical change per PR.
+- Open a PR when the change is complete and verified; do not bypass review
+  by fast-forwarding `main` locally.
+- Trivial one-line fixes may still go through a branch and PR; the only
+  exception is when the user explicitly asks for a direct push.
+
 ## Behavioral Principles
 
 ### Goal-Driven Execution


### PR DESCRIPTION
## Summary

Add explicit rule that all code changes must reach `main` through pull requests,
not direct pushes.

## Changes

- `guides/coding-agent-workflow.md`: new "Git Workflow" section with branch + PR requirements.
- `AGENTS.md`: one-line guard in "Critical Defaults" referencing the PR rule.

## Rationale

Prevents accidental direct pushes to `main` by AI agents and enforces review
gating for all non-trivial work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)