### PR TITLE
[codex] add key range scans

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -17,7 +17,7 @@
 
 ### 🧱 API таблиц
 - `KeyValueTable<K, V>` — основная таблица: одно значение на ключ, методы
-  `insert`, `insert_or_assign`, `find`, `range`, `erase`, `clear`, `load`, `reconcile`,
+  `insert`, `insert_or_assign`, `find`, `range`, `range_values`, `erase`, `clear`, `load`, `reconcile`,
   `operator[]` и связанные помощники.
 - `HashedKeyValueStore<K, V, H, Layout>` хранит одно значение на строковый или
   byte-vector ключ через hash-index и проверяет исходные байты ключа, чтобы
@@ -30,7 +30,7 @@
 - `KeyTable<K>` хранит уникальные ключи со `std::set`-подобным API: `insert`,
   `contains`, `range`, `erase`, `clear`, `load`, `reconcile` и связанные помощники.
 - `KeyMultiValueTable<K, V>` хранит несколько значений на один ключ со
-  `std::multimap`-подобным API, диапазонами по ключам и сохраняет повторяющиеся одинаковые пары
+  `std::multimap`-подобным API, `range`/`range_values` по диапазонам ключей и сохраняет повторяющиеся одинаковые пары
   `(key, value)`.
 - `SequenceTable<ValueT>` хранит значения по стабильному uint64_t id с
   append-only семантикой и разреженными индексами. Append возвращает

--- a/README-RU.md
+++ b/README-RU.md
@@ -142,6 +142,22 @@ int main() {
 }
 ```
 
+### Сканирование диапазонов
+
+`range()` использует тот же стиль контейнеров, что `retrieve_all()` и
+`operator()()`: `KeyTable` по умолчанию возвращает `std::set`, `KeyValueTable`
+возвращает `std::map`, а `KeyMultiValueTable` возвращает `std::multimap`.
+Для упорядоченного результата в `KeyTable` и `KeyValueTable` используйте
+`range<std::vector>()`; для всех физических пар `KeyMultiValueTable` используйте
+`range_vector()`. `range_values()` по умолчанию возвращает `std::vector`, но
+может заполнять и другие контейнеры, например `std::set`.
+
+```cpp
+auto by_key = table.range(10, 20);
+auto ordered_pairs = table.range<std::vector>(10, 20);
+auto unique_values = table.range_values<std::set>(10, 20);
+```
+
 ### Hash-indexed key-value store
 
 ```cpp

--- a/README-RU.md
+++ b/README-RU.md
@@ -17,7 +17,7 @@
 
 ### 🧱 API таблиц
 - `KeyValueTable<K, V>` — основная таблица: одно значение на ключ, методы
-  `insert`, `insert_or_assign`, `find`, `erase`, `clear`, `load`, `reconcile`,
+  `insert`, `insert_or_assign`, `find`, `range`, `erase`, `clear`, `load`, `reconcile`,
   `operator[]` и связанные помощники.
 - `HashedKeyValueStore<K, V, H, Layout>` хранит одно значение на строковый или
   byte-vector ключ через hash-index и проверяет исходные байты ключа, чтобы
@@ -28,9 +28,9 @@
   типу и поддерживает типизированные `set`, `insert`, `get`, `find`, `get_or`,
   `update`, `contains`, `erase` и `keys`.
 - `KeyTable<K>` хранит уникальные ключи со `std::set`-подобным API: `insert`,
-  `contains`, `erase`, `clear`, `load`, `reconcile` и связанные помощники.
+  `contains`, `range`, `erase`, `clear`, `load`, `reconcile` и связанные помощники.
 - `KeyMultiValueTable<K, V>` хранит несколько значений на один ключ со
-  `std::multimap`-подобным API и сохраняет повторяющиеся одинаковые пары
+  `std::multimap`-подобным API, диапазонами по ключам и сохраняет повторяющиеся одинаковые пары
   `(key, value)`.
 - `SequenceTable<ValueT>` хранит значения по стабильному uint64_t id с
   append-only семантикой и разреженными индексами. Append возвращает

--- a/README.md
+++ b/README.md
@@ -114,6 +114,22 @@ int main() {
 }
 ```
 
+### Range scans
+
+`range()` follows the same container style as `retrieve_all()` and `operator()()`:
+`KeyTable` defaults to `std::set`, `KeyValueTable` defaults to `std::map`, and
+`KeyMultiValueTable` defaults to `std::multimap`. Use `range<std::vector>()`
+for ordered key or key-value results in `KeyTable` and `KeyValueTable`; use
+`range_vector()` when every physical `KeyMultiValueTable` pair must remain
+visible as a vector element. `range_values()` defaults to `std::vector` and can
+also target containers such as `std::set`.
+
+```cpp
+auto by_key = table.range(10, 20);
+auto ordered_pairs = table.range<std::vector>(10, 20);
+auto unique_values = table.range_values<std::set>(10, 20);
+```
+
 ### Hash-indexed key-value store
 
 ```cpp

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@
 ## ⚙️ Features
 
 ### 🧱 Table APIs
-- `KeyValueTable<K, V>` is the main implemented table: one value per key with `insert`, `insert_or_assign`, `find`, `range`, `erase`, `clear`, `load`, `reconcile`, `operator[]`, and related helpers.
+- `KeyValueTable<K, V>` is the main implemented table: one value per key with `insert`, `insert_or_assign`, `find`, `range`, `range_values`, `erase`, `clear`, `load`, `reconcile`, `operator[]`, and related helpers.
 - `HashedKeyValueStore<K, V, H, Layout>` stores one value per string or byte-vector key through a hash index and verifies original key bytes to handle collisions.
 - `ValueTable<V>` stores one strongly typed singleton value per named table for metadata, module state, snapshots, and single-object configuration records.
 - `AnyValueTable<K>` stores heterogeneous values by caller-selected type and supports typed `set`, `insert`, `get`, `find`, `get_or`, `update`, `contains`, `erase`, and `keys`.
 - `KeyTable<K>` stores unique keys with a `std::set`-like API: `insert`, `contains`, `range`, `erase`, `clear`, `load`, `reconcile`, and related helpers.
-- `KeyMultiValueTable<K, V>` stores multiple values per key with a `std::multimap`-like API, key-range scans, and repeated identical `(key, value)` pair preservation.
+- `KeyMultiValueTable<K, V>` stores multiple values per key with a `std::multimap`-like API, `range`/`range_values` key-range scans, and repeated identical `(key, value)` pair preservation.
 - `SequenceTable<ValueT>` stores values by stable uint64_t id with append-only semantics and sparse index support. Append returns a stable id; erase does not reindex following records.
 - `AnyValueTable` type-tag prefix verification is opt-in via `set_type_tag_check(true)` and is disabled by default for compatibility with existing raw records.
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@
 ## ⚙️ Features
 
 ### 🧱 Table APIs
-- `KeyValueTable<K, V>` is the main implemented table: one value per key with `insert`, `insert_or_assign`, `find`, `erase`, `clear`, `load`, `reconcile`, `operator[]`, and related helpers.
+- `KeyValueTable<K, V>` is the main implemented table: one value per key with `insert`, `insert_or_assign`, `find`, `range`, `erase`, `clear`, `load`, `reconcile`, `operator[]`, and related helpers.
 - `HashedKeyValueStore<K, V, H, Layout>` stores one value per string or byte-vector key through a hash index and verifies original key bytes to handle collisions.
 - `ValueTable<V>` stores one strongly typed singleton value per named table for metadata, module state, snapshots, and single-object configuration records.
 - `AnyValueTable<K>` stores heterogeneous values by caller-selected type and supports typed `set`, `insert`, `get`, `find`, `get_or`, `update`, `contains`, `erase`, and `keys`.
-- `KeyTable<K>` stores unique keys with a `std::set`-like API: `insert`, `contains`, `erase`, `clear`, `load`, `reconcile`, and related helpers.
-- `KeyMultiValueTable<K, V>` stores multiple values per key with a `std::multimap`-like API and preserves repeated identical `(key, value)` pairs.
+- `KeyTable<K>` stores unique keys with a `std::set`-like API: `insert`, `contains`, `range`, `erase`, `clear`, `load`, `reconcile`, and related helpers.
+- `KeyMultiValueTable<K, V>` stores multiple values per key with a `std::multimap`-like API, key-range scans, and repeated identical `(key, value)` pair preservation.
 - `SequenceTable<ValueT>` stores values by stable uint64_t id with append-only semantics and sparse index support. Append returns a stable id; erase does not reindex following records.
 - `AnyValueTable` type-tag prefix verification is opt-in via `set_type_tag_check(true)` and is disabled by default for compatibility with existing raw records.
 

--- a/docs/tables.dox
+++ b/docs/tables.dox
@@ -27,8 +27,10 @@ Use \c insert() when an existing key must remain unchanged, and
 \c append() upserts source keys without deleting unrelated database records.
 \c reconcile() upserts all source keys and removes database keys that are not
 present in the source. \c range(from_key, to_key) returns key-value pairs whose
-keys fall inside an inclusive MDBX key-order range; \c range_values() returns
-only values for the same range.
+keys fall inside an inclusive MDBX key-order range and defaults to
+\c std::map. Use \c range<std::vector>() when MDBX iteration order must remain
+visible. \c range_values() returns only values for the same range and defaults
+to \c std::vector.
 
 \warning Reading a missing key through \c operator[] inserts and persists a
          default-constructed value, just like \c std::map::operator[].
@@ -144,7 +146,9 @@ small.insert_or_assign("flag", 1);
 core \c std::set workflow with \c insert(), \c contains(), \c erase(),
 \c clear(), \c load(), \c range(), and \c reconcile(). Records store the
 serialized key as the MDBX key and an empty MDBX value. Duplicate inserts use
-MDBX no-overwrite semantics and return \c false.
+MDBX no-overwrite semantics and return \c false. \c range(from_key, to_key)
+defaults to \c std::set; use \c range<std::vector>() when MDBX iteration order
+must remain visible.
 
 \note \c append() inserts only missing keys. \c reconcile() currently clears the
       table and appends source keys, so it is replacement-oriented rather than
@@ -175,8 +179,10 @@ separate element, including repeated identical pairs. Reconciliation compares
 pair multiplicity, keeps matching records, deletes surplus records, and inserts
 missing records; it does not reorder already matching records to match source
 iteration order. \c range(from_key, to_key) returns key-value pairs whose keys
-fall inside an inclusive MDBX key-order range; \c range_values() returns only
-values for the same range.
+fall inside an inclusive MDBX key-order range and defaults to
+\c std::multimap. Use \c range_vector() when every physical pair must remain
+visible as a vector element. \c range_values() returns only values for the same
+range and defaults to \c std::vector.
 
 ```cpp
 mdbxc::KeyMultiValueTable<int, std::string> events(conn, "events");

--- a/docs/tables.dox
+++ b/docs/tables.dox
@@ -26,8 +26,9 @@ Use \c insert() when an existing key must remain unchanged, and
 \c insert_or_assign() when the source value should replace any current value.
 \c append() upserts source keys without deleting unrelated database records.
 \c reconcile() upserts all source keys and removes database keys that are not
-present in the source. \c range(from_key, to_key) returns values whose keys fall
-inside an inclusive MDBX key-order range.
+present in the source. \c range(from_key, to_key) returns key-value pairs whose
+keys fall inside an inclusive MDBX key-order range; \c range_values() returns
+only values for the same range.
 
 \warning Reading a missing key through \c operator[] inserts and persists a
          default-constructed value, just like \c std::map::operator[].
@@ -173,8 +174,9 @@ The default \c retrieve_all() container is \c std::multimap. Use
 separate element, including repeated identical pairs. Reconciliation compares
 pair multiplicity, keeps matching records, deletes surplus records, and inserts
 missing records; it does not reorder already matching records to match source
-iteration order. \c range(from_key, to_key) returns values whose keys fall
-inside an inclusive MDBX key-order range.
+iteration order. \c range(from_key, to_key) returns key-value pairs whose keys
+fall inside an inclusive MDBX key-order range; \c range_values() returns only
+values for the same range.
 
 ```cpp
 mdbxc::KeyMultiValueTable<int, std::string> events(conn, "events");

--- a/docs/tables.dox
+++ b/docs/tables.dox
@@ -26,7 +26,8 @@ Use \c insert() when an existing key must remain unchanged, and
 \c insert_or_assign() when the source value should replace any current value.
 \c append() upserts source keys without deleting unrelated database records.
 \c reconcile() upserts all source keys and removes database keys that are not
-present in the source.
+present in the source. \c range(from_key, to_key) returns values whose keys fall
+inside an inclusive MDBX key-order range.
 
 \warning Reading a missing key through \c operator[] inserts and persists a
          default-constructed value, just like \c std::map::operator[].
@@ -140,9 +141,9 @@ small.insert_or_assign("flag", 1);
 
 \ref mdbxc::KeyTable stores unique keys without user values. It mirrors the
 core \c std::set workflow with \c insert(), \c contains(), \c erase(),
-\c clear(), \c load(), and \c reconcile(). Records store the serialized key as
-the MDBX key and an empty MDBX value. Duplicate inserts use MDBX no-overwrite
-semantics and return \c false.
+\c clear(), \c load(), \c range(), and \c reconcile(). Records store the
+serialized key as the MDBX key and an empty MDBX value. Duplicate inserts use
+MDBX no-overwrite semantics and return \c false.
 
 \note \c append() inserts only missing keys. \c reconcile() currently clears the
       table and appends source keys, so it is replacement-oriented rather than
@@ -172,7 +173,8 @@ The default \c retrieve_all() container is \c std::multimap. Use
 separate element, including repeated identical pairs. Reconciliation compares
 pair multiplicity, keeps matching records, deletes surplus records, and inserts
 missing records; it does not reorder already matching records to match source
-iteration order.
+iteration order. \c range(from_key, to_key) returns values whose keys fall
+inside an inclusive MDBX key-order range.
 
 ```cpp
 mdbxc::KeyMultiValueTable<int, std::string> events(conn, "events");

--- a/guides/table-api-guide.md
+++ b/guides/table-api-guide.md
@@ -127,6 +127,8 @@ Read/meta methods:
 - `find(key)` returns `std::optional<ValueT>` in C++17.
 - `find(key)` in C++11 returns `std::pair<bool, ValueT>`.
 - `find_compat(key)` is the pair-based compatibility form.
+- `range(from_key, to_key)` returns values for keys inside an inclusive key
+  range using a cursor scan.
 - `contains(key)`, `count()`, `empty()`, and `erase(key)` mirror map-like
   metadata/removal operations.
 - `operator[]` returns an assignment proxy.
@@ -139,6 +141,7 @@ Restrictions and common mistakes:
   writes for the same key.
 - Retrieval into unique-key containers follows the container's own insertion
   rules.
+- `range()` follows MDBX key ordering, not insertion order.
 
 Use it for:
 
@@ -160,10 +163,11 @@ hash index for lookup by default. Hash collisions do not affect correctness
 because reads, updates, and deletes compare the stored original key bytes after
 selecting the hash bucket.
 
-Write/read methods mirror `KeyValueTable`: `insert()`, `insert_or_assign()`,
-`append()`, `reconcile()`, `at()`, `try_get()`, `find()`/`find_compat()`,
-`contains()`, `erase()`, `count()`, `empty()`, `clear()`, `load()`, and
-`retrieve_all()`.
+Write/read methods mirror `KeyValueTable` for point lookups and full-table
+retrieval: `insert()`, `insert_or_assign()`, `append()`, `reconcile()`,
+`at()`, `try_get()`, `find()`/`find_compat()`, `contains()`, `erase()`,
+`count()`, `empty()`, `clear()`, `load()`, and `retrieve_all()`. It does not
+expose original-key `range()` because records are ordered by hash buckets.
 
 Restrictions and common mistakes:
 
@@ -213,6 +217,8 @@ Write methods:
 Read/meta methods:
 
 - `contains(key)` checks membership.
+- `range(from_key, to_key)` returns stored keys inside an inclusive key range
+  using a cursor scan.
 - `count()` returns stored key count.
 - `empty()` checks whether the table has no keys.
 - `erase(key)` removes one key.
@@ -224,6 +230,7 @@ Restrictions and common mistakes:
   is truly a set.
 - `reconcile()` is replacement-oriented and not an incremental set diff.
 - Key order follows MDBX key ordering, not insertion order.
+- `range()` uses the same MDBX key ordering.
 
 Use it for:
 
@@ -366,6 +373,8 @@ Write methods:
 Read/meta methods:
 
 - `find(key)` returns `std::vector<ValueT>` in insertion order for that key.
+- `range(from_key, to_key)` returns values for all keys inside an inclusive key
+  range using a cursor scan.
 - `contains(key)` checks whether any value exists for a key.
 - `contains(key, value)` checks whether an exact pair exists.
 - `count()` counts all stored pairs.
@@ -387,6 +396,8 @@ Restrictions and common mistakes:
   `retrieve_all_vector()`.
 - `reconcile()` avoids unnecessary writes, but it does not reorder existing
   matching records to match source iteration order.
+- `range()` follows MDBX key ordering; values for the same key follow stored
+  duplicate order.
 
 Use it for:
 

--- a/guides/table-api-guide.md
+++ b/guides/table-api-guide.md
@@ -127,8 +127,9 @@ Read/meta methods:
 - `find(key)` returns `std::optional<ValueT>` in C++17.
 - `find(key)` in C++11 returns `std::pair<bool, ValueT>`.
 - `find_compat(key)` is the pair-based compatibility form.
-- `range(from_key, to_key)` returns values for keys inside an inclusive key
+- `range(from_key, to_key)` returns key-value pairs inside an inclusive key
   range using a cursor scan.
+- `range_values(from_key, to_key)` returns only values for the same range.
 - `contains(key)`, `count()`, `empty()`, and `erase(key)` mirror map-like
   metadata/removal operations.
 - `operator[]` returns an assignment proxy.
@@ -141,7 +142,7 @@ Restrictions and common mistakes:
   writes for the same key.
 - Retrieval into unique-key containers follows the container's own insertion
   rules.
-- `range()` follows MDBX key ordering, not insertion order.
+- `range()` and `range_values()` follow MDBX key ordering, not insertion order.
 
 Use it for:
 
@@ -373,8 +374,9 @@ Write methods:
 Read/meta methods:
 
 - `find(key)` returns `std::vector<ValueT>` in insertion order for that key.
-- `range(from_key, to_key)` returns values for all keys inside an inclusive key
-  range using a cursor scan.
+- `range(from_key, to_key)` returns key-value pairs for all keys inside an
+  inclusive key range using a cursor scan.
+- `range_values(from_key, to_key)` returns only values for the same range.
 - `contains(key)` checks whether any value exists for a key.
 - `contains(key, value)` checks whether an exact pair exists.
 - `count()` counts all stored pairs.
@@ -396,8 +398,8 @@ Restrictions and common mistakes:
   `retrieve_all_vector()`.
 - `reconcile()` avoids unnecessary writes, but it does not reorder existing
   matching records to match source iteration order.
-- `range()` follows MDBX key ordering; values for the same key follow stored
-  duplicate order.
+- `range()` and `range_values()` follow MDBX key ordering; values for the same
+  key follow stored duplicate order.
 
 Use it for:
 

--- a/guides/table-api-guide.md
+++ b/guides/table-api-guide.md
@@ -128,8 +128,11 @@ Read/meta methods:
 - `find(key)` in C++11 returns `std::pair<bool, ValueT>`.
 - `find_compat(key)` is the pair-based compatibility form.
 - `range(from_key, to_key)` returns key-value pairs inside an inclusive key
-  range using a cursor scan.
-- `range_values(from_key, to_key)` returns only values for the same range.
+  range using a cursor scan. It defaults to `std::map`; use
+  `range<std::vector>()` for MDBX iteration-order pairs.
+- `range_values(from_key, to_key)` returns only values for the same range. It
+  defaults to `std::vector`; use `range_values<std::set>()` when container
+  semantics should deduplicate values.
 - `contains(key)`, `count()`, `empty()`, and `erase(key)` mirror map-like
   metadata/removal operations.
 - `operator[]` returns an assignment proxy.
@@ -142,7 +145,8 @@ Restrictions and common mistakes:
   writes for the same key.
 - Retrieval into unique-key containers follows the container's own insertion
   rules.
-- `range()` and `range_values()` follow MDBX key ordering, not insertion order.
+- `range()` and `range_values()` scan in MDBX key order before the requested
+  output container applies its own ordering or deduplication rules.
 
 Use it for:
 
@@ -219,7 +223,8 @@ Read/meta methods:
 
 - `contains(key)` checks membership.
 - `range(from_key, to_key)` returns stored keys inside an inclusive key range
-  using a cursor scan.
+  using a cursor scan. It defaults to `std::set`; use `range<std::vector>()`
+  for MDBX iteration-order keys.
 - `count()` returns stored key count.
 - `empty()` checks whether the table has no keys.
 - `erase(key)` removes one key.
@@ -231,7 +236,8 @@ Restrictions and common mistakes:
   is truly a set.
 - `reconcile()` is replacement-oriented and not an incremental set diff.
 - Key order follows MDBX key ordering, not insertion order.
-- `range()` uses the same MDBX key ordering.
+- `range()` scans in the same MDBX key ordering before the requested output
+  container applies its own ordering or deduplication rules.
 
 Use it for:
 
@@ -375,8 +381,11 @@ Read/meta methods:
 
 - `find(key)` returns `std::vector<ValueT>` in insertion order for that key.
 - `range(from_key, to_key)` returns key-value pairs for all keys inside an
-  inclusive key range using a cursor scan.
-- `range_values(from_key, to_key)` returns only values for the same range.
+  inclusive key range using a cursor scan. It defaults to `std::multimap`; use
+  `range_vector()` when every physical pair must remain a vector element.
+- `range_values(from_key, to_key)` returns only values for the same range. It
+  defaults to `std::vector`; use `range_values<std::set>()` when container
+  semantics should deduplicate values.
 - `contains(key)` checks whether any value exists for a key.
 - `contains(key, value)` checks whether an exact pair exists.
 - `count()` counts all stored pairs.
@@ -398,8 +407,8 @@ Restrictions and common mistakes:
   `retrieve_all_vector()`.
 - `reconcile()` avoids unnecessary writes, but it does not reorder existing
   matching records to match source iteration order.
-- `range()` and `range_values()` follow MDBX key ordering; values for the same
-  key follow stored duplicate order.
+- `range()` and `range_values()` follow MDBX key ordering before the requested
+  output container applies its own ordering or deduplication rules.
 
 Use it for:
 

--- a/include/mdbx_containers/AnyValueTable.hpp
+++ b/include/mdbx_containers/AnyValueTable.hpp
@@ -442,7 +442,7 @@ namespace mdbxc {
                 MDBX_val db_key, db_val;
                 int rc = MDBX_SUCCESS;
                 while ((rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
-                    out.emplace_back(deserialize_value<KeyT>(db_key));
+                    out.emplace_back(deserialize_key<KeyT>(db_key));
                 }
                 if (rc != MDBX_NOTFOUND) {
                     check_mdbx(rc, "Failed to list AnyValueTable keys");

--- a/include/mdbx_containers/KeyMultiValueTable.hpp
+++ b/include/mdbx_containers/KeyMultiValueTable.hpp
@@ -189,6 +189,34 @@ namespace mdbxc {
             return retrieve_all_vector(txn.handle());
         }
 
+        /// \brief Retrieves key-value pairs within an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Optional transaction handle.
+        /// \return Vector of key-value pairs in MDBX key order.
+        /// \throws MdbxException if a database error occurs.
+        /// \complexity O(log n + m), where m is the number of returned pairs.
+        std::vector<value_type> range(const KeyT& from_key, const KeyT& to_key,
+                                      MDBX_txn* txn = nullptr) const {
+            std::vector<value_type> pairs;
+            with_transaction([this, &from_key, &to_key, &pairs](MDBX_txn* t) {
+                db_range(from_key, to_key, pairs, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return pairs;
+        }
+
+        /// \brief Retrieves key-value pairs within an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Active transaction wrapper.
+        /// \return Vector of key-value pairs in MDBX key order.
+        /// \throws MdbxException if a database error occurs.
+        /// \complexity O(log n + m), where m is the number of returned pairs.
+        std::vector<value_type> range(const KeyT& from_key, const KeyT& to_key,
+                                      const Transaction& txn) const {
+            return range(from_key, to_key, txn.handle());
+        }
+
         /// \brief Retrieves values whose keys are within an inclusive key range.
         /// \param from_key Start key in MDBX key order.
         /// \param to_key End key in MDBX key order.
@@ -196,11 +224,11 @@ namespace mdbxc {
         /// \return Vector of values in MDBX key order.
         /// \throws MdbxException if a database error occurs.
         /// \complexity O(log n + m), where m is the number of returned values.
-        std::vector<ValueT> range(const KeyT& from_key, const KeyT& to_key,
-                                  MDBX_txn* txn = nullptr) const {
+        std::vector<ValueT> range_values(const KeyT& from_key, const KeyT& to_key,
+                                         MDBX_txn* txn = nullptr) const {
             std::vector<ValueT> values;
             with_transaction([this, &from_key, &to_key, &values](MDBX_txn* t) {
-                db_range(from_key, to_key, values, t);
+                db_range_values(from_key, to_key, values, t);
             }, TransactionMode::READ_ONLY, txn);
             return values;
         }
@@ -212,9 +240,9 @@ namespace mdbxc {
         /// \return Vector of values in MDBX key order.
         /// \throws MdbxException if a database error occurs.
         /// \complexity O(log n + m), where m is the number of returned values.
-        std::vector<ValueT> range(const KeyT& from_key, const KeyT& to_key,
-                                  const Transaction& txn) const {
-            return range(from_key, to_key, txn.handle());
+        std::vector<ValueT> range_values(const KeyT& from_key, const KeyT& to_key,
+                                         const Transaction& txn) const {
+            return range_values(from_key, to_key, txn.handle());
         }
 
         /// \brief Appends pairs to the table.
@@ -732,7 +760,38 @@ namespace mdbxc {
         }
 
         void db_range(const KeyT& from_key, const KeyT& to_key,
-                      std::vector<ValueT>& values, MDBX_txn* txn) const {
+                      std::vector<value_type>& pairs, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
+
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
+            try {
+                MDBX_val db_key = db_from_key;
+                MDBX_val db_val;
+                int rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_SET_RANGE);
+                while (rc == MDBX_SUCCESS) {
+                    if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
+                    KeyT key = deserialize_value<KeyT>(db_key);
+                    ValueT value = deserialize_value<ValueT>(strip_sequence(db_val));
+                    pairs.emplace_back(std::move(key), std::move(value));
+                    rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "Failed to read multi-value key range");
+                }
+                mdbx_cursor_close(cursor);
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+        }
+
+        void db_range_values(const KeyT& from_key, const KeyT& to_key,
+                             std::vector<ValueT>& values, MDBX_txn* txn) const {
             SerializeScratch sc_from_key;
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
@@ -751,7 +810,7 @@ namespace mdbxc {
                     rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT);
                 }
                 if (rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc, "Failed to read multi-value key range");
+                    check_mdbx(rc, "Failed to read multi-value key range values");
                 }
                 mdbx_cursor_close(cursor);
             } catch (...) {

--- a/include/mdbx_containers/KeyMultiValueTable.hpp
+++ b/include/mdbx_containers/KeyMultiValueTable.hpp
@@ -724,7 +724,7 @@ namespace mdbxc {
                 MDBX_val db_key, db_val;
                 int rc = MDBX_SUCCESS;
                 while ((rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
-                    KeyT key = deserialize_value<KeyT>(db_key);
+                    KeyT key = deserialize_key<KeyT>(db_key);
                     ValueT value = deserialize_value<ValueT>(strip_sequence(db_val));
                     container.emplace(std::move(key), std::move(value));
                 }
@@ -745,7 +745,7 @@ namespace mdbxc {
                 MDBX_val db_key, db_val;
                 int rc = MDBX_SUCCESS;
                 while ((rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
-                    KeyT key = deserialize_value<KeyT>(db_key);
+                    KeyT key = deserialize_key<KeyT>(db_key);
                     ValueT value = deserialize_value<ValueT>(strip_sequence(db_val));
                     container.emplace_back(std::move(key), std::move(value));
                 }
@@ -775,7 +775,7 @@ namespace mdbxc {
                 int rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_SET_RANGE);
                 while (rc == MDBX_SUCCESS) {
                     if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
-                    KeyT key = deserialize_value<KeyT>(db_key);
+                    KeyT key = deserialize_key<KeyT>(db_key);
                     ValueT value = deserialize_value<ValueT>(strip_sequence(db_val));
                     pairs.emplace_back(std::move(key), std::move(value));
                     rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT);

--- a/include/mdbx_containers/KeyMultiValueTable.hpp
+++ b/include/mdbx_containers/KeyMultiValueTable.hpp
@@ -767,26 +767,21 @@ namespace mdbxc {
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
             if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
-            MDBX_cursor* cursor = nullptr;
-            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
-            try {
-                MDBX_val db_key = db_from_key;
-                MDBX_val db_val;
-                int rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_SET_RANGE);
-                while (rc == MDBX_SUCCESS) {
-                    if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
-                    KeyT key = deserialize_key<KeyT>(db_key);
-                    ValueT value = deserialize_value<ValueT>(strip_sequence(db_val));
-                    pairs.emplace_back(std::move(key), std::move(value));
-                    rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT);
-                }
-                if (rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc, "Failed to read multi-value key range");
-                }
-                mdbx_cursor_close(cursor);
-            } catch (...) {
-                mdbx_cursor_close(cursor);
-                throw;
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_from_key;
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            while (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
+                KeyT key = deserialize_key<KeyT>(db_key);
+                ValueT value = deserialize_value<ValueT>(strip_sequence(db_val));
+                pairs.emplace_back(std::move(key), std::move(value));
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to read multi-value key range");
             }
         }
 
@@ -798,24 +793,19 @@ namespace mdbxc {
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
             if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
-            MDBX_cursor* cursor = nullptr;
-            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
-            try {
-                MDBX_val db_key = db_from_key;
-                MDBX_val db_val;
-                int rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_SET_RANGE);
-                while (rc == MDBX_SUCCESS) {
-                    if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
-                    values.emplace_back(deserialize_value<ValueT>(strip_sequence(db_val)));
-                    rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT);
-                }
-                if (rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc, "Failed to read multi-value key range values");
-                }
-                mdbx_cursor_close(cursor);
-            } catch (...) {
-                mdbx_cursor_close(cursor);
-                throw;
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_from_key;
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            while (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
+                values.emplace_back(deserialize_value<ValueT>(strip_sequence(db_val)));
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to read multi-value key range values");
             }
         }
 

--- a/include/mdbx_containers/KeyMultiValueTable.hpp
+++ b/include/mdbx_containers/KeyMultiValueTable.hpp
@@ -772,15 +772,19 @@ namespace mdbxc {
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
+            bool stopped_by_upper_bound = false;
             int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
             while (rc == MDBX_SUCCESS) {
-                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    stopped_by_upper_bound = true;
+                    break;
+                }
                 KeyT key = deserialize_key<KeyT>(db_key);
                 ValueT value = deserialize_value<ValueT>(strip_sequence(db_val));
                 pairs.emplace_back(std::move(key), std::move(value));
                 rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
             }
-            if (rc != MDBX_NOTFOUND) {
+            if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
                 check_mdbx(rc, "Failed to read multi-value key range");
             }
         }
@@ -798,13 +802,17 @@ namespace mdbxc {
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
+            bool stopped_by_upper_bound = false;
             int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
             while (rc == MDBX_SUCCESS) {
-                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    stopped_by_upper_bound = true;
+                    break;
+                }
                 values.emplace_back(deserialize_value<ValueT>(strip_sequence(db_val)));
                 rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
             }
-            if (rc != MDBX_NOTFOUND) {
+            if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
                 check_mdbx(rc, "Failed to read multi-value key range values");
             }
         }

--- a/include/mdbx_containers/KeyMultiValueTable.hpp
+++ b/include/mdbx_containers/KeyMultiValueTable.hpp
@@ -190,15 +190,20 @@ namespace mdbxc {
         }
 
         /// \brief Retrieves key-value pairs within an inclusive key range.
+        /// \tparam ContainerT Container type storing pairs.
         /// \param from_key Start key in MDBX key order.
         /// \param to_key End key in MDBX key order.
         /// \param txn Optional transaction handle.
-        /// \return Vector of key-value pairs in MDBX key order.
+        /// \return Container with key-value pairs from the requested range.
         /// \throws MdbxException if a database error occurs.
+        /// \note The default \c std::multimap preserves multiple values for one
+        ///       key. Use \c range_vector() to preserve every physical pair as a
+        ///       vector element.
         /// \complexity O(log n + m), where m is the number of returned pairs.
-        std::vector<value_type> range(const KeyT& from_key, const KeyT& to_key,
-                                      MDBX_txn* txn = nullptr) const {
-            std::vector<value_type> pairs;
+        template<template<class...> class ContainerT = std::multimap>
+        ContainerT<KeyT, ValueT> range(const KeyT& from_key, const KeyT& to_key,
+                                       MDBX_txn* txn = nullptr) const {
+            ContainerT<KeyT, ValueT> pairs;
             with_transaction([this, &from_key, &to_key, &pairs](MDBX_txn* t) {
                 db_range(from_key, to_key, pairs, t);
             }, TransactionMode::READ_ONLY, txn);
@@ -206,27 +211,61 @@ namespace mdbxc {
         }
 
         /// \brief Retrieves key-value pairs within an inclusive key range.
+        /// \tparam ContainerT Container type storing pairs.
         /// \param from_key Start key in MDBX key order.
         /// \param to_key End key in MDBX key order.
         /// \param txn Active transaction wrapper.
-        /// \return Vector of key-value pairs in MDBX key order.
+        /// \return Container with key-value pairs from the requested range.
         /// \throws MdbxException if a database error occurs.
         /// \complexity O(log n + m), where m is the number of returned pairs.
-        std::vector<value_type> range(const KeyT& from_key, const KeyT& to_key,
-                                      const Transaction& txn) const {
-            return range(from_key, to_key, txn.handle());
+        template<template<class...> class ContainerT = std::multimap>
+        ContainerT<KeyT, ValueT> range(const KeyT& from_key, const KeyT& to_key,
+                                       const Transaction& txn) const {
+            return range<ContainerT>(from_key, to_key, txn.handle());
         }
 
-        /// \brief Retrieves values whose keys are within an inclusive key range.
+        /// \brief Retrieves key-value pairs within an inclusive key range into a vector.
         /// \param from_key Start key in MDBX key order.
         /// \param to_key End key in MDBX key order.
         /// \param txn Optional transaction handle.
-        /// \return Vector of values in MDBX key order.
+        /// \return Vector containing every physical pair in MDBX key order.
         /// \throws MdbxException if a database error occurs.
+        /// \complexity O(log n + m), where m is the number of returned pairs.
+        std::vector<value_type> range_vector(const KeyT& from_key, const KeyT& to_key,
+                                             MDBX_txn* txn = nullptr) const {
+            std::vector<value_type> pairs;
+            with_transaction([this, &from_key, &to_key, &pairs](MDBX_txn* t) {
+                db_range(from_key, to_key, pairs, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return pairs;
+        }
+
+        /// \brief Retrieves key-value pairs within an inclusive key range into a vector.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Active transaction wrapper.
+        /// \return Vector containing every physical pair in MDBX key order.
+        /// \throws MdbxException if a database error occurs.
+        /// \complexity O(log n + m), where m is the number of returned pairs.
+        std::vector<value_type> range_vector(const KeyT& from_key, const KeyT& to_key,
+                                             const Transaction& txn) const {
+            return range_vector(from_key, to_key, txn.handle());
+        }
+
+        /// \brief Retrieves values whose keys are within an inclusive key range.
+        /// \tparam ContainerT Container type storing values.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Optional transaction handle.
+        /// \return Container with values from the requested range.
+        /// \throws MdbxException if a database error occurs.
+        /// \note The default \c std::vector preserves MDBX iteration order and
+        ///       duplicate values. Associative containers apply their own rules.
         /// \complexity O(log n + m), where m is the number of returned values.
-        std::vector<ValueT> range_values(const KeyT& from_key, const KeyT& to_key,
-                                         MDBX_txn* txn = nullptr) const {
-            std::vector<ValueT> values;
+        template<template<class...> class ContainerT = std::vector>
+        ContainerT<ValueT> range_values(const KeyT& from_key, const KeyT& to_key,
+                                        MDBX_txn* txn = nullptr) const {
+            ContainerT<ValueT> values;
             with_transaction([this, &from_key, &to_key, &values](MDBX_txn* t) {
                 db_range_values(from_key, to_key, values, t);
             }, TransactionMode::READ_ONLY, txn);
@@ -234,15 +273,17 @@ namespace mdbxc {
         }
 
         /// \brief Retrieves values whose keys are within an inclusive key range.
+        /// \tparam ContainerT Container type storing values.
         /// \param from_key Start key in MDBX key order.
         /// \param to_key End key in MDBX key order.
         /// \param txn Active transaction wrapper.
-        /// \return Vector of values in MDBX key order.
+        /// \return Container with values from the requested range.
         /// \throws MdbxException if a database error occurs.
         /// \complexity O(log n + m), where m is the number of returned values.
-        std::vector<ValueT> range_values(const KeyT& from_key, const KeyT& to_key,
-                                         const Transaction& txn) const {
-            return range_values(from_key, to_key, txn.handle());
+        template<template<class...> class ContainerT = std::vector>
+        ContainerT<ValueT> range_values(const KeyT& from_key, const KeyT& to_key,
+                                        const Transaction& txn) const {
+            return range_values<ContainerT>(from_key, to_key, txn.handle());
         }
 
         /// \brief Appends pairs to the table.
@@ -690,77 +731,62 @@ namespace mdbxc {
         }
 
         uint64_t next_sequence(const KeyT& key, MDBX_txn* txn) const {
-            MDBX_cursor* cursor = nullptr;
-            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
-            try {
-                SerializeScratch sc_key;
-                MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
-                MDBX_val db_val;
-                int rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_SET_KEY);
-                if (rc == MDBX_NOTFOUND) {
-                    mdbx_cursor_close(cursor);
-                    return 0;
-                }
-                check_mdbx(rc, "Failed to seek key");
-                rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_LAST_DUP);
-                check_mdbx(rc, "Failed to seek last value");
-                uint64_t last = decode_sequence(db_val);
-                if (last == std::numeric_limits<uint64_t>::max()) {
-                    throw std::overflow_error("Per-key multi-value sequence exhausted");
-                }
-                mdbx_cursor_close(cursor);
-                return last + 1;
-            } catch (...) {
-                mdbx_cursor_close(cursor);
-                throw;
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_KEY);
+            if (rc == MDBX_NOTFOUND) {
+                return 0;
             }
+            check_mdbx(rc, "Failed to seek key");
+            rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST_DUP);
+            check_mdbx(rc, "Failed to seek last value");
+            uint64_t last = decode_sequence(db_val);
+            if (last == std::numeric_limits<uint64_t>::max()) {
+                throw std::overflow_error("Per-key multi-value sequence exhausted");
+            }
+            return last + 1;
         }
 
         template<template<class...> class ContainerT>
         void db_load(ContainerT<KeyT, ValueT>& container, MDBX_txn* txn) const {
-            MDBX_cursor* cursor = nullptr;
-            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
-            try {
-                MDBX_val db_key, db_val;
-                int rc = MDBX_SUCCESS;
-                while ((rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
-                    KeyT key = deserialize_key<KeyT>(db_key);
-                    ValueT value = deserialize_value<ValueT>(strip_sequence(db_val));
-                    container.emplace(std::move(key), std::move(value));
-                }
-                if (rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc, "Failed to read multi-value table");
-                }
-                mdbx_cursor_close(cursor);
-            } catch (...) {
-                mdbx_cursor_close(cursor);
-                throw;
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key, db_val;
+            int rc = MDBX_SUCCESS;
+            while ((rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
+                KeyT key = deserialize_key<KeyT>(db_key);
+                ValueT value = deserialize_value<ValueT>(strip_sequence(db_val));
+                container.emplace(std::move(key), std::move(value));
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to read multi-value table");
             }
         }
 
         void db_load(std::vector<value_type>& container, MDBX_txn* txn) const {
-            MDBX_cursor* cursor = nullptr;
-            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
-            try {
-                MDBX_val db_key, db_val;
-                int rc = MDBX_SUCCESS;
-                while ((rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
-                    KeyT key = deserialize_key<KeyT>(db_key);
-                    ValueT value = deserialize_value<ValueT>(strip_sequence(db_val));
-                    container.emplace_back(std::move(key), std::move(value));
-                }
-                if (rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc, "Failed to read multi-value table");
-                }
-                mdbx_cursor_close(cursor);
-            } catch (...) {
-                mdbx_cursor_close(cursor);
-                throw;
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key, db_val;
+            int rc = MDBX_SUCCESS;
+            while ((rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
+                KeyT key = deserialize_key<KeyT>(db_key);
+                ValueT value = deserialize_value<ValueT>(strip_sequence(db_val));
+                container.emplace_back(std::move(key), std::move(value));
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to read multi-value table");
             }
         }
 
+        template<class ContainerT>
         void db_range(const KeyT& from_key, const KeyT& to_key,
-                      std::vector<value_type>& pairs, MDBX_txn* txn) const {
+                      ContainerT& pairs, MDBX_txn* txn) const {
             SerializeScratch sc_from_key;
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
@@ -781,7 +807,7 @@ namespace mdbxc {
                 }
                 KeyT key = deserialize_key<KeyT>(db_key);
                 ValueT value = deserialize_value<ValueT>(strip_sequence(db_val));
-                pairs.emplace_back(std::move(key), std::move(value));
+                pairs.insert(pairs.end(), value_type(std::move(key), std::move(value)));
                 rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
             }
             if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
@@ -789,8 +815,9 @@ namespace mdbxc {
             }
         }
 
+        template<class ContainerT>
         void db_range_values(const KeyT& from_key, const KeyT& to_key,
-                             std::vector<ValueT>& values, MDBX_txn* txn) const {
+                             ContainerT& values, MDBX_txn* txn) const {
             SerializeScratch sc_from_key;
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
@@ -809,7 +836,7 @@ namespace mdbxc {
                     stopped_by_upper_bound = true;
                     break;
                 }
-                values.emplace_back(deserialize_value<ValueT>(strip_sequence(db_val)));
+                values.insert(values.end(), deserialize_value<ValueT>(strip_sequence(db_val)));
                 rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
             }
             if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
@@ -863,27 +890,24 @@ namespace mdbxc {
             collect_reconcile_entries(container, entries, desired);
 
             PairCountMap kept;
-            MDBX_cursor* cursor = nullptr;
-            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
-            try {
+            {
+                CursorGuard cursor;
+                check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
                 MDBX_val db_key, db_val;
                 int rc = MDBX_SUCCESS;
-                while ((rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
+                while ((rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
                     SerializedPairKey serialized = make_serialized_pair_key(db_key, db_val);
                     typename PairCountMap::const_iterator desired_it = desired.find(serialized);
                     if (desired_it != desired.end() && kept[serialized] < desired_it->second) {
                         ++kept[serialized];
                     } else {
-                        check_mdbx(mdbx_cursor_del(cursor, MDBX_CURRENT), "Failed to erase surplus record");
+                        check_mdbx(mdbx_cursor_del(cursor.get(), MDBX_CURRENT), "Failed to erase surplus record");
                     }
                 }
                 if (rc != MDBX_NOTFOUND) {
                     check_mdbx(rc, "Failed to scan multi-value table");
                 }
-                mdbx_cursor_close(cursor);
-            } catch (...) {
-                mdbx_cursor_close(cursor);
-                throw;
             }
 
             PairCountMap inserted;
@@ -917,29 +941,23 @@ namespace mdbxc {
         }
 
         void db_find(const KeyT& key, std::vector<ValueT>& values, MDBX_txn* txn) const {
-            MDBX_cursor* cursor = nullptr;
-            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
-            try {
-                SerializeScratch sc_key;
-                MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
-                MDBX_val db_val;
-                int rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_SET_KEY);
-                if (rc == MDBX_NOTFOUND) {
-                    mdbx_cursor_close(cursor);
-                    return;
-                }
-                check_mdbx(rc, "Failed to seek key");
-                while (rc == MDBX_SUCCESS) {
-                    values.emplace_back(deserialize_value<ValueT>(strip_sequence(db_val)));
-                    rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT_DUP);
-                }
-                if (rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc, "Failed to read duplicate values");
-                }
-                mdbx_cursor_close(cursor);
-            } catch (...) {
-                mdbx_cursor_close(cursor);
-                throw;
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_KEY);
+            if (rc == MDBX_NOTFOUND) {
+                return;
+            }
+            check_mdbx(rc, "Failed to seek key");
+            while (rc == MDBX_SUCCESS) {
+                values.emplace_back(deserialize_value<ValueT>(strip_sequence(db_val)));
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT_DUP);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to read duplicate values");
             }
         }
 
@@ -965,59 +983,47 @@ namespace mdbxc {
         }
 
         std::size_t db_count_key(const KeyT& key, MDBX_txn* txn) const {
-            MDBX_cursor* cursor = nullptr;
-            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
-            try {
-                SerializeScratch sc_key;
-                MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
-                MDBX_val db_val;
-                int rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_SET_KEY);
-                if (rc == MDBX_NOTFOUND) {
-                    mdbx_cursor_close(cursor);
-                    return 0;
-                }
-                check_mdbx(rc, "Failed to seek key");
-                size_t found = 0;
-                check_mdbx(mdbx_cursor_count(cursor, &found), "Failed to count duplicate values");
-                mdbx_cursor_close(cursor);
-                return found;
-            } catch (...) {
-                mdbx_cursor_close(cursor);
-                throw;
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_KEY);
+            if (rc == MDBX_NOTFOUND) {
+                return 0;
             }
+            check_mdbx(rc, "Failed to seek key");
+            size_t found = 0;
+            check_mdbx(mdbx_cursor_count(cursor.get(), &found), "Failed to count duplicate values");
+            return found;
         }
 
         std::size_t db_count_pair(const KeyT& key, const ValueT& value, MDBX_txn* txn) const {
-            MDBX_cursor* cursor = nullptr;
-            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
-            try {
-                SerializeScratch sc_key;
-                SerializeScratch sc_value;
-                MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
-                MDBX_val raw_value = make_comparable_value(value, sc_value);
-                MDBX_val db_val;
-                int rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_SET_KEY);
-                if (rc == MDBX_NOTFOUND) {
-                    mdbx_cursor_close(cursor);
-                    return 0;
-                }
-                check_mdbx(rc, "Failed to seek key");
-                std::size_t found = 0;
-                while (rc == MDBX_SUCCESS) {
-                    if (stored_value_matches(db_val, raw_value)) {
-                        ++found;
-                    }
-                    rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT_DUP);
-                }
-                if (rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc, "Failed to scan duplicate values");
-                }
-                mdbx_cursor_close(cursor);
-                return found;
-            } catch (...) {
-                mdbx_cursor_close(cursor);
-                throw;
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            SerializeScratch sc_key;
+            SerializeScratch sc_value;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val raw_value = make_comparable_value(value, sc_value);
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_KEY);
+            if (rc == MDBX_NOTFOUND) {
+                return 0;
             }
+            check_mdbx(rc, "Failed to seek key");
+            std::size_t found = 0;
+            while (rc == MDBX_SUCCESS) {
+                if (stored_value_matches(db_val, raw_value)) {
+                    ++found;
+                }
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT_DUP);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to scan duplicate values");
+            }
+            return found;
         }
 
         bool db_erase_key(const KeyT& key, MDBX_txn* txn) {
@@ -1031,38 +1037,32 @@ namespace mdbxc {
         }
 
         std::size_t db_erase_pair(const KeyT& key, const ValueT& value, MDBX_txn* txn) {
-            MDBX_cursor* cursor = nullptr;
-            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
-            try {
-                SerializeScratch sc_key;
-                SerializeScratch sc_value;
-                MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
-                MDBX_val raw_value = make_comparable_value(value, sc_value);
-                MDBX_val db_val;
-                int rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_SET_KEY);
-                if (rc == MDBX_NOTFOUND) {
-                    mdbx_cursor_close(cursor);
-                    return 0;
-                }
-                check_mdbx(rc, "Failed to seek key");
-                std::size_t removed = 0;
-                while (rc == MDBX_SUCCESS) {
-                    bool should_remove = stored_value_matches(db_val, raw_value);
-                    if (should_remove) {
-                        check_mdbx(mdbx_cursor_del(cursor, MDBX_CURRENT), "Failed to erase duplicate value");
-                        ++removed;
-                    }
-                    rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT_DUP);
-                }
-                if (rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc, "Failed to scan duplicate values");
-                }
-                mdbx_cursor_close(cursor);
-                return removed;
-            } catch (...) {
-                mdbx_cursor_close(cursor);
-                throw;
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            SerializeScratch sc_key;
+            SerializeScratch sc_value;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val raw_value = make_comparable_value(value, sc_value);
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_KEY);
+            if (rc == MDBX_NOTFOUND) {
+                return 0;
             }
+            check_mdbx(rc, "Failed to seek key");
+            std::size_t removed = 0;
+            while (rc == MDBX_SUCCESS) {
+                bool should_remove = stored_value_matches(db_val, raw_value);
+                if (should_remove) {
+                    check_mdbx(mdbx_cursor_del(cursor.get(), MDBX_CURRENT), "Failed to erase duplicate value");
+                    ++removed;
+                }
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT_DUP);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to scan duplicate values");
+            }
+            return removed;
         }
 
         void db_clear(MDBX_txn* txn) {

--- a/include/mdbx_containers/KeyMultiValueTable.hpp
+++ b/include/mdbx_containers/KeyMultiValueTable.hpp
@@ -189,6 +189,34 @@ namespace mdbxc {
             return retrieve_all_vector(txn.handle());
         }
 
+        /// \brief Retrieves values whose keys are within an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Optional transaction handle.
+        /// \return Vector of values in MDBX key order.
+        /// \throws MdbxException if a database error occurs.
+        /// \complexity O(log n + m), where m is the number of returned values.
+        std::vector<ValueT> range(const KeyT& from_key, const KeyT& to_key,
+                                  MDBX_txn* txn = nullptr) const {
+            std::vector<ValueT> values;
+            with_transaction([this, &from_key, &to_key, &values](MDBX_txn* t) {
+                db_range(from_key, to_key, values, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return values;
+        }
+
+        /// \brief Retrieves values whose keys are within an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Active transaction wrapper.
+        /// \return Vector of values in MDBX key order.
+        /// \throws MdbxException if a database error occurs.
+        /// \complexity O(log n + m), where m is the number of returned values.
+        std::vector<ValueT> range(const KeyT& from_key, const KeyT& to_key,
+                                  const Transaction& txn) const {
+            return range(from_key, to_key, txn.handle());
+        }
+
         /// \brief Appends pairs to the table.
         /// \tparam ContainerT Container type storing pairs.
         /// \param container Source pairs.
@@ -695,6 +723,35 @@ namespace mdbxc {
                 }
                 if (rc != MDBX_NOTFOUND) {
                     check_mdbx(rc, "Failed to read multi-value table");
+                }
+                mdbx_cursor_close(cursor);
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+        }
+
+        void db_range(const KeyT& from_key, const KeyT& to_key,
+                      std::vector<ValueT>& values, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
+
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
+            try {
+                MDBX_val db_key = db_from_key;
+                MDBX_val db_val;
+                int rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_SET_RANGE);
+                while (rc == MDBX_SUCCESS) {
+                    if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
+                    values.emplace_back(deserialize_value<ValueT>(strip_sequence(db_val)));
+                    rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "Failed to read multi-value key range");
                 }
                 mdbx_cursor_close(cursor);
             } catch (...) {

--- a/include/mdbx_containers/KeyTable.hpp
+++ b/include/mdbx_containers/KeyTable.hpp
@@ -366,13 +366,17 @@ namespace mdbxc {
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
+            bool stopped_by_upper_bound = false;
             int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
             while (rc == MDBX_SUCCESS) {
-                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    stopped_by_upper_bound = true;
+                    break;
+                }
                 out.emplace_back(deserialize_key<KeyT>(db_key));
                 rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
             }
-            if (rc != MDBX_NOTFOUND) {
+            if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
                 check_mdbx(rc, "Failed to read key range");
             }
         }

--- a/include/mdbx_containers/KeyTable.hpp
+++ b/include/mdbx_containers/KeyTable.hpp
@@ -122,6 +122,34 @@ namespace mdbxc {
             return retrieve_all<ContainerT>(txn.handle());
         }
 
+        /// \brief Retrieves keys within an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Optional transaction handle.
+        /// \return Vector of keys in MDBX key order.
+        /// \throws MdbxException if a database error occurs.
+        /// \complexity O(log n + m), where m is the number of returned keys.
+        std::vector<KeyT> range(const KeyT& from_key, const KeyT& to_key,
+                                MDBX_txn* txn = nullptr) const {
+            std::vector<KeyT> out;
+            with_transaction([this, &from_key, &to_key, &out](MDBX_txn* t) {
+                db_range(from_key, to_key, out, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return out;
+        }
+
+        /// \brief Retrieves keys within an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Active transaction wrapper.
+        /// \return Vector of keys in MDBX key order.
+        /// \throws MdbxException if a database error occurs.
+        /// \complexity O(log n + m), where m is the number of returned keys.
+        std::vector<KeyT> range(const KeyT& from_key, const KeyT& to_key,
+                                const Transaction& txn) const {
+            return range(from_key, to_key, txn.handle());
+        }
+
         /// \brief Appends keys to the table.
         /// \tparam ContainerT Container type storing keys.
         /// \param container Source keys.
@@ -317,6 +345,35 @@ namespace mdbxc {
                 }
                 if (rc != MDBX_NOTFOUND) {
                     check_mdbx(rc, "Failed to read key table");
+                }
+                mdbx_cursor_close(cursor);
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+        }
+
+        void db_range(const KeyT& from_key, const KeyT& to_key,
+                      std::vector<KeyT>& out, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
+
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
+            try {
+                MDBX_val db_key = db_from_key;
+                MDBX_val db_val;
+                int rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_SET_RANGE);
+                while (rc == MDBX_SUCCESS) {
+                    if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
+                    out.emplace_back(deserialize_value<KeyT>(db_key));
+                    rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "Failed to read key range");
                 }
                 mdbx_cursor_close(cursor);
             } catch (...) {

--- a/include/mdbx_containers/KeyTable.hpp
+++ b/include/mdbx_containers/KeyTable.hpp
@@ -341,7 +341,7 @@ namespace mdbxc {
                 MDBX_val db_key, db_val;
                 int rc = MDBX_SUCCESS;
                 while ((rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
-                    container.insert(container.end(), deserialize_value<KeyT>(db_key));
+                    container.insert(container.end(), deserialize_key<KeyT>(db_key));
                 }
                 if (rc != MDBX_NOTFOUND) {
                     check_mdbx(rc, "Failed to read key table");
@@ -369,7 +369,7 @@ namespace mdbxc {
                 int rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_SET_RANGE);
                 while (rc == MDBX_SUCCESS) {
                     if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
-                    out.emplace_back(deserialize_value<KeyT>(db_key));
+                    out.emplace_back(deserialize_key<KeyT>(db_key));
                     rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT);
                 }
                 if (rc != MDBX_NOTFOUND) {

--- a/include/mdbx_containers/KeyTable.hpp
+++ b/include/mdbx_containers/KeyTable.hpp
@@ -361,24 +361,19 @@ namespace mdbxc {
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
             if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
-            MDBX_cursor* cursor = nullptr;
-            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
-            try {
-                MDBX_val db_key = db_from_key;
-                MDBX_val db_val;
-                int rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_SET_RANGE);
-                while (rc == MDBX_SUCCESS) {
-                    if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
-                    out.emplace_back(deserialize_key<KeyT>(db_key));
-                    rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT);
-                }
-                if (rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc, "Failed to read key range");
-                }
-                mdbx_cursor_close(cursor);
-            } catch (...) {
-                mdbx_cursor_close(cursor);
-                throw;
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_from_key;
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            while (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
+                out.emplace_back(deserialize_key<KeyT>(db_key));
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to read key range");
             }
         }
 

--- a/include/mdbx_containers/KeyTable.hpp
+++ b/include/mdbx_containers/KeyTable.hpp
@@ -123,15 +123,19 @@ namespace mdbxc {
         }
 
         /// \brief Retrieves keys within an inclusive key range.
+        /// \tparam ContainerT Container type storing keys.
         /// \param from_key Start key in MDBX key order.
         /// \param to_key End key in MDBX key order.
         /// \param txn Optional transaction handle.
-        /// \return Vector of keys in MDBX key order.
+        /// \return Container with keys from the requested range.
         /// \throws MdbxException if a database error occurs.
+        /// \note The default \c std::set preserves key-only table semantics.
+        ///       Use \c range<std::vector>() to preserve MDBX iteration order.
         /// \complexity O(log n + m), where m is the number of returned keys.
-        std::vector<KeyT> range(const KeyT& from_key, const KeyT& to_key,
-                                MDBX_txn* txn = nullptr) const {
-            std::vector<KeyT> out;
+        template<template<class...> class ContainerT = std::set>
+        ContainerT<KeyT> range(const KeyT& from_key, const KeyT& to_key,
+                               MDBX_txn* txn = nullptr) const {
+            ContainerT<KeyT> out;
             with_transaction([this, &from_key, &to_key, &out](MDBX_txn* t) {
                 db_range(from_key, to_key, out, t);
             }, TransactionMode::READ_ONLY, txn);
@@ -139,15 +143,17 @@ namespace mdbxc {
         }
 
         /// \brief Retrieves keys within an inclusive key range.
+        /// \tparam ContainerT Container type storing keys.
         /// \param from_key Start key in MDBX key order.
         /// \param to_key End key in MDBX key order.
         /// \param txn Active transaction wrapper.
-        /// \return Vector of keys in MDBX key order.
+        /// \return Container with keys from the requested range.
         /// \throws MdbxException if a database error occurs.
         /// \complexity O(log n + m), where m is the number of returned keys.
-        std::vector<KeyT> range(const KeyT& from_key, const KeyT& to_key,
-                                const Transaction& txn) const {
-            return range(from_key, to_key, txn.handle());
+        template<template<class...> class ContainerT = std::set>
+        ContainerT<KeyT> range(const KeyT& from_key, const KeyT& to_key,
+                               const Transaction& txn) const {
+            return range<ContainerT>(from_key, to_key, txn.handle());
         }
 
         /// \brief Appends keys to the table.
@@ -335,26 +341,22 @@ namespace mdbxc {
 
         template<template<class...> class ContainerT>
         void db_load(ContainerT<KeyT>& container, MDBX_txn* txn) const {
-            MDBX_cursor* cursor = nullptr;
-            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
-            try {
-                MDBX_val db_key, db_val;
-                int rc = MDBX_SUCCESS;
-                while ((rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
-                    container.insert(container.end(), deserialize_key<KeyT>(db_key));
-                }
-                if (rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc, "Failed to read key table");
-                }
-                mdbx_cursor_close(cursor);
-            } catch (...) {
-                mdbx_cursor_close(cursor);
-                throw;
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key, db_val;
+            int rc = MDBX_SUCCESS;
+            while ((rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
+                container.insert(container.end(), deserialize_key<KeyT>(db_key));
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to read key table");
             }
         }
 
+        template<class ContainerT>
         void db_range(const KeyT& from_key, const KeyT& to_key,
-                      std::vector<KeyT>& out, MDBX_txn* txn) const {
+                      ContainerT& out, MDBX_txn* txn) const {
             SerializeScratch sc_from_key;
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
@@ -373,7 +375,7 @@ namespace mdbxc {
                     stopped_by_upper_bound = true;
                     break;
                 }
-                out.emplace_back(deserialize_key<KeyT>(db_key));
+                out.insert(out.end(), deserialize_key<KeyT>(db_key));
                 rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
             }
             if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {

--- a/include/mdbx_containers/KeyValueTable.hpp
+++ b/include/mdbx_containers/KeyValueTable.hpp
@@ -39,6 +39,7 @@ namespace mdbxc {
     template<class KeyT, class ValueT, class Options = DefaultTableOptions>
     class KeyValueTable final : public BaseTable {
     public:
+        typedef std::pair<KeyT, ValueT> value_type;
 
         /// \brief Default constructor.
         /// \param connection Existing \ref Connection instance.
@@ -294,6 +295,34 @@ namespace mdbxc {
         }
 #endif
 
+        /// \brief Retrieves key-value pairs within an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Optional transaction handle.
+        /// \return Vector of key-value pairs in MDBX key order.
+        /// \throws MdbxException if a database error occurs.
+        /// \complexity O(log n + m), where m is the number of returned pairs.
+        std::vector<value_type> range(const KeyT& from_key, const KeyT& to_key,
+                                      MDBX_txn* txn = nullptr) const {
+            std::vector<value_type> pairs;
+            with_transaction([this, &from_key, &to_key, &pairs](MDBX_txn* txn) {
+                db_range(from_key, to_key, pairs, txn);
+            }, TransactionMode::READ_ONLY, txn);
+            return pairs;
+        }
+
+        /// \brief Retrieves key-value pairs within an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Active transaction wrapper.
+        /// \return Vector of key-value pairs in MDBX key order.
+        /// \throws MdbxException if a database error occurs.
+        /// \complexity O(log n + m), where m is the number of returned pairs.
+        std::vector<value_type> range(const KeyT& from_key, const KeyT& to_key,
+                                      const Transaction& txn) const {
+            return range(from_key, to_key, txn.handle());
+        }
+
         /// \brief Retrieves values whose keys are within an inclusive key range.
         /// \param from_key Start key in MDBX key order.
         /// \param to_key End key in MDBX key order.
@@ -301,11 +330,11 @@ namespace mdbxc {
         /// \return Vector of values in MDBX key order.
         /// \throws MdbxException if a database error occurs.
         /// \complexity O(log n + m), where m is the number of returned values.
-        std::vector<ValueT> range(const KeyT& from_key, const KeyT& to_key,
-                                  MDBX_txn* txn = nullptr) const {
+        std::vector<ValueT> range_values(const KeyT& from_key, const KeyT& to_key,
+                                         MDBX_txn* txn = nullptr) const {
             std::vector<ValueT> values;
             with_transaction([this, &from_key, &to_key, &values](MDBX_txn* txn) {
-                db_range(from_key, to_key, values, txn);
+                db_range_values(from_key, to_key, values, txn);
             }, TransactionMode::READ_ONLY, txn);
             return values;
         }
@@ -317,9 +346,9 @@ namespace mdbxc {
         /// \return Vector of values in MDBX key order.
         /// \throws MdbxException if a database error occurs.
         /// \complexity O(log n + m), where m is the number of returned values.
-        std::vector<ValueT> range(const KeyT& from_key, const KeyT& to_key,
-                                  const Transaction& txn) const {
-            return range(from_key, to_key, txn.handle());
+        std::vector<ValueT> range_values(const KeyT& from_key, const KeyT& to_key,
+                                         const Transaction& txn) const {
+            return range_values(from_key, to_key, txn.handle());
         }
 
         /// \brief Appends data to the database.
@@ -809,7 +838,38 @@ namespace mdbxc {
         }
 
         void db_range(const KeyT& from_key, const KeyT& to_key,
-                      std::vector<ValueT>& values, MDBX_txn* txn) const {
+                      std::vector<value_type>& pairs, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
+
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
+            try {
+                MDBX_val db_key = db_from_key;
+                MDBX_val db_val;
+                int rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_SET_RANGE);
+                while (rc == MDBX_SUCCESS) {
+                    if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
+                    KeyT key = deserialize_value<KeyT>(db_key);
+                    ValueT value = deserialize_value<ValueT>(db_val);
+                    pairs.emplace_back(std::move(key), std::move(value));
+                    rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "Failed to read key-value range");
+                }
+                mdbx_cursor_close(cursor);
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+        }
+
+        void db_range_values(const KeyT& from_key, const KeyT& to_key,
+                             std::vector<ValueT>& values, MDBX_txn* txn) const {
             SerializeScratch sc_from_key;
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
@@ -828,7 +888,7 @@ namespace mdbxc {
                     rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT);
                 }
                 if (rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc, "Failed to read key-value range");
+                    check_mdbx(rc, "Failed to read key-value range values");
                 }
                 mdbx_cursor_close(cursor);
             } catch (...) {

--- a/include/mdbx_containers/KeyValueTable.hpp
+++ b/include/mdbx_containers/KeyValueTable.hpp
@@ -798,7 +798,7 @@ namespace mdbxc {
                 MDBX_val db_key, db_val;
                 int rc = MDBX_SUCCESS;
                 while ((rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
-                    KeyT key = deserialize_value<KeyT>(db_key);
+                    KeyT key = deserialize_key<KeyT>(db_key);
                     ValueT value = deserialize_value<ValueT>(db_val);
                     container.emplace(std::move(key), std::move(value));
                 }
@@ -823,7 +823,7 @@ namespace mdbxc {
                 MDBX_val db_key, db_val;
                 int rc = MDBX_SUCCESS;
                 while ((rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
-                    KeyT key = deserialize_value<KeyT>(db_key);
+                    KeyT key = deserialize_key<KeyT>(db_key);
                     ValueT value = deserialize_value<ValueT>(db_val);
                     out_vector.emplace_back(std::move(key), std::move(value));
                 }
@@ -853,7 +853,7 @@ namespace mdbxc {
                 int rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_SET_RANGE);
                 while (rc == MDBX_SUCCESS) {
                     if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
-                    KeyT key = deserialize_value<KeyT>(db_key);
+                    KeyT key = deserialize_key<KeyT>(db_key);
                     ValueT value = deserialize_value<ValueT>(db_val);
                     pairs.emplace_back(std::move(key), std::move(value));
                     rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT);
@@ -1022,7 +1022,7 @@ namespace mdbxc {
                 MDBX_val db_key, db_val;
                 int rc = MDBX_SUCCESS;
                 while ((rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
-                    KeyT key = deserialize_value<KeyT>(db_key);
+                    KeyT key = deserialize_key<KeyT>(db_key);
                     if (new_keys.find(key) == new_keys.end()) {
                         check_mdbx(mdbx_cursor_del(cursor, MDBX_CURRENT), "Failed to delete record using cursor");
                     }
@@ -1069,7 +1069,7 @@ namespace mdbxc {
                 MDBX_val db_key, db_val;
                 int rc = MDBX_SUCCESS;
                 while ((rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
-                    KeyT key = deserialize_value<KeyT>(db_key);
+                    KeyT key = deserialize_key<KeyT>(db_key);
                     if (new_keys.find(key) == new_keys.end()) {
                         check_mdbx(mdbx_cursor_del(cursor, MDBX_CURRENT), "Failed to delete record using cursor");
                     }

--- a/include/mdbx_containers/KeyValueTable.hpp
+++ b/include/mdbx_containers/KeyValueTable.hpp
@@ -294,6 +294,34 @@ namespace mdbxc {
         }
 #endif
 
+        /// \brief Retrieves values whose keys are within an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Optional transaction handle.
+        /// \return Vector of values in MDBX key order.
+        /// \throws MdbxException if a database error occurs.
+        /// \complexity O(log n + m), where m is the number of returned values.
+        std::vector<ValueT> range(const KeyT& from_key, const KeyT& to_key,
+                                  MDBX_txn* txn = nullptr) const {
+            std::vector<ValueT> values;
+            with_transaction([this, &from_key, &to_key, &values](MDBX_txn* txn) {
+                db_range(from_key, to_key, values, txn);
+            }, TransactionMode::READ_ONLY, txn);
+            return values;
+        }
+
+        /// \brief Retrieves values whose keys are within an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Active transaction wrapper.
+        /// \return Vector of values in MDBX key order.
+        /// \throws MdbxException if a database error occurs.
+        /// \complexity O(log n + m), where m is the number of returned values.
+        std::vector<ValueT> range(const KeyT& from_key, const KeyT& to_key,
+                                  const Transaction& txn) const {
+            return range(from_key, to_key, txn.handle());
+        }
+
         /// \brief Appends data to the database.
         /// \tparam ContainerT Container type (e.g., std::map or std::unordered_map).
         /// \param container Container with content to be synchronized.
@@ -772,6 +800,35 @@ namespace mdbxc {
                 }
                 if (rc != MDBX_NOTFOUND) {
                     check_mdbx(rc, "Failed to load key-value table");
+                }
+                mdbx_cursor_close(cursor);
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+        }
+
+        void db_range(const KeyT& from_key, const KeyT& to_key,
+                      std::vector<ValueT>& values, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
+
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
+            try {
+                MDBX_val db_key = db_from_key;
+                MDBX_val db_val;
+                int rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_SET_RANGE);
+                while (rc == MDBX_SUCCESS) {
+                    if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
+                    values.emplace_back(deserialize_value<ValueT>(db_val));
+                    rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "Failed to read key-value range");
                 }
                 mdbx_cursor_close(cursor);
             } catch (...) {

--- a/include/mdbx_containers/KeyValueTable.hpp
+++ b/include/mdbx_containers/KeyValueTable.hpp
@@ -850,15 +850,19 @@ namespace mdbxc {
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
+            bool stopped_by_upper_bound = false;
             int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
             while (rc == MDBX_SUCCESS) {
-                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    stopped_by_upper_bound = true;
+                    break;
+                }
                 KeyT key = deserialize_key<KeyT>(db_key);
                 ValueT value = deserialize_value<ValueT>(db_val);
                 pairs.emplace_back(std::move(key), std::move(value));
                 rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
             }
-            if (rc != MDBX_NOTFOUND) {
+            if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
                 check_mdbx(rc, "Failed to read key-value range");
             }
         }
@@ -876,13 +880,17 @@ namespace mdbxc {
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
+            bool stopped_by_upper_bound = false;
             int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
             while (rc == MDBX_SUCCESS) {
-                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    stopped_by_upper_bound = true;
+                    break;
+                }
                 values.emplace_back(deserialize_value<ValueT>(db_val));
                 rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
             }
-            if (rc != MDBX_NOTFOUND) {
+            if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
                 check_mdbx(rc, "Failed to read key-value range values");
             }
         }

--- a/include/mdbx_containers/KeyValueTable.hpp
+++ b/include/mdbx_containers/KeyValueTable.hpp
@@ -845,26 +845,21 @@ namespace mdbxc {
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
             if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
-            MDBX_cursor* cursor = nullptr;
-            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
-            try {
-                MDBX_val db_key = db_from_key;
-                MDBX_val db_val;
-                int rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_SET_RANGE);
-                while (rc == MDBX_SUCCESS) {
-                    if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
-                    KeyT key = deserialize_key<KeyT>(db_key);
-                    ValueT value = deserialize_value<ValueT>(db_val);
-                    pairs.emplace_back(std::move(key), std::move(value));
-                    rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT);
-                }
-                if (rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc, "Failed to read key-value range");
-                }
-                mdbx_cursor_close(cursor);
-            } catch (...) {
-                mdbx_cursor_close(cursor);
-                throw;
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_from_key;
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            while (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
+                KeyT key = deserialize_key<KeyT>(db_key);
+                ValueT value = deserialize_value<ValueT>(db_val);
+                pairs.emplace_back(std::move(key), std::move(value));
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to read key-value range");
             }
         }
 
@@ -876,24 +871,19 @@ namespace mdbxc {
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
             if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
-            MDBX_cursor* cursor = nullptr;
-            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
-            try {
-                MDBX_val db_key = db_from_key;
-                MDBX_val db_val;
-                int rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_SET_RANGE);
-                while (rc == MDBX_SUCCESS) {
-                    if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
-                    values.emplace_back(deserialize_value<ValueT>(db_val));
-                    rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT);
-                }
-                if (rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc, "Failed to read key-value range values");
-                }
-                mdbx_cursor_close(cursor);
-            } catch (...) {
-                mdbx_cursor_close(cursor);
-                throw;
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_from_key;
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            while (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) break;
+                values.emplace_back(deserialize_value<ValueT>(db_val));
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to read key-value range values");
             }
         }
 

--- a/include/mdbx_containers/KeyValueTable.hpp
+++ b/include/mdbx_containers/KeyValueTable.hpp
@@ -14,6 +14,18 @@
 
 namespace mdbxc {
 
+    namespace detail {
+        template<template<class...> class ContainerT, class KeyT, class ValueT>
+        struct KeyValuePairRangeContainer {
+            typedef ContainerT<KeyT, ValueT> type;
+        };
+
+        template<class KeyT, class ValueT>
+        struct KeyValuePairRangeContainer<std::vector, KeyT, ValueT> {
+            typedef std::vector<std::pair<KeyT, ValueT> > type;
+        };
+    }
+
     /// \class KeyValueTable
     /// \ingroup mdbxc_tables
     /// \brief Map-like table persisted in MDBX.
@@ -296,15 +308,21 @@ namespace mdbxc {
 #endif
 
         /// \brief Retrieves key-value pairs within an inclusive key range.
+        /// \tparam ContainerT Container type storing key-value pairs.
         /// \param from_key Start key in MDBX key order.
         /// \param to_key End key in MDBX key order.
         /// \param txn Optional transaction handle.
-        /// \return Vector of key-value pairs in MDBX key order.
+        /// \return Container with key-value pairs from the requested range.
         /// \throws MdbxException if a database error occurs.
+        /// \note The default \c std::map matches unique-key table semantics.
+        ///       Use \c range<std::vector>() to preserve MDBX iteration order.
         /// \complexity O(log n + m), where m is the number of returned pairs.
-        std::vector<value_type> range(const KeyT& from_key, const KeyT& to_key,
-                                      MDBX_txn* txn = nullptr) const {
-            std::vector<value_type> pairs;
+        template<template<class...> class ContainerT = std::map>
+        typename detail::KeyValuePairRangeContainer<ContainerT, KeyT, ValueT>::type
+        range(const KeyT& from_key, const KeyT& to_key,
+              MDBX_txn* txn = nullptr) const {
+            typedef typename detail::KeyValuePairRangeContainer<ContainerT, KeyT, ValueT>::type ReturnT;
+            ReturnT pairs;
             with_transaction([this, &from_key, &to_key, &pairs](MDBX_txn* txn) {
                 db_range(from_key, to_key, pairs, txn);
             }, TransactionMode::READ_ONLY, txn);
@@ -312,27 +330,34 @@ namespace mdbxc {
         }
 
         /// \brief Retrieves key-value pairs within an inclusive key range.
+        /// \tparam ContainerT Container type storing key-value pairs.
         /// \param from_key Start key in MDBX key order.
         /// \param to_key End key in MDBX key order.
         /// \param txn Active transaction wrapper.
-        /// \return Vector of key-value pairs in MDBX key order.
+        /// \return Container with key-value pairs from the requested range.
         /// \throws MdbxException if a database error occurs.
         /// \complexity O(log n + m), where m is the number of returned pairs.
-        std::vector<value_type> range(const KeyT& from_key, const KeyT& to_key,
-                                      const Transaction& txn) const {
-            return range(from_key, to_key, txn.handle());
+        template<template<class...> class ContainerT = std::map>
+        typename detail::KeyValuePairRangeContainer<ContainerT, KeyT, ValueT>::type
+        range(const KeyT& from_key, const KeyT& to_key,
+              const Transaction& txn) const {
+            return range<ContainerT>(from_key, to_key, txn.handle());
         }
 
         /// \brief Retrieves values whose keys are within an inclusive key range.
+        /// \tparam ContainerT Container type storing values.
         /// \param from_key Start key in MDBX key order.
         /// \param to_key End key in MDBX key order.
         /// \param txn Optional transaction handle.
-        /// \return Vector of values in MDBX key order.
+        /// \return Container with values from the requested range.
         /// \throws MdbxException if a database error occurs.
+        /// \note The default \c std::vector preserves MDBX iteration order and
+        ///       duplicate values. Associative containers apply their own rules.
         /// \complexity O(log n + m), where m is the number of returned values.
-        std::vector<ValueT> range_values(const KeyT& from_key, const KeyT& to_key,
-                                         MDBX_txn* txn = nullptr) const {
-            std::vector<ValueT> values;
+        template<template<class...> class ContainerT = std::vector>
+        ContainerT<ValueT> range_values(const KeyT& from_key, const KeyT& to_key,
+                                        MDBX_txn* txn = nullptr) const {
+            ContainerT<ValueT> values;
             with_transaction([this, &from_key, &to_key, &values](MDBX_txn* txn) {
                 db_range_values(from_key, to_key, values, txn);
             }, TransactionMode::READ_ONLY, txn);
@@ -340,15 +365,17 @@ namespace mdbxc {
         }
 
         /// \brief Retrieves values whose keys are within an inclusive key range.
+        /// \tparam ContainerT Container type storing values.
         /// \param from_key Start key in MDBX key order.
         /// \param to_key End key in MDBX key order.
         /// \param txn Active transaction wrapper.
-        /// \return Vector of values in MDBX key order.
+        /// \return Container with values from the requested range.
         /// \throws MdbxException if a database error occurs.
         /// \complexity O(log n + m), where m is the number of returned values.
-        std::vector<ValueT> range_values(const KeyT& from_key, const KeyT& to_key,
-                                         const Transaction& txn) const {
-            return range_values(from_key, to_key, txn.handle());
+        template<template<class...> class ContainerT = std::vector>
+        ContainerT<ValueT> range_values(const KeyT& from_key, const KeyT& to_key,
+                                        const Transaction& txn) const {
+            return range_values<ContainerT>(from_key, to_key, txn.handle());
         }
 
         /// \brief Appends data to the database.
@@ -792,23 +819,18 @@ namespace mdbxc {
         /// \throws MdbxException if a database error occurs.
         template<template <class...> class ContainerT>
         void db_load(ContainerT<KeyT, ValueT>& container, MDBX_txn* txn_handle) {
-            MDBX_cursor* cursor = nullptr;
-            check_mdbx(mdbx_cursor_open(txn_handle, m_dbi, &cursor), "Failed to open MDBX cursor");
-            try {
-                MDBX_val db_key, db_val;
-                int rc = MDBX_SUCCESS;
-                while ((rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
-                    KeyT key = deserialize_key<KeyT>(db_key);
-                    ValueT value = deserialize_value<ValueT>(db_val);
-                    container.emplace(std::move(key), std::move(value));
-                }
-                if (rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc, "Failed to load key-value table");
-                }
-                mdbx_cursor_close(cursor);
-            } catch (...) {
-                mdbx_cursor_close(cursor);
-                throw;
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn_handle, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key, db_val;
+            int rc = MDBX_SUCCESS;
+            while ((rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
+                KeyT key = deserialize_key<KeyT>(db_key);
+                ValueT value = deserialize_value<ValueT>(db_val);
+                container.emplace(std::move(key), std::move(value));
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to load key-value table");
             }
         }
         
@@ -817,28 +839,24 @@ namespace mdbxc {
         /// \param txn Optional transaction.
         /// \throws MdbxException if a database error occurs.
         void db_load(std::vector<std::pair<KeyT, ValueT>>& out_vector, MDBX_txn* txn) {
-            MDBX_cursor* cursor = nullptr;
-            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor), "Failed to open MDBX cursor");
-            try {
-                MDBX_val db_key, db_val;
-                int rc = MDBX_SUCCESS;
-                while ((rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
-                    KeyT key = deserialize_key<KeyT>(db_key);
-                    ValueT value = deserialize_value<ValueT>(db_val);
-                    out_vector.emplace_back(std::move(key), std::move(value));
-                }
-                if (rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc, "Failed to load key-value table");
-                }
-                mdbx_cursor_close(cursor);
-            } catch (...) {
-                mdbx_cursor_close(cursor);
-                throw;
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key, db_val;
+            int rc = MDBX_SUCCESS;
+            while ((rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
+                KeyT key = deserialize_key<KeyT>(db_key);
+                ValueT value = deserialize_value<ValueT>(db_val);
+                out_vector.emplace_back(std::move(key), std::move(value));
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to load key-value table");
             }
         }
 
+        template<class ContainerT>
         void db_range(const KeyT& from_key, const KeyT& to_key,
-                      std::vector<value_type>& pairs, MDBX_txn* txn) const {
+                      ContainerT& pairs, MDBX_txn* txn) const {
             SerializeScratch sc_from_key;
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
@@ -859,7 +877,7 @@ namespace mdbxc {
                 }
                 KeyT key = deserialize_key<KeyT>(db_key);
                 ValueT value = deserialize_value<ValueT>(db_val);
-                pairs.emplace_back(std::move(key), std::move(value));
+                pairs.insert(pairs.end(), value_type(std::move(key), std::move(value)));
                 rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
             }
             if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
@@ -867,8 +885,9 @@ namespace mdbxc {
             }
         }
 
+        template<class ContainerT>
         void db_range_values(const KeyT& from_key, const KeyT& to_key,
-                             std::vector<ValueT>& values, MDBX_txn* txn) const {
+                             ContainerT& values, MDBX_txn* txn) const {
             SerializeScratch sc_from_key;
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
@@ -887,7 +906,7 @@ namespace mdbxc {
                     stopped_by_upper_bound = true;
                     break;
                 }
-                values.emplace_back(deserialize_value<ValueT>(db_val));
+                values.insert(values.end(), deserialize_value<ValueT>(db_val));
                 rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
             }
             if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
@@ -1014,24 +1033,19 @@ namespace mdbxc {
             }
 
             // 2. Iterate over existing keys in the DB and remove the extras
-            MDBX_cursor* cursor = nullptr;
-            check_mdbx(mdbx_cursor_open(txn_handle, m_dbi, &cursor), "Failed to open MDBX cursor");
-            try {
-                MDBX_val db_key, db_val;
-                int rc = MDBX_SUCCESS;
-                while ((rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
-                    KeyT key = deserialize_key<KeyT>(db_key);
-                    if (new_keys.find(key) == new_keys.end()) {
-                        check_mdbx(mdbx_cursor_del(cursor, MDBX_CURRENT), "Failed to delete record using cursor");
-                    }
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn_handle, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key, db_val;
+            int rc = MDBX_SUCCESS;
+            while ((rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
+                KeyT key = deserialize_key<KeyT>(db_key);
+                if (new_keys.find(key) == new_keys.end()) {
+                    check_mdbx(mdbx_cursor_del(cursor.get(), MDBX_CURRENT), "Failed to delete record using cursor");
                 }
-                if (rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc, "Failed to reconcile key-value table");
-                }
-                mdbx_cursor_close(cursor);
-            } catch (...) {
-                mdbx_cursor_close(cursor);
-                throw;
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to reconcile key-value table");
             }
         }
         
@@ -1061,24 +1075,19 @@ namespace mdbxc {
             }
 
             // 2. Delete stale keys from DB
-            MDBX_cursor* cursor = nullptr;
-            check_mdbx(mdbx_cursor_open(txn_handle, m_dbi, &cursor), "Failed to open MDBX cursor");
-            try {
-                MDBX_val db_key, db_val;
-                int rc = MDBX_SUCCESS;
-                while ((rc = mdbx_cursor_get(cursor, &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
-                    KeyT key = deserialize_key<KeyT>(db_key);
-                    if (new_keys.find(key) == new_keys.end()) {
-                        check_mdbx(mdbx_cursor_del(cursor, MDBX_CURRENT), "Failed to delete record using cursor");
-                    }
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn_handle, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key, db_val;
+            int rc = MDBX_SUCCESS;
+            while ((rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
+                KeyT key = deserialize_key<KeyT>(db_key);
+                if (new_keys.find(key) == new_keys.end()) {
+                    check_mdbx(mdbx_cursor_del(cursor.get(), MDBX_CURRENT), "Failed to delete record using cursor");
                 }
-                if (rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc, "Failed to reconcile key-value table");
-                }
-                mdbx_cursor_close(cursor);
-            } catch (...) {
-                mdbx_cursor_close(cursor);
-                throw;
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to reconcile key-value table");
             }
         }
         

--- a/include/mdbx_containers/SequenceTable.hpp
+++ b/include/mdbx_containers/SequenceTable.hpp
@@ -518,23 +518,6 @@ namespace mdbxc {
             return id;
         }
 
-        struct CursorGuard {
-            MDBX_cursor* m_cursor;
-            explicit CursorGuard(MDBX_cursor* c) : m_cursor(c) {}
-            ~CursorGuard() noexcept { close(); }
-            void close() noexcept {
-                if (m_cursor) {
-                    mdbx_cursor_close(m_cursor);
-                    m_cursor = nullptr;
-                }
-            }
-            MDBX_cursor* get() const noexcept { return m_cursor; }
-            CursorGuard(const CursorGuard&) = delete;
-            CursorGuard& operator=(const CursorGuard&) = delete;
-            CursorGuard(CursorGuard&&) = delete;
-            CursorGuard& operator=(CursorGuard&&) = delete;
-        };
-
         static MDBX_val make_key(uint64_t id, SerializeScratch& sc) {
             return serialize_key<true>(id, sc);
         }

--- a/include/mdbx_containers/SequenceTable.hpp
+++ b/include/mdbx_containers/SequenceTable.hpp
@@ -692,14 +692,18 @@ namespace mdbxc {
             SerializeScratch sc_key;
             MDBX_val db_key = make_key(from, sc_key);
             MDBX_val db_val;
+            bool stopped_by_upper_bound = false;
             int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
             while (rc == MDBX_SUCCESS) {
                 uint64_t id = read_index_key(db_key);
-                if (id > to) break;
+                if (id > to) {
+                    stopped_by_upper_bound = true;
+                    break;
+                }
                 result.push_back(std::make_pair(id, deserialize_value<ValueT>(db_val)));
                 rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
             }
-            if (rc != MDBX_NOTFOUND) {
+            if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
                 check_mdbx(rc, "Failed to iterate range");
             }
             return result;

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -109,6 +109,29 @@ namespace mdbxc {
         }
 
     protected:
+        struct CursorGuard {
+            MDBX_cursor* m_cursor;
+
+            CursorGuard() noexcept : m_cursor(nullptr) {}
+            explicit CursorGuard(MDBX_cursor* cursor) noexcept : m_cursor(cursor) {}
+            ~CursorGuard() noexcept { close(); }
+
+            MDBX_cursor** out() noexcept { return &m_cursor; }
+            MDBX_cursor* get() const noexcept { return m_cursor; }
+
+            void close() noexcept {
+                if (m_cursor) {
+                    mdbx_cursor_close(m_cursor);
+                    m_cursor = nullptr;
+                }
+            }
+
+            CursorGuard(const CursorGuard&) = delete;
+            CursorGuard& operator=(const CursorGuard&) = delete;
+            CursorGuard(CursorGuard&&) = delete;
+            CursorGuard& operator=(CursorGuard&&) = delete;
+        };
+
         std::shared_ptr<Connection>  m_connection;   ///< Shared connection to MDBX environment.
         MDBX_dbi                     m_dbi{};         ///< DBI handle for the opened table.
 

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -110,19 +110,19 @@ namespace mdbxc {
 
     protected:
         struct CursorGuard {
-            MDBX_cursor* m_cursor;
+            MDBX_cursor* cursor;
 
-            CursorGuard() noexcept : m_cursor(nullptr) {}
-            explicit CursorGuard(MDBX_cursor* cursor) noexcept : m_cursor(cursor) {}
+            CursorGuard() noexcept : cursor(nullptr) {}
+            explicit CursorGuard(MDBX_cursor* cursor_handle) noexcept : cursor(cursor_handle) {}
             ~CursorGuard() noexcept { close(); }
 
-            MDBX_cursor** out() noexcept { return &m_cursor; }
-            MDBX_cursor* get() const noexcept { return m_cursor; }
+            MDBX_cursor** out() noexcept { return &cursor; }
+            MDBX_cursor* get() const noexcept { return cursor; }
 
             void close() noexcept {
-                if (m_cursor) {
-                    mdbx_cursor_close(m_cursor);
-                    m_cursor = nullptr;
+                if (cursor) {
+                    mdbx_cursor_close(cursor);
+                    cursor = nullptr;
                 }
             }
 

--- a/include/mdbx_containers/detail/utils.hpp
+++ b/include/mdbx_containers/detail/utils.hpp
@@ -795,6 +795,114 @@ namespace mdbxc {
         return result;
     }
 
+    template<typename T>
+    typename std::enable_if<std::is_same<T, std::string>::value, T>::type
+    deserialize_key(const MDBX_val& val) {
+        return deserialize_value<T>(val);
+    }
+
+    template<typename T>
+    typename std::enable_if<
+#       if __cplusplus >= 201703L
+        std::is_same<T, std::vector<std::byte>>::value ||
+#       endif
+        std::is_same<T, std::vector<uint8_t>>::value ||
+        std::is_same<T, std::vector<char>>::value ||
+        std::is_same<T, std::vector<unsigned char>>::value, T>::type
+    deserialize_key(const MDBX_val& val) {
+        return deserialize_value<T>(val);
+    }
+
+    template<typename T>
+    typename std::enable_if<
+        std::is_integral<T>::value &&
+        (sizeof(T) <= 2), T>::type
+    deserialize_key(const MDBX_val& val) {
+        if (val.iov_len != sizeof(uint32_t)) {
+            throw std::runtime_error("deserialize_key: size mismatch");
+        }
+        uint32_t out;
+        std::memcpy(&out, val.iov_base, sizeof(uint32_t));
+        return static_cast<T>(out);
+    }
+
+    template<typename T>
+    typename std::enable_if<
+        std::is_same<T, int32_t>::value ||
+        std::is_same<T, uint32_t>::value ||
+        std::is_same<T, int64_t>::value ||
+        std::is_same<T, uint64_t>::value, T>::type
+    deserialize_key(const MDBX_val& val) {
+        return deserialize_value<T>(val);
+    }
+
+    inline float float_from_sortable_key(uint32_t key) {
+        uint32_t bits = (key & 0x80000000u) ? (key ^ 0x80000000u) : ~key;
+        float out;
+        std::memcpy(&out, &bits, sizeof(float));
+        return out;
+    }
+
+    inline double double_from_sortable_key(uint64_t key) {
+        uint64_t bits = (key & 0x8000000000000000ull)
+            ? (key ^ 0x8000000000000000ull)
+            : ~key;
+        double out;
+        std::memcpy(&out, &bits, sizeof(double));
+        return out;
+    }
+
+    template<typename T>
+    typename std::enable_if<std::is_same<T, float>::value, T>::type
+    deserialize_key(const MDBX_val& val) {
+        if (val.iov_len != sizeof(uint32_t)) {
+            throw std::runtime_error("deserialize_key: size mismatch");
+        }
+        uint32_t raw;
+        std::memcpy(&raw, val.iov_base, sizeof(uint32_t));
+        return float_from_sortable_key(raw);
+    }
+
+    template<typename T>
+    typename std::enable_if<std::is_same<T, double>::value, T>::type
+    deserialize_key(const MDBX_val& val) {
+        if (val.iov_len != sizeof(uint64_t)) {
+            throw std::runtime_error("deserialize_key: size mismatch");
+        }
+        uint64_t raw;
+        std::memcpy(&raw, val.iov_base, sizeof(uint64_t));
+        return double_from_sortable_key(raw);
+    }
+
+    template <size_t N>
+    inline std::bitset<N> deserialize_key(const MDBX_val& val) {
+        const size_t num_bytes = (N + 7) / 8;
+        if (val.iov_len != num_bytes) {
+            throw std::runtime_error("deserialize_key: size mismatch");
+        }
+        const uint8_t* bytes = static_cast<const uint8_t*>(val.iov_base);
+        std::bitset<N> out;
+        for (size_t i = 0; i < N; ++i) {
+            if (bytes[i / 8] & (1u << (i % 8))) out.set(i);
+        }
+        return out;
+    }
+
+    template<typename T>
+    typename std::enable_if<
+        std::is_trivially_copyable<T>::value &&
+        !std::is_same<T, std::string>::value &&
+        !(std::is_integral<T>::value && sizeof(T) <= 2) &&
+        !std::is_same<T, int32_t>::value &&
+        !std::is_same<T, uint32_t>::value &&
+        !std::is_same<T, float>::value &&
+        !std::is_same<T, int64_t>::value &&
+        !std::is_same<T, uint64_t>::value &&
+        !std::is_same<T, double>::value, T>::type
+    deserialize_key(const MDBX_val& val) {
+        return deserialize_value<T>(val);
+    }
+
 }; // namespace mdbxc
 
 /// @}

--- a/tests/key_multi_value_table_test.cpp
+++ b/tests/key_multi_value_table_test.cpp
@@ -1,6 +1,7 @@
 #include <cassert>
 #include <iostream>
 #include <map>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -63,13 +64,20 @@ int main() {
         range_pairs.push_back(std::make_pair(7, std::string("created")));
         range_pairs.push_back(std::make_pair(7, std::string("sent")));
         range_pairs.push_back(std::make_pair(8, std::string("queued")));
-        assert_vector_equal(table.range(7, 8), range_pairs);
+        std::multimap<int, std::string> range_multimap = table.range(7, 8);
+        assert(range_multimap.size() == 4);
+        assert(range_multimap.count(7) == 3);
+        assert(range_multimap.count(8) == 1);
+        assert_vector_equal(table.range_vector(7, 8), range_pairs);
         assert_vector_equal(table.range_values(7, 8),
                             std::vector<std::string>{"created", "created", "sent", "queued"});
+        assert(table.range_values<std::set>(7, 8) ==
+               (std::set<std::string>{"created", "queued", "sent"}));
 
         std::vector<std::pair<int, std::string> > queued_pair;
         queued_pair.push_back(std::make_pair(8, std::string("queued")));
-        assert_vector_equal(table.range(8, 8), queued_pair);
+        assert(table.range(8, 8).size() == 1);
+        assert_vector_equal(table.range_vector(8, 8), queued_pair);
         assert_vector_equal(table.range_values(8, 8), std::vector<std::string>{"queued"});
         assert(table.range(9, 10).empty());
         assert(table.range(8, 7).empty());
@@ -126,7 +134,8 @@ int main() {
         expected_pairs.push_back(std::make_pair(1, std::string("b")));
         expected_pairs.push_back(std::make_pair(2, std::string("c")));
         expected_pairs.push_back(std::make_pair(2, std::string("d")));
-        assert_vector_equal(table.range(1, 2), expected_pairs);
+        assert(table.range(1, 2).size() == 4);
+        assert_vector_equal(table.range_vector(1, 2), expected_pairs);
         assert_vector_equal(table.range_values(1, 2),
                             std::vector<std::string>{"a", "b", "c", "d"});
     }
@@ -146,7 +155,8 @@ int main() {
         std::vector<std::pair<int, std::string> > one_pairs;
         one_pairs.push_back(std::make_pair(1, std::string("one")));
         one_pairs.push_back(std::make_pair(1, std::string("one")));
-        assert_vector_equal(table.range(1, 1, read_txn), one_pairs);
+        assert(table.range(1, 1, read_txn).size() == 2);
+        assert_vector_equal(table.range_vector(1, 1, read_txn), one_pairs);
         assert_vector_equal(table.range_values(1, 1, read_txn), std::vector<std::string>{"one", "one"});
         read_txn.commit();
     }

--- a/tests/key_multi_value_table_test.cpp
+++ b/tests/key_multi_value_table_test.cpp
@@ -58,6 +58,11 @@ int main() {
         assert(!table.contains(9));
 
         assert_vector_equal(table.find(7), std::vector<std::string>{"created", "created", "sent"});
+        assert_vector_equal(table.range(7, 8),
+                            std::vector<std::string>{"created", "created", "sent", "queued"});
+        assert_vector_equal(table.range(8, 8), std::vector<std::string>{"queued"});
+        assert(table.range(9, 10).empty());
+        assert(table.range(8, 7).empty());
 
         std::multimap<int, std::string> as_multimap;
         table.load(as_multimap);
@@ -108,6 +113,7 @@ int main() {
         auto read_txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
         assert(table.count(1, read_txn) == 2);
         assert(table.count(1, std::string("one"), read_txn) == 2);
+        assert_vector_equal(table.range(1, 1, read_txn), std::vector<std::string>{"one", "one"});
         read_txn.commit();
     }
 

--- a/tests/key_multi_value_table_test.cpp
+++ b/tests/key_multi_value_table_test.cpp
@@ -112,6 +112,26 @@ int main() {
     }
 
     {
+        mdbxc::KeyMultiValueTable<int, std::string> table(conn, "multi_key_range");
+        table.clear();
+
+        table.insert(1, "a");
+        table.insert(1, "b");
+        table.insert(2, "c");
+        table.insert(2, "d");
+        table.insert(3, "e");
+
+        std::vector<std::pair<int, std::string> > expected_pairs;
+        expected_pairs.push_back(std::make_pair(1, std::string("a")));
+        expected_pairs.push_back(std::make_pair(1, std::string("b")));
+        expected_pairs.push_back(std::make_pair(2, std::string("c")));
+        expected_pairs.push_back(std::make_pair(2, std::string("d")));
+        assert_vector_equal(table.range(1, 2), expected_pairs);
+        assert_vector_equal(table.range_values(1, 2),
+                            std::vector<std::string>{"a", "b", "c", "d"});
+    }
+
+    {
         mdbxc::KeyMultiValueTable<int, std::string> table(conn, "manual_multi_values");
         table.clear();
 

--- a/tests/key_multi_value_table_test.cpp
+++ b/tests/key_multi_value_table_test.cpp
@@ -58,9 +58,19 @@ int main() {
         assert(!table.contains(9));
 
         assert_vector_equal(table.find(7), std::vector<std::string>{"created", "created", "sent"});
-        assert_vector_equal(table.range(7, 8),
+        std::vector<std::pair<int, std::string> > range_pairs;
+        range_pairs.push_back(std::make_pair(7, std::string("created")));
+        range_pairs.push_back(std::make_pair(7, std::string("created")));
+        range_pairs.push_back(std::make_pair(7, std::string("sent")));
+        range_pairs.push_back(std::make_pair(8, std::string("queued")));
+        assert_vector_equal(table.range(7, 8), range_pairs);
+        assert_vector_equal(table.range_values(7, 8),
                             std::vector<std::string>{"created", "created", "sent", "queued"});
-        assert_vector_equal(table.range(8, 8), std::vector<std::string>{"queued"});
+
+        std::vector<std::pair<int, std::string> > queued_pair;
+        queued_pair.push_back(std::make_pair(8, std::string("queued")));
+        assert_vector_equal(table.range(8, 8), queued_pair);
+        assert_vector_equal(table.range_values(8, 8), std::vector<std::string>{"queued"});
         assert(table.range(9, 10).empty());
         assert(table.range(8, 7).empty());
 
@@ -113,7 +123,11 @@ int main() {
         auto read_txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
         assert(table.count(1, read_txn) == 2);
         assert(table.count(1, std::string("one"), read_txn) == 2);
-        assert_vector_equal(table.range(1, 1, read_txn), std::vector<std::string>{"one", "one"});
+        std::vector<std::pair<int, std::string> > one_pairs;
+        one_pairs.push_back(std::make_pair(1, std::string("one")));
+        one_pairs.push_back(std::make_pair(1, std::string("one")));
+        assert_vector_equal(table.range(1, 1, read_txn), one_pairs);
+        assert_vector_equal(table.range_values(1, 1, read_txn), std::vector<std::string>{"one", "one"});
         read_txn.commit();
     }
 

--- a/tests/key_table_test.cpp
+++ b/tests/key_table_test.cpp
@@ -35,9 +35,11 @@ int main() {
         assert(as_vector.size() == 2);
 
         assert(table.range("alpha", "beta") ==
+               (std::set<std::string>{"alpha", "beta"}));
+        assert(table.range<std::vector>("alpha", "beta") ==
                (std::vector<std::string>{"alpha", "beta"}));
         assert(table.range("aardvark", "alpha") ==
-               (std::vector<std::string>{"alpha"}));
+               (std::set<std::string>{"alpha"}));
         assert(table.range("gamma", "omega").empty());
         assert(table.range("zeta", "alpha").empty());
 
@@ -70,7 +72,8 @@ int main() {
         auto read_txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
         assert(table.contains(1, read_txn));
         assert(table.count(read_txn) == 2);
-        assert(table.range(1, 2, read_txn) == (std::vector<int>{1, 2}));
+        assert(table.range(1, 2, read_txn) == (std::set<int>{1, 2}));
+        assert(table.range<std::vector>(1, 2, read_txn) == (std::vector<int>{1, 2}));
         read_txn.commit();
     }
 
@@ -82,8 +85,8 @@ int main() {
         assert(fast_table.contains(11));
         assert(fast_table.insert(12));
         assert(safe_table.contains(12));
-        assert(safe_table.range(10, 12) == (std::vector<int>{11, 12}));
-        assert(fast_table.range(12, 12) == (std::vector<int>{12}));
+        assert(safe_table.range(10, 12) == (std::set<int>{11, 12}));
+        assert(fast_table.range(12, 12) == (std::set<int>{12}));
     }
 
     std::cout << "KeyTable test passed.\n";

--- a/tests/key_table_test.cpp
+++ b/tests/key_table_test.cpp
@@ -34,6 +34,13 @@ int main() {
         std::vector<std::string> as_vector = table.retrieve_all<std::vector>();
         assert(as_vector.size() == 2);
 
+        assert(table.range("alpha", "beta") ==
+               (std::vector<std::string>{"alpha", "beta"}));
+        assert(table.range("aardvark", "alpha") ==
+               (std::vector<std::string>{"alpha"}));
+        assert(table.range("gamma", "omega").empty());
+        assert(table.range("zeta", "alpha").empty());
+
         assert(table.erase("alpha"));
         assert(!table.erase("alpha"));
         assert(!table.contains("alpha"));
@@ -63,6 +70,7 @@ int main() {
         auto read_txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
         assert(table.contains(1, read_txn));
         assert(table.count(read_txn) == 2);
+        assert(table.range(1, 2, read_txn) == (std::vector<int>{1, 2}));
         read_txn.commit();
     }
 
@@ -74,6 +82,8 @@ int main() {
         assert(fast_table.contains(11));
         assert(fast_table.insert(12));
         assert(safe_table.contains(12));
+        assert(safe_table.range(10, 12) == (std::vector<int>{11, 12}));
+        assert(fast_table.range(12, 12) == (std::vector<int>{12}));
     }
 
     std::cout << "KeyTable test passed.\n";

--- a/tests/kv_container_all_types_test.cpp
+++ b/tests/kv_container_all_types_test.cpp
@@ -228,13 +228,25 @@ int main() {
         kv.insert_or_assign(4, "four");
         kv.insert_or_assign(5, "five");
 
-        assert(kv.range(2, 4) == (std::vector<std::string>{"two", "four"}));
-        assert(kv.range(0, 1) == (std::vector<std::string>{"one"}));
+        std::vector<std::pair<int, std::string> > middle_pairs;
+        middle_pairs.push_back(std::make_pair(2, std::string("two")));
+        middle_pairs.push_back(std::make_pair(4, std::string("four")));
+        assert(kv.range(2, 4) == middle_pairs);
+        assert(kv.range_values(2, 4) == (std::vector<std::string>{"two", "four"}));
+
+        std::vector<std::pair<int, std::string> > first_pair;
+        first_pair.push_back(std::make_pair(1, std::string("one")));
+        assert(kv.range(0, 1) == first_pair);
+        assert(kv.range_values(0, 1) == (std::vector<std::string>{"one"}));
         assert(kv.range(3, 3).empty());
         assert(kv.range(5, 2).empty());
 
         mdbxc::Transaction read_txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
-        assert(kv.range(1, 2, read_txn) == (std::vector<std::string>{"one", "two"}));
+        std::vector<std::pair<int, std::string> > txn_pairs;
+        txn_pairs.push_back(std::make_pair(1, std::string("one")));
+        txn_pairs.push_back(std::make_pair(2, std::string("two")));
+        assert(kv.range(1, 2, read_txn) == txn_pairs);
+        assert(kv.range_values(1, 2, read_txn) == (std::vector<std::string>{"one", "two"}));
         read_txn.commit();
     }
 

--- a/tests/kv_container_all_types_test.cpp
+++ b/tests/kv_container_all_types_test.cpp
@@ -16,6 +16,7 @@
 #include <utility>
 #include <stdexcept>
 #include <limits>
+#include <map>
 
 #include <mdbx_containers/KeyValueTable.hpp>
 
@@ -232,12 +233,14 @@ int main() {
         std::vector<std::pair<int, std::string> > middle_pairs;
         middle_pairs.push_back(std::make_pair(2, std::string("two")));
         middle_pairs.push_back(std::make_pair(4, std::string("four")));
-        assert(kv.range(2, 4) == middle_pairs);
+        assert((kv.range(2, 4) == std::map<int, std::string>(middle_pairs.begin(), middle_pairs.end())));
+        assert(kv.range<std::vector>(2, 4) == middle_pairs);
         assert(kv.range_values(2, 4) == (std::vector<std::string>{"two", "four"}));
+        assert(kv.range_values<std::set>(2, 4) == (std::set<std::string>{"four", "two"}));
 
         std::vector<std::pair<int, std::string> > first_pair;
         first_pair.push_back(std::make_pair(1, std::string("one")));
-        assert(kv.range(0, 1) == first_pair);
+        assert((kv.range(0, 1) == std::map<int, std::string>(first_pair.begin(), first_pair.end())));
         assert(kv.range_values(0, 1) == (std::vector<std::string>{"one"}));
         assert(kv.range(3, 3).empty());
         assert(kv.range(5, 2).empty());
@@ -246,7 +249,8 @@ int main() {
         std::vector<std::pair<int, std::string> > txn_pairs;
         txn_pairs.push_back(std::make_pair(1, std::string("one")));
         txn_pairs.push_back(std::make_pair(2, std::string("two")));
-        assert(kv.range(1, 2, read_txn) == txn_pairs);
+        assert((kv.range(1, 2, read_txn) == std::map<int, std::string>(txn_pairs.begin(), txn_pairs.end())));
+        assert(kv.range<std::vector>(1, 2, read_txn) == txn_pairs);
         assert(kv.range_values(1, 2, read_txn) == (std::vector<std::string>{"one", "two"}));
         read_txn.commit();
     }
@@ -264,14 +268,15 @@ int main() {
         std::vector<std::pair<int, std::string> > negative_pairs;
         negative_pairs.push_back(std::make_pair(-2, std::string("minus-two")));
         negative_pairs.push_back(std::make_pair(-1, std::string("minus-one")));
-        assert(kv.range(-2, -1) == negative_pairs);
+        assert((kv.range(-2, -1) == std::map<int, std::string>(negative_pairs.begin(), negative_pairs.end())));
+        assert(kv.range<std::vector>(-2, -1) == negative_pairs);
         assert(kv.range_values(-2, -1) ==
                (std::vector<std::string>{"minus-two", "minus-one"}));
 
         std::vector<std::pair<int, std::string> > nonnegative_pairs;
         nonnegative_pairs.push_back(std::make_pair(0, std::string("zero")));
         nonnegative_pairs.push_back(std::make_pair(1, std::string("one")));
-        assert(kv.range(0, 1) == nonnegative_pairs);
+        assert((kv.range(0, 1) == std::map<int, std::string>(nonnegative_pairs.begin(), nonnegative_pairs.end())));
         assert(kv.range_values(0, 1) == (std::vector<std::string>{"zero", "one"}));
     }
 
@@ -288,7 +293,9 @@ int main() {
         all_pairs.push_back(std::make_pair(uint64_t(0), std::string("zero")));
         all_pairs.push_back(std::make_pair(uint64_t(1), std::string("one")));
         all_pairs.push_back(std::make_pair(max_key, std::string("max")));
-        assert(kv.range(0u, max_key) == all_pairs);
+        assert((kv.range(0u, max_key) ==
+                std::map<uint64_t, std::string>(all_pairs.begin(), all_pairs.end())));
+        assert(kv.range<std::vector>(0u, max_key) == all_pairs);
         assert(kv.range_values(0u, max_key) ==
                (std::vector<std::string>{"zero", "one", "max"}));
     }
@@ -305,7 +312,9 @@ int main() {
         all_pairs.push_back(std::make_pair(-1.0, std::string("minus-one")));
         all_pairs.push_back(std::make_pair(0.0, std::string("zero")));
         all_pairs.push_back(std::make_pair(1.0, std::string("one")));
-        assert(kv.range(-1.0, 1.0) == all_pairs);
+        assert((kv.range(-1.0, 1.0) ==
+                std::map<double, std::string>(all_pairs.begin(), all_pairs.end())));
+        assert(kv.range<std::vector>(-1.0, 1.0) == all_pairs);
         assert(kv.range_values(-1.0, 1.0) ==
                (std::vector<std::string>{"minus-one", "zero", "one"}));
     }

--- a/tests/kv_container_all_types_test.cpp
+++ b/tests/kv_container_all_types_test.cpp
@@ -218,6 +218,26 @@ int main() {
         ASSERT_FOUND(kv, 2, std::string("two"));
     }
 
+    std::cout << "[case] key range values\n";
+    {
+        mdbxc::KeyValueTable<int, std::string> kv(conn, "range_values");
+        kv.clear();
+
+        kv.insert_or_assign(1, "one");
+        kv.insert_or_assign(2, "two");
+        kv.insert_or_assign(4, "four");
+        kv.insert_or_assign(5, "five");
+
+        assert(kv.range(2, 4) == (std::vector<std::string>{"two", "four"}));
+        assert(kv.range(0, 1) == (std::vector<std::string>{"one"}));
+        assert(kv.range(3, 3).empty());
+        assert(kv.range(5, 2).empty());
+
+        mdbxc::Transaction read_txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        assert(kv.range(1, 2, read_txn) == (std::vector<std::string>{"one", "two"}));
+        read_txn.commit();
+    }
+
     std::cout << "[case] string -> POD(SimpleStruct)\n";
     {
         mdbxc::KeyValueTable<std::string, SimpleStruct> kv(conn, "str_struct");

--- a/tests/kv_container_all_types_test.cpp
+++ b/tests/kv_container_all_types_test.cpp
@@ -15,6 +15,7 @@
 #include <bitset>
 #include <utility>
 #include <stdexcept>
+#include <limits>
 
 #include <mdbx_containers/KeyValueTable.hpp>
 
@@ -248,6 +249,65 @@ int main() {
         assert(kv.range(1, 2, read_txn) == txn_pairs);
         assert(kv.range_values(1, 2, read_txn) == (std::vector<std::string>{"one", "two"}));
         read_txn.commit();
+    }
+
+    std::cout << "[case] numeric key range boundaries\n";
+    {
+        mdbxc::KeyValueTable<int, std::string> kv(conn, "range_int_boundaries");
+        kv.clear();
+
+        kv.insert_or_assign(-2, "minus-two");
+        kv.insert_or_assign(-1, "minus-one");
+        kv.insert_or_assign(0, "zero");
+        kv.insert_or_assign(1, "one");
+
+        std::vector<std::pair<int, std::string> > negative_pairs;
+        negative_pairs.push_back(std::make_pair(-2, std::string("minus-two")));
+        negative_pairs.push_back(std::make_pair(-1, std::string("minus-one")));
+        assert(kv.range(-2, -1) == negative_pairs);
+        assert(kv.range_values(-2, -1) ==
+               (std::vector<std::string>{"minus-two", "minus-one"}));
+
+        std::vector<std::pair<int, std::string> > nonnegative_pairs;
+        nonnegative_pairs.push_back(std::make_pair(0, std::string("zero")));
+        nonnegative_pairs.push_back(std::make_pair(1, std::string("one")));
+        assert(kv.range(0, 1) == nonnegative_pairs);
+        assert(kv.range_values(0, 1) == (std::vector<std::string>{"zero", "one"}));
+    }
+
+    {
+        mdbxc::KeyValueTable<uint64_t, std::string> kv(conn, "range_u64_boundaries");
+        kv.clear();
+
+        const uint64_t max_key = std::numeric_limits<uint64_t>::max();
+        kv.insert_or_assign(0u, "zero");
+        kv.insert_or_assign(1u, "one");
+        kv.insert_or_assign(max_key, "max");
+
+        std::vector<std::pair<uint64_t, std::string> > all_pairs;
+        all_pairs.push_back(std::make_pair(uint64_t(0), std::string("zero")));
+        all_pairs.push_back(std::make_pair(uint64_t(1), std::string("one")));
+        all_pairs.push_back(std::make_pair(max_key, std::string("max")));
+        assert(kv.range(0u, max_key) == all_pairs);
+        assert(kv.range_values(0u, max_key) ==
+               (std::vector<std::string>{"zero", "one", "max"}));
+    }
+
+    {
+        mdbxc::KeyValueTable<double, std::string> kv(conn, "range_double_boundaries");
+        kv.clear();
+
+        kv.insert_or_assign(-1.0, "minus-one");
+        kv.insert_or_assign(0.0, "zero");
+        kv.insert_or_assign(1.0, "one");
+
+        std::vector<std::pair<double, std::string> > all_pairs;
+        all_pairs.push_back(std::make_pair(-1.0, std::string("minus-one")));
+        all_pairs.push_back(std::make_pair(0.0, std::string("zero")));
+        all_pairs.push_back(std::make_pair(1.0, std::string("one")));
+        assert(kv.range(-1.0, 1.0) == all_pairs);
+        assert(kv.range_values(-1.0, 1.0) ==
+               (std::vector<std::string>{"minus-one", "zero", "one"}));
     }
 
     std::cout << "[case] string -> POD(SimpleStruct)\n";


### PR DESCRIPTION
## Summary

Adds cursor-based inclusive key-range reads where MDBX key ordering matches the table model:

- `KeyTable::range<ContainerT = std::set>(from_key, to_key)` returns keys in the requested key range; use `range<std::vector>()` for MDBX iteration-order keys.
- `KeyValueTable::range<ContainerT = std::map>(from_key, to_key)` returns key-value pairs; `range<std::vector>()` returns `std::vector<std::pair<KeyT, ValueT>>`.
- `KeyValueTable::range_values<ContainerT = std::vector>(from_key, to_key)` returns only values for the same range.
- `KeyMultiValueTable::range<ContainerT = std::multimap>(from_key, to_key)` returns key-value pairs, including duplicate-key groups according to the output container rules.
- `KeyMultiValueTable::range_vector(from_key, to_key)` returns every physical pair as `std::vector<std::pair<KeyT, ValueT>>`.
- `KeyMultiValueTable::range_values<ContainerT = std::vector>(from_key, to_key)` returns only values for the same range.

The implementations use `MDBX_SET_RANGE` plus `MDBX_NEXT` and stop with `mdbx_cmp()` at the upper bound, avoiding full-table loading and caller-side filtering. Cursor reads use key-specific deserialization so range pairs preserve original keys for sortable float/double keys and small integer keys. Tests cover DUPSORT iteration across multiple duplicate-key groups, not only duplicates under a single key.

## Notes

The range API now follows the same container-template style as `retrieve_all()` and `operator()()`, so no public `load_range()` was added. `HashedKeyValueStore` intentionally does not expose original-key `range()` because its physical ordering is by hash buckets, not by original key.

Range scans and existing Key* cursor scans use a shared `BaseTable::CursorGuard`, with automatic close on normal paths, early returns, and exception paths. The guard field is named `cursor`.

Range scan termination tracks the upper-bound stop separately from MDBX cursor status, so `check_mdbx()` only sees `MDBX_NOTFOUND` or a real cursor error after the loop.

## Validation

- Configured and built focused tests with MinGW C++11.
- `ctest --test-dir tmp\range-mingw-cpp11 -R "key_table_test|key_multi_value_table_test|kv_container_all_types_test" --output-on-failure`
- Configured and built focused tests with MinGW C++17.
- `ctest --test-dir tmp\range-mingw-cpp17 -R "key_table_test|key_multi_value_table_test|kv_container_all_types_test" --output-on-failure`
- Follow-up targeted check: `key_multi_value_table_test` passed in both MinGW C++11 and C++17 after adding the multikey duplicate-range case.
- Follow-up focused check: `key_table_test`, `key_multi_value_table_test`, and `kv_container_all_types_test` passed in both MinGW C++11 and C++17 after adding numeric key boundary coverage.
- Cursor lifetime check: `key_table_test`, `key_multi_value_table_test`, `kv_container_all_types_test`, and `sequence_table_test` passed in both MinGW C++11 and C++17 after introducing the shared cursor guard.
- Range termination check: `key_table_test`, `key_multi_value_table_test`, `kv_container_all_types_test`, and `sequence_table_test` passed in both MinGW C++11 and C++17 after making upper-bound termination explicit.
- Container-style range check: `key_table_test`, `key_multi_value_table_test`, `kv_container_all_types_test`, and `sequence_table_test` passed in both MinGW C++11 and C++17 after aligning defaults with set/map/multimap APIs.
- `git diff --check`