### PR TITLE
fix(transaction): explicit rc handling in commit(), assert in release()

### DIFF
--- a/include/mdbx_containers/common/Config.hpp
+++ b/include/mdbx_containers/common/Config.hpp
@@ -24,7 +24,7 @@ namespace mdbxc {
         int64_t size_upper  = -1;               ///< Upper bound for database size.
         int64_t growth_step = 16 * 1024 * 1024; ///< Step size for database growth.
         int64_t shrink_threshold = 16 * 1024 * 1024; ///< Threshold for database shrinking.
-        int64_t page_size   = 0;                ///< Page size (must be a power of two).
+        int64_t page_size   = 0;                ///< Page size (must be 0 for default, or a power of two between 256 and 65536).
         int64_t max_readers = 0;                ///< Maximum reader slots; use 0 for the default (twice the CPU count).
         int64_t max_dbs = 10;                   ///< Maximum number of named databases (DBI) in the environment.
         int64_t max_dupsort_value_size = -1;        ///< Proactive MDBX_DUPSORT duplicate value size limit; <= 0 disables it.

--- a/include/mdbx_containers/common/Transaction.ipp
+++ b/include/mdbx_containers/common/Transaction.ipp
@@ -117,23 +117,22 @@ namespace mdbxc {
             MDBX_txn* txn = m_txn;
             const int rc = mdbx_txn_commit(txn);
 
-            if (rc == MDBX_SUCCESS) {
-                m_registry->unbind_txn(txn);
-                m_registry->unregister_txn_handle();
-                m_txn = nullptr;
-                m_started = false;
-                break;
-            }
-
             if (rc == MDBX_THREAD_MISMATCH) {
                 check_mdbx(rc, "Failed to commit writable transaction");
             }
 
-            m_registry->unbind_txn(txn);
-            m_registry->unregister_txn_handle();
+            // MDBX_SUCCESS or any other error: the native handle is already
+            // terminated (or we threw above for THREAD_MISMATCH). Null the
+            // wrapper state before tracker cleanup so that a tracker throw
+            // does not cause a double-abort in the destructor.
             m_txn = nullptr;
             m_started = false;
+
+            m_registry->unbind_txn(txn);
+            m_registry->unregister_txn_handle();
+
             check_mdbx(rc, "Failed to commit writable transaction");
+            break;
         }
         };
     }

--- a/include/mdbx_containers/common/Transaction.ipp
+++ b/include/mdbx_containers/common/Transaction.ipp
@@ -33,6 +33,8 @@ namespace mdbxc {
 
         if (txn) {
             const int rc = mdbx_txn_abort(txn);
+            assert((rc == MDBX_SUCCESS || rc == MDBX_THREAD_MISMATCH) &&
+                   "mdbx_txn_abort() failed in Transaction::release()");
             (void)rc;
         }
 
@@ -100,36 +102,40 @@ namespace mdbxc {
 
     inline void Transaction::commit() {
         if (!m_txn || !m_started) throw MdbxException("No active transaction to commit.");
-        try {
-            switch (m_mode) {
-            case TransactionMode::READ_ONLY:
-            {
-                MDBX_txn* txn = m_txn;
-                check_mdbx(mdbx_txn_reset(txn), "Failed to reset read-only transaction");
-                m_registry->unbind_txn(txn);
-                break;
-            }
-            case TransactionMode::WRITABLE:
-            {
-                MDBX_txn* txn = m_txn;
-                check_mdbx(mdbx_txn_commit(txn), "Failed to commit writable transaction");
-                m_registry->unbind_txn(txn);
-                m_registry->unregister_txn_handle();
-                m_txn = nullptr;
-                break;
-            }
-            };
+
+        switch (m_mode) {
+        case TransactionMode::READ_ONLY:
+        {
+            MDBX_txn* txn = m_txn;
+            check_mdbx(mdbx_txn_reset(txn), "Failed to reset read-only transaction");
+            m_registry->unbind_txn(txn);
             m_started = false;
-        } catch (...) {
-            if (m_txn) {
-                MDBX_txn* txn = m_txn;
-                m_registry->unbind_txn(txn);
-                m_registry->unregister_txn_handle();
-                m_txn = nullptr;
-            }
-            m_started = false;
-            throw;
+            break;
         }
+        case TransactionMode::WRITABLE:
+        {
+            MDBX_txn* txn = m_txn;
+            const int rc = mdbx_txn_commit(txn);
+
+            if (rc == MDBX_SUCCESS) {
+                m_registry->unbind_txn(txn);
+                m_registry->unregister_txn_handle();
+                m_txn = nullptr;
+                m_started = false;
+                break;
+            }
+
+            if (rc == MDBX_THREAD_MISMATCH) {
+                check_mdbx(rc, "Failed to commit writable transaction");
+            }
+
+            m_registry->unbind_txn(txn);
+            m_registry->unregister_txn_handle();
+            m_txn = nullptr;
+            m_started = false;
+            check_mdbx(rc, "Failed to commit writable transaction");
+        }
+        };
     }
 
     inline void Transaction::rollback() {


### PR DESCRIPTION
## Summary

Rewrite `Transaction::commit()` to handle `mdbx_txn_commit()` return codes
explicitly instead of relying on a single `check_mdbx()` + `catch (...)`.

## Problem

The previous catch-all handler treated every `mdbx_txn_commit()` failure the
same way: it unbound the transaction from the tracker, unregistered the
handle, and set `m_txn = nullptr`. This is correct for most errors (MDBX
already aborts the transaction), but wrong for `MDBX_THREAD_MISMATCH` — MDBX
does **not** terminate the transaction in that case, so the code was
silently dropping a live native handle.

## Changes

- `Transaction::commit()` (writable path):
  - `MDBX_SUCCESS` → clean up tracker state, mark finished.
  - `MDBX_THREAD_MISMATCH` → throw via `check_mdbx()` while leaving `m_txn`
    and `m_started` intact so the caller can retry from the owning thread
    or roll back.
  - Any other error → MDBX already aborted the transaction, so clean up
    tracker state and rethrow.
- `Transaction::release()` → add `assert(rc == MDBX_SUCCESS || rc == MDBX_THREAD_MISMATCH)`
  after `mdbx_txn_abort()` to catch unexpected failures in debug builds.
- `Config::page_size` Doxygen comment → mention the `256..65536` range.

## Verification

- `g++ -fsyntax-only -std=c++17` passes on the changed headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)