### PR TITLE
feat(tables): add ordered range navigation APIs

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -17,7 +17,8 @@
 
 ### 🧱 API таблиц
 - `KeyValueTable<K, V>` — основная таблица: одно значение на ключ, методы
-  `insert`, `insert_or_assign`, `find`, `range`, `range_values`, `erase`, `clear`, `load`, `reconcile`,
+  `insert`, `insert_or_assign`, `find`, `range`, `range_values`, `for_each_range`, `filter_range`,
+  `lower_bound`, `upper_bound`, `range_reverse`, `erase_range`, `update`, `find_many`,
   `operator[]` и связанные помощники.
 - `HashedKeyValueStore<K, V, H, Layout>` хранит одно значение на строковый или
   byte-vector ключ через hash-index и проверяет исходные байты ключа, чтобы
@@ -28,10 +29,11 @@
   типу и поддерживает типизированные `set`, `insert`, `get`, `find`, `get_or`,
   `update`, `contains`, `erase` и `keys`.
 - `KeyTable<K>` хранит уникальные ключи со `std::set`-подобным API: `insert`,
-  `contains`, `range`, `erase`, `clear`, `load`, `reconcile` и связанные помощники.
+  `contains`, `range`, `for_each_range`, `filter_range`, `lower_bound`, `upper_bound`,
+  `range_reverse`, `erase_range`, `clear`, `load`, `reconcile` и связанные помощники.
 - `KeyMultiValueTable<K, V>` хранит несколько значений на один ключ со
-  `std::multimap`-подобным API, `range`/`range_values` по диапазонам ключей и сохраняет повторяющиеся одинаковые пары
-  `(key, value)`.
+  `std::multimap`-подобным API, потоковыми и материализованными range-scan методами,
+  обратным сканированием, удалением диапазонов и сохранением повторяющихся одинаковых пар `(key, value)`.
 - `SequenceTable<ValueT>` хранит значения по стабильному uint64_t id с
   append-only семантикой и разреженными индексами. Append возвращает
   стабильный id; удаление не переиндексирует следующие записи.
@@ -157,6 +159,11 @@ auto by_key = table.range(10, 20);
 auto ordered_pairs = table.range<std::vector>(10, 20);
 auto unique_values = table.range_values<std::set>(10, 20);
 ```
+
+Упорядоченные key-based таблицы также предоставляют `for_each_range()` для потокового обхода,
+`filter_range()` как тонкий collecting-helper, `lower_bound()`/`upper_bound()`,
+`first()`/`last()`, `min_key()`/`max_key()`, `range_reverse()`,
+`contains_range()`, `count_range()` и `erase_range()`.
 
 ### Hash-indexed key-value store
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@
 ## ⚙️ Features
 
 ### 🧱 Table APIs
-- `KeyValueTable<K, V>` is the main implemented table: one value per key with `insert`, `insert_or_assign`, `find`, `range`, `range_values`, `erase`, `clear`, `load`, `reconcile`, `operator[]`, and related helpers.
+- `KeyValueTable<K, V>` is the main implemented table: one value per key with `insert`, `insert_or_assign`, `find`, `range`, `range_values`, `for_each_range`, `filter_range`, `lower_bound`, `upper_bound`, `range_reverse`, `erase_range`, `update`, `find_many`, `operator[]`, and related helpers.
 - `HashedKeyValueStore<K, V, H, Layout>` stores one value per string or byte-vector key through a hash index and verifies original key bytes to handle collisions.
 - `ValueTable<V>` stores one strongly typed singleton value per named table for metadata, module state, snapshots, and single-object configuration records.
 - `AnyValueTable<K>` stores heterogeneous values by caller-selected type and supports typed `set`, `insert`, `get`, `find`, `get_or`, `update`, `contains`, `erase`, and `keys`.
-- `KeyTable<K>` stores unique keys with a `std::set`-like API: `insert`, `contains`, `range`, `erase`, `clear`, `load`, `reconcile`, and related helpers.
-- `KeyMultiValueTable<K, V>` stores multiple values per key with a `std::multimap`-like API, `range`/`range_values` key-range scans, and repeated identical `(key, value)` pair preservation.
+- `KeyTable<K>` stores unique keys with a `std::set`-like API: `insert`, `contains`, `range`, `for_each_range`, `filter_range`, `lower_bound`, `upper_bound`, `range_reverse`, `erase_range`, `clear`, `load`, `reconcile`, and related helpers.
+- `KeyMultiValueTable<K, V>` stores multiple values per key with a `std::multimap`-like API, streaming and materialized key-range scans, reverse scans, range erasure, and repeated identical `(key, value)` pair preservation.
 - `SequenceTable<ValueT>` stores values by stable uint64_t id with append-only semantics and sparse index support. Append returns a stable id; erase does not reindex following records.
 - `AnyValueTable` type-tag prefix verification is opt-in via `set_type_tag_check(true)` and is disabled by default for compatibility with existing raw records.
 
@@ -129,6 +129,11 @@ auto by_key = table.range(10, 20);
 auto ordered_pairs = table.range<std::vector>(10, 20);
 auto unique_values = table.range_values<std::set>(10, 20);
 ```
+
+Ordered key-based tables also provide `for_each_range()` for streaming scans,
+`filter_range()` as a thin collecting helper, `lower_bound()`/`upper_bound()`,
+`first()`/`last()`, `min_key()`/`max_key()`, `range_reverse()`,
+`contains_range()`, `count_range()`, and `erase_range()`.
 
 ### Hash-indexed key-value store
 

--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -16,6 +16,10 @@ Key features:
 - Implemented `KeyTable` API for set-like key storage.
 - Implemented `KeyMultiValueTable` API for multimap-like storage with repeated
   identical pairs preserved.
+- Ordered key-based tables provide streaming range scans, bounds and edge
+  helpers, reverse scans, range metadata, and range erasure.
+- `KeyValueTable` includes read-modify-write `update()` and batch point lookup
+  helpers.
 - Automatic serialization of trivially copyable types and custom `to_bytes()`/`from_bytes()` support.
 - Multiple logical tables inside one MDBX environment.
 - Read-only configuration for inspecting existing DBIs without creating tables.

--- a/docs/tables.dox
+++ b/docs/tables.dox
@@ -47,6 +47,22 @@ if (v.first) std::cout << v.second;
 #endif
 ```
 
+\c for_each_range(from_key, to_key, callback) streams every pair in an inclusive
+MDBX key-order range and stops early when the callback returns \c false.
+\c filter_range() collects pairs matching a predicate as a
+\c std::vector<std::pair<KeyT,ValueT>>.
+\c lower_bound(), \c upper_bound(), \c first(), and \c last() return optional
+edge pairs (or \c std::pair<bool,T> in C++11). \c min_key() and \c max_key()
+return only edge keys without deserializing values.
+\c range_reverse() returns a vector in descending key order; an overload with
+\c limit caps the result size. \c contains_range() and \c count_range() report
+range metadata without deserializing values. \c erase_range() removes every
+pair in the range and returns the deleted count.
+\c update(key, fn) mutates an existing value in place and returns \c false
+when the key is missing. \c find_many(keys) returns a \c std::map of found
+pairs; \c find_many_vector(keys) preserves input order in a vector and omits
+missing keys.
+
 ### Loading and synchronization
 
 Loading into an existing container appends/inserts records into that container;
@@ -161,6 +177,17 @@ tags.insert("archived");
 std::set<std::string> all_tags = tags.retrieve_all();
 ```
 
+\c for_each_range(from_key, to_key, callback) streams keys in an inclusive
+range and stops early when the callback returns \c false.
+\c filter_range() collects keys matching a predicate as a \c std::vector<KeyT>.
+\c lower_bound(), \c upper_bound(), \c first(), and \c last() return optional
+edge keys (or \c std::pair<bool,KeyT> in C++11). \c min_key() and \c max_key()
+are aliases for \c first() and \c last().
+\c range_reverse() returns a vector in descending key order; an overload with
+\c limit caps the result size. \c contains_range() and \c count_range() report
+range metadata without deserializing values. \c erase_range() removes every key
+in the range and returns the deleted count.
+
 ## Multi-value tables
 
 \ref mdbxc::KeyMultiValueTable stores multiple values for the same key. Repeated
@@ -191,6 +218,18 @@ events.insert(7, "created");
 events.insert(7, "sent");
 std::vector<std::string> values = events.find(7);
 ```
+
+\c for_each_range(from_key, to_key, callback) streams every physical pair
+in an inclusive key range and stops early when the callback returns \c false.
+\c filter_range() collects pairs matching a predicate as a
+\c std::vector<std::pair<KeyT,ValueT>>.
+\c lower_bound() and \c upper_bound() return physical pairs at the lower or
+upper key bound. \c first() and \c last() return the edge pairs. \c min_key()
+and \c max_key() return only edge keys without deserializing duplicate values.
+\c range_reverse() iterates in descending MDBX order; for an exact upper key
+it starts from the last duplicate value. A \c limit overload caps the result.
+\c contains_range(), \c count_range(), and \c erase_range() operate on the
+inclusive key range; duplicates are counted and removed individually.
 
 ## Heterogeneous values
 

--- a/docs/tables.dox
+++ b/docs/tables.dox
@@ -50,7 +50,9 @@ if (v.first) std::cout << v.second;
 \c for_each_range(from_key, to_key, callback) streams every pair in an inclusive
 MDBX key-order range and stops early when the callback returns \c false.
 \c filter_range() collects pairs matching a predicate as a
-\c std::vector<std::pair<KeyT,ValueT>>.
+\c std::vector<std::pair<KeyT,ValueT>> by default. Its container template
+parameter accepts pair-associative containers such as \c std::map and
+\c std::multimap, with \c std::vector handled as a vector of pairs.
 \c lower_bound(), \c upper_bound(), \c first(), and \c last() return optional
 edge pairs (or \c std::pair<bool,T> in C++11). \c min_key() and \c max_key()
 return only edge keys without deserializing values.
@@ -222,7 +224,9 @@ std::vector<std::string> values = events.find(7);
 \c for_each_range(from_key, to_key, callback) streams every physical pair
 in an inclusive key range and stops early when the callback returns \c false.
 \c filter_range() collects pairs matching a predicate as a
-\c std::vector<std::pair<KeyT,ValueT>>.
+\c std::vector<std::pair<KeyT,ValueT>> by default. Unlike \c range(), its
+container template parameter is a single-value container over
+\c std::pair<KeyT,ValueT>, such as \c std::vector or \c std::set.
 \c lower_bound() and \c upper_bound() return physical pairs at the lower or
 upper key bound. \c first() and \c last() return the edge pairs. \c min_key()
 and \c max_key() return only edge keys without deserializing duplicate values.

--- a/include/mdbx_containers/KeyMultiValueTable.hpp
+++ b/include/mdbx_containers/KeyMultiValueTable.hpp
@@ -319,13 +319,16 @@ namespace mdbxc {
         }
 
         /// \brief Collects physical pairs matching a predicate within an inclusive range.
-        /// \tparam ContainerT Container type storing key-value pairs (default \c std::vector<std::pair<KeyT,ValueT>>).
+        /// \tparam ContainerT Single-value container template storing \c value_type,
+        /// such as \c std::vector or \c std::set.
         /// \param from_key Start key in MDBX key order.
         /// \param to_key End key in MDBX key order.
         /// \param pred Predicate invoked as \c pred(const KeyT&, const ValueT&). Return \c true to collect.
         /// \param txn Optional transaction handle.
         /// \return Container with matching pairs in MDBX order.
         /// \throws MdbxException if a database error occurs.
+        /// \note Unlike \c range(), \c ContainerT is not a pair-associative container
+        /// template; \c std::multimap is not supported by this overload.
         template<template<class...> class ContainerT = std::vector, typename PredicateT>
         ContainerT<value_type> filter_range(const KeyT& from_key, const KeyT& to_key,
                                             PredicateT pred, MDBX_txn* txn = nullptr) const {
@@ -340,13 +343,16 @@ namespace mdbxc {
         }
 
         /// \brief Collects physical pairs matching a predicate within an inclusive range.
-        /// \tparam ContainerT Container type storing key-value pairs (default \c std::vector<std::pair<KeyT,ValueT>>).
+        /// \tparam ContainerT Single-value container template storing \c value_type,
+        /// such as \c std::vector or \c std::set.
         /// \param from_key Start key in MDBX key order.
         /// \param to_key End key in MDBX key order.
         /// \param pred Predicate invoked as \c pred(const KeyT&, const ValueT&). Return \c true to collect.
         /// \param txn Active transaction wrapper.
         /// \return Container with matching pairs in MDBX order.
         /// \throws MdbxException if a database error occurs.
+        /// \note Unlike \c range(), \c ContainerT is not a pair-associative container
+        /// template; \c std::multimap is not supported by this overload.
         template<template<class...> class ContainerT = std::vector, typename PredicateT>
         ContainerT<value_type> filter_range(const KeyT& from_key, const KeyT& to_key,
                                             PredicateT pred, const Transaction& txn) const {
@@ -1647,14 +1653,21 @@ namespace mdbxc {
             if (rc == MDBX_NOTFOUND) return;
             check_mdbx(rc, "Failed to seek reverse range start");
 
-            while (rc == MDBX_SUCCESS && out.size() < limit) {
+            bool stopped_by_limit = false;
+            bool stopped_by_lower_bound = false;
+            while (rc == MDBX_SUCCESS) {
                 if (mdbx_cmp(txn, m_dbi, &db_key, &db_from_key) < 0) {
+                    stopped_by_lower_bound = true;
                     break;
                 }
                 out.push_back(value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(strip_sequence(db_val))));
+                if (out.size() >= limit) {
+                    stopped_by_limit = true;
+                    break;
+                }
                 rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_PREV);
             }
-            if (rc != MDBX_NOTFOUND) {
+            if (!stopped_by_limit && !stopped_by_lower_bound && rc != MDBX_NOTFOUND) {
                 check_mdbx(rc, "Failed to iterate reverse multi-value range");
             }
         }

--- a/include/mdbx_containers/KeyMultiValueTable.hpp
+++ b/include/mdbx_containers/KeyMultiValueTable.hpp
@@ -286,6 +286,526 @@ namespace mdbxc {
             return range_values<ContainerT>(from_key, to_key, txn.handle());
         }
 
+        // --- Streaming and range helpers ---
+
+        /// \brief Calls a callback for every physical pair in an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param callback Invoked as \c callback(const KeyT&, const ValueT&). Return \c true to continue.
+        /// \param txn Optional transaction handle.
+        /// \return \c true if every pair was visited, \c false if the callback stopped early.
+        /// \throws MdbxException if a database error occurs.
+        template<typename CallbackT>
+        bool for_each_range(const KeyT& from_key, const KeyT& to_key,
+                            CallbackT callback, MDBX_txn* txn = nullptr) const {
+            bool completed = false;
+            with_transaction([this, &from_key, &to_key, &callback, &completed](MDBX_txn* t) {
+                completed = db_for_each_range(from_key, to_key, callback, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return completed;
+        }
+
+        /// \brief Calls a callback for every physical pair in an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param callback Invoked as \c callback(const KeyT&, const ValueT&). Return \c true to continue.
+        /// \param txn Active transaction wrapper.
+        /// \return \c true if every pair was visited, \c false if the callback stopped early.
+        /// \throws MdbxException if a database error occurs.
+        template<typename CallbackT>
+        bool for_each_range(const KeyT& from_key, const KeyT& to_key,
+                            CallbackT callback, const Transaction& txn) const {
+            return for_each_range(from_key, to_key, callback, txn.handle());
+        }
+
+        /// \brief Collects physical pairs matching a predicate within an inclusive range.
+        /// \tparam ContainerT Container type storing key-value pairs (default \c std::vector<std::pair<KeyT,ValueT>>).
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param pred Predicate invoked as \c pred(const KeyT&, const ValueT&). Return \c true to collect.
+        /// \param txn Optional transaction handle.
+        /// \return Container with matching pairs in MDBX order.
+        /// \throws MdbxException if a database error occurs.
+        template<template<class...> class ContainerT = std::vector, typename PredicateT>
+        ContainerT<value_type> filter_range(const KeyT& from_key, const KeyT& to_key,
+                                            PredicateT pred, MDBX_txn* txn = nullptr) const {
+            ContainerT<value_type> out;
+            for_each_range(from_key, to_key, [&out, &pred](const KeyT& key, const ValueT& value) -> bool {
+                if (pred(key, value)) {
+                    out.insert(out.end(), value_type(key, value));
+                }
+                return true;
+            }, txn);
+            return out;
+        }
+
+        /// \brief Collects physical pairs matching a predicate within an inclusive range.
+        /// \tparam ContainerT Container type storing key-value pairs (default \c std::vector<std::pair<KeyT,ValueT>>).
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param pred Predicate invoked as \c pred(const KeyT&, const ValueT&). Return \c true to collect.
+        /// \param txn Active transaction wrapper.
+        /// \return Container with matching pairs in MDBX order.
+        /// \throws MdbxException if a database error occurs.
+        template<template<class...> class ContainerT = std::vector, typename PredicateT>
+        ContainerT<value_type> filter_range(const KeyT& from_key, const KeyT& to_key,
+                                            PredicateT pred, const Transaction& txn) const {
+            return filter_range<ContainerT>(from_key, to_key, pred, txn.handle());
+        }
+
+        // --- Bounds / edges ---
+
+#if __cplusplus >= 201703L
+        /// \brief Finds the first physical pair whose key is not less than the given key.
+        /// \param key Key to bound.
+        /// \param txn Optional transaction handle.
+        /// \return \c std::optional<value_type> with the lower-bound pair, or empty if none.
+        std::optional<value_type> lower_bound(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            std::optional<value_type> result;
+            with_transaction([this, &key, &result](MDBX_txn* t) {
+                result = db_lower_bound(key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Finds the first physical pair whose key is not less than the given key.
+        /// \param key Key to bound.
+        /// \param txn Active transaction wrapper.
+        /// \return \c std::optional<value_type> with the lower-bound pair, or empty if none.
+        std::optional<value_type> lower_bound(const KeyT& key, const Transaction& txn) const {
+            return lower_bound(key, txn.handle());
+        }
+
+        /// \brief Finds the first physical pair whose key is strictly greater than the given key.
+        /// \param key Key to bound.
+        /// \param txn Optional transaction handle.
+        /// \return \c std::optional<value_type> with the upper-bound pair, or empty if none.
+        std::optional<value_type> upper_bound(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            std::optional<value_type> result;
+            with_transaction([this, &key, &result](MDBX_txn* t) {
+                result = db_upper_bound(key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Finds the first physical pair whose key is strictly greater than the given key.
+        /// \param key Key to bound.
+        /// \param txn Active transaction wrapper.
+        /// \return \c std::optional<value_type> with the upper-bound pair, or empty if none.
+        std::optional<value_type> upper_bound(const KeyT& key, const Transaction& txn) const {
+            return upper_bound(key, txn.handle());
+        }
+
+        /// \brief Retrieves the first physical pair in key order.
+        /// \param txn Optional transaction handle.
+        /// \return \c std::optional<value_type> with the first pair, or empty if the table is empty.
+        std::optional<value_type> first(MDBX_txn* txn = nullptr) const {
+            std::optional<value_type> result;
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_first(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the first physical pair in key order.
+        /// \param txn Active transaction wrapper.
+        /// \return \c std::optional<value_type> with the first pair, or empty if the table is empty.
+        std::optional<value_type> first(const Transaction& txn) const {
+            return first(txn.handle());
+        }
+
+        /// \brief Retrieves the last physical pair in key order.
+        /// \param txn Optional transaction handle.
+        /// \return \c std::optional<value_type> with the last pair, or empty if the table is empty.
+        std::optional<value_type> last(MDBX_txn* txn = nullptr) const {
+            std::optional<value_type> result;
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_last(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the last physical pair in key order.
+        /// \param txn Active transaction wrapper.
+        /// \return \c std::optional<value_type> with the last pair, or empty if the table is empty.
+        std::optional<value_type> last(const Transaction& txn) const {
+            return last(txn.handle());
+        }
+
+        /// \brief Retrieves the smallest key without deserializing duplicate values.
+        /// \param txn Optional transaction handle.
+        /// \return \c std::optional<KeyT> with the smallest key, or empty if the table is empty.
+        std::optional<KeyT> min_key(MDBX_txn* txn = nullptr) const {
+            std::optional<KeyT> result;
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_min_key(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the smallest key without deserializing duplicate values.
+        /// \param txn Active transaction wrapper.
+        /// \return \c std::optional<KeyT> with the smallest key, or empty if the table is empty.
+        std::optional<KeyT> min_key(const Transaction& txn) const {
+            return min_key(txn.handle());
+        }
+
+        /// \brief Retrieves the largest key without deserializing duplicate values.
+        /// \param txn Optional transaction handle.
+        /// \return \c std::optional<KeyT> with the largest key, or empty if the table is empty.
+        std::optional<KeyT> max_key(MDBX_txn* txn = nullptr) const {
+            std::optional<KeyT> result;
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_max_key(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the largest key without deserializing duplicate values.
+        /// \param txn Active transaction wrapper.
+        /// \return \c std::optional<KeyT> with the largest key, or empty if the table is empty.
+        std::optional<KeyT> max_key(const Transaction& txn) const {
+            return max_key(txn.handle());
+        }
+#else
+        /// \brief Finds the first physical pair whose key is not less than the given key.
+        /// \param key Key to bound.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> lower_bound(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            return lower_bound_compat(key, txn);
+        }
+
+        /// \brief Finds the first physical pair whose key is not less than the given key.
+        /// \param key Key to bound.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> lower_bound(const KeyT& key, const Transaction& txn) const {
+            return lower_bound(key, txn.handle());
+        }
+
+        /// \brief Finds the first physical pair whose key is not less than the given key (C++11-compatible).
+        /// \param key Key to bound.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> lower_bound_compat(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            std::pair<bool, value_type> result(false, value_type(KeyT(), ValueT()));
+            with_transaction([this, &key, &result](MDBX_txn* t) {
+                result = db_lower_bound_compat(key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Finds the first physical pair whose key is not less than the given key (C++11-compatible).
+        /// \param key Key to bound.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> lower_bound_compat(const KeyT& key, const Transaction& txn) const {
+            return lower_bound_compat(key, txn.handle());
+        }
+
+        /// \brief Finds the first physical pair whose key is strictly greater than the given key.
+        /// \param key Key to bound.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> upper_bound(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            return upper_bound_compat(key, txn);
+        }
+
+        /// \brief Finds the first physical pair whose key is strictly greater than the given key.
+        /// \param key Key to bound.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> upper_bound(const KeyT& key, const Transaction& txn) const {
+            return upper_bound(key, txn.handle());
+        }
+
+        /// \brief Finds the first physical pair whose key is strictly greater than the given key (C++11-compatible).
+        /// \param key Key to bound.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> upper_bound_compat(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            std::pair<bool, value_type> result(false, value_type(KeyT(), ValueT()));
+            with_transaction([this, &key, &result](MDBX_txn* t) {
+                result = db_upper_bound_compat(key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Finds the first physical pair whose key is strictly greater than the given key (C++11-compatible).
+        /// \param key Key to bound.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> upper_bound_compat(const KeyT& key, const Transaction& txn) const {
+            return upper_bound_compat(key, txn.handle());
+        }
+
+        /// \brief Retrieves the first physical pair in key order.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> first(MDBX_txn* txn = nullptr) const {
+            return first_compat(txn);
+        }
+
+        /// \brief Retrieves the first physical pair in key order.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> first(const Transaction& txn) const {
+            return first(txn.handle());
+        }
+
+        /// \brief Retrieves the first physical pair in key order (C++11-compatible).
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> first_compat(MDBX_txn* txn = nullptr) const {
+            std::pair<bool, value_type> result(false, value_type(KeyT(), ValueT()));
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_first_compat(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the first physical pair in key order (C++11-compatible).
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> first_compat(const Transaction& txn) const {
+            return first_compat(txn.handle());
+        }
+
+        /// \brief Retrieves the last physical pair in key order.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> last(MDBX_txn* txn = nullptr) const {
+            return last_compat(txn);
+        }
+
+        /// \brief Retrieves the last physical pair in key order.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> last(const Transaction& txn) const {
+            return last(txn.handle());
+        }
+
+        /// \brief Retrieves the last physical pair in key order (C++11-compatible).
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> last_compat(MDBX_txn* txn = nullptr) const {
+            std::pair<bool, value_type> result(false, value_type(KeyT(), ValueT()));
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_last_compat(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the last physical pair in key order (C++11-compatible).
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> last_compat(const Transaction& txn) const {
+            return last_compat(txn.handle());
+        }
+
+        /// \brief Retrieves the smallest key without deserializing duplicate values.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and smallest key.
+        std::pair<bool, KeyT> min_key(MDBX_txn* txn = nullptr) const {
+            return min_key_compat(txn);
+        }
+
+        /// \brief Retrieves the smallest key without deserializing duplicate values.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and smallest key.
+        std::pair<bool, KeyT> min_key(const Transaction& txn) const {
+            return min_key(txn.handle());
+        }
+
+        /// \brief Retrieves the smallest key without deserializing duplicate values (C++11-compatible).
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and smallest key.
+        std::pair<bool, KeyT> min_key_compat(MDBX_txn* txn = nullptr) const {
+            std::pair<bool, KeyT> result(false, KeyT());
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_min_key_compat(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the smallest key without deserializing duplicate values (C++11-compatible).
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and smallest key.
+        std::pair<bool, KeyT> min_key_compat(const Transaction& txn) const {
+            return min_key_compat(txn.handle());
+        }
+
+        /// \brief Retrieves the largest key without deserializing duplicate values.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and largest key.
+        std::pair<bool, KeyT> max_key(MDBX_txn* txn = nullptr) const {
+            return max_key_compat(txn);
+        }
+
+        /// \brief Retrieves the largest key without deserializing duplicate values.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and largest key.
+        std::pair<bool, KeyT> max_key(const Transaction& txn) const {
+            return max_key(txn.handle());
+        }
+
+        /// \brief Retrieves the largest key without deserializing duplicate values (C++11-compatible).
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and largest key.
+        std::pair<bool, KeyT> max_key_compat(MDBX_txn* txn = nullptr) const {
+            std::pair<bool, KeyT> result(false, KeyT());
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_max_key_compat(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the largest key without deserializing duplicate values (C++11-compatible).
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and largest key.
+        std::pair<bool, KeyT> max_key_compat(const Transaction& txn) const {
+            return max_key_compat(txn.handle());
+        }
+#endif
+
+        // --- Reverse scan ---
+
+        /// \brief Retrieves physical pairs within an inclusive key range in reverse MDBX order.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Optional transaction handle.
+        /// \return Vector containing every pair in descending key order, with duplicate values in reverse insertion order within each key.
+        /// \throws MdbxException if a database error occurs.
+        std::vector<value_type> range_reverse(const KeyT& from_key, const KeyT& to_key,
+                                              MDBX_txn* txn = nullptr) const {
+            std::vector<value_type> out;
+            with_transaction([this, &from_key, &to_key, &out](MDBX_txn* t) {
+                db_range_reverse(from_key, to_key, out, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return out;
+        }
+
+        /// \brief Retrieves physical pairs within an inclusive key range in reverse MDBX order.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Active transaction wrapper.
+        /// \return Vector containing every pair in descending key order, with duplicate values in reverse insertion order within each key.
+        /// \throws MdbxException if a database error occurs.
+        std::vector<value_type> range_reverse(const KeyT& from_key, const KeyT& to_key,
+                                              const Transaction& txn) const {
+            return range_reverse(from_key, to_key, txn.handle());
+        }
+
+        /// \brief Retrieves up to \p limit physical pairs within an inclusive key range in reverse MDBX order.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param limit Maximum number of pairs to return.
+        /// \param txn Optional transaction handle.
+        /// \return Vector containing pairs in descending key order, with duplicate values in reverse insertion order within each key.
+        /// \throws MdbxException if a database error occurs.
+        /// \note \c limit == 0 returns an empty vector.
+        std::vector<value_type> range_reverse(const KeyT& from_key, const KeyT& to_key,
+                                              std::size_t limit, MDBX_txn* txn = nullptr) const {
+            std::vector<value_type> out;
+            with_transaction([this, &from_key, &to_key, &limit, &out](MDBX_txn* t) {
+                db_range_reverse(from_key, to_key, limit, out, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return out;
+        }
+
+        /// \brief Retrieves up to \p limit physical pairs within an inclusive key range in reverse MDBX order.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param limit Maximum number of pairs to return.
+        /// \param txn Active transaction wrapper.
+        /// \return Vector containing pairs in descending key order, with duplicate values in reverse insertion order within each key.
+        /// \throws MdbxException if a database error occurs.
+        std::vector<value_type> range_reverse(const KeyT& from_key, const KeyT& to_key,
+                                              std::size_t limit, const Transaction& txn) const {
+            return range_reverse(from_key, to_key, limit, txn.handle());
+        }
+
+        // --- Range metadata and removal ---
+
+        /// \brief Checks whether the table contains any pair within an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Optional transaction handle.
+        /// \return \c true if at least one key exists in the range.
+        /// \throws MdbxException if a database error occurs.
+        bool contains_range(const KeyT& from_key, const KeyT& to_key,
+                            MDBX_txn* txn = nullptr) const {
+            bool result = false;
+            with_transaction([this, &from_key, &to_key, &result](MDBX_txn* t) {
+                result = db_contains_range(from_key, to_key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Checks whether the table contains any pair within an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Active transaction wrapper.
+        /// \return \c true if at least one key exists in the range.
+        /// \throws MdbxException if a database error occurs.
+        bool contains_range(const KeyT& from_key, const KeyT& to_key,
+                            const Transaction& txn) const {
+            return contains_range(from_key, to_key, txn.handle());
+        }
+
+        /// \brief Counts physical pairs within an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Optional transaction handle.
+        /// \return Number of pairs in the requested range.
+        /// \throws MdbxException if a database error occurs.
+        std::size_t count_range(const KeyT& from_key, const KeyT& to_key,
+                                MDBX_txn* txn = nullptr) const {
+            std::size_t result = 0;
+            with_transaction([this, &from_key, &to_key, &result](MDBX_txn* t) {
+                result = db_count_range(from_key, to_key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Counts physical pairs within an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Active transaction wrapper.
+        /// \return Number of pairs in the requested range.
+        /// \throws MdbxException if a database error occurs.
+        std::size_t count_range(const KeyT& from_key, const KeyT& to_key,
+                                const Transaction& txn) const {
+            return count_range(from_key, to_key, txn.handle());
+        }
+
+        /// \brief Removes all physical pairs within an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Optional transaction handle.
+        /// \return Number of deleted records.
+        /// \throws MdbxException if a database error occurs.
+        std::size_t erase_range(const KeyT& from_key, const KeyT& to_key,
+                                MDBX_txn* txn = nullptr) {
+            std::size_t result = 0;
+            with_transaction([this, &from_key, &to_key, &result](MDBX_txn* t) {
+                result = db_erase_range(from_key, to_key, t);
+            }, TransactionMode::WRITABLE, txn);
+            return result;
+        }
+
+        /// \brief Removes all physical pairs within an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Active transaction wrapper.
+        /// \return Number of deleted records.
+        /// \throws MdbxException if a database error occurs.
+        std::size_t erase_range(const KeyT& from_key, const KeyT& to_key,
+                                const Transaction& txn) {
+            return erase_range(from_key, to_key, txn.handle());
+        }
+
         /// \brief Appends pairs to the table.
         /// \tparam ContainerT Container type storing pairs.
         /// \param container Source pairs.
@@ -842,6 +1362,378 @@ namespace mdbxc {
             if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
                 check_mdbx(rc, "Failed to read multi-value key range values");
             }
+        }
+
+        template<typename CallbackT>
+        bool db_for_each_range(const KeyT& from_key, const KeyT& to_key,
+                               CallbackT& callback, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) {
+                return true;
+            }
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_from_key;
+            MDBX_val db_val;
+            bool stopped_by_upper_bound = false;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            while (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    stopped_by_upper_bound = true;
+                    break;
+                }
+                KeyT key = deserialize_key<KeyT>(db_key);
+                ValueT value = deserialize_value<ValueT>(strip_sequence(db_val));
+                if (!callback(key, value)) {
+                    return false;
+                }
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+            }
+            if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to iterate multi-value range");
+            }
+            return true;
+        }
+
+#if __cplusplus >= 201703L
+        std::optional<value_type> db_lower_bound(const KeyT& key, MDBX_txn* txn) const {
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_val;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_NOTFOUND) {
+                return std::nullopt;
+            }
+            check_mdbx(rc, "Failed to seek lower bound");
+            return value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(strip_sequence(db_val)));
+        }
+
+        std::optional<value_type> db_upper_bound(const KeyT& key, MDBX_txn* txn) const {
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_key_exact = db_key;
+            MDBX_val db_val;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_NOTFOUND) {
+                return std::nullopt;
+            }
+            check_mdbx(rc, "Failed to seek upper bound");
+
+            if (mdbx_cmp(txn, m_dbi, &db_key, &db_key_exact) == 0) {
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT_NODUP);
+                if (rc == MDBX_NOTFOUND) {
+                    return std::nullopt;
+                }
+                check_mdbx(rc, "Failed to seek next distinct key for upper bound");
+            }
+            return value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(strip_sequence(db_val)));
+        }
+
+        std::optional<value_type> db_first(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_FIRST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::nullopt;
+            }
+            check_mdbx(rc, "Failed to seek first pair");
+            return value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(strip_sequence(db_val)));
+        }
+
+        std::optional<value_type> db_last(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::nullopt;
+            }
+            check_mdbx(rc, "Failed to seek last pair");
+            return value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(strip_sequence(db_val)));
+        }
+
+        std::optional<KeyT> db_min_key(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_FIRST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::nullopt;
+            }
+            check_mdbx(rc, "Failed to seek minimum key");
+            return deserialize_key<KeyT>(db_key);
+        }
+
+        std::optional<KeyT> db_max_key(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::nullopt;
+            }
+            check_mdbx(rc, "Failed to seek maximum key");
+            return deserialize_key<KeyT>(db_key);
+        }
+#else
+        std::pair<bool, value_type> db_lower_bound_compat(const KeyT& key, MDBX_txn* txn) const {
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_val;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_NOTFOUND) {
+                return std::make_pair(false, value_type(KeyT(), ValueT()));
+            }
+            check_mdbx(rc, "Failed to seek lower bound");
+            return std::make_pair(true, value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(strip_sequence(db_val))));
+        }
+
+        std::pair<bool, value_type> db_upper_bound_compat(const KeyT& key, MDBX_txn* txn) const {
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_key_exact = db_key;
+            MDBX_val db_val;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_NOTFOUND) {
+                return std::make_pair(false, value_type(KeyT(), ValueT()));
+            }
+            check_mdbx(rc, "Failed to seek upper bound");
+
+            if (mdbx_cmp(txn, m_dbi, &db_key, &db_key_exact) == 0) {
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT_NODUP);
+                if (rc == MDBX_NOTFOUND) {
+                    return std::make_pair(false, value_type(KeyT(), ValueT()));
+                }
+                check_mdbx(rc, "Failed to seek next distinct key for upper bound");
+            }
+            return std::make_pair(true, value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(strip_sequence(db_val))));
+        }
+
+        std::pair<bool, value_type> db_first_compat(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_FIRST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::make_pair(false, value_type(KeyT(), ValueT()));
+            }
+            check_mdbx(rc, "Failed to seek first pair");
+            return std::make_pair(true, value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(strip_sequence(db_val))));
+        }
+
+        std::pair<bool, value_type> db_last_compat(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::make_pair(false, value_type(KeyT(), ValueT()));
+            }
+            check_mdbx(rc, "Failed to seek last pair");
+            return std::make_pair(true, value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(strip_sequence(db_val))));
+        }
+
+        std::pair<bool, KeyT> db_min_key_compat(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_FIRST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::make_pair(false, KeyT());
+            }
+            check_mdbx(rc, "Failed to seek minimum key");
+            return std::make_pair(true, deserialize_key<KeyT>(db_key));
+        }
+
+        std::pair<bool, KeyT> db_max_key_compat(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::make_pair(false, KeyT());
+            }
+            check_mdbx(rc, "Failed to seek maximum key");
+            return std::make_pair(true, deserialize_key<KeyT>(db_key));
+        }
+#endif
+
+        void db_range_reverse(const KeyT& from_key, const KeyT& to_key,
+                              std::vector<value_type>& out, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_to_key;
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_NOTFOUND) {
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST);
+            } else if (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_PREV);
+                } else if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) == 0) {
+                    rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST_DUP);
+                    if (rc == MDBX_NOTFOUND) {
+                        rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_PREV);
+                    }
+                }
+            }
+            if (rc == MDBX_NOTFOUND) return;
+            check_mdbx(rc, "Failed to seek reverse range start");
+
+            while (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_from_key) < 0) {
+                    break;
+                }
+                out.push_back(value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(strip_sequence(db_val))));
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_PREV);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to iterate reverse multi-value range");
+            }
+        }
+
+        void db_range_reverse(const KeyT& from_key, const KeyT& to_key,
+                              std::size_t limit, std::vector<value_type>& out, MDBX_txn* txn) const {
+            if (limit == 0) return;
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_to_key;
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_NOTFOUND) {
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST);
+            } else if (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_PREV);
+                } else if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) == 0) {
+                    rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST_DUP);
+                    if (rc == MDBX_NOTFOUND) {
+                        rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_PREV);
+                    }
+                }
+            }
+            if (rc == MDBX_NOTFOUND) return;
+            check_mdbx(rc, "Failed to seek reverse range start");
+
+            while (rc == MDBX_SUCCESS && out.size() < limit) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_from_key) < 0) {
+                    break;
+                }
+                out.push_back(value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(strip_sequence(db_val))));
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_PREV);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to iterate reverse multi-value range");
+            }
+        }
+
+        bool db_contains_range(const KeyT& from_key, const KeyT& to_key, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return false;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_from_key;
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "Failed to seek range for contains");
+            return mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) <= 0;
+        }
+
+        std::size_t db_count_range(const KeyT& from_key, const KeyT& to_key, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return 0;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_from_key;
+            MDBX_val db_val;
+            std::size_t count = 0;
+            bool stopped_by_upper_bound = false;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            while (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    stopped_by_upper_bound = true;
+                    break;
+                }
+                ++count;
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+            }
+            if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to count multi-value range");
+            }
+            return count;
+        }
+
+        std::size_t db_erase_range(const KeyT& from_key, const KeyT& to_key, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return 0;
+
+            std::size_t removed = 0;
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_from_key;
+            MDBX_val db_val;
+            bool stopped_by_upper_bound = false;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            while (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    stopped_by_upper_bound = true;
+                    break;
+                }
+                check_mdbx(mdbx_cursor_del(cursor.get(), MDBX_CURRENT), "Failed to erase pair in range");
+                ++removed;
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+            }
+            if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to erase multi-value range");
+            }
+            return removed;
         }
 
         template<template<class...> class ContainerT>

--- a/include/mdbx_containers/KeyTable.hpp
+++ b/include/mdbx_containers/KeyTable.hpp
@@ -1114,14 +1114,21 @@ namespace mdbxc {
             if (rc == MDBX_NOTFOUND) return;
             check_mdbx(rc, "Failed to seek reverse range start");
 
-            while (rc == MDBX_SUCCESS && out.size() < limit) {
+            bool stopped_by_limit = false;
+            bool stopped_by_lower_bound = false;
+            while (rc == MDBX_SUCCESS) {
                 if (mdbx_cmp(txn, m_dbi, &db_key, &db_from_key) < 0) {
+                    stopped_by_lower_bound = true;
                     break;
                 }
                 out.push_back(deserialize_key<KeyT>(db_key));
+                if (out.size() >= limit) {
+                    stopped_by_limit = true;
+                    break;
+                }
                 rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_PREV);
             }
-            if (rc != MDBX_NOTFOUND) {
+            if (!stopped_by_limit && !stopped_by_lower_bound && rc != MDBX_NOTFOUND) {
                 check_mdbx(rc, "Failed to iterate reverse key range");
             }
         }

--- a/include/mdbx_containers/KeyTable.hpp
+++ b/include/mdbx_containers/KeyTable.hpp
@@ -9,6 +9,7 @@
 /// \c std::set -like workflow over an MDBX table.
 
 #include "common.hpp"
+#include <vector>
 
 namespace mdbxc {
 
@@ -155,6 +156,490 @@ namespace mdbxc {
                                const Transaction& txn) const {
             return range<ContainerT>(from_key, to_key, txn.handle());
         }
+
+        // --- Streaming and range helpers ---
+
+        /// \brief Calls a callback for every key in an inclusive range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param callback Invoked as \c callback(const KeyT&). Return \c true to continue.
+        /// \param txn Optional transaction handle.
+        /// \return \c true if every key was visited, \c false if the callback stopped early.
+        /// \throws MdbxException if a database error occurs.
+        template<typename CallbackT>
+        bool for_each_range(const KeyT& from_key, const KeyT& to_key,
+                            CallbackT callback, MDBX_txn* txn = nullptr) const {
+            bool completed = false;
+            with_transaction([this, &from_key, &to_key, &callback, &completed](MDBX_txn* t) {
+                completed = db_for_each_range(from_key, to_key, callback, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return completed;
+        }
+
+        /// \brief Calls a callback for every key in an inclusive range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param callback Invoked as \c callback(const KeyT&). Return \c true to continue.
+        /// \param txn Active transaction wrapper.
+        /// \return \c true if every key was visited, \c false if the callback stopped early.
+        /// \throws MdbxException if a database error occurs.
+        template<typename CallbackT>
+        bool for_each_range(const KeyT& from_key, const KeyT& to_key,
+                            CallbackT callback, const Transaction& txn) const {
+            return for_each_range(from_key, to_key, callback, txn.handle());
+        }
+
+        /// \brief Collects keys matching a predicate within an inclusive range.
+        /// \tparam ContainerT Container type storing keys (default \c std::vector).
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param pred Predicate invoked as \c pred(const KeyT&). Return \c true to collect.
+        /// \param txn Optional transaction handle.
+        /// \return Container with matching keys in MDBX order.
+        /// \throws MdbxException if a database error occurs.
+        template<template<class...> class ContainerT = std::vector, typename PredicateT>
+        ContainerT<KeyT> filter_range(const KeyT& from_key, const KeyT& to_key,
+                                      PredicateT pred, MDBX_txn* txn = nullptr) const {
+            ContainerT<KeyT> out;
+            for_each_range(from_key, to_key, [&out, &pred](const KeyT& key) -> bool {
+                if (pred(key)) {
+                    out.insert(out.end(), key);
+                }
+                return true;
+            }, txn);
+            return out;
+        }
+
+        /// \brief Collects keys matching a predicate within an inclusive range.
+        /// \tparam ContainerT Container type storing keys (default \c std::vector).
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param pred Predicate invoked as \c pred(const KeyT&). Return \c true to collect.
+        /// \param txn Active transaction wrapper.
+        /// \return Container with matching keys in MDBX order.
+        /// \throws MdbxException if a database error occurs.
+        template<template<class...> class ContainerT = std::vector, typename PredicateT>
+        ContainerT<KeyT> filter_range(const KeyT& from_key, const KeyT& to_key,
+                                      PredicateT pred, const Transaction& txn) const {
+            return filter_range<ContainerT>(from_key, to_key, pred, txn.handle());
+        }
+
+        // --- Bounds / edges ---
+
+#if __cplusplus >= 201703L
+        /// \brief Finds the first key not less than the given key.
+        /// \param key Key to bound.
+        /// \param txn Optional transaction handle.
+        /// \return \c std::optional<KeyT> with the lower-bound key, or empty if none.
+        std::optional<KeyT> lower_bound(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            std::optional<KeyT> result;
+            with_transaction([this, &key, &result](MDBX_txn* t) {
+                result = db_lower_bound(key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Finds the first key not less than the given key.
+        /// \param key Key to bound.
+        /// \param txn Active transaction wrapper.
+        /// \return \c std::optional<KeyT> with the lower-bound key, or empty if none.
+        std::optional<KeyT> lower_bound(const KeyT& key, const Transaction& txn) const {
+            return lower_bound(key, txn.handle());
+        }
+
+        /// \brief Finds the first key strictly greater than the given key.
+        /// \param key Key to bound.
+        /// \param txn Optional transaction handle.
+        /// \return \c std::optional<KeyT> with the upper-bound key, or empty if none.
+        std::optional<KeyT> upper_bound(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            std::optional<KeyT> result;
+            with_transaction([this, &key, &result](MDBX_txn* t) {
+                result = db_upper_bound(key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Finds the first key strictly greater than the given key.
+        /// \param key Key to bound.
+        /// \param txn Active transaction wrapper.
+        /// \return \c std::optional<KeyT> with the upper-bound key, or empty if none.
+        std::optional<KeyT> upper_bound(const KeyT& key, const Transaction& txn) const {
+            return upper_bound(key, txn.handle());
+        }
+
+        /// \brief Retrieves the smallest key.
+        /// \param txn Optional transaction handle.
+        /// \return \c std::optional<KeyT> with the minimum key, or empty if the table is empty.
+        std::optional<KeyT> first(MDBX_txn* txn = nullptr) const {
+            std::optional<KeyT> result;
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_first(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the smallest key.
+        /// \param txn Active transaction wrapper.
+        /// \return \c std::optional<KeyT> with the minimum key, or empty if the table is empty.
+        std::optional<KeyT> first(const Transaction& txn) const {
+            return first(txn.handle());
+        }
+
+        /// \brief Retrieves the largest key.
+        /// \param txn Optional transaction handle.
+        /// \return \c std::optional<KeyT> with the maximum key, or empty if the table is empty.
+        std::optional<KeyT> last(MDBX_txn* txn = nullptr) const {
+            std::optional<KeyT> result;
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_last(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the largest key.
+        /// \param txn Active transaction wrapper.
+        /// \return \c std::optional<KeyT> with the maximum key, or empty if the table is empty.
+        std::optional<KeyT> last(const Transaction& txn) const {
+            return last(txn.handle());
+        }
+
+        /// \brief Retrieves the smallest key.
+        /// \param txn Optional transaction handle.
+        /// \return \c std::optional<KeyT> with the minimum key, or empty if the table is empty.
+        std::optional<KeyT> min_key(MDBX_txn* txn = nullptr) const { return first(txn); }
+        /// \brief Retrieves the smallest key.
+        /// \param txn Active transaction wrapper.
+        /// \return \c std::optional<KeyT> with the minimum key, or empty if the table is empty.
+        std::optional<KeyT> min_key(const Transaction& txn) const { return first(txn); }
+        /// \brief Retrieves the largest key.
+        /// \param txn Optional transaction handle.
+        /// \return \c std::optional<KeyT> with the maximum key, or empty if the table is empty.
+        std::optional<KeyT> max_key(MDBX_txn* txn = nullptr) const { return last(txn); }
+        /// \brief Retrieves the largest key.
+        /// \param txn Active transaction wrapper.
+        /// \return \c std::optional<KeyT> with the maximum key, or empty if the table is empty.
+        std::optional<KeyT> max_key(const Transaction& txn) const { return last(txn); }
+#else
+        /// \brief Finds the first key not less than the given key.
+        /// \param key Key to bound.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> lower_bound(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            return lower_bound_compat(key, txn);
+        }
+
+        /// \brief Finds the first key not less than the given key.
+        /// \param key Key to bound.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> lower_bound(const KeyT& key, const Transaction& txn) const {
+            return lower_bound(key, txn.handle());
+        }
+
+        /// \brief Finds the first key not less than the given key (C++11-compatible).
+        /// \param key Key to bound.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> lower_bound_compat(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            std::pair<bool, KeyT> result(false, KeyT());
+            with_transaction([this, &key, &result](MDBX_txn* t) {
+                result = db_lower_bound_compat(key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Finds the first key not less than the given key (C++11-compatible).
+        /// \param key Key to bound.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> lower_bound_compat(const KeyT& key, const Transaction& txn) const {
+            return lower_bound_compat(key, txn.handle());
+        }
+
+        /// \brief Finds the first key strictly greater than the given key.
+        /// \param key Key to bound.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> upper_bound(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            return upper_bound_compat(key, txn);
+        }
+
+        /// \brief Finds the first key strictly greater than the given key.
+        /// \param key Key to bound.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> upper_bound(const KeyT& key, const Transaction& txn) const {
+            return upper_bound(key, txn.handle());
+        }
+
+        /// \brief Finds the first key strictly greater than the given key (C++11-compatible).
+        /// \param key Key to bound.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> upper_bound_compat(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            std::pair<bool, KeyT> result(false, KeyT());
+            with_transaction([this, &key, &result](MDBX_txn* t) {
+                result = db_upper_bound_compat(key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Finds the first key strictly greater than the given key (C++11-compatible).
+        /// \param key Key to bound.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> upper_bound_compat(const KeyT& key, const Transaction& txn) const {
+            return upper_bound_compat(key, txn.handle());
+        }
+
+        /// \brief Retrieves the smallest key.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> first(MDBX_txn* txn = nullptr) const {
+            return first_compat(txn);
+        }
+
+        /// \brief Retrieves the smallest key.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> first(const Transaction& txn) const {
+            return first(txn.handle());
+        }
+
+        /// \brief Retrieves the smallest key (C++11-compatible).
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> first_compat(MDBX_txn* txn = nullptr) const {
+            std::pair<bool, KeyT> result(false, KeyT());
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_first_compat(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the smallest key (C++11-compatible).
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> first_compat(const Transaction& txn) const {
+            return first_compat(txn.handle());
+        }
+
+        /// \brief Retrieves the largest key.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> last(MDBX_txn* txn = nullptr) const {
+            return last_compat(txn);
+        }
+
+        /// \brief Retrieves the largest key.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> last(const Transaction& txn) const {
+            return last(txn.handle());
+        }
+
+        /// \brief Retrieves the largest key (C++11-compatible).
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> last_compat(MDBX_txn* txn = nullptr) const {
+            std::pair<bool, KeyT> result(false, KeyT());
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_last_compat(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the largest key (C++11-compatible).
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> last_compat(const Transaction& txn) const {
+            return last_compat(txn.handle());
+        }
+
+        /// \brief Retrieves the smallest key.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> min_key(MDBX_txn* txn = nullptr) const {
+            return min_key_compat(txn);
+        }
+
+        /// \brief Retrieves the smallest key.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> min_key(const Transaction& txn) const {
+            return min_key(txn.handle());
+        }
+
+        /// \brief Retrieves the smallest key (C++11-compatible).
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> min_key_compat(MDBX_txn* txn = nullptr) const { return first_compat(txn); }
+        /// \brief Retrieves the smallest key (C++11-compatible).
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> min_key_compat(const Transaction& txn) const { return first_compat(txn); }
+        /// \brief Retrieves the largest key.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> max_key(MDBX_txn* txn = nullptr) const {
+            return max_key_compat(txn);
+        }
+
+        /// \brief Retrieves the largest key.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> max_key(const Transaction& txn) const {
+            return max_key(txn.handle());
+        }
+
+        /// \brief Retrieves the largest key (C++11-compatible).
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> max_key_compat(MDBX_txn* txn = nullptr) const { return last_compat(txn); }
+        /// \brief Retrieves the largest key (C++11-compatible).
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key.
+        std::pair<bool, KeyT> max_key_compat(const Transaction& txn) const { return last_compat(txn); }
+#endif
+
+        // --- Reverse scan ---
+
+        /// \brief Retrieves keys within an inclusive range in reverse MDBX order.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Optional transaction handle.
+        /// \return Vector with keys from the requested range in descending order.
+        /// \throws MdbxException if a database error occurs.
+        std::vector<KeyT> range_reverse(const KeyT& from_key, const KeyT& to_key,
+                                        MDBX_txn* txn = nullptr) const {
+            std::vector<KeyT> out;
+            with_transaction([this, &from_key, &to_key, &out](MDBX_txn* t) {
+                db_range_reverse(from_key, to_key, out, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return out;
+        }
+
+        /// \brief Retrieves keys within an inclusive range in reverse MDBX order.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Active transaction wrapper.
+        /// \return Vector with keys from the requested range in descending order.
+        /// \throws MdbxException if a database error occurs.
+        std::vector<KeyT> range_reverse(const KeyT& from_key, const KeyT& to_key,
+                                        const Transaction& txn) const {
+            return range_reverse(from_key, to_key, txn.handle());
+        }
+
+        /// \brief Retrieves up to \p limit keys within an inclusive range in reverse MDBX order.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param limit Maximum number of keys to return.
+        /// \param txn Optional transaction handle.
+        /// \return Vector with keys from the requested range in descending order.
+        /// \throws MdbxException if a database error occurs.
+        /// \note \c limit == 0 returns an empty vector.
+        std::vector<KeyT> range_reverse(const KeyT& from_key, const KeyT& to_key,
+                                        std::size_t limit, MDBX_txn* txn = nullptr) const {
+            std::vector<KeyT> out;
+            with_transaction([this, &from_key, &to_key, &limit, &out](MDBX_txn* t) {
+                db_range_reverse(from_key, to_key, limit, out, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return out;
+        }
+
+        /// \brief Retrieves up to \p limit keys within an inclusive range in reverse MDBX order.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param limit Maximum number of keys to return.
+        /// \param txn Active transaction wrapper.
+        /// \return Vector with keys from the requested range in descending order.
+        /// \throws MdbxException if a database error occurs.
+        std::vector<KeyT> range_reverse(const KeyT& from_key, const KeyT& to_key,
+                                        std::size_t limit, const Transaction& txn) const {
+            return range_reverse(from_key, to_key, limit, txn.handle());
+        }
+
+        // --- Range metadata and removal ---
+
+        /// \brief Checks whether the table contains any key within an inclusive range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Optional transaction handle.
+        /// \return \c true if at least one key exists in the range.
+        /// \throws MdbxException if a database error occurs.
+        bool contains_range(const KeyT& from_key, const KeyT& to_key,
+                            MDBX_txn* txn = nullptr) const {
+            bool result = false;
+            with_transaction([this, &from_key, &to_key, &result](MDBX_txn* t) {
+                result = db_contains_range(from_key, to_key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Checks whether the table contains any key within an inclusive range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Active transaction wrapper.
+        /// \return \c true if at least one key exists in the range.
+        /// \throws MdbxException if a database error occurs.
+        bool contains_range(const KeyT& from_key, const KeyT& to_key,
+                            const Transaction& txn) const {
+            return contains_range(from_key, to_key, txn.handle());
+        }
+
+        /// \brief Counts keys within an inclusive range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Optional transaction handle.
+        /// \return Number of keys in the requested range.
+        /// \throws MdbxException if a database error occurs.
+        std::size_t count_range(const KeyT& from_key, const KeyT& to_key,
+                                MDBX_txn* txn = nullptr) const {
+            std::size_t result = 0;
+            with_transaction([this, &from_key, &to_key, &result](MDBX_txn* t) {
+                result = db_count_range(from_key, to_key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Counts keys within an inclusive range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Active transaction wrapper.
+        /// \return Number of keys in the requested range.
+        /// \throws MdbxException if a database error occurs.
+        std::size_t count_range(const KeyT& from_key, const KeyT& to_key,
+                                const Transaction& txn) const {
+            return count_range(from_key, to_key, txn.handle());
+        }
+
+        /// \brief Removes all keys within an inclusive range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Optional transaction handle.
+        /// \return Number of deleted records.
+        /// \throws MdbxException if a database error occurs.
+        std::size_t erase_range(const KeyT& from_key, const KeyT& to_key,
+                                MDBX_txn* txn = nullptr) {
+            std::size_t result = 0;
+            with_transaction([this, &from_key, &to_key, &result](MDBX_txn* t) {
+                result = db_erase_range(from_key, to_key, t);
+            }, TransactionMode::WRITABLE, txn);
+            return result;
+        }
+
+        /// \brief Removes all keys within an inclusive range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Active transaction wrapper.
+        /// \return Number of deleted records.
+        /// \throws MdbxException if a database error occurs.
+        std::size_t erase_range(const KeyT& from_key, const KeyT& to_key,
+                                const Transaction& txn) {
+            return erase_range(from_key, to_key, txn.handle());
+        }
+
+        // --- Existing bulk / point API ---
 
         /// \brief Appends keys to the table.
         /// \tparam ContainerT Container type storing keys.
@@ -382,6 +867,345 @@ namespace mdbxc {
                 check_mdbx(rc, "Failed to read key range");
             }
         }
+
+        // --- Streaming / range helpers ---
+
+        template<typename CallbackT>
+        bool db_for_each_range(const KeyT& from_key, const KeyT& to_key,
+                               CallbackT& callback, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) {
+                return true;
+            }
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_from_key;
+            MDBX_val db_val;
+            bool stopped_by_upper_bound = false;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            while (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    stopped_by_upper_bound = true;
+                    break;
+                }
+                if (!callback(deserialize_key<KeyT>(db_key))) {
+                    return false;
+                }
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+            }
+            if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to iterate key range");
+            }
+            return true;
+        }
+
+        // --- Bounds ---
+
+#if __cplusplus >= 201703L
+        std::optional<KeyT> db_lower_bound(const KeyT& key, MDBX_txn* txn) const {
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_val;
+            int rc = mdbx_get(txn, m_dbi, &db_key, &db_val);
+            if (rc == MDBX_SUCCESS) {
+                return deserialize_key<KeyT>(db_key);
+            }
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_SUCCESS) {
+                return deserialize_key<KeyT>(db_key);
+            }
+            if (rc == MDBX_NOTFOUND) {
+                return std::nullopt;
+            }
+            check_mdbx(rc, "Failed to seek lower bound");
+            return std::nullopt;
+        }
+
+        std::optional<KeyT> db_upper_bound(const KeyT& key, MDBX_txn* txn) const {
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_key_exact = db_key;
+            MDBX_val db_val;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_NOTFOUND) {
+                return std::nullopt;
+            }
+            check_mdbx(rc, "Failed to seek upper bound");
+
+            // If exact match found, move to next distinct key
+            if (mdbx_cmp(txn, m_dbi, &db_key, &db_key_exact) == 0) {
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+                if (rc == MDBX_NOTFOUND) {
+                    return std::nullopt;
+                }
+                check_mdbx(rc, "Failed to seek next key for upper bound");
+            }
+            return deserialize_key<KeyT>(db_key);
+        }
+
+        std::optional<KeyT> db_first(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_FIRST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::nullopt;
+            }
+            check_mdbx(rc, "Failed to seek first key");
+            return deserialize_key<KeyT>(db_key);
+        }
+
+        std::optional<KeyT> db_last(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::nullopt;
+            }
+            check_mdbx(rc, "Failed to seek last key");
+            return deserialize_key<KeyT>(db_key);
+        }
+#else
+        std::pair<bool, KeyT> db_lower_bound_compat(const KeyT& key, MDBX_txn* txn) const {
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_val;
+            int rc = mdbx_get(txn, m_dbi, &db_key, &db_val);
+            if (rc == MDBX_SUCCESS) {
+                return std::make_pair(true, deserialize_key<KeyT>(db_key));
+            }
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_SUCCESS) {
+                return std::make_pair(true, deserialize_key<KeyT>(db_key));
+            }
+            if (rc == MDBX_NOTFOUND) {
+                return std::make_pair(false, KeyT());
+            }
+            check_mdbx(rc, "Failed to seek lower bound");
+            return std::make_pair(false, KeyT());
+        }
+
+        std::pair<bool, KeyT> db_upper_bound_compat(const KeyT& key, MDBX_txn* txn) const {
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_key_exact = db_key;
+            MDBX_val db_val;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_NOTFOUND) {
+                return std::make_pair(false, KeyT());
+            }
+            check_mdbx(rc, "Failed to seek upper bound");
+
+            if (mdbx_cmp(txn, m_dbi, &db_key, &db_key_exact) == 0) {
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+                if (rc == MDBX_NOTFOUND) {
+                    return std::make_pair(false, KeyT());
+                }
+                check_mdbx(rc, "Failed to seek next key for upper bound");
+            }
+            return std::make_pair(true, deserialize_key<KeyT>(db_key));
+        }
+
+        std::pair<bool, KeyT> db_first_compat(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_FIRST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::make_pair(false, KeyT());
+            }
+            check_mdbx(rc, "Failed to seek first key");
+            return std::make_pair(true, deserialize_key<KeyT>(db_key));
+        }
+
+        std::pair<bool, KeyT> db_last_compat(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::make_pair(false, KeyT());
+            }
+            check_mdbx(rc, "Failed to seek last key");
+            return std::make_pair(true, deserialize_key<KeyT>(db_key));
+        }
+#endif
+
+        // --- Reverse scan ---
+
+        void db_range_reverse(const KeyT& from_key, const KeyT& to_key,
+                              std::vector<KeyT>& out, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_to_key;
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_NOTFOUND) {
+                // All keys are less than to_key; seek to last and walk backward
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST);
+            } else if (rc == MDBX_SUCCESS) {
+                // If the found key is greater than to_key, step back once
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_PREV);
+                }
+            }
+            if (rc == MDBX_NOTFOUND) return;
+            check_mdbx(rc, "Failed to seek reverse range start");
+
+            while (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_from_key) < 0) {
+                    break;
+                }
+                out.push_back(deserialize_key<KeyT>(db_key));
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_PREV);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to iterate reverse key range");
+            }
+        }
+
+        void db_range_reverse(const KeyT& from_key, const KeyT& to_key,
+                              std::size_t limit, std::vector<KeyT>& out, MDBX_txn* txn) const {
+            if (limit == 0) return;
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_to_key;
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_NOTFOUND) {
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST);
+            } else if (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_PREV);
+                }
+            }
+            if (rc == MDBX_NOTFOUND) return;
+            check_mdbx(rc, "Failed to seek reverse range start");
+
+            while (rc == MDBX_SUCCESS && out.size() < limit) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_from_key) < 0) {
+                    break;
+                }
+                out.push_back(deserialize_key<KeyT>(db_key));
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_PREV);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to iterate reverse key range");
+            }
+        }
+
+        // --- Range metadata and removal ---
+
+        bool db_contains_range(const KeyT& from_key, const KeyT& to_key, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return false;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_from_key;
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "Failed to seek range for contains");
+            return mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) <= 0;
+        }
+
+        std::size_t db_count_range(const KeyT& from_key, const KeyT& to_key, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return 0;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_from_key;
+            MDBX_val db_val;
+            std::size_t count = 0;
+            bool stopped_by_upper_bound = false;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            while (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    stopped_by_upper_bound = true;
+                    break;
+                }
+                ++count;
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+            }
+            if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to count key range");
+            }
+            return count;
+        }
+
+        std::size_t db_erase_range(const KeyT& from_key, const KeyT& to_key, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return 0;
+
+            std::size_t removed = 0;
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_from_key;
+            MDBX_val db_val;
+            bool stopped_by_upper_bound = false;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            while (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    stopped_by_upper_bound = true;
+                    break;
+                }
+                check_mdbx(mdbx_cursor_del(cursor.get(), MDBX_CURRENT), "Failed to erase key in range");
+                ++removed;
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+            }
+            if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to erase key range");
+            }
+            return removed;
+        }
+
+        // --- Existing private helpers ---
 
         template<template<class...> class ContainerT>
         void db_append(const ContainerT<KeyT>& container, MDBX_txn* txn) {

--- a/include/mdbx_containers/KeyValueTable.hpp
+++ b/include/mdbx_containers/KeyValueTable.hpp
@@ -411,7 +411,8 @@ namespace mdbxc {
         }
 
         /// \brief Collects key-value pairs matching a predicate within an inclusive range.
-        /// \tparam ContainerT Container type storing key-value pairs (default \c std::vector<std::pair<KeyT,ValueT>>).
+        /// \tparam ContainerT Pair-associative container template such as \c std::map or
+        /// \c std::multimap, or \c std::vector for \c std::vector<std::pair<KeyT,ValueT>>.
         /// \param from_key Start key in MDBX key order.
         /// \param to_key End key in MDBX key order.
         /// \param pred Predicate invoked as \c pred(const KeyT&, const ValueT&). Return \c true to collect.
@@ -434,7 +435,8 @@ namespace mdbxc {
         }
 
         /// \brief Collects key-value pairs matching a predicate within an inclusive range.
-        /// \tparam ContainerT Container type storing key-value pairs (default \c std::vector<std::pair<KeyT,ValueT>>).
+        /// \tparam ContainerT Pair-associative container template such as \c std::map or
+        /// \c std::multimap, or \c std::vector for \c std::vector<std::pair<KeyT,ValueT>>.
         /// \param from_key Start key in MDBX key order.
         /// \param to_key End key in MDBX key order.
         /// \param pred Predicate invoked as \c pred(const KeyT&, const ValueT&). Return \c true to collect.
@@ -1207,7 +1209,8 @@ namespace mdbxc {
         /// \param txn Optional transaction handle.
         /// \return \c true if the key existed and was updated, \c false if the key was missing.
         /// \throws MdbxException if a database error occurs.
-        /// \note If \c fn throws, the active transaction is rolled back.
+        /// \note If \c txn is \c nullptr and \c fn throws, the internally created
+        /// transaction is rolled back. Caller-owned transactions remain caller-managed.
         template<typename Fn>
         bool update(const KeyT& key, Fn fn, MDBX_txn* txn = nullptr) {
             bool result = false;
@@ -1223,6 +1226,8 @@ namespace mdbxc {
         /// \param txn Active transaction wrapper.
         /// \return \c true if the key existed and was updated, \c false if the key was missing.
         /// \throws MdbxException if a database error occurs.
+        /// \note This overload uses a caller-owned transaction. If \c fn throws,
+        /// transaction rollback remains caller-managed.
         template<typename Fn>
         bool update(const KeyT& key, Fn fn, const Transaction& txn) {
             return update(key, fn, txn.handle());
@@ -1805,14 +1810,21 @@ namespace mdbxc {
             if (rc == MDBX_NOTFOUND) return;
             check_mdbx(rc, "Failed to seek reverse range start");
 
-            while (rc == MDBX_SUCCESS && out.size() < limit) {
+            bool stopped_by_limit = false;
+            bool stopped_by_lower_bound = false;
+            while (rc == MDBX_SUCCESS) {
                 if (mdbx_cmp(txn, m_dbi, &db_key, &db_from_key) < 0) {
+                    stopped_by_lower_bound = true;
                     break;
                 }
                 out.push_back(value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(db_val)));
+                if (out.size() >= limit) {
+                    stopped_by_limit = true;
+                    break;
+                }
                 rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_PREV);
             }
-            if (rc != MDBX_NOTFOUND) {
+            if (!stopped_by_limit && !stopped_by_lower_bound && rc != MDBX_NOTFOUND) {
                 check_mdbx(rc, "Failed to iterate reverse key-value range");
             }
         }

--- a/include/mdbx_containers/KeyValueTable.hpp
+++ b/include/mdbx_containers/KeyValueTable.hpp
@@ -378,6 +378,529 @@ namespace mdbxc {
             return range_values<ContainerT>(from_key, to_key, txn.handle());
         }
 
+        // --- Streaming and range helpers ---
+
+        /// \brief Calls a callback for every key-value pair in an inclusive range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param callback Invoked as \c callback(const KeyT&, const ValueT&). Return \c true to continue.
+        /// \param txn Optional transaction handle.
+        /// \return \c true if every pair was visited, \c false if the callback stopped early.
+        /// \throws MdbxException if a database error occurs.
+        template<typename CallbackT>
+        bool for_each_range(const KeyT& from_key, const KeyT& to_key,
+                            CallbackT callback, MDBX_txn* txn = nullptr) const {
+            bool completed = false;
+            with_transaction([this, &from_key, &to_key, &callback, &completed](MDBX_txn* t) {
+                completed = db_for_each_range(from_key, to_key, callback, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return completed;
+        }
+
+        /// \brief Calls a callback for every key-value pair in an inclusive range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param callback Invoked as \c callback(const KeyT&, const ValueT&). Return \c true to continue.
+        /// \param txn Active transaction wrapper.
+        /// \return \c true if every pair was visited, \c false if the callback stopped early.
+        /// \throws MdbxException if a database error occurs.
+        template<typename CallbackT>
+        bool for_each_range(const KeyT& from_key, const KeyT& to_key,
+                            CallbackT callback, const Transaction& txn) const {
+            return for_each_range(from_key, to_key, callback, txn.handle());
+        }
+
+        /// \brief Collects key-value pairs matching a predicate within an inclusive range.
+        /// \tparam ContainerT Container type storing key-value pairs (default \c std::vector<std::pair<KeyT,ValueT>>).
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param pred Predicate invoked as \c pred(const KeyT&, const ValueT&). Return \c true to collect.
+        /// \param txn Optional transaction handle.
+        /// \return Container with matching pairs in MDBX order.
+        /// \throws MdbxException if a database error occurs.
+        template<template<class...> class ContainerT = std::vector, typename PredicateT>
+        typename detail::KeyValuePairRangeContainer<ContainerT, KeyT, ValueT>::type
+        filter_range(const KeyT& from_key, const KeyT& to_key,
+                     PredicateT pred, MDBX_txn* txn = nullptr) const {
+            typedef typename detail::KeyValuePairRangeContainer<ContainerT, KeyT, ValueT>::type ReturnT;
+            ReturnT out;
+            for_each_range(from_key, to_key, [&out, &pred](const KeyT& key, const ValueT& value) -> bool {
+                if (pred(key, value)) {
+                    out.insert(out.end(), value_type(key, value));
+                }
+                return true;
+            }, txn);
+            return out;
+        }
+
+        /// \brief Collects key-value pairs matching a predicate within an inclusive range.
+        /// \tparam ContainerT Container type storing key-value pairs (default \c std::vector<std::pair<KeyT,ValueT>>).
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param pred Predicate invoked as \c pred(const KeyT&, const ValueT&). Return \c true to collect.
+        /// \param txn Active transaction wrapper.
+        /// \return Container with matching pairs in MDBX order.
+        /// \throws MdbxException if a database error occurs.
+        template<template<class...> class ContainerT = std::vector, typename PredicateT>
+        typename detail::KeyValuePairRangeContainer<ContainerT, KeyT, ValueT>::type
+        filter_range(const KeyT& from_key, const KeyT& to_key,
+                     PredicateT pred, const Transaction& txn) const {
+            return filter_range<ContainerT>(from_key, to_key, pred, txn.handle());
+        }
+
+        // --- Bounds / edges ---
+
+#if __cplusplus >= 201703L
+        /// \brief Finds the first key-value pair whose key is not less than the given key.
+        /// \param key Key to bound.
+        /// \param txn Optional transaction handle.
+        /// \return \c std::optional<value_type> with the lower-bound pair, or empty if none.
+        std::optional<value_type> lower_bound(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            std::optional<value_type> result;
+            with_transaction([this, &key, &result](MDBX_txn* t) {
+                result = db_lower_bound(key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Finds the first key-value pair whose key is not less than the given key.
+        /// \param key Key to bound.
+        /// \param txn Active transaction wrapper.
+        /// \return \c std::optional<value_type> with the lower-bound pair, or empty if none.
+        std::optional<value_type> lower_bound(const KeyT& key, const Transaction& txn) const {
+            return lower_bound(key, txn.handle());
+        }
+
+        /// \brief Finds the first key-value pair whose key is strictly greater than the given key.
+        /// \param key Key to bound.
+        /// \param txn Optional transaction handle.
+        /// \return \c std::optional<value_type> with the upper-bound pair, or empty if none.
+        std::optional<value_type> upper_bound(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            std::optional<value_type> result;
+            with_transaction([this, &key, &result](MDBX_txn* t) {
+                result = db_upper_bound(key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Finds the first key-value pair whose key is strictly greater than the given key.
+        /// \param key Key to bound.
+        /// \param txn Active transaction wrapper.
+        /// \return \c std::optional<value_type> with the upper-bound pair, or empty if none.
+        std::optional<value_type> upper_bound(const KeyT& key, const Transaction& txn) const {
+            return upper_bound(key, txn.handle());
+        }
+
+        /// \brief Retrieves the pair with the smallest key.
+        /// \param txn Optional transaction handle.
+        /// \return \c std::optional<value_type> with the first pair, or empty if the table is empty.
+        std::optional<value_type> first(MDBX_txn* txn = nullptr) const {
+            std::optional<value_type> result;
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_first(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the pair with the smallest key.
+        /// \param txn Active transaction wrapper.
+        /// \return \c std::optional<value_type> with the first pair, or empty if the table is empty.
+        std::optional<value_type> first(const Transaction& txn) const {
+            return first(txn.handle());
+        }
+
+        /// \brief Retrieves the pair with the largest key.
+        /// \param txn Optional transaction handle.
+        /// \return \c std::optional<value_type> with the last pair, or empty if the table is empty.
+        std::optional<value_type> last(MDBX_txn* txn = nullptr) const {
+            std::optional<value_type> result;
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_last(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the pair with the largest key.
+        /// \param txn Active transaction wrapper.
+        /// \return \c std::optional<value_type> with the last pair, or empty if the table is empty.
+        std::optional<value_type> last(const Transaction& txn) const {
+            return last(txn.handle());
+        }
+
+        /// \brief Retrieves the smallest key without deserializing the value.
+        /// \param txn Optional transaction handle.
+        /// \return \c std::optional<KeyT> with the smallest key, or empty if the table is empty.
+        std::optional<KeyT> min_key(MDBX_txn* txn = nullptr) const {
+            std::optional<KeyT> result;
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_min_key(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the smallest key without deserializing the value.
+        /// \param txn Active transaction wrapper.
+        /// \return \c std::optional<KeyT> with the smallest key, or empty if the table is empty.
+        std::optional<KeyT> min_key(const Transaction& txn) const {
+            return min_key(txn.handle());
+        }
+
+        /// \brief Retrieves the largest key without deserializing the value.
+        /// \param txn Optional transaction handle.
+        /// \return \c std::optional<KeyT> with the largest key, or empty if the table is empty.
+        std::optional<KeyT> max_key(MDBX_txn* txn = nullptr) const {
+            std::optional<KeyT> result;
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_max_key(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the largest key without deserializing the value.
+        /// \param txn Active transaction wrapper.
+        /// \return \c std::optional<KeyT> with the largest key, or empty if the table is empty.
+        std::optional<KeyT> max_key(const Transaction& txn) const {
+            return max_key(txn.handle());
+        }
+#else
+        /// \brief Finds the first key-value pair whose key is not less than the given key.
+        /// \param key Key to bound.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> lower_bound(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            return lower_bound_compat(key, txn);
+        }
+
+        /// \brief Finds the first key-value pair whose key is not less than the given key.
+        /// \param key Key to bound.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> lower_bound(const KeyT& key, const Transaction& txn) const {
+            return lower_bound(key, txn.handle());
+        }
+
+        /// \brief Finds the first key-value pair whose key is not less than the given key (C++11-compatible).
+        /// \param key Key to bound.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> lower_bound_compat(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            std::pair<bool, value_type> result(false, value_type(KeyT(), ValueT()));
+            with_transaction([this, &key, &result](MDBX_txn* t) {
+                result = db_lower_bound_compat(key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Finds the first key-value pair whose key is not less than the given key (C++11-compatible).
+        /// \param key Key to bound.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> lower_bound_compat(const KeyT& key, const Transaction& txn) const {
+            return lower_bound_compat(key, txn.handle());
+        }
+
+        /// \brief Finds the first key-value pair whose key is strictly greater than the given key.
+        /// \param key Key to bound.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> upper_bound(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            return upper_bound_compat(key, txn);
+        }
+
+        /// \brief Finds the first key-value pair whose key is strictly greater than the given key.
+        /// \param key Key to bound.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> upper_bound(const KeyT& key, const Transaction& txn) const {
+            return upper_bound(key, txn.handle());
+        }
+
+        /// \brief Finds the first key-value pair whose key is strictly greater than the given key (C++11-compatible).
+        /// \param key Key to bound.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> upper_bound_compat(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            std::pair<bool, value_type> result(false, value_type(KeyT(), ValueT()));
+            with_transaction([this, &key, &result](MDBX_txn* t) {
+                result = db_upper_bound_compat(key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Finds the first key-value pair whose key is strictly greater than the given key (C++11-compatible).
+        /// \param key Key to bound.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> upper_bound_compat(const KeyT& key, const Transaction& txn) const {
+            return upper_bound_compat(key, txn.handle());
+        }
+
+        /// \brief Retrieves the pair with the smallest key.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> first(MDBX_txn* txn = nullptr) const {
+            return first_compat(txn);
+        }
+
+        /// \brief Retrieves the pair with the smallest key.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> first(const Transaction& txn) const {
+            return first(txn.handle());
+        }
+
+        /// \brief Retrieves the pair with the smallest key (C++11-compatible).
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> first_compat(MDBX_txn* txn = nullptr) const {
+            std::pair<bool, value_type> result(false, value_type(KeyT(), ValueT()));
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_first_compat(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the pair with the smallest key (C++11-compatible).
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> first_compat(const Transaction& txn) const {
+            return first_compat(txn.handle());
+        }
+
+        /// \brief Retrieves the pair with the largest key.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> last(MDBX_txn* txn = nullptr) const {
+            return last_compat(txn);
+        }
+
+        /// \brief Retrieves the pair with the largest key.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> last(const Transaction& txn) const {
+            return last(txn.handle());
+        }
+
+        /// \brief Retrieves the pair with the largest key (C++11-compatible).
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> last_compat(MDBX_txn* txn = nullptr) const {
+            std::pair<bool, value_type> result(false, value_type(KeyT(), ValueT()));
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_last_compat(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the pair with the largest key (C++11-compatible).
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and key-value pair.
+        std::pair<bool, value_type> last_compat(const Transaction& txn) const {
+            return last_compat(txn.handle());
+        }
+
+        /// \brief Retrieves the smallest key without deserializing the value.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and smallest key.
+        std::pair<bool, KeyT> min_key(MDBX_txn* txn = nullptr) const {
+            return min_key_compat(txn);
+        }
+
+        /// \brief Retrieves the smallest key without deserializing the value.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and smallest key.
+        std::pair<bool, KeyT> min_key(const Transaction& txn) const {
+            return min_key(txn.handle());
+        }
+
+        /// \brief Retrieves the smallest key without deserializing the value (C++11-compatible).
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and smallest key.
+        std::pair<bool, KeyT> min_key_compat(MDBX_txn* txn = nullptr) const {
+            std::pair<bool, KeyT> result(false, KeyT());
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_min_key_compat(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the smallest key without deserializing the value (C++11-compatible).
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and smallest key.
+        std::pair<bool, KeyT> min_key_compat(const Transaction& txn) const {
+            return min_key_compat(txn.handle());
+        }
+
+        /// \brief Retrieves the largest key without deserializing the value.
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and largest key.
+        std::pair<bool, KeyT> max_key(MDBX_txn* txn = nullptr) const {
+            return max_key_compat(txn);
+        }
+
+        /// \brief Retrieves the largest key without deserializing the value.
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and largest key.
+        std::pair<bool, KeyT> max_key(const Transaction& txn) const {
+            return max_key(txn.handle());
+        }
+
+        /// \brief Retrieves the largest key without deserializing the value (C++11-compatible).
+        /// \param txn Optional transaction handle.
+        /// \return Pair of success flag and largest key.
+        std::pair<bool, KeyT> max_key_compat(MDBX_txn* txn = nullptr) const {
+            std::pair<bool, KeyT> result(false, KeyT());
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_max_key_compat(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Retrieves the largest key without deserializing the value (C++11-compatible).
+        /// \param txn Active transaction wrapper.
+        /// \return Pair of success flag and largest key.
+        std::pair<bool, KeyT> max_key_compat(const Transaction& txn) const {
+            return max_key_compat(txn.handle());
+        }
+#endif
+
+        // --- Reverse scan ---
+
+        /// \brief Retrieves key-value pairs within an inclusive range in reverse MDBX order.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Optional transaction handle.
+        /// \return Vector containing every pair in descending MDBX key order.
+        /// \throws MdbxException if a database error occurs.
+        std::vector<value_type> range_reverse(const KeyT& from_key, const KeyT& to_key,
+                                              MDBX_txn* txn = nullptr) const {
+            std::vector<value_type> out;
+            with_transaction([this, &from_key, &to_key, &out](MDBX_txn* t) {
+                db_range_reverse(from_key, to_key, out, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return out;
+        }
+
+        /// \brief Retrieves key-value pairs within an inclusive range in reverse MDBX order.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Active transaction wrapper.
+        /// \return Vector containing every pair in descending MDBX key order.
+        /// \throws MdbxException if a database error occurs.
+        std::vector<value_type> range_reverse(const KeyT& from_key, const KeyT& to_key,
+                                              const Transaction& txn) const {
+            return range_reverse(from_key, to_key, txn.handle());
+        }
+
+        /// \brief Retrieves up to \p limit key-value pairs within an inclusive range in reverse MDBX order.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param limit Maximum number of pairs to return.
+        /// \param txn Optional transaction handle.
+        /// \return Vector containing pairs in descending MDBX key order.
+        /// \throws MdbxException if a database error occurs.
+        /// \note \c limit == 0 returns an empty vector.
+        std::vector<value_type> range_reverse(const KeyT& from_key, const KeyT& to_key,
+                                              std::size_t limit, MDBX_txn* txn = nullptr) const {
+            std::vector<value_type> out;
+            with_transaction([this, &from_key, &to_key, &limit, &out](MDBX_txn* t) {
+                db_range_reverse(from_key, to_key, limit, out, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return out;
+        }
+
+        /// \brief Retrieves up to \p limit key-value pairs within an inclusive range in reverse MDBX order.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param limit Maximum number of pairs to return.
+        /// \param txn Active transaction wrapper.
+        /// \return Vector containing pairs in descending MDBX key order.
+        /// \throws MdbxException if a database error occurs.
+        std::vector<value_type> range_reverse(const KeyT& from_key, const KeyT& to_key,
+                                              std::size_t limit, const Transaction& txn) const {
+            return range_reverse(from_key, to_key, limit, txn.handle());
+        }
+
+        // --- Range metadata and removal ---
+
+        /// \brief Checks whether the table contains any key within an inclusive range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Optional transaction handle.
+        /// \return \c true if at least one key exists in the range.
+        /// \throws MdbxException if a database error occurs.
+        bool contains_range(const KeyT& from_key, const KeyT& to_key,
+                            MDBX_txn* txn = nullptr) const {
+            bool result = false;
+            with_transaction([this, &from_key, &to_key, &result](MDBX_txn* t) {
+                result = db_contains_range(from_key, to_key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Checks whether the table contains any key within an inclusive range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Active transaction wrapper.
+        /// \return \c true if at least one key exists in the range.
+        /// \throws MdbxException if a database error occurs.
+        bool contains_range(const KeyT& from_key, const KeyT& to_key,
+                            const Transaction& txn) const {
+            return contains_range(from_key, to_key, txn.handle());
+        }
+
+        /// \brief Counts key-value pairs within an inclusive range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Optional transaction handle.
+        /// \return Number of pairs in the requested range.
+        /// \throws MdbxException if a database error occurs.
+        std::size_t count_range(const KeyT& from_key, const KeyT& to_key,
+                                MDBX_txn* txn = nullptr) const {
+            std::size_t result = 0;
+            with_transaction([this, &from_key, &to_key, &result](MDBX_txn* t) {
+                result = db_count_range(from_key, to_key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Counts key-value pairs within an inclusive range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Active transaction wrapper.
+        /// \return Number of pairs in the requested range.
+        /// \throws MdbxException if a database error occurs.
+        std::size_t count_range(const KeyT& from_key, const KeyT& to_key,
+                                const Transaction& txn) const {
+            return count_range(from_key, to_key, txn.handle());
+        }
+
+        /// \brief Removes all key-value pairs within an inclusive range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Optional transaction handle.
+        /// \return Number of deleted records.
+        /// \throws MdbxException if a database error occurs.
+        std::size_t erase_range(const KeyT& from_key, const KeyT& to_key,
+                                MDBX_txn* txn = nullptr) {
+            std::size_t result = 0;
+            with_transaction([this, &from_key, &to_key, &result](MDBX_txn* t) {
+                result = db_erase_range(from_key, to_key, t);
+            }, TransactionMode::WRITABLE, txn);
+            return result;
+        }
+
+        /// \brief Removes all key-value pairs within an inclusive range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Active transaction wrapper.
+        /// \return Number of deleted records.
+        /// \throws MdbxException if a database error occurs.
+        std::size_t erase_range(const KeyT& from_key, const KeyT& to_key,
+                                const Transaction& txn) {
+            return erase_range(from_key, to_key, txn.handle());
+        }
+
         /// \brief Appends data to the database.
         /// \tparam ContainerT Container type (e.g., std::map or std::unordered_map).
         /// \param container Container with content to be synchronized.
@@ -678,6 +1201,81 @@ namespace mdbxc {
             return find_compat(key, txn.handle());
         }
 
+        /// \brief Updates an existing value by calling a mutator function.
+        /// \param key Key to update.
+        /// \param fn Mutator function invoked as \c fn(ValueT&).
+        /// \param txn Optional transaction handle.
+        /// \return \c true if the key existed and was updated, \c false if the key was missing.
+        /// \throws MdbxException if a database error occurs.
+        /// \note If \c fn throws, the active transaction is rolled back.
+        template<typename Fn>
+        bool update(const KeyT& key, Fn fn, MDBX_txn* txn = nullptr) {
+            bool result = false;
+            with_transaction([this, &key, &fn, &result](MDBX_txn* t) {
+                result = db_update(key, fn, t);
+            }, TransactionMode::WRITABLE, txn);
+            return result;
+        }
+
+        /// \brief Updates an existing value by calling a mutator function.
+        /// \param key Key to update.
+        /// \param fn Mutator function invoked as \c fn(ValueT&).
+        /// \param txn Active transaction wrapper.
+        /// \return \c true if the key existed and was updated, \c false if the key was missing.
+        /// \throws MdbxException if a database error occurs.
+        template<typename Fn>
+        bool update(const KeyT& key, Fn fn, const Transaction& txn) {
+            return update(key, fn, txn.handle());
+        }
+
+        /// \brief Looks up multiple keys and returns found pairs in a map.
+        /// \param keys Vector of keys to search.
+        /// \param txn Optional transaction handle.
+        /// \return \c std::map with found keys and their values. Missing keys are omitted.
+        /// \throws MdbxException if a database error occurs.
+        std::map<KeyT, ValueT> find_many(const std::vector<KeyT>& keys,
+                                         MDBX_txn* txn = nullptr) const {
+            std::map<KeyT, ValueT> result;
+            with_transaction([this, &keys, &result](MDBX_txn* t) {
+                db_find_many(keys, result, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Looks up multiple keys and returns found pairs in a map.
+        /// \param keys Vector of keys to search.
+        /// \param txn Active transaction wrapper.
+        /// \return \c std::map with found keys and their values. Missing keys are omitted.
+        /// \throws MdbxException if a database error occurs.
+        std::map<KeyT, ValueT> find_many(const std::vector<KeyT>& keys,
+                                         const Transaction& txn) const {
+            return find_many(keys, txn.handle());
+        }
+
+        /// \brief Looks up multiple keys and returns found pairs in input order.
+        /// \param keys Vector of keys to search.
+        /// \param txn Optional transaction handle.
+        /// \return Vector of found key-value pairs, preserving input key order. Missing keys are omitted.
+        /// \throws MdbxException if a database error occurs.
+        std::vector<value_type> find_many_vector(const std::vector<KeyT>& keys,
+                                                 MDBX_txn* txn = nullptr) const {
+            std::vector<value_type> result;
+            with_transaction([this, &keys, &result](MDBX_txn* t) {
+                db_find_many_vector(keys, result, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Looks up multiple keys and returns found pairs in input order.
+        /// \param keys Vector of keys to search.
+        /// \param txn Active transaction wrapper.
+        /// \return Vector of found key-value pairs, preserving input key order. Missing keys are omitted.
+        /// \throws MdbxException if a database error occurs.
+        std::vector<value_type> find_many_vector(const std::vector<KeyT>& keys,
+                                                 const Transaction& txn) const {
+            return find_many_vector(keys, txn.handle());
+        }
+
         /// \brief Checks whether a key exists in the database.
         /// \param key The key to look up.
         /// \param txn Active transaction.
@@ -920,6 +1518,382 @@ namespace mdbxc {
         /// \param txn_handle The active transaction.
         /// \return True if found, false otherwise.
         /// \throws MdbxException if a database error occurs.
+        template<typename CallbackT>
+        bool db_for_each_range(const KeyT& from_key, const KeyT& to_key,
+                               CallbackT& callback, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) {
+                return true;
+            }
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_from_key;
+            MDBX_val db_val;
+            bool stopped_by_upper_bound = false;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            while (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    stopped_by_upper_bound = true;
+                    break;
+                }
+                KeyT key = deserialize_key<KeyT>(db_key);
+                ValueT value = deserialize_value<ValueT>(db_val);
+                if (!callback(key, value)) {
+                    return false;
+                }
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+            }
+            if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to iterate key-value range");
+            }
+            return true;
+        }
+
+#if __cplusplus >= 201703L
+        std::optional<value_type> db_lower_bound(const KeyT& key, MDBX_txn* txn) const {
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_val;
+            int rc = mdbx_get(txn, m_dbi, &db_key, &db_val);
+            if (rc == MDBX_SUCCESS) {
+                return value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(db_val));
+            }
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_SUCCESS) {
+                return value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(db_val));
+            }
+            if (rc == MDBX_NOTFOUND) {
+                return std::nullopt;
+            }
+            check_mdbx(rc, "Failed to seek lower bound");
+            return std::nullopt;
+        }
+
+        std::optional<value_type> db_upper_bound(const KeyT& key, MDBX_txn* txn) const {
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_key_exact = db_key;
+            MDBX_val db_val;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_NOTFOUND) {
+                return std::nullopt;
+            }
+            check_mdbx(rc, "Failed to seek upper bound");
+
+            if (mdbx_cmp(txn, m_dbi, &db_key, &db_key_exact) == 0) {
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+                if (rc == MDBX_NOTFOUND) {
+                    return std::nullopt;
+                }
+                check_mdbx(rc, "Failed to seek next key for upper bound");
+            }
+            return value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(db_val));
+        }
+
+        std::optional<value_type> db_first(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_FIRST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::nullopt;
+            }
+            check_mdbx(rc, "Failed to seek first pair");
+            return value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(db_val));
+        }
+
+        std::optional<value_type> db_last(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::nullopt;
+            }
+            check_mdbx(rc, "Failed to seek last pair");
+            return value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(db_val));
+        }
+
+        std::optional<KeyT> db_min_key(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_FIRST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::nullopt;
+            }
+            check_mdbx(rc, "Failed to seek minimum key");
+            return deserialize_key<KeyT>(db_key);
+        }
+
+        std::optional<KeyT> db_max_key(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::nullopt;
+            }
+            check_mdbx(rc, "Failed to seek maximum key");
+            return deserialize_key<KeyT>(db_key);
+        }
+#else
+        std::pair<bool, value_type> db_lower_bound_compat(const KeyT& key, MDBX_txn* txn) const {
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_val;
+            int rc = mdbx_get(txn, m_dbi, &db_key, &db_val);
+            if (rc == MDBX_SUCCESS) {
+                return std::make_pair(true, value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(db_val)));
+            }
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_SUCCESS) {
+                return std::make_pair(true, value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(db_val)));
+            }
+            if (rc == MDBX_NOTFOUND) {
+                return std::make_pair(false, value_type(KeyT(), ValueT()));
+            }
+            check_mdbx(rc, "Failed to seek lower bound");
+            return std::make_pair(false, value_type(KeyT(), ValueT()));
+        }
+
+        std::pair<bool, value_type> db_upper_bound_compat(const KeyT& key, MDBX_txn* txn) const {
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_key_exact = db_key;
+            MDBX_val db_val;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_NOTFOUND) {
+                return std::make_pair(false, value_type(KeyT(), ValueT()));
+            }
+            check_mdbx(rc, "Failed to seek upper bound");
+
+            if (mdbx_cmp(txn, m_dbi, &db_key, &db_key_exact) == 0) {
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+                if (rc == MDBX_NOTFOUND) {
+                    return std::make_pair(false, value_type(KeyT(), ValueT()));
+                }
+                check_mdbx(rc, "Failed to seek next key for upper bound");
+            }
+            return std::make_pair(true, value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(db_val)));
+        }
+
+        std::pair<bool, value_type> db_first_compat(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_FIRST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::make_pair(false, value_type(KeyT(), ValueT()));
+            }
+            check_mdbx(rc, "Failed to seek first pair");
+            return std::make_pair(true, value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(db_val)));
+        }
+
+        std::pair<bool, value_type> db_last_compat(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::make_pair(false, value_type(KeyT(), ValueT()));
+            }
+            check_mdbx(rc, "Failed to seek last pair");
+            return std::make_pair(true, value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(db_val)));
+        }
+
+        std::pair<bool, KeyT> db_min_key_compat(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_FIRST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::make_pair(false, KeyT());
+            }
+            check_mdbx(rc, "Failed to seek minimum key");
+            return std::make_pair(true, deserialize_key<KeyT>(db_key));
+        }
+
+        std::pair<bool, KeyT> db_max_key_compat(MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            MDBX_val db_key, db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST);
+            if (rc == MDBX_NOTFOUND) {
+                return std::make_pair(false, KeyT());
+            }
+            check_mdbx(rc, "Failed to seek maximum key");
+            return std::make_pair(true, deserialize_key<KeyT>(db_key));
+        }
+#endif
+
+        void db_range_reverse(const KeyT& from_key, const KeyT& to_key,
+                              std::vector<value_type>& out, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_to_key;
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_NOTFOUND) {
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST);
+            } else if (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_PREV);
+                }
+            }
+            if (rc == MDBX_NOTFOUND) return;
+            check_mdbx(rc, "Failed to seek reverse range start");
+
+            while (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_from_key) < 0) {
+                    break;
+                }
+                out.push_back(value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(db_val)));
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_PREV);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to iterate reverse key-value range");
+            }
+        }
+
+        void db_range_reverse(const KeyT& from_key, const KeyT& to_key,
+                              std::size_t limit, std::vector<value_type>& out, MDBX_txn* txn) const {
+            if (limit == 0) return;
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_to_key;
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_NOTFOUND) {
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST);
+            } else if (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_PREV);
+                }
+            }
+            if (rc == MDBX_NOTFOUND) return;
+            check_mdbx(rc, "Failed to seek reverse range start");
+
+            while (rc == MDBX_SUCCESS && out.size() < limit) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_from_key) < 0) {
+                    break;
+                }
+                out.push_back(value_type(deserialize_key<KeyT>(db_key), deserialize_value<ValueT>(db_val)));
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_PREV);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to iterate reverse key-value range");
+            }
+        }
+
+        bool db_contains_range(const KeyT& from_key, const KeyT& to_key, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return false;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_from_key;
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "Failed to seek range for contains");
+            return mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) <= 0;
+        }
+
+        std::size_t db_count_range(const KeyT& from_key, const KeyT& to_key, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return 0;
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_from_key;
+            MDBX_val db_val;
+            std::size_t count = 0;
+            bool stopped_by_upper_bound = false;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            while (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    stopped_by_upper_bound = true;
+                    break;
+                }
+                ++count;
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+            }
+            if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to count key-value range");
+            }
+            return count;
+        }
+
+        std::size_t db_erase_range(const KeyT& from_key, const KeyT& to_key, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return 0;
+
+            std::size_t removed = 0;
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key = db_from_key;
+            MDBX_val db_val;
+            bool stopped_by_upper_bound = false;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            while (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    stopped_by_upper_bound = true;
+                    break;
+                }
+                check_mdbx(mdbx_cursor_del(cursor.get(), MDBX_CURRENT), "Failed to erase pair in range");
+                ++removed;
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+            }
+            if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to erase key-value range");
+            }
+            return removed;
+        }
+
         bool db_get(const KeyT& key, ValueT& value, MDBX_txn* txn_handle) const {
             SerializeScratch sc_key;
             MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
@@ -1127,6 +2101,40 @@ namespace mdbxc {
                 mdbx_put(txn_handle, m_dbi, &db_key, &db_val, MDBX_UPSERT),  // or 0
                 "Failed to insert or assign key-value pair"
             );
+        }
+
+        template<typename Fn>
+        bool db_update(const KeyT& key, Fn& fn, MDBX_txn* txn) {
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_val;
+            int rc = mdbx_get(txn, m_dbi, &db_key, &db_val);
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "Failed to read value for update");
+            ValueT value = deserialize_value<ValueT>(db_val);
+            fn(value);
+            db_insert_or_assign(key, value, txn);
+            return true;
+        }
+
+        void db_find_many(const std::vector<KeyT>& keys,
+                          std::map<KeyT, ValueT>& out, MDBX_txn* txn) const {
+            for (typename std::vector<KeyT>::const_iterator it = keys.begin(); it != keys.end(); ++it) {
+                ValueT value;
+                if (db_get(*it, value, txn)) {
+                    out.emplace(*it, std::move(value));
+                }
+            }
+        }
+
+        void db_find_many_vector(const std::vector<KeyT>& keys,
+                                 std::vector<value_type>& out, MDBX_txn* txn) const {
+            for (typename std::vector<KeyT>::const_iterator it = keys.begin(); it != keys.end(); ++it) {
+                ValueT value;
+                if (db_get(*it, value, txn)) {
+                    out.push_back(value_type(*it, std::move(value)));
+                }
+            }
         }
 
         /// \brief Removes a key from the database.

--- a/tests/any_value_table_test.cpp
+++ b/tests/any_value_table_test.cpp
@@ -1,4 +1,4 @@
-#include <cassert>
+#include "test_assert.hpp"
 #include <mdbx_containers/AnyValueTable.hpp>
 #include <vector>
 #include <string>
@@ -100,41 +100,41 @@ int main() {
     MyStruct expected{7, 3.5};
     table.set<MyStruct>("object", expected);
 
-    assert(table.get<int>("answer") == 42);
+    MDBXC_TEST_ASSERT(table.get<int>("answer") == 42);
 #if __cplusplus >= 201703L
-    assert(table.find<std::string>("greeting").value() == "hello");
+    MDBXC_TEST_ASSERT(table.find<std::string>("greeting").value() == "hello");
 #else
     {
         auto res = table.find_compat<std::string>("greeting");
-        assert(res.first && res.second == "hello");
+        MDBXC_TEST_ASSERT(res.first && res.second == "hello");
     }
 #endif
-    assert(table.get<MyStruct>("object") == expected);
-    assert(table.contains("answer"));
-    assert(!table.contains("missing"));
+    MDBXC_TEST_ASSERT(table.get<MyStruct>("object") == expected);
+    MDBXC_TEST_ASSERT(table.contains("answer"));
+    MDBXC_TEST_ASSERT(!table.contains("missing"));
 
     auto ks = table.keys();
-    assert(ks.size() == 3);
+    MDBXC_TEST_ASSERT(ks.size() == 3);
 
     mdbxc::AnyValueTable<int> safe_int_table(conn, "test_any_int_options");
     mdbxc::AnyValueTable<int, mdbxc::FastIntegerKeyOptions> fast_int_table(conn, "test_any_int_options");
     safe_int_table.set<std::string>(11, "safe");
     fast_int_table.set<int>(12, 99);
-    assert(fast_int_table.get<std::string>(11) == "safe");
-    assert(safe_int_table.get<int>(12) == 99);
+    MDBXC_TEST_ASSERT(fast_int_table.get<std::string>(11) == "safe");
+    MDBXC_TEST_ASSERT(safe_int_table.get<int>(12) == 99);
 
     mdbxc::AnyValueTable<std::string> tagged(conn, "test_any_tagged");
     tagged.erase("answer");
     tagged.erase("stable");
     tagged.set_type_tag_check(true);
     tagged.set<int>("answer", 42);
-    assert(tagged.get<int>("answer") == 42);
-    assert(tagged.contains("answer"));
+    MDBXC_TEST_ASSERT(tagged.get<int>("answer") == 42);
+    MDBXC_TEST_ASSERT(tagged.contains("answer"));
 
     tagged.update<int>("answer", [](int& value) {
         value += 1;
     });
-    assert(tagged.get<int>("answer") == 43);
+    MDBXC_TEST_ASSERT(tagged.get<int>("answer") == 43);
 
     bool bad_cast_thrown = false;
     try {
@@ -142,29 +142,29 @@ int main() {
     } catch (const std::bad_cast&) {
         bad_cast_thrown = true;
     }
-    assert(bad_cast_thrown);
+    MDBXC_TEST_ASSERT(bad_cast_thrown);
 
 #if __cplusplus >= 201703L
-    assert(!tagged.find<std::string>("answer").has_value());
+    MDBXC_TEST_ASSERT(!tagged.find<std::string>("answer").has_value());
 #else
     {
         auto mismatch = tagged.find_compat<std::string>("answer");
-        assert(!mismatch.first);
+        MDBXC_TEST_ASSERT(!mismatch.first);
     }
 #endif
-    assert(tagged.get_or<std::string>("answer", std::string("fallback")) == "fallback");
+    MDBXC_TEST_ASSERT(tagged.get_or<std::string>("answer", std::string("fallback")) == "fallback");
 
     StableTagged stable{};
     stable.value = 77;
     tagged.set<StableTagged>("stable", stable);
     StableTaggedAlias alias = tagged.get<StableTaggedAlias>("stable");
-    assert(alias.value == stable.value);
-    assert(std::string(mdbxc::AnyValueTypeTag<StableTagged>::value()) == "tests.StableTagged.v1");
+    MDBXC_TEST_ASSERT(alias.value == stable.value);
+    MDBXC_TEST_ASSERT(std::string(mdbxc::AnyValueTypeTag<StableTagged>::value()) == "tests.StableTagged.v1");
 
     mdbxc::AnyValueTable<std::string> legacy(conn, "test_any_legacy_raw");
     legacy.erase("legacy");
     legacy.set<int>("legacy", 7);
-    assert(legacy.get<int>("legacy") == 7);
+    MDBXC_TEST_ASSERT(legacy.get<int>("legacy") == 7);
     legacy.set_type_tag_check(true);
     bool legacy_bad_cast = false;
     try {
@@ -172,14 +172,14 @@ int main() {
     } catch (const std::bad_cast&) {
         legacy_bad_cast = true;
     }
-    assert(legacy_bad_cast);
+    MDBXC_TEST_ASSERT(legacy_bad_cast);
 
 #if __cplusplus >= 201703L
-    assert(!legacy.find<int>("legacy").has_value());
+    MDBXC_TEST_ASSERT(!legacy.find<int>("legacy").has_value());
 #else
     {
         auto legacy_lookup = legacy.find_compat<int>("legacy");
-        assert(!legacy_lookup.first);
+        MDBXC_TEST_ASSERT(!legacy_lookup.first);
     }
 #endif
 

--- a/tests/hashed_key_value_store_test.cpp
+++ b/tests/hashed_key_value_store_test.cpp
@@ -1,4 +1,4 @@
-#include <cassert>
+#include "test_assert.hpp"
 #include <iostream>
 #include <map>
 #include <stdexcept>
@@ -23,12 +23,12 @@ template<class Store, class Key, class Value>
 void assert_found(const Store& store, const Key& key, const Value& expected) {
 #if __cplusplus >= 201703L
     std::optional<Value> found = store.find(key);
-    assert(found.has_value());
-    assert(*found == expected);
+    MDBXC_TEST_ASSERT(found.has_value());
+    MDBXC_TEST_ASSERT(*found == expected);
 #else
     std::pair<bool, Value> found = store.find_compat(key);
-    assert(found.first);
-    assert(found.second == expected);
+    MDBXC_TEST_ASSERT(found.first);
+    MDBXC_TEST_ASSERT(found.second == expected);
 #endif
 }
 
@@ -40,7 +40,7 @@ void assert_throws_length_error(Fn fn) {
     } catch (const std::length_error&) {
         thrown = true;
     }
-    assert(thrown);
+    MDBXC_TEST_ASSERT(thrown);
 }
 
 template<class Fn>
@@ -51,7 +51,7 @@ void assert_throws_any(Fn fn) {
     } catch (const std::exception&) {
         thrown = true;
     }
-    assert(thrown);
+    MDBXC_TEST_ASSERT(thrown);
 }
 
 } // namespace
@@ -69,38 +69,38 @@ int main() {
         mdbxc::HashedKeyValueStore<std::string, int> store(conn, "hashed_strings");
         store.clear();
 
-        assert(store.empty());
-        assert(store.insert("alpha", 1));
-        assert(!store.insert("alpha", 11));
+        MDBXC_TEST_ASSERT(store.empty());
+        MDBXC_TEST_ASSERT(store.insert("alpha", 1));
+        MDBXC_TEST_ASSERT(!store.insert("alpha", 11));
         store.insert_or_assign("beta", 2);
         assert_found<decltype(store), std::string, int>(store, "alpha", 1);
-        assert(store.at("beta") == 2);
+        MDBXC_TEST_ASSERT(store.at("beta") == 2);
 
         int out = 0;
-        assert(store.try_get("alpha", out));
-        assert(out == 1);
-        assert(!store.try_get("missing", out));
-        assert(store.contains("alpha"));
-        assert(!store.contains("missing"));
+        MDBXC_TEST_ASSERT(store.try_get("alpha", out));
+        MDBXC_TEST_ASSERT(out == 1);
+        MDBXC_TEST_ASSERT(!store.try_get("missing", out));
+        MDBXC_TEST_ASSERT(store.contains("alpha"));
+        MDBXC_TEST_ASSERT(!store.contains("missing"));
 
         store["gamma"] = 3;
-        assert(static_cast<int>(store["gamma"]) == 3);
-        assert(static_cast<int>(store["defaulted"]) == 0);
-        assert(store.count() == 4);
+        MDBXC_TEST_ASSERT(static_cast<int>(store["gamma"]) == 3);
+        MDBXC_TEST_ASSERT(static_cast<int>(store["defaulted"]) == 0);
+        MDBXC_TEST_ASSERT(store.count() == 4);
 
         std::map<std::string, int> as_map;
         store.load(as_map);
-        assert(as_map["alpha"] == 1);
-        assert(as_map["beta"] == 2);
-        assert(as_map["gamma"] == 3);
+        MDBXC_TEST_ASSERT(as_map["alpha"] == 1);
+        MDBXC_TEST_ASSERT(as_map["beta"] == 2);
+        MDBXC_TEST_ASSERT(as_map["gamma"] == 3);
 
         std::vector<std::pair<std::string, int> > as_vector = store.retrieve_all<std::vector>();
-        assert(as_vector.size() == 4);
+        MDBXC_TEST_ASSERT(as_vector.size() == 4);
 
-        assert(store.erase("alpha"));
-        assert(!store.erase("alpha"));
-        assert(!store.contains("alpha"));
-        assert(store.count() == 3);
+        MDBXC_TEST_ASSERT(store.erase("alpha"));
+        MDBXC_TEST_ASSERT(!store.erase("alpha"));
+        MDBXC_TEST_ASSERT(!store.contains("alpha"));
+        MDBXC_TEST_ASSERT(store.count() == 3);
     }
 
     {
@@ -111,25 +111,25 @@ int main() {
         source["one"] = 1;
         source["two"] = 2;
         store.reconcile(source);
-        assert(store.count() == 2);
+        MDBXC_TEST_ASSERT(store.count() == 2);
 
         std::vector<std::pair<std::string, int> > additions;
         additions.push_back(std::make_pair(std::string("two"), 20));
         additions.push_back(std::make_pair(std::string("three"), 3));
         store.append(additions);
-        assert(store.at("two") == 20);
-        assert(store.at("three") == 3);
+        MDBXC_TEST_ASSERT(store.at("two") == 20);
+        MDBXC_TEST_ASSERT(store.at("three") == 3);
 
         std::vector<std::pair<std::string, int> > replacement;
         replacement.push_back(std::make_pair(std::string("two"), 200));
         replacement.push_back(std::make_pair(std::string("two"), 201));
         replacement.push_back(std::make_pair(std::string("four"), 4));
         store = replacement;
-        assert(store.count() == 2);
-        assert(store.at("two") == 201);
-        assert(store.at("four") == 4);
-        assert(!store.contains("one"));
-        assert(!store.contains("three"));
+        MDBXC_TEST_ASSERT(store.count() == 2);
+        MDBXC_TEST_ASSERT(store.at("two") == 201);
+        MDBXC_TEST_ASSERT(store.at("four") == 4);
+        MDBXC_TEST_ASSERT(!store.contains("one"));
+        MDBXC_TEST_ASSERT(!store.contains("three"));
     }
 
     {
@@ -140,18 +140,18 @@ int main() {
         );
         store.clear();
 
-        assert(store.insert("alpha", "one"));
-        assert(store.insert("beta", "two"));
-        assert(store.insert("gamma", "three"));
+        MDBXC_TEST_ASSERT(store.insert("alpha", "one"));
+        MDBXC_TEST_ASSERT(store.insert("beta", "two"));
+        MDBXC_TEST_ASSERT(store.insert("gamma", "three"));
         store.insert_or_assign("beta", "TWO");
 
         assert_found<decltype(store), std::string, std::string>(store, "alpha", "one");
         assert_found<decltype(store), std::string, std::string>(store, "beta", "TWO");
         assert_found<decltype(store), std::string, std::string>(store, "gamma", "three");
-        assert(store.erase("alpha"));
-        assert(!store.contains("alpha"));
-        assert(store.contains("beta"));
-        assert(store.count() == 2);
+        MDBXC_TEST_ASSERT(store.erase("alpha"));
+        MDBXC_TEST_ASSERT(!store.contains("alpha"));
+        MDBXC_TEST_ASSERT(store.contains("beta"));
+        MDBXC_TEST_ASSERT(store.count() == 2);
     }
 
     {
@@ -169,14 +169,14 @@ int main() {
         second.push_back(1);
         second.push_back(3);
 
-        assert(store.insert(first, "first"));
+        MDBXC_TEST_ASSERT(store.insert(first, "first"));
         store.insert_or_assign(second, "second");
         assert_found<decltype(store), Bytes, std::string>(store, first, "first");
         assert_found<decltype(store), Bytes, std::string>(store, second, "second");
 
         std::map<Bytes, std::string> as_map = store.retrieve_all();
-        assert(as_map[first] == "first");
-        assert(as_map[second] == "second");
+        MDBXC_TEST_ASSERT(as_map[first] == "first");
+        MDBXC_TEST_ASSERT(as_map[second] == "second");
     }
 
     {
@@ -208,7 +208,7 @@ int main() {
         assert_found<decltype(store), StdBytes, std::string>(store, key, "byte-key");
 
         std::map<StdBytes, std::string> as_map = store.retrieve_all();
-        assert(as_map[key] == "byte-key");
+        MDBXC_TEST_ASSERT(as_map[key] == "byte-key");
     }
 #endif
 
@@ -223,16 +223,16 @@ int main() {
             "hashed_sip",
             mdbxc::SipHashHasher(UINT64_C(0x0706050403020100), UINT64_C(0x0f0e0d0c0b0a0908))
         );
-        assert(reopened.contains("token"));
-        assert(reopened.at("token") == 123);
+        MDBXC_TEST_ASSERT(reopened.contains("token"));
+        MDBXC_TEST_ASSERT(reopened.at("token") == 123);
 
         mdbxc::HashedKeyValueStore<std::string, int, mdbxc::SipHashHasher> wrong_key(
             conn,
             "hashed_sip",
             mdbxc::SipHashHasher(1, 2)
         );
-        assert(wrong_key.count() == 1);
-        assert(!wrong_key.contains("token"));
+        MDBXC_TEST_ASSERT(wrong_key.count() == 1);
+        MDBXC_TEST_ASSERT(!wrong_key.contains("token"));
     }
 
     {
@@ -240,14 +240,14 @@ int main() {
         store.clear();
 
         auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
-        assert(store.insert("one", "1", txn));
+        MDBXC_TEST_ASSERT(store.insert("one", "1", txn));
         store.insert_or_assign("two", "2", txn);
         txn.commit();
 
         auto read_txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
-        assert(store.count(read_txn) == 2);
-        assert(store.at("one", read_txn) == "1");
-        assert(store.contains("two", read_txn));
+        MDBXC_TEST_ASSERT(store.count(read_txn) == 2);
+        MDBXC_TEST_ASSERT(store.at("one", read_txn) == "1");
+        MDBXC_TEST_ASSERT(store.contains("two", read_txn));
         read_txn.commit();
     }
 
@@ -259,7 +259,7 @@ int main() {
         large[0] = 'A';
         large[large.size() - 1] = 'Z';
         store.insert_or_assign("large", large);
-        assert(store.at("large") == large);
+        MDBXC_TEST_ASSERT(store.at("large") == large);
     }
 
     {
@@ -285,8 +285,8 @@ int main() {
             read_conn,
             "hashed_large_read_only"
         );
-        assert(read_store.at("alpha") == "one");
-        assert(read_store.contains("alpha"));
+        MDBXC_TEST_ASSERT(read_store.at("alpha") == "one");
+        MDBXC_TEST_ASSERT(read_store.contains("alpha"));
 
         bool write_failed = false;
         try {
@@ -294,8 +294,8 @@ int main() {
         } catch (const mdbxc::MdbxException&) {
             write_failed = true;
         }
-        assert(write_failed);
-        assert(!read_store.contains("beta"));
+        MDBXC_TEST_ASSERT(write_failed);
+        MDBXC_TEST_ASSERT(!read_store.contains("beta"));
     }
 
     {
@@ -307,30 +307,30 @@ int main() {
         SmallStore store(conn, "hashed_small_values");
         store.clear();
 
-        assert(store.empty());
-        assert(store.insert("a", 1));
-        assert(!store.insert("a", 11));
+        MDBXC_TEST_ASSERT(store.empty());
+        MDBXC_TEST_ASSERT(store.insert("a", 1));
+        MDBXC_TEST_ASSERT(!store.insert("a", 11));
         store.insert_or_assign("b", 2);
         store.insert_or_assign("b", 22);
         assert_found<SmallStore, std::string, int>(store, "a", 1);
         assert_found<SmallStore, std::string, int>(store, "b", 22);
-        assert(store.contains("a"));
-        assert(store.count() == 2);
+        MDBXC_TEST_ASSERT(store.contains("a"));
+        MDBXC_TEST_ASSERT(store.count() == 2);
 
         std::map<std::string, int> as_map;
         store.load(as_map);
-        assert(as_map["a"] == 1);
-        assert(as_map["b"] == 22);
+        MDBXC_TEST_ASSERT(as_map["a"] == 1);
+        MDBXC_TEST_ASSERT(as_map["b"] == 22);
 
         std::vector<std::pair<std::string, int> > replacement;
         replacement.push_back(std::make_pair(std::string("b"), 200));
         replacement.push_back(std::make_pair(std::string("b"), 201));
         replacement.push_back(std::make_pair(std::string("c"), 3));
         store.reconcile(replacement);
-        assert(store.count() == 2);
-        assert(store.at("b") == 201);
-        assert(store.at("c") == 3);
-        assert(!store.contains("a"));
+        MDBXC_TEST_ASSERT(store.count() == 2);
+        MDBXC_TEST_ASSERT(store.at("b") == 201);
+        MDBXC_TEST_ASSERT(store.at("c") == 3);
+        MDBXC_TEST_ASSERT(!store.contains("a"));
     }
 
     {
@@ -342,19 +342,19 @@ int main() {
         SmallCollisionStore store(conn, "hashed_small_collisions", ConstantHasher());
         store.clear();
 
-        assert(store.insert("alpha", "one"));
-        assert(store.insert("beta", "two"));
-        assert(store.insert("gamma", "three"));
+        MDBXC_TEST_ASSERT(store.insert("alpha", "one"));
+        MDBXC_TEST_ASSERT(store.insert("beta", "two"));
+        MDBXC_TEST_ASSERT(store.insert("gamma", "three"));
         store.insert_or_assign("beta", "TWO");
 
         assert_found<SmallCollisionStore, std::string, std::string>(store, "alpha", "one");
         assert_found<SmallCollisionStore, std::string, std::string>(store, "beta", "TWO");
         assert_found<SmallCollisionStore, std::string, std::string>(store, "gamma", "three");
-        assert(store.erase("beta"));
-        assert(!store.contains("beta"));
-        assert(store.contains("alpha"));
-        assert(store.contains("gamma"));
-        assert(store.count() == 2);
+        MDBXC_TEST_ASSERT(store.erase("beta"));
+        MDBXC_TEST_ASSERT(!store.contains("beta"));
+        MDBXC_TEST_ASSERT(store.contains("alpha"));
+        MDBXC_TEST_ASSERT(store.contains("gamma"));
+        MDBXC_TEST_ASSERT(store.count() == 2);
     }
 
     {
@@ -395,7 +395,7 @@ int main() {
         SmallStore store(small_conn, "one_dbi_small");
         store.clear();
         store.insert_or_assign("ok", 7);
-        assert(store.at("ok") == 7);
+        MDBXC_TEST_ASSERT(store.at("ok") == 7);
     }
 
     {

--- a/tests/key_multi_value_table_test.cpp
+++ b/tests/key_multi_value_table_test.cpp
@@ -1,3 +1,6 @@
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
 #include <cassert>
 #include <iostream>
 #include <map>
@@ -246,6 +249,123 @@ int main() {
             table.insert(1, large);
         });
     }
+
+    // --- Range API extension tests ---
+    {
+        mdbxc::KeyMultiValueTable<int, std::string> table(conn, "multi_range_api");
+        table.clear();
+        table.insert(1, "a");
+        table.insert(1, "b");
+        table.insert(2, "c");
+        table.insert(3, "d");
+        table.insert(3, "e");
+        table.insert(3, "f");
+
+        // for_each_range visits every physical pair
+        std::vector<std::pair<int, std::string>> collected;
+        bool completed = table.for_each_range(1, 3, [&collected](const int& k, const std::string& v) -> bool {
+            collected.push_back(std::make_pair(k, v));
+            return true;
+        });
+        assert(completed);
+        assert(collected.size() == 6);
+
+        // filter_range
+        std::vector<std::pair<int, std::string>> filtered = table.filter_range(1, 3, [](const int&, const std::string& v) -> bool {
+            return v >= "d";
+        });
+        assert(filtered.size() == 3); // d, e, f
+
+        // reverse range
+        std::vector<std::pair<int, std::string>> rev = table.range_reverse(1, 3);
+        assert(rev.size() == 6);
+        assert(rev[0] == std::make_pair(3, std::string("f")));
+        assert(rev[5] == std::make_pair(1, std::string("a")));
+
+        // reverse range limit
+        std::vector<std::pair<int, std::string>> rev_limit = table.range_reverse(1, 3, 2);
+        assert(rev_limit.size() == 2);
+        assert(rev_limit[0] == std::make_pair(3, std::string("f")));
+        assert(rev_limit[1] == std::make_pair(3, std::string("e")));
+
+        // contains_range / count_range / erase_range
+        assert(table.contains_range(2, 3));
+        assert(table.count_range(2, 3) == 4); // c + d,e,f
+        std::size_t erased = table.erase_range(2, 3);
+        assert(erased == 4);
+        assert(table.count() == 2);
+
+    }
+
+#if __cplusplus >= 201703L
+    {
+        mdbxc::KeyMultiValueTable<int, std::string> table(conn, "multi_range_api_opt");
+        table.clear();
+        table.insert(10, "x");
+        table.insert(10, "z");
+        table.insert(20, "y");
+
+        auto lb = table.lower_bound(10);
+        if (!lb.has_value() || lb->first != 10 || lb->second != "x") {
+            throw std::runtime_error("lower_bound failed for KeyMultiValueTable");
+        }
+        auto ub = table.upper_bound(10);
+        if (!ub.has_value() || ub->first != 20 || ub->second != "y") {
+            throw std::runtime_error("upper_bound skipped to duplicate instead of next key");
+        }
+        auto fr = table.first();
+        if (!fr.has_value() || fr->first != 10) {
+            throw std::runtime_error("first failed for KeyMultiValueTable");
+        }
+        auto la = table.last();
+        if (!la.has_value() || la->first != 20) {
+            throw std::runtime_error("last failed for KeyMultiValueTable");
+        }
+        auto min_key = table.min_key();
+        if (!min_key.has_value() || min_key.value() != 10) {
+            throw std::runtime_error("min_key failed for KeyMultiValueTable");
+        }
+        auto max_key = table.max_key();
+        if (!max_key.has_value() || max_key.value() != 20) {
+            throw std::runtime_error("max_key failed for KeyMultiValueTable");
+        }
+    }
+#endif
+
+#if __cplusplus < 201703L
+    {
+        mdbxc::KeyMultiValueTable<int, std::string> bounds_table(conn, "multi_range_api_bounds");
+        bounds_table.clear();
+        bounds_table.insert(1, "a");
+        bounds_table.insert(1, "b");
+        bounds_table.insert(2, "c");
+        bounds_table.insert(3, "d");
+        std::pair<bool, std::pair<int, std::string>> lb = bounds_table.lower_bound_compat(1);
+        if (!lb.first || lb.second != std::make_pair(1, std::string("a"))) {
+            throw std::runtime_error("lower_bound_compat failed for KeyMultiValueTable");
+        }
+        std::pair<bool, std::pair<int, std::string>> ub = bounds_table.upper_bound_compat(1);
+        if (!ub.first || ub.second != std::make_pair(2, std::string("c"))) {
+            throw std::runtime_error("upper_bound_compat skipped to duplicate instead of next key");
+        }
+        std::pair<bool, std::pair<int, std::string>> named_ub = bounds_table.upper_bound(1);
+        if (!named_ub.first || named_ub.second != std::make_pair(2, std::string("c"))) {
+            throw std::runtime_error("upper_bound skipped to duplicate instead of next key in C++11");
+        }
+        std::pair<bool, int> min_key = bounds_table.min_key_compat();
+        if (!min_key.first || min_key.second != 1) {
+            throw std::runtime_error("min_key_compat failed for KeyMultiValueTable");
+        }
+        std::pair<bool, int> max_key = bounds_table.max_key_compat();
+        if (!max_key.first || max_key.second != 3) {
+            throw std::runtime_error("max_key_compat failed for KeyMultiValueTable");
+        }
+        std::pair<bool, int> named_max_key = bounds_table.max_key();
+        if (!named_max_key.first || named_max_key.second != 3) {
+            throw std::runtime_error("max_key failed for KeyMultiValueTable C++11");
+        }
+    }
+#endif
 
     std::cout << "KeyMultiValueTable test passed.\n";
     return 0;

--- a/tests/key_multi_value_table_test.cpp
+++ b/tests/key_multi_value_table_test.cpp
@@ -1,7 +1,4 @@
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-#include <cassert>
+#include "test_assert.hpp"
 #include <iostream>
 #include <map>
 #include <set>
@@ -15,9 +12,9 @@ namespace {
 
 template <class T>
 void assert_vector_equal(const std::vector<T>& actual, const std::vector<T>& expected) {
-    assert(actual.size() == expected.size());
+    MDBXC_TEST_ASSERT(actual.size() == expected.size());
     for (std::size_t i = 0; i < actual.size(); ++i) {
-        assert(actual[i] == expected[i]);
+        MDBXC_TEST_ASSERT(actual[i] == expected[i]);
     }
 }
 
@@ -29,7 +26,7 @@ void assert_throws_length_error(Fn fn) {
     } catch (const std::length_error&) {
         thrown = true;
     }
-    assert(thrown);
+    MDBXC_TEST_ASSERT(thrown);
 }
 
 } // namespace
@@ -47,19 +44,19 @@ int main() {
         mdbxc::KeyMultiValueTable<int, std::string> table(conn, "multi_values");
         table.clear();
 
-        assert(table.empty());
+        MDBXC_TEST_ASSERT(table.empty());
         table.insert(7, "created");
         table.insert(7, "created");
         table.insert(7, "sent");
         table.insert(8, "queued");
 
-        assert(table.count() == 4);
-        assert(table.count(7) == 3);
-        assert(table.count(7, std::string("created")) == 2);
-        assert(table.count(7, std::string("missing")) == 0);
-        assert(table.contains(7));
-        assert(table.contains(7, std::string("sent")));
-        assert(!table.contains(9));
+        MDBXC_TEST_ASSERT(table.count() == 4);
+        MDBXC_TEST_ASSERT(table.count(7) == 3);
+        MDBXC_TEST_ASSERT(table.count(7, std::string("created")) == 2);
+        MDBXC_TEST_ASSERT(table.count(7, std::string("missing")) == 0);
+        MDBXC_TEST_ASSERT(table.contains(7));
+        MDBXC_TEST_ASSERT(table.contains(7, std::string("sent")));
+        MDBXC_TEST_ASSERT(!table.contains(9));
 
         assert_vector_equal(table.find(7), std::vector<std::string>{"created", "created", "sent"});
         std::vector<std::pair<int, std::string> > range_pairs;
@@ -68,58 +65,58 @@ int main() {
         range_pairs.push_back(std::make_pair(7, std::string("sent")));
         range_pairs.push_back(std::make_pair(8, std::string("queued")));
         std::multimap<int, std::string> range_multimap = table.range(7, 8);
-        assert(range_multimap.size() == 4);
-        assert(range_multimap.count(7) == 3);
-        assert(range_multimap.count(8) == 1);
+        MDBXC_TEST_ASSERT(range_multimap.size() == 4);
+        MDBXC_TEST_ASSERT(range_multimap.count(7) == 3);
+        MDBXC_TEST_ASSERT(range_multimap.count(8) == 1);
         assert_vector_equal(table.range_vector(7, 8), range_pairs);
         assert_vector_equal(table.range_values(7, 8),
                             std::vector<std::string>{"created", "created", "sent", "queued"});
-        assert(table.range_values<std::set>(7, 8) ==
+        MDBXC_TEST_ASSERT(table.range_values<std::set>(7, 8) ==
                (std::set<std::string>{"created", "queued", "sent"}));
 
         std::vector<std::pair<int, std::string> > queued_pair;
         queued_pair.push_back(std::make_pair(8, std::string("queued")));
-        assert(table.range(8, 8).size() == 1);
+        MDBXC_TEST_ASSERT(table.range(8, 8).size() == 1);
         assert_vector_equal(table.range_vector(8, 8), queued_pair);
         assert_vector_equal(table.range_values(8, 8), std::vector<std::string>{"queued"});
-        assert(table.range(9, 10).empty());
-        assert(table.range(8, 7).empty());
+        MDBXC_TEST_ASSERT(table.range(9, 10).empty());
+        MDBXC_TEST_ASSERT(table.range(8, 7).empty());
 
         std::multimap<int, std::string> as_multimap;
         table.load(as_multimap);
-        assert(as_multimap.size() == 4);
-        assert(as_multimap.count(7) == 3);
+        MDBXC_TEST_ASSERT(as_multimap.size() == 4);
+        MDBXC_TEST_ASSERT(as_multimap.count(7) == 3);
 
         std::vector<std::pair<int, std::string> > as_vector;
         table.load(as_vector);
-        assert(as_vector.size() == 4);
-        assert(as_vector[0] == std::make_pair(7, std::string("created")));
-        assert(as_vector[1] == std::make_pair(7, std::string("created")));
-        assert(as_vector[2] == std::make_pair(7, std::string("sent")));
-        assert(as_vector[3] == std::make_pair(8, std::string("queued")));
+        MDBXC_TEST_ASSERT(as_vector.size() == 4);
+        MDBXC_TEST_ASSERT(as_vector[0] == std::make_pair(7, std::string("created")));
+        MDBXC_TEST_ASSERT(as_vector[1] == std::make_pair(7, std::string("created")));
+        MDBXC_TEST_ASSERT(as_vector[2] == std::make_pair(7, std::string("sent")));
+        MDBXC_TEST_ASSERT(as_vector[3] == std::make_pair(8, std::string("queued")));
 
-        assert(table.erase(7, std::string("created")) == 2);
+        MDBXC_TEST_ASSERT(table.erase(7, std::string("created")) == 2);
         assert_vector_equal(table.find(7), std::vector<std::string>{"sent"});
-        assert(table.erase(7));
-        assert(!table.contains(7));
-        assert(table.count() == 1);
+        MDBXC_TEST_ASSERT(table.erase(7));
+        MDBXC_TEST_ASSERT(!table.contains(7));
+        MDBXC_TEST_ASSERT(table.count() == 1);
 
         std::vector<std::pair<int, std::string> > replacement;
         replacement.push_back(std::make_pair(3, std::string("a")));
         replacement.push_back(std::make_pair(3, std::string("a")));
         replacement.push_back(std::make_pair(3, std::string("b")));
         table.reconcile(replacement);
-        assert(table.count() == 3);
-        assert(table.count(3, std::string("a")) == 2);
+        MDBXC_TEST_ASSERT(table.count() == 3);
+        MDBXC_TEST_ASSERT(table.count(3, std::string("a")) == 2);
         assert_vector_equal(table.find(3), std::vector<std::string>{"a", "a", "b"});
 
         std::multimap<int, std::string> assigned;
         assigned.emplace(4, "x");
         assigned.emplace(4, "x");
         table = assigned;
-        assert(table.count() == 2);
-        assert(table.count(4, std::string("x")) == 2);
-        assert(!table.contains(3));
+        MDBXC_TEST_ASSERT(table.count() == 2);
+        MDBXC_TEST_ASSERT(table.count(4, std::string("x")) == 2);
+        MDBXC_TEST_ASSERT(!table.contains(3));
     }
 
     {
@@ -137,7 +134,7 @@ int main() {
         expected_pairs.push_back(std::make_pair(1, std::string("b")));
         expected_pairs.push_back(std::make_pair(2, std::string("c")));
         expected_pairs.push_back(std::make_pair(2, std::string("d")));
-        assert(table.range(1, 2).size() == 4);
+        MDBXC_TEST_ASSERT(table.range(1, 2).size() == 4);
         assert_vector_equal(table.range_vector(1, 2), expected_pairs);
         assert_vector_equal(table.range_values(1, 2),
                             std::vector<std::string>{"a", "b", "c", "d"});
@@ -153,12 +150,12 @@ int main() {
         txn.commit();
 
         auto read_txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
-        assert(table.count(1, read_txn) == 2);
-        assert(table.count(1, std::string("one"), read_txn) == 2);
+        MDBXC_TEST_ASSERT(table.count(1, read_txn) == 2);
+        MDBXC_TEST_ASSERT(table.count(1, std::string("one"), read_txn) == 2);
         std::vector<std::pair<int, std::string> > one_pairs;
         one_pairs.push_back(std::make_pair(1, std::string("one")));
         one_pairs.push_back(std::make_pair(1, std::string("one")));
-        assert(table.range(1, 1, read_txn).size() == 2);
+        MDBXC_TEST_ASSERT(table.range(1, 1, read_txn).size() == 2);
         assert_vector_equal(table.range_vector(1, 1, read_txn), one_pairs);
         assert_vector_equal(table.range_values(1, 1, read_txn), std::vector<std::string>{"one", "one"});
         read_txn.commit();
@@ -179,15 +176,15 @@ int main() {
         same_multiset_reordered.push_back(std::make_pair(1, std::string("a")));
         same_multiset_reordered.push_back(std::make_pair(2, std::string("old")));
         table.reconcile(same_multiset_reordered);
-        assert(table.count() == 4);
+        MDBXC_TEST_ASSERT(table.count() == 4);
         assert_vector_equal(table.find(1), std::vector<std::string>{"a", "b", "a"});
 
         std::vector<std::pair<int, std::string> > fewer_duplicates;
         fewer_duplicates.push_back(std::make_pair(1, std::string("a")));
         table.reconcile(fewer_duplicates);
-        assert(table.count() == 1);
-        assert(table.count(1, std::string("a")) == 1);
-        assert(!table.contains(2));
+        MDBXC_TEST_ASSERT(table.count() == 1);
+        MDBXC_TEST_ASSERT(table.count(1, std::string("a")) == 1);
+        MDBXC_TEST_ASSERT(!table.contains(2));
         assert_vector_equal(table.find(1), std::vector<std::string>{"a"});
 
         std::vector<std::pair<int, std::string> > more_and_changed;
@@ -196,10 +193,10 @@ int main() {
         more_and_changed.push_back(std::make_pair(1, std::string("c")));
         more_and_changed.push_back(std::make_pair(3, std::string("z")));
         table.reconcile(more_and_changed);
-        assert(table.count() == 4);
-        assert(table.count(1, std::string("a")) == 2);
-        assert(table.count(1, std::string("c")) == 1);
-        assert(table.count(3, std::string("z")) == 1);
+        MDBXC_TEST_ASSERT(table.count() == 4);
+        MDBXC_TEST_ASSERT(table.count(1, std::string("a")) == 2);
+        MDBXC_TEST_ASSERT(table.count(1, std::string("c")) == 1);
+        MDBXC_TEST_ASSERT(table.count(3, std::string("z")) == 1);
         assert_vector_equal(table.find(1), std::vector<std::string>{"a", "a", "c"});
 
         std::multimap<int, std::string> multimap_source;
@@ -207,10 +204,10 @@ int main() {
         multimap_source.insert(std::make_pair(4, std::string("x")));
         multimap_source.insert(std::make_pair(4, std::string("y")));
         table.reconcile(multimap_source);
-        assert(table.count() == 3);
-        assert(table.count(4, std::string("x")) == 2);
-        assert(table.count(4, std::string("y")) == 1);
-        assert(!table.contains(1));
+        MDBXC_TEST_ASSERT(table.count() == 3);
+        MDBXC_TEST_ASSERT(table.count(4, std::string("x")) == 2);
+        MDBXC_TEST_ASSERT(table.count(4, std::string("y")) == 1);
+        MDBXC_TEST_ASSERT(!table.contains(1));
 
         auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
         std::vector<std::pair<int, std::string> > txn_source;
@@ -218,9 +215,9 @@ int main() {
         txn_source.push_back(std::make_pair(5, std::string("txn")));
         table.reconcile(txn_source, txn);
         txn.commit();
-        assert(table.count() == 2);
-        assert(table.count(5, std::string("txn")) == 2);
-        assert(!table.contains(4));
+        MDBXC_TEST_ASSERT(table.count() == 2);
+        MDBXC_TEST_ASSERT(table.count(5, std::string("txn")) == 2);
+        MDBXC_TEST_ASSERT(!table.contains(4));
     }
 
     {
@@ -229,8 +226,8 @@ int main() {
         safe_table.clear();
         safe_table.insert(11, "safe");
         fast_table.insert(12, "fast");
-        assert(fast_table.count(11, std::string("safe")) == 1);
-        assert(safe_table.count(12, std::string("fast")) == 1);
+        MDBXC_TEST_ASSERT(fast_table.count(11, std::string("safe")) == 1);
+        MDBXC_TEST_ASSERT(safe_table.count(12, std::string("fast")) == 1);
     }
 
     {
@@ -267,33 +264,33 @@ int main() {
             collected.push_back(std::make_pair(k, v));
             return true;
         });
-        assert(completed);
-        assert(collected.size() == 6);
+        MDBXC_TEST_ASSERT(completed);
+        MDBXC_TEST_ASSERT(collected.size() == 6);
 
         // filter_range
         std::vector<std::pair<int, std::string>> filtered = table.filter_range(1, 3, [](const int&, const std::string& v) -> bool {
             return v >= "d";
         });
-        assert(filtered.size() == 3); // d, e, f
+        MDBXC_TEST_ASSERT(filtered.size() == 3); // d, e, f
 
         // reverse range
         std::vector<std::pair<int, std::string>> rev = table.range_reverse(1, 3);
-        assert(rev.size() == 6);
-        assert(rev[0] == std::make_pair(3, std::string("f")));
-        assert(rev[5] == std::make_pair(1, std::string("a")));
+        MDBXC_TEST_ASSERT(rev.size() == 6);
+        MDBXC_TEST_ASSERT(rev[0] == std::make_pair(3, std::string("f")));
+        MDBXC_TEST_ASSERT(rev[5] == std::make_pair(1, std::string("a")));
 
         // reverse range limit
         std::vector<std::pair<int, std::string>> rev_limit = table.range_reverse(1, 3, 2);
-        assert(rev_limit.size() == 2);
-        assert(rev_limit[0] == std::make_pair(3, std::string("f")));
-        assert(rev_limit[1] == std::make_pair(3, std::string("e")));
+        MDBXC_TEST_ASSERT(rev_limit.size() == 2);
+        MDBXC_TEST_ASSERT(rev_limit[0] == std::make_pair(3, std::string("f")));
+        MDBXC_TEST_ASSERT(rev_limit[1] == std::make_pair(3, std::string("e")));
 
         // contains_range / count_range / erase_range
-        assert(table.contains_range(2, 3));
-        assert(table.count_range(2, 3) == 4); // c + d,e,f
+        MDBXC_TEST_ASSERT(table.contains_range(2, 3));
+        MDBXC_TEST_ASSERT(table.count_range(2, 3) == 4); // c + d,e,f
         std::size_t erased = table.erase_range(2, 3);
-        assert(erased == 4);
-        assert(table.count() == 2);
+        MDBXC_TEST_ASSERT(erased == 4);
+        MDBXC_TEST_ASSERT(table.count() == 2);
 
     }
 

--- a/tests/key_table_test.cpp
+++ b/tests/key_table_test.cpp
@@ -1,6 +1,10 @@
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
 #include <cassert>
 #include <iostream>
 #include <set>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -88,6 +92,158 @@ int main() {
         assert(safe_table.range(10, 12) == (std::set<int>{11, 12}));
         assert(fast_table.range(12, 12) == (std::set<int>{12}));
     }
+
+    // --- Range API extension tests ---
+    {
+        mdbxc::KeyTable<int> table(conn, "range_api_keys");
+        table.clear();
+        table.insert(1);
+        table.insert(2);
+        table.insert(3);
+        table.insert(4);
+        table.insert(5);
+
+        // for_each_range full scan
+        std::vector<int> collected;
+        bool completed = table.for_each_range(1, 5, [&collected](const int& key) -> bool {
+            collected.push_back(key);
+            return true;
+        });
+        assert(completed);
+        assert(collected == (std::vector<int>{1, 2, 3, 4, 5}));
+
+        // for_each_range early stop
+        collected.clear();
+        completed = table.for_each_range(1, 5, [&collected](const int& key) -> bool {
+            collected.push_back(key);
+            return collected.size() < 3;
+        });
+        assert(!completed);
+        assert(collected.size() == 3);
+
+        // filter_range
+        std::vector<int> evens = table.filter_range(1, 5, [](const int& key) -> bool {
+            return key % 2 == 0;
+        });
+        assert(evens == (std::vector<int>{2, 4}));
+
+        // reverse range
+        std::vector<int> rev = table.range_reverse(1, 5);
+        assert(rev == (std::vector<int>{5, 4, 3, 2, 1}));
+
+        // reverse range limit
+        std::vector<int> rev_limit = table.range_reverse(1, 5, 2);
+        assert(rev_limit == (std::vector<int>{5, 4}));
+
+        // reverse range limit 0
+        assert(table.range_reverse(1, 5, static_cast<std::size_t>(0)).empty());
+
+        // contains_range / count_range / erase_range
+        assert(table.contains_range(2, 4));
+        assert(!table.contains_range(10, 20));
+        assert(table.count_range(2, 4) == 3);
+        assert(table.count_range(10, 20) == 0);
+
+        std::size_t erased = table.erase_range(2, 4);
+        assert(erased == 3);
+        assert(table.count() == 2);
+        assert(table.contains(1));
+        assert(table.contains(5));
+        assert(!table.contains(3));
+
+        // from > to returns empty / 0 / false
+        assert(table.range_reverse(5, 1).empty());
+        assert(table.count_range(5, 1) == 0);
+        assert(!table.contains_range(5, 1));
+    }
+
+#if __cplusplus < 201703L
+    // --- Bounds compat (C++11) ---
+    {
+        mdbxc::KeyTable<int> table(conn, "range_api_compat_keys");
+        table.clear();
+        table.insert(10);
+        table.insert(20);
+
+        std::pair<bool, int> lb = table.lower_bound_compat(10);
+        assert(lb.first && lb.second == 10);
+        std::pair<bool, int> ub = table.upper_bound_compat(10);
+        assert(ub.first && ub.second == 20);
+        std::pair<bool, int> named_ub = table.upper_bound(10);
+        if (!named_ub.first || named_ub.second != 20) {
+            throw std::runtime_error("upper_bound failed for KeyTable C++11");
+        }
+        std::pair<bool, int> f = table.first_compat();
+        assert(f.first && f.second == 10);
+        std::pair<bool, int> l = table.last_compat();
+        assert(l.first && l.second == 20);
+        std::pair<bool, int> mn = table.min_key_compat();
+        assert(mn.first && mn.second == 10);
+        std::pair<bool, int> mx = table.max_key_compat();
+        assert(mx.first && mx.second == 20);
+        std::pair<bool, int> named_mx = table.max_key();
+        if (!named_mx.first || named_mx.second != 20) {
+            throw std::runtime_error("max_key failed for KeyTable C++11");
+        }
+
+        mdbxc::KeyTable<int> empty_table(conn, "range_api_compat_empty");
+        empty_table.clear();
+        assert(!empty_table.lower_bound_compat(1).first);
+        assert(!empty_table.first_compat().first);
+    }
+
+    {
+        mdbxc::KeyTable<std::string> table(conn, "range_api_compat_string_bounds");
+        table.clear();
+        table.insert("alpha");
+        table.insert("beta");
+
+        std::pair<bool, std::string> upper = table.upper_bound_compat(std::string("alpha"));
+        if (!upper.first || upper.second != "beta") {
+            throw std::runtime_error("string upper_bound_compat failed for KeyTable");
+        }
+    }
+#endif
+
+#if __cplusplus >= 201703L
+    // --- Bounds optional (C++17) ---
+    {
+        mdbxc::KeyTable<int> table(conn, "range_api_opt_keys");
+        table.clear();
+        table.insert(1);
+        table.insert(2);
+        table.insert(3);
+
+        assert(table.lower_bound(2) == std::optional<int>(2));
+        auto upper = table.upper_bound(2);
+        if (!upper.has_value() || upper.value() != 3) {
+            throw std::runtime_error("upper_bound failed for KeyTable");
+        }
+        assert(table.first() == std::optional<int>(1));
+        assert(table.last() == std::optional<int>(3));
+        assert(table.min_key() == std::optional<int>(1));
+        assert(table.max_key() == std::optional<int>(3));
+
+        mdbxc::Transaction read_txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        auto txn_lower = table.lower_bound(2, read_txn);
+        if (!txn_lower.has_value() || txn_lower.value() != 2) {
+            throw std::runtime_error("transaction lower_bound failed for KeyTable");
+        }
+        read_txn.commit();
+    }
+
+    {
+        mdbxc::KeyTable<std::string> table(conn, "range_api_string_bounds");
+        table.clear();
+        table.insert("alpha");
+        table.insert("beta");
+
+        auto upper = table.upper_bound(std::string("alpha"));
+        if (!upper.has_value() || upper.value() != "beta") {
+            throw std::runtime_error("string upper_bound failed for KeyTable");
+        }
+    }
+#endif
 
     std::cout << "KeyTable test passed.\n";
     return 0;

--- a/tests/key_table_test.cpp
+++ b/tests/key_table_test.cpp
@@ -1,7 +1,4 @@
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-#include <cassert>
+#include "test_assert.hpp"
 #include <iostream>
 #include <set>
 #include <stdexcept>
@@ -23,45 +20,45 @@ int main() {
         mdbxc::KeyTable<std::string> table(conn, "keys");
         table.clear();
 
-        assert(table.empty());
-        assert(table.insert("alpha"));
-        assert(!table.insert("alpha"));
-        assert(table.insert("beta"));
-        assert(table.contains("alpha"));
-        assert(!table.contains("gamma"));
-        assert(table.count() == 2);
+        MDBXC_TEST_ASSERT(table.empty());
+        MDBXC_TEST_ASSERT(table.insert("alpha"));
+        MDBXC_TEST_ASSERT(!table.insert("alpha"));
+        MDBXC_TEST_ASSERT(table.insert("beta"));
+        MDBXC_TEST_ASSERT(table.contains("alpha"));
+        MDBXC_TEST_ASSERT(!table.contains("gamma"));
+        MDBXC_TEST_ASSERT(table.count() == 2);
 
         std::set<std::string> as_set;
         table.load(as_set);
-        assert(as_set == (std::set<std::string>{"alpha", "beta"}));
+        MDBXC_TEST_ASSERT(as_set == (std::set<std::string>{"alpha", "beta"}));
 
         std::vector<std::string> as_vector = table.retrieve_all<std::vector>();
-        assert(as_vector.size() == 2);
+        MDBXC_TEST_ASSERT(as_vector.size() == 2);
 
-        assert(table.range("alpha", "beta") ==
+        MDBXC_TEST_ASSERT(table.range("alpha", "beta") ==
                (std::set<std::string>{"alpha", "beta"}));
-        assert(table.range<std::vector>("alpha", "beta") ==
+        MDBXC_TEST_ASSERT(table.range<std::vector>("alpha", "beta") ==
                (std::vector<std::string>{"alpha", "beta"}));
-        assert(table.range("aardvark", "alpha") ==
+        MDBXC_TEST_ASSERT(table.range("aardvark", "alpha") ==
                (std::set<std::string>{"alpha"}));
-        assert(table.range("gamma", "omega").empty());
-        assert(table.range("zeta", "alpha").empty());
+        MDBXC_TEST_ASSERT(table.range("gamma", "omega").empty());
+        MDBXC_TEST_ASSERT(table.range("zeta", "alpha").empty());
 
-        assert(table.erase("alpha"));
-        assert(!table.erase("alpha"));
-        assert(!table.contains("alpha"));
-        assert(table.count() == 1);
+        MDBXC_TEST_ASSERT(table.erase("alpha"));
+        MDBXC_TEST_ASSERT(!table.erase("alpha"));
+        MDBXC_TEST_ASSERT(!table.contains("alpha"));
+        MDBXC_TEST_ASSERT(table.count() == 1);
 
         std::set<std::string> replacement{"delta", "epsilon"};
         table.reconcile(replacement);
-        assert(table.count() == 2);
-        assert(table.contains("delta"));
-        assert(!table.contains("beta"));
+        MDBXC_TEST_ASSERT(table.count() == 2);
+        MDBXC_TEST_ASSERT(table.contains("delta"));
+        MDBXC_TEST_ASSERT(!table.contains("beta"));
 
         std::set<std::string> assigned{"zeta"};
         table = assigned;
-        assert(table.count() == 1);
-        assert(table.contains("zeta"));
+        MDBXC_TEST_ASSERT(table.count() == 1);
+        MDBXC_TEST_ASSERT(table.contains("zeta"));
     }
 
     {
@@ -69,15 +66,15 @@ int main() {
         table.clear();
 
         auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
-        assert(table.insert(1, txn));
-        assert(table.insert(2, txn));
+        MDBXC_TEST_ASSERT(table.insert(1, txn));
+        MDBXC_TEST_ASSERT(table.insert(2, txn));
         txn.commit();
 
         auto read_txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
-        assert(table.contains(1, read_txn));
-        assert(table.count(read_txn) == 2);
-        assert(table.range(1, 2, read_txn) == (std::set<int>{1, 2}));
-        assert(table.range<std::vector>(1, 2, read_txn) == (std::vector<int>{1, 2}));
+        MDBXC_TEST_ASSERT(table.contains(1, read_txn));
+        MDBXC_TEST_ASSERT(table.count(read_txn) == 2);
+        MDBXC_TEST_ASSERT(table.range(1, 2, read_txn) == (std::set<int>{1, 2}));
+        MDBXC_TEST_ASSERT(table.range<std::vector>(1, 2, read_txn) == (std::vector<int>{1, 2}));
         read_txn.commit();
     }
 
@@ -85,12 +82,12 @@ int main() {
         mdbxc::KeyTable<int> safe_table(conn, "key_options");
         mdbxc::KeyTable<int, mdbxc::FastIntegerKeyOptions> fast_table(conn, "key_options");
         safe_table.clear();
-        assert(safe_table.insert(11));
-        assert(fast_table.contains(11));
-        assert(fast_table.insert(12));
-        assert(safe_table.contains(12));
-        assert(safe_table.range(10, 12) == (std::set<int>{11, 12}));
-        assert(fast_table.range(12, 12) == (std::set<int>{12}));
+        MDBXC_TEST_ASSERT(safe_table.insert(11));
+        MDBXC_TEST_ASSERT(fast_table.contains(11));
+        MDBXC_TEST_ASSERT(fast_table.insert(12));
+        MDBXC_TEST_ASSERT(safe_table.contains(12));
+        MDBXC_TEST_ASSERT(safe_table.range(10, 12) == (std::set<int>{11, 12}));
+        MDBXC_TEST_ASSERT(fast_table.range(12, 12) == (std::set<int>{12}));
     }
 
     // --- Range API extension tests ---
@@ -109,8 +106,8 @@ int main() {
             collected.push_back(key);
             return true;
         });
-        assert(completed);
-        assert(collected == (std::vector<int>{1, 2, 3, 4, 5}));
+        MDBXC_TEST_ASSERT(completed);
+        MDBXC_TEST_ASSERT(collected == (std::vector<int>{1, 2, 3, 4, 5}));
 
         // for_each_range early stop
         collected.clear();
@@ -118,43 +115,43 @@ int main() {
             collected.push_back(key);
             return collected.size() < 3;
         });
-        assert(!completed);
-        assert(collected.size() == 3);
+        MDBXC_TEST_ASSERT(!completed);
+        MDBXC_TEST_ASSERT(collected.size() == 3);
 
         // filter_range
         std::vector<int> evens = table.filter_range(1, 5, [](const int& key) -> bool {
             return key % 2 == 0;
         });
-        assert(evens == (std::vector<int>{2, 4}));
+        MDBXC_TEST_ASSERT(evens == (std::vector<int>{2, 4}));
 
         // reverse range
         std::vector<int> rev = table.range_reverse(1, 5);
-        assert(rev == (std::vector<int>{5, 4, 3, 2, 1}));
+        MDBXC_TEST_ASSERT(rev == (std::vector<int>{5, 4, 3, 2, 1}));
 
         // reverse range limit
         std::vector<int> rev_limit = table.range_reverse(1, 5, 2);
-        assert(rev_limit == (std::vector<int>{5, 4}));
+        MDBXC_TEST_ASSERT(rev_limit == (std::vector<int>{5, 4}));
 
         // reverse range limit 0
-        assert(table.range_reverse(1, 5, static_cast<std::size_t>(0)).empty());
+        MDBXC_TEST_ASSERT(table.range_reverse(1, 5, static_cast<std::size_t>(0)).empty());
 
         // contains_range / count_range / erase_range
-        assert(table.contains_range(2, 4));
-        assert(!table.contains_range(10, 20));
-        assert(table.count_range(2, 4) == 3);
-        assert(table.count_range(10, 20) == 0);
+        MDBXC_TEST_ASSERT(table.contains_range(2, 4));
+        MDBXC_TEST_ASSERT(!table.contains_range(10, 20));
+        MDBXC_TEST_ASSERT(table.count_range(2, 4) == 3);
+        MDBXC_TEST_ASSERT(table.count_range(10, 20) == 0);
 
         std::size_t erased = table.erase_range(2, 4);
-        assert(erased == 3);
-        assert(table.count() == 2);
-        assert(table.contains(1));
-        assert(table.contains(5));
-        assert(!table.contains(3));
+        MDBXC_TEST_ASSERT(erased == 3);
+        MDBXC_TEST_ASSERT(table.count() == 2);
+        MDBXC_TEST_ASSERT(table.contains(1));
+        MDBXC_TEST_ASSERT(table.contains(5));
+        MDBXC_TEST_ASSERT(!table.contains(3));
 
         // from > to returns empty / 0 / false
-        assert(table.range_reverse(5, 1).empty());
-        assert(table.count_range(5, 1) == 0);
-        assert(!table.contains_range(5, 1));
+        MDBXC_TEST_ASSERT(table.range_reverse(5, 1).empty());
+        MDBXC_TEST_ASSERT(table.count_range(5, 1) == 0);
+        MDBXC_TEST_ASSERT(!table.contains_range(5, 1));
     }
 
 #if __cplusplus < 201703L
@@ -166,21 +163,21 @@ int main() {
         table.insert(20);
 
         std::pair<bool, int> lb = table.lower_bound_compat(10);
-        assert(lb.first && lb.second == 10);
+        MDBXC_TEST_ASSERT(lb.first && lb.second == 10);
         std::pair<bool, int> ub = table.upper_bound_compat(10);
-        assert(ub.first && ub.second == 20);
+        MDBXC_TEST_ASSERT(ub.first && ub.second == 20);
         std::pair<bool, int> named_ub = table.upper_bound(10);
         if (!named_ub.first || named_ub.second != 20) {
             throw std::runtime_error("upper_bound failed for KeyTable C++11");
         }
         std::pair<bool, int> f = table.first_compat();
-        assert(f.first && f.second == 10);
+        MDBXC_TEST_ASSERT(f.first && f.second == 10);
         std::pair<bool, int> l = table.last_compat();
-        assert(l.first && l.second == 20);
+        MDBXC_TEST_ASSERT(l.first && l.second == 20);
         std::pair<bool, int> mn = table.min_key_compat();
-        assert(mn.first && mn.second == 10);
+        MDBXC_TEST_ASSERT(mn.first && mn.second == 10);
         std::pair<bool, int> mx = table.max_key_compat();
-        assert(mx.first && mx.second == 20);
+        MDBXC_TEST_ASSERT(mx.first && mx.second == 20);
         std::pair<bool, int> named_mx = table.max_key();
         if (!named_mx.first || named_mx.second != 20) {
             throw std::runtime_error("max_key failed for KeyTable C++11");
@@ -188,8 +185,8 @@ int main() {
 
         mdbxc::KeyTable<int> empty_table(conn, "range_api_compat_empty");
         empty_table.clear();
-        assert(!empty_table.lower_bound_compat(1).first);
-        assert(!empty_table.first_compat().first);
+        MDBXC_TEST_ASSERT(!empty_table.lower_bound_compat(1).first);
+        MDBXC_TEST_ASSERT(!empty_table.first_compat().first);
     }
 
     {
@@ -214,15 +211,15 @@ int main() {
         table.insert(2);
         table.insert(3);
 
-        assert(table.lower_bound(2) == std::optional<int>(2));
+        MDBXC_TEST_ASSERT(table.lower_bound(2) == std::optional<int>(2));
         auto upper = table.upper_bound(2);
         if (!upper.has_value() || upper.value() != 3) {
             throw std::runtime_error("upper_bound failed for KeyTable");
         }
-        assert(table.first() == std::optional<int>(1));
-        assert(table.last() == std::optional<int>(3));
-        assert(table.min_key() == std::optional<int>(1));
-        assert(table.max_key() == std::optional<int>(3));
+        MDBXC_TEST_ASSERT(table.first() == std::optional<int>(1));
+        MDBXC_TEST_ASSERT(table.last() == std::optional<int>(3));
+        MDBXC_TEST_ASSERT(table.min_key() == std::optional<int>(1));
+        MDBXC_TEST_ASSERT(table.max_key() == std::optional<int>(3));
 
         mdbxc::Transaction read_txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
         auto txn_lower = table.lower_bound(2, read_txn);

--- a/tests/kv_container_all_types_test.cpp
+++ b/tests/kv_container_all_types_test.cpp
@@ -1,13 +1,10 @@
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
 #include <iostream>
 #include <sstream>
 #include <thread>
 #include <mutex>
 #include <condition_variable>
 #include <atomic>
-#include <cassert>
+#include "test_assert.hpp"
 #include <chrono>
 #include <vector>
 #include <deque>
@@ -236,25 +233,25 @@ int main() {
         std::vector<std::pair<int, std::string> > middle_pairs;
         middle_pairs.push_back(std::make_pair(2, std::string("two")));
         middle_pairs.push_back(std::make_pair(4, std::string("four")));
-        assert((kv.range(2, 4) == std::map<int, std::string>(middle_pairs.begin(), middle_pairs.end())));
-        assert(kv.range<std::vector>(2, 4) == middle_pairs);
-        assert(kv.range_values(2, 4) == (std::vector<std::string>{"two", "four"}));
-        assert(kv.range_values<std::set>(2, 4) == (std::set<std::string>{"four", "two"}));
+        MDBXC_TEST_ASSERT((kv.range(2, 4) == std::map<int, std::string>(middle_pairs.begin(), middle_pairs.end())));
+        MDBXC_TEST_ASSERT(kv.range<std::vector>(2, 4) == middle_pairs);
+        MDBXC_TEST_ASSERT(kv.range_values(2, 4) == (std::vector<std::string>{"two", "four"}));
+        MDBXC_TEST_ASSERT(kv.range_values<std::set>(2, 4) == (std::set<std::string>{"four", "two"}));
 
         std::vector<std::pair<int, std::string> > first_pair;
         first_pair.push_back(std::make_pair(1, std::string("one")));
-        assert((kv.range(0, 1) == std::map<int, std::string>(first_pair.begin(), first_pair.end())));
-        assert(kv.range_values(0, 1) == (std::vector<std::string>{"one"}));
-        assert(kv.range(3, 3).empty());
-        assert(kv.range(5, 2).empty());
+        MDBXC_TEST_ASSERT((kv.range(0, 1) == std::map<int, std::string>(first_pair.begin(), first_pair.end())));
+        MDBXC_TEST_ASSERT(kv.range_values(0, 1) == (std::vector<std::string>{"one"}));
+        MDBXC_TEST_ASSERT(kv.range(3, 3).empty());
+        MDBXC_TEST_ASSERT(kv.range(5, 2).empty());
 
         mdbxc::Transaction read_txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
         std::vector<std::pair<int, std::string> > txn_pairs;
         txn_pairs.push_back(std::make_pair(1, std::string("one")));
         txn_pairs.push_back(std::make_pair(2, std::string("two")));
-        assert((kv.range(1, 2, read_txn) == std::map<int, std::string>(txn_pairs.begin(), txn_pairs.end())));
-        assert(kv.range<std::vector>(1, 2, read_txn) == txn_pairs);
-        assert(kv.range_values(1, 2, read_txn) == (std::vector<std::string>{"one", "two"}));
+        MDBXC_TEST_ASSERT((kv.range(1, 2, read_txn) == std::map<int, std::string>(txn_pairs.begin(), txn_pairs.end())));
+        MDBXC_TEST_ASSERT(kv.range<std::vector>(1, 2, read_txn) == txn_pairs);
+        MDBXC_TEST_ASSERT(kv.range_values(1, 2, read_txn) == (std::vector<std::string>{"one", "two"}));
         read_txn.commit();
     }
 
@@ -271,16 +268,16 @@ int main() {
         std::vector<std::pair<int, std::string> > negative_pairs;
         negative_pairs.push_back(std::make_pair(-2, std::string("minus-two")));
         negative_pairs.push_back(std::make_pair(-1, std::string("minus-one")));
-        assert((kv.range(-2, -1) == std::map<int, std::string>(negative_pairs.begin(), negative_pairs.end())));
-        assert(kv.range<std::vector>(-2, -1) == negative_pairs);
-        assert(kv.range_values(-2, -1) ==
+        MDBXC_TEST_ASSERT((kv.range(-2, -1) == std::map<int, std::string>(negative_pairs.begin(), negative_pairs.end())));
+        MDBXC_TEST_ASSERT(kv.range<std::vector>(-2, -1) == negative_pairs);
+        MDBXC_TEST_ASSERT(kv.range_values(-2, -1) ==
                (std::vector<std::string>{"minus-two", "minus-one"}));
 
         std::vector<std::pair<int, std::string> > nonnegative_pairs;
         nonnegative_pairs.push_back(std::make_pair(0, std::string("zero")));
         nonnegative_pairs.push_back(std::make_pair(1, std::string("one")));
-        assert((kv.range(0, 1) == std::map<int, std::string>(nonnegative_pairs.begin(), nonnegative_pairs.end())));
-        assert(kv.range_values(0, 1) == (std::vector<std::string>{"zero", "one"}));
+        MDBXC_TEST_ASSERT((kv.range(0, 1) == std::map<int, std::string>(nonnegative_pairs.begin(), nonnegative_pairs.end())));
+        MDBXC_TEST_ASSERT(kv.range_values(0, 1) == (std::vector<std::string>{"zero", "one"}));
     }
 
     {
@@ -296,10 +293,10 @@ int main() {
         all_pairs.push_back(std::make_pair(uint64_t(0), std::string("zero")));
         all_pairs.push_back(std::make_pair(uint64_t(1), std::string("one")));
         all_pairs.push_back(std::make_pair(max_key, std::string("max")));
-        assert((kv.range(0u, max_key) ==
+        MDBXC_TEST_ASSERT((kv.range(0u, max_key) ==
                 std::map<uint64_t, std::string>(all_pairs.begin(), all_pairs.end())));
-        assert(kv.range<std::vector>(0u, max_key) == all_pairs);
-        assert(kv.range_values(0u, max_key) ==
+        MDBXC_TEST_ASSERT(kv.range<std::vector>(0u, max_key) == all_pairs);
+        MDBXC_TEST_ASSERT(kv.range_values(0u, max_key) ==
                (std::vector<std::string>{"zero", "one", "max"}));
     }
 
@@ -315,10 +312,10 @@ int main() {
         all_pairs.push_back(std::make_pair(-1.0, std::string("minus-one")));
         all_pairs.push_back(std::make_pair(0.0, std::string("zero")));
         all_pairs.push_back(std::make_pair(1.0, std::string("one")));
-        assert((kv.range(-1.0, 1.0) ==
+        MDBXC_TEST_ASSERT((kv.range(-1.0, 1.0) ==
                 std::map<double, std::string>(all_pairs.begin(), all_pairs.end())));
-        assert(kv.range<std::vector>(-1.0, 1.0) == all_pairs);
-        assert(kv.range_values(-1.0, 1.0) ==
+        MDBXC_TEST_ASSERT(kv.range<std::vector>(-1.0, 1.0) == all_pairs);
+        MDBXC_TEST_ASSERT(kv.range_values(-1.0, 1.0) ==
                (std::vector<std::string>{"minus-one", "zero", "one"}));
     }
 
@@ -600,47 +597,47 @@ int main() {
             collected.push_back(std::make_pair(k, v));
             return true;
         });
-        assert(completed);
-        assert(collected.size() == 5);
+        MDBXC_TEST_ASSERT(completed);
+        MDBXC_TEST_ASSERT(collected.size() == 5);
 
         // filter_range
         std::vector<std::pair<int, std::string>> evens = kv.filter_range(1, 5, [](const int& k, const std::string&) -> bool {
             return k % 2 == 0;
         });
-        assert(evens.size() == 2);
-        assert(evens[0].first == 2);
-        assert(evens[1].first == 4);
+        MDBXC_TEST_ASSERT(evens.size() == 2);
+        MDBXC_TEST_ASSERT(evens[0].first == 2);
+        MDBXC_TEST_ASSERT(evens[1].first == 4);
 
         // reverse range
         std::vector<std::pair<int, std::string>> rev = kv.range_reverse(1, 5);
-        assert(rev.size() == 5);
-        assert(rev[0].first == 5);
-        assert(rev[4].first == 1);
+        MDBXC_TEST_ASSERT(rev.size() == 5);
+        MDBXC_TEST_ASSERT(rev[0].first == 5);
+        MDBXC_TEST_ASSERT(rev[4].first == 1);
 
         // reverse range limit
         std::vector<std::pair<int, std::string>> rev_limit = kv.range_reverse(1, 5, 2);
-        assert(rev_limit.size() == 2);
-        assert(rev_limit[0].first == 5);
+        MDBXC_TEST_ASSERT(rev_limit.size() == 2);
+        MDBXC_TEST_ASSERT(rev_limit[0].first == 5);
 
         // contains_range / count_range / erase_range
-        assert(kv.contains_range(2, 4));
-        assert(kv.count_range(2, 4) == 3);
+        MDBXC_TEST_ASSERT(kv.contains_range(2, 4));
+        MDBXC_TEST_ASSERT(kv.count_range(2, 4) == 3);
         std::size_t erased = kv.erase_range(2, 4);
-        assert(erased == 3);
-        assert(kv.count() == 2);
+        MDBXC_TEST_ASSERT(erased == 3);
+        MDBXC_TEST_ASSERT(kv.count() == 2);
 
         // update existing
         bool updated = kv.update(1, [](std::string& v) {
             v = "ONE";
         });
-        assert(updated);
+        MDBXC_TEST_ASSERT(updated);
         ASSERT_FOUND(kv, 1, std::string("ONE"));
 
         // update missing
         bool missing_updated = kv.update(99, [](std::string& v) {
             v = "X";
         });
-        assert(!missing_updated);
+        MDBXC_TEST_ASSERT(!missing_updated);
 
         // update rollback when mutator throws
         bool update_threw = false;
@@ -652,33 +649,33 @@ int main() {
         } catch (const std::runtime_error&) {
             update_threw = true;
         }
-        assert(update_threw);
+        MDBXC_TEST_ASSERT(update_threw);
         ASSERT_FOUND(kv, 1, std::string("ONE"));
 
         // find_many
         kv.insert_or_assign(2, "two");
         kv.insert_or_assign(3, "three");
         std::map<int, std::string> many = kv.find_many(std::vector<int>{1, 2, 99});
-        assert(many.size() == 2);
-        assert(many[1] == "ONE");
-        assert(many[2] == "two");
+        MDBXC_TEST_ASSERT(many.size() == 2);
+        MDBXC_TEST_ASSERT(many[1] == "ONE");
+        MDBXC_TEST_ASSERT(many[2] == "two");
 
         // find_many_vector preserves order, skips missing
         std::vector<std::pair<int, std::string>> many_vec = kv.find_many_vector(std::vector<int>{99, 3, 1});
-        assert(many_vec.size() == 2);
-        assert(many_vec[0].first == 3);
-        assert(many_vec[1].first == 1);
+        MDBXC_TEST_ASSERT(many_vec.size() == 2);
+        MDBXC_TEST_ASSERT(many_vec[0].first == 3);
+        MDBXC_TEST_ASSERT(many_vec[1].first == 1);
 
         // bounds compat (C++11 only)
 #if __cplusplus < 201703L
         std::pair<bool, std::pair<int, std::string>> lb = kv.lower_bound_compat(2);
-        assert(lb.first && lb.second.first == 2);
+        MDBXC_TEST_ASSERT(lb.first && lb.second.first == 2);
         std::pair<bool, std::pair<int, std::string>> lb_named = kv.lower_bound(2);
         if (!lb_named.first || lb_named.second.first != 2) {
             throw std::runtime_error("lower_bound failed for KeyValueTable C++11");
         }
         std::pair<bool, std::pair<int, std::string>> f = kv.first_compat();
-        assert(f.first && f.second.first == 1);
+        MDBXC_TEST_ASSERT(f.first && f.second.first == 1);
         std::pair<bool, std::pair<int, std::string>> l = kv.last_compat();
         if (!l.first || l.second.first != 5) {
             throw std::runtime_error("last_compat failed for KeyValueTable");

--- a/tests/kv_container_all_types_test.cpp
+++ b/tests/kv_container_all_types_test.cpp
@@ -1,3 +1,6 @@
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
 #include <iostream>
 #include <sstream>
 #include <thread>
@@ -578,6 +581,181 @@ int main() {
         }
 
         std::cout << "[concurrency] ok\n";
+    }
+
+    // --- Range API extension tests ---
+    std::cout << "[case] range api extensions\n";
+    {
+        mdbxc::KeyValueTable<int, std::string> kv(conn, "kv_range_api");
+        kv.clear();
+        kv.insert_or_assign(1, "one");
+        kv.insert_or_assign(2, "two");
+        kv.insert_or_assign(3, "three");
+        kv.insert_or_assign(4, "four");
+        kv.insert_or_assign(5, "five");
+
+        // for_each_range
+        std::vector<std::pair<int, std::string>> collected;
+        bool completed = kv.for_each_range(1, 5, [&collected](const int& k, const std::string& v) -> bool {
+            collected.push_back(std::make_pair(k, v));
+            return true;
+        });
+        assert(completed);
+        assert(collected.size() == 5);
+
+        // filter_range
+        std::vector<std::pair<int, std::string>> evens = kv.filter_range(1, 5, [](const int& k, const std::string&) -> bool {
+            return k % 2 == 0;
+        });
+        assert(evens.size() == 2);
+        assert(evens[0].first == 2);
+        assert(evens[1].first == 4);
+
+        // reverse range
+        std::vector<std::pair<int, std::string>> rev = kv.range_reverse(1, 5);
+        assert(rev.size() == 5);
+        assert(rev[0].first == 5);
+        assert(rev[4].first == 1);
+
+        // reverse range limit
+        std::vector<std::pair<int, std::string>> rev_limit = kv.range_reverse(1, 5, 2);
+        assert(rev_limit.size() == 2);
+        assert(rev_limit[0].first == 5);
+
+        // contains_range / count_range / erase_range
+        assert(kv.contains_range(2, 4));
+        assert(kv.count_range(2, 4) == 3);
+        std::size_t erased = kv.erase_range(2, 4);
+        assert(erased == 3);
+        assert(kv.count() == 2);
+
+        // update existing
+        bool updated = kv.update(1, [](std::string& v) {
+            v = "ONE";
+        });
+        assert(updated);
+        ASSERT_FOUND(kv, 1, std::string("ONE"));
+
+        // update missing
+        bool missing_updated = kv.update(99, [](std::string& v) {
+            v = "X";
+        });
+        assert(!missing_updated);
+
+        // update rollback when mutator throws
+        bool update_threw = false;
+        try {
+            kv.update(1, [](std::string& v) {
+                v = "BAD";
+                throw std::runtime_error("update failure");
+            });
+        } catch (const std::runtime_error&) {
+            update_threw = true;
+        }
+        assert(update_threw);
+        ASSERT_FOUND(kv, 1, std::string("ONE"));
+
+        // find_many
+        kv.insert_or_assign(2, "two");
+        kv.insert_or_assign(3, "three");
+        std::map<int, std::string> many = kv.find_many(std::vector<int>{1, 2, 99});
+        assert(many.size() == 2);
+        assert(many[1] == "ONE");
+        assert(many[2] == "two");
+
+        // find_many_vector preserves order, skips missing
+        std::vector<std::pair<int, std::string>> many_vec = kv.find_many_vector(std::vector<int>{99, 3, 1});
+        assert(many_vec.size() == 2);
+        assert(many_vec[0].first == 3);
+        assert(many_vec[1].first == 1);
+
+        // bounds compat (C++11 only)
+#if __cplusplus < 201703L
+        std::pair<bool, std::pair<int, std::string>> lb = kv.lower_bound_compat(2);
+        assert(lb.first && lb.second.first == 2);
+        std::pair<bool, std::pair<int, std::string>> lb_named = kv.lower_bound(2);
+        if (!lb_named.first || lb_named.second.first != 2) {
+            throw std::runtime_error("lower_bound failed for KeyValueTable C++11");
+        }
+        std::pair<bool, std::pair<int, std::string>> f = kv.first_compat();
+        assert(f.first && f.second.first == 1);
+        std::pair<bool, std::pair<int, std::string>> l = kv.last_compat();
+        if (!l.first || l.second.first != 5) {
+            throw std::runtime_error("last_compat failed for KeyValueTable");
+        }
+        std::pair<bool, int> min_key = kv.min_key_compat();
+        if (!min_key.first || min_key.second != 1) {
+            throw std::runtime_error("min_key_compat failed for KeyValueTable");
+        }
+        std::pair<bool, int> max_key = kv.max_key_compat();
+        if (!max_key.first || max_key.second != 5) {
+            throw std::runtime_error("max_key_compat failed for KeyValueTable");
+        }
+        std::pair<bool, int> named_max_key = kv.max_key();
+        if (!named_max_key.first || named_max_key.second != 5) {
+            throw std::runtime_error("max_key failed for KeyValueTable C++11");
+        }
+#endif
+    }
+
+#if __cplusplus >= 201703L
+    {
+        mdbxc::KeyValueTable<int, std::string> kv(conn, "kv_range_api_opt");
+        kv.clear();
+        kv.insert_or_assign(1, "a");
+        kv.insert_or_assign(3, "c");
+        kv.insert_or_assign(2, "b");
+
+        auto lb = kv.lower_bound(1);
+        if (!lb.has_value() || lb->first != 1) {
+            throw std::runtime_error("lower_bound failed for KeyValueTable");
+        }
+        auto ub = kv.upper_bound(1);
+        if (!ub.has_value() || ub->first != 2) {
+            throw std::runtime_error("upper_bound failed for KeyValueTable");
+        }
+        auto fr = kv.first();
+        if (!fr.has_value() || fr->first != 1) {
+            throw std::runtime_error("first failed for KeyValueTable");
+        }
+        auto la = kv.last();
+        if (!la.has_value() || la->first != 3) {
+            throw std::runtime_error("last failed for KeyValueTable");
+        }
+        auto min_key = kv.min_key();
+        if (!min_key.has_value() || min_key.value() != 1) {
+            throw std::runtime_error("min_key failed for KeyValueTable");
+        }
+        auto max_key = kv.max_key();
+        if (!max_key.has_value() || max_key.value() != 3) {
+            throw std::runtime_error("max_key failed for KeyValueTable");
+        }
+
+        mdbxc::Transaction read_txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        auto txn_bound = kv.lower_bound(2, read_txn);
+        if (!txn_bound.has_value() || txn_bound->first != 2) {
+            throw std::runtime_error("transaction lower_bound failed for KeyValueTable");
+        }
+        read_txn.commit();
+    }
+#endif
+
+    {
+        mdbxc::KeyValueTable<std::string, int> kv(conn, "kv_range_api_string_bounds");
+        kv.clear();
+        kv.insert_or_assign("alpha", 1);
+        kv.insert_or_assign("beta", 2);
+#if __cplusplus >= 201703L
+        auto ub = kv.upper_bound(std::string("alpha"));
+        if (!ub.has_value() || ub->first != "beta") {
+            throw std::runtime_error("string upper_bound failed for KeyValueTable");
+        }
+#else
+        std::pair<bool, std::pair<std::string, int>> ub = kv.upper_bound_compat(std::string("alpha"));
+        if (!ub.first || ub.second.first != "beta") {
+            throw std::runtime_error("string upper_bound_compat failed for KeyValueTable");
+        }
+#endif
     }
 
     std::cout << "[result] all tests passed\n";

--- a/tests/path_resolution_test.cpp
+++ b/tests/path_resolution_test.cpp
@@ -13,7 +13,7 @@ int main() {
 //
 // Тестирует политику разрешения путей и работу no_subdir.
 
-#include <cassert>
+#include "test_assert.hpp"
 #include <cstdint>
 #include <iostream>
 #include <fstream>
@@ -80,7 +80,7 @@ static void assert_read_only_does_not_create_parent(const fs::path& db_path,
                                                     bool no_subdir) {
     fs::path parent = db_path.parent_path();
     fs::remove_all(parent);
-    assert(!fs::exists(parent));
+    MDBXC_TEST_ASSERT(!fs::exists(parent));
 
     mdbxc::Config cfg;
     cfg.pathname = db_path.u8string();
@@ -97,8 +97,8 @@ static void assert_read_only_does_not_create_parent(const fs::path& db_path,
         failed = true;
     }
 
-    assert(failed);
-    assert(!fs::exists(parent));
+    MDBXC_TEST_ASSERT(failed);
+    MDBXC_TEST_ASSERT(!fs::exists(parent));
 }
 
 // Правило разрешения пути, которое должна соблюдать библиотека.
@@ -160,13 +160,13 @@ static void run_case(const std::string& case_name,
     // проверки на ФС
     if (!no_subdir) {
         // директория БД должна существовать и быть не пустой
-        assert(fs::exists(expect));
-        assert(fs::is_directory(expect));
-        assert(dir_nonempty(expect));
+        MDBXC_TEST_ASSERT(fs::exists(expect));
+        MDBXC_TEST_ASSERT(fs::is_directory(expect));
+        MDBXC_TEST_ASSERT(dir_nonempty(expect));
     } else {
         // файл БД должен существовать (lock-файл может быть рядом)
-        assert(fs::exists(expect));
-        assert(fs::is_regular_file(expect));
+        MDBXC_TEST_ASSERT(fs::exists(expect));
+        MDBXC_TEST_ASSERT(fs::is_regular_file(expect));
     }
 }
 
@@ -196,10 +196,10 @@ int main() try {
                  kv.insert_or_assign(1, (int8_t)42);
 #if __cplusplus >= 201703L
                  auto v = kv.find(1);
-                 assert(v && *v == (int8_t)42);
+                 MDBXC_TEST_ASSERT(v && *v == (int8_t)42);
 #else
                  auto v = kv.find_compat(1);
-                 assert(v.first && v.second == (int8_t)42);
+                 MDBXC_TEST_ASSERT(v.first && v.second == (int8_t)42);
 #endif
              });
 
@@ -213,10 +213,10 @@ int main() try {
                  kv.insert_or_assign(1, (int8_t)7);
 #if __cplusplus >= 201703L
                  auto v = kv.find(1);
-                 assert(v && *v == (int8_t)7);
+                 MDBXC_TEST_ASSERT(v && *v == (int8_t)7);
 #else
                  auto v = kv.find_compat(1);
-                 assert(v.first && v.second == (int8_t)7);
+                 MDBXC_TEST_ASSERT(v.first && v.second == (int8_t)7);
 #endif
              });
 
@@ -230,10 +230,10 @@ int main() try {
                  kv.insert_or_assign(1, (int8_t)-5);
 #if __cplusplus >= 201703L
                  auto v = kv.find(1);
-                 assert(v && *v == (int8_t)-5);
+                 MDBXC_TEST_ASSERT(v && *v == (int8_t)-5);
 #else
                  auto v = kv.find_compat(1);
-                 assert(v.first && v.second == (int8_t)-5);
+                 MDBXC_TEST_ASSERT(v.first && v.second == (int8_t)-5);
 #endif
              });
 
@@ -250,10 +250,10 @@ int main() try {
                  kv.insert_or_assign(1, (int8_t)11);
 #if __cplusplus >= 201703L
                  auto v = kv.find(1);
-                 assert(v && *v == (int8_t)11);
+                 MDBXC_TEST_ASSERT(v && *v == (int8_t)11);
 #else
                  auto v = kv.find_compat(1);
-                 assert(v.first && v.second == (int8_t)11);
+                 MDBXC_TEST_ASSERT(v.first && v.second == (int8_t)11);
 #endif
              });
 
@@ -267,10 +267,10 @@ int main() try {
                  kv.insert_or_assign(1, (int8_t)12);
 #if __cplusplus >= 201703L
                  auto v = kv.find(1);
-                 assert(v && *v == (int8_t)12);
+                 MDBXC_TEST_ASSERT(v && *v == (int8_t)12);
 #else
                  auto v = kv.find_compat(1);
-                 assert(v.first && v.second == (int8_t)12);
+                 MDBXC_TEST_ASSERT(v.first && v.second == (int8_t)12);
 #endif
              });
 
@@ -284,10 +284,10 @@ int main() try {
                  kv.insert_or_assign(1, (int8_t)13);
 #if __cplusplus >= 201703L
                  auto v = kv.find(1);
-                 assert(v && *v == (int8_t)13);
+                 MDBXC_TEST_ASSERT(v && *v == (int8_t)13);
 #else
                  auto v = kv.find_compat(1);
-                 assert(v.first && v.second == (int8_t)13);
+                 MDBXC_TEST_ASSERT(v.first && v.second == (int8_t)13);
 #endif
              });
 

--- a/tests/sequence_table_test.cpp
+++ b/tests/sequence_table_test.cpp
@@ -1,4 +1,4 @@
-#include <cassert>
+#include "test_assert.hpp"
 #include <cstring>
 #include <iostream>
 #include <list>
@@ -60,26 +60,26 @@ int main() {
         mdbxc::SequenceTable<std::string> table(conn, "seq_basic");
         table.clear();
 
-        assert(table.empty());
-        assert(table.count() == 0);
+        MDBXC_TEST_ASSERT(table.empty());
+        MDBXC_TEST_ASSERT(table.count() == 0);
 
         uint64_t id0 = table.append("alpha");
         uint64_t id1 = table.append("beta");
-        assert(id0 == 0);
-        assert(id1 == 1);
-        assert(table.count() == 2);
-        assert(!table.empty());
+        MDBXC_TEST_ASSERT(id0 == 0);
+        MDBXC_TEST_ASSERT(id1 == 1);
+        MDBXC_TEST_ASSERT(table.count() == 2);
+        MDBXC_TEST_ASSERT(!table.empty());
 
-        assert(table.at(0) == "alpha");
-        assert(table.at(1) == "beta");
+        MDBXC_TEST_ASSERT(table.at(0) == "alpha");
+        MDBXC_TEST_ASSERT(table.at(1) == "beta");
 
-        assert(table.contains(0));
-        assert(table.contains(1));
-        assert(!table.contains(99));
+        MDBXC_TEST_ASSERT(table.contains(0));
+        MDBXC_TEST_ASSERT(table.contains(1));
+        MDBXC_TEST_ASSERT(!table.contains(99));
 
         std::string out;
-        assert(table.try_get(0, out) && out == "alpha");
-        assert(!table.try_get(99, out));
+        MDBXC_TEST_ASSERT(table.try_get(0, out) && out == "alpha");
+        MDBXC_TEST_ASSERT(!table.try_get(99, out));
 
         bool threw = false;
         try {
@@ -87,18 +87,18 @@ int main() {
         } catch (const std::out_of_range&) {
             threw = true;
         }
-        assert(threw);
+        MDBXC_TEST_ASSERT(threw);
 
         std::pair<bool, std::string> fc = table.find_compat(0);
-        assert(fc.first && fc.second == "alpha");
+        MDBXC_TEST_ASSERT(fc.first && fc.second == "alpha");
         fc = table.find_compat(99);
-        assert(!fc.first);
+        MDBXC_TEST_ASSERT(!fc.first);
 
 #if __cplusplus >= 201703L
         auto found = table.find(0);
-        assert(found.has_value() && *found == "alpha");
+        MDBXC_TEST_ASSERT(found.has_value() && *found == "alpha");
         found = table.find(99);
-        assert(!found.has_value());
+        MDBXC_TEST_ASSERT(!found.has_value());
 #endif
     }
 
@@ -110,26 +110,26 @@ int main() {
         uint64_t id0 = table.append("zero");
         uint64_t id1 = table.append("one");
         uint64_t id2 = table.append("two");
-        assert(id0 == 0);
-        assert(id1 == 1);
-        assert(id2 == 2);
+        MDBXC_TEST_ASSERT(id0 == 0);
+        MDBXC_TEST_ASSERT(id1 == 1);
+        MDBXC_TEST_ASSERT(id2 == 2);
 
-        assert(table.erase(1));
-        assert(!table.erase(1));
-        assert(table.count() == 2);
+        MDBXC_TEST_ASSERT(table.erase(1));
+        MDBXC_TEST_ASSERT(!table.erase(1));
+        MDBXC_TEST_ASSERT(table.count() == 2);
 
         std::vector<std::string> vals = table.retrieve_all();
-        assert(vals.size() == 2);
-        assert(vals[0] == "zero");
-        assert(vals[1] == "two");
+        MDBXC_TEST_ASSERT(vals.size() == 2);
+        MDBXC_TEST_ASSERT(vals[0] == "zero");
+        MDBXC_TEST_ASSERT(vals[1] == "two");
 
         std::vector<std::pair<uint64_t, std::string>> entries = table.retrieve_entries();
-        assert(entries.size() == 2);
-        assert(entries[0].first == 0 && entries[0].second == "zero");
-        assert(entries[1].first == 2 && entries[1].second == "two");
+        MDBXC_TEST_ASSERT(entries.size() == 2);
+        MDBXC_TEST_ASSERT(entries[0].first == 0 && entries[0].second == "zero");
+        MDBXC_TEST_ASSERT(entries[1].first == 2 && entries[1].second == "two");
 
         uint64_t id3 = table.append("three");
-        assert(id3 == 3);
+        MDBXC_TEST_ASSERT(id3 == 3);
     }
 
     // --- 3. set_insert_or_assign ---
@@ -138,24 +138,24 @@ int main() {
         table.clear();
 
         table.set(10, "ten");
-        assert(table.count() == 1);
+        MDBXC_TEST_ASSERT(table.count() == 1);
 
         std::pair<bool, uint64_t> first = table.first_index_compat();
         std::pair<bool, uint64_t> last = table.last_index_compat();
-        assert(first.first && first.second == 10);
-        assert(last.first && last.second == 10);
+        MDBXC_TEST_ASSERT(first.first && first.second == 10);
+        MDBXC_TEST_ASSERT(last.first && last.second == 10);
 
         uint64_t id_next = table.append("eleven");
-        assert(id_next == 11);
+        MDBXC_TEST_ASSERT(id_next == 11);
 
         table.insert_or_assign(10, "TEN");
-        assert(table.at(10) == "TEN");
+        MDBXC_TEST_ASSERT(table.at(10) == "TEN");
 
 #if __cplusplus >= 201703L
         auto fi = table.first_index();
-        assert(fi.has_value() && *fi == 10);
+        MDBXC_TEST_ASSERT(fi.has_value() && *fi == 10);
         auto li = table.last_index();
-        assert(li.has_value() && *li == 11);
+        MDBXC_TEST_ASSERT(li.has_value() && *li == 11);
 #endif
     }
 
@@ -172,19 +172,19 @@ int main() {
         std::vector<std::pair<uint64_t, std::string>> r;
 
         r = table.range(3, 6);
-        assert(r.size() == 2);
-        assert(r[0].first == 4 && r[0].second == "v4");
-        assert(r[1].first == 5 && r[1].second == "v5");
+        MDBXC_TEST_ASSERT(r.size() == 2);
+        MDBXC_TEST_ASSERT(r[0].first == 4 && r[0].second == "v4");
+        MDBXC_TEST_ASSERT(r[1].first == 5 && r[1].second == "v5");
 
         r = table.range(0, 2);
-        assert(r.size() == 1);
-        assert(r[0].first == 2 && r[0].second == "v2");
+        MDBXC_TEST_ASSERT(r.size() == 1);
+        MDBXC_TEST_ASSERT(r[0].first == 2 && r[0].second == "v2");
 
         r = table.range(11, 20);
-        assert(r.empty());
+        MDBXC_TEST_ASSERT(r.empty());
 
         r = table.range(7, 3);
-        assert(r.empty());
+        MDBXC_TEST_ASSERT(r.empty());
     }
 
     // --- 5. append_many ---
@@ -198,16 +198,16 @@ int main() {
         src.push_back(3);
 
         std::vector<uint64_t> ids = table.append_many(src);
-        assert(ids.size() == 3);
-        assert(ids[0] == 0);
-        assert(ids[1] == 1);
-        assert(ids[2] == 2);
+        MDBXC_TEST_ASSERT(ids.size() == 3);
+        MDBXC_TEST_ASSERT(ids[0] == 0);
+        MDBXC_TEST_ASSERT(ids[1] == 1);
+        MDBXC_TEST_ASSERT(ids[2] == 2);
 
         std::vector<int> all = table.retrieve_all();
-        assert(all.size() == 3);
-        assert(all[0] == 1);
-        assert(all[1] == 2);
-        assert(all[2] == 3);
+        MDBXC_TEST_ASSERT(all.size() == 3);
+        MDBXC_TEST_ASSERT(all[0] == 1);
+        MDBXC_TEST_ASSERT(all[1] == 2);
+        MDBXC_TEST_ASSERT(all[2] == 3);
 
         // Test with std::list<int>
         mdbxc::SequenceTable<int> table2(conn, "seq_many_list");
@@ -219,16 +219,16 @@ int main() {
         lst.push_back(30);
 
         std::vector<uint64_t> ids2 = table2.append_many(lst);
-        assert(ids2.size() == 3);
-        assert(ids2[0] == 0);
-        assert(ids2[1] == 1);
-        assert(ids2[2] == 2);
+        MDBXC_TEST_ASSERT(ids2.size() == 3);
+        MDBXC_TEST_ASSERT(ids2[0] == 0);
+        MDBXC_TEST_ASSERT(ids2[1] == 1);
+        MDBXC_TEST_ASSERT(ids2[2] == 2);
 
         std::vector<int> all2 = table2.retrieve_all();
-        assert(all2.size() == 3);
-        assert(all2[0] == 10);
-        assert(all2[1] == 20);
-        assert(all2[2] == 30);
+        MDBXC_TEST_ASSERT(all2.size() == 3);
+        MDBXC_TEST_ASSERT(all2[0] == 10);
+        MDBXC_TEST_ASSERT(all2[1] == 20);
+        MDBXC_TEST_ASSERT(all2[2] == 30);
     }
 
     // --- 6. transaction overloads ---
@@ -238,16 +238,16 @@ int main() {
 
         auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
         uint64_t id = table.append("txn_val", txn);
-        assert(id == 0);
+        MDBXC_TEST_ASSERT(id == 0);
         txn.commit();
 
         auto read_txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
-        assert(table.count(read_txn) == 1);
-        assert(table.at(0, read_txn) == "txn_val");
+        MDBXC_TEST_ASSERT(table.count(read_txn) == 1);
+        MDBXC_TEST_ASSERT(table.at(0, read_txn) == "txn_val");
         std::vector<std::pair<uint64_t, std::string>> r =
             table.range(0, 10, read_txn);
-        assert(r.size() == 1);
-        assert(r[0].first == 0 && r[0].second == "txn_val");
+        MDBXC_TEST_ASSERT(r.size() == 1);
+        MDBXC_TEST_ASSERT(r[0].first == 0 && r[0].second == "txn_val");
         read_txn.commit();
     }
 
@@ -259,22 +259,22 @@ int main() {
         table.append("a");
         table.append("b");
         table.append("c");
-        assert(table.count() == 3);
+        MDBXC_TEST_ASSERT(table.count() == 3);
 
         table.clear();
-        assert(table.empty());
-        assert(table.count() == 0);
+        MDBXC_TEST_ASSERT(table.empty());
+        MDBXC_TEST_ASSERT(table.count() == 0);
 
         std::pair<bool, uint64_t> first = table.first_index_compat();
         std::pair<bool, uint64_t> last = table.last_index_compat();
-        assert(!first.first);
-        assert(!last.first);
+        MDBXC_TEST_ASSERT(!first.first);
+        MDBXC_TEST_ASSERT(!last.first);
 
 #if __cplusplus >= 201703L
         auto fi = table.first_index();
         auto li = table.last_index();
-        assert(!fi.has_value());
-        assert(!li.has_value());
+        MDBXC_TEST_ASSERT(!fi.has_value());
+        MDBXC_TEST_ASSERT(!li.has_value());
 #endif
     }
 
@@ -287,23 +287,23 @@ int main() {
         p.id = 7;
         p.name = "alice";
         uint64_t id = table.append(p);
-        assert(id == 0);
+        MDBXC_TEST_ASSERT(id == 0);
 
         Profile loaded = table.at(0);
-        assert(loaded == p);
+        MDBXC_TEST_ASSERT(loaded == p);
 
-        assert(table.contains(0));
-        assert(!table.contains(1));
+        MDBXC_TEST_ASSERT(table.contains(0));
+        MDBXC_TEST_ASSERT(!table.contains(1));
 
         Profile p2;
         p2.id = 42;
         p2.name = "bob";
         table.insert_or_assign(5, p2);
         Profile loaded2 = table.at(5);
-        assert(loaded2 == p2);
+        MDBXC_TEST_ASSERT(loaded2 == p2);
 
         std::pair<bool, Profile> fc = table.find_compat(5);
-        assert(fc.first && fc.second == p2);
+        MDBXC_TEST_ASSERT(fc.first && fc.second == p2);
     }
 
     // --- 9. Config constructor ---
@@ -317,8 +317,8 @@ int main() {
         mdbxc::SequenceTable<std::string> table(standalone_cfg, "config_seq");
         table.clear();
         uint64_t id = table.append("config_test");
-        assert(id == 0);
-        assert(table.at(0) == "config_test");
+        MDBXC_TEST_ASSERT(id == 0);
+        MDBXC_TEST_ASSERT(table.at(0) == "config_test");
     }
 
     std::cout << "SequenceTable test passed.\n";

--- a/tests/test_assert.hpp
+++ b/tests/test_assert.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+#define MDBXC_TEST_STRINGIFY_IMPL(x) #x
+#define MDBXC_TEST_STRINGIFY(x) MDBXC_TEST_STRINGIFY_IMPL(x)
+
+#define MDBXC_TEST_ASSERT(expr)                                                               \
+    do {                                                                                      \
+        if (!(expr)) {                                                                        \
+            throw std::runtime_error(std::string(__FILE__) + ":" +                            \
+                                     MDBXC_TEST_STRINGIFY(__LINE__) +                         \
+                                     ": assertion failed: " #expr);                           \
+        }                                                                                     \
+    } while (false)

--- a/tests/transaction_test.cpp
+++ b/tests/transaction_test.cpp
@@ -1,4 +1,4 @@
-#include <cassert>
+#include "test_assert.hpp"
 #include <chrono>
 #include <condition_variable>
 #include <iostream>
@@ -41,18 +41,18 @@ int main() {
         version.set(1, txn);
         txn.commit();
 
-        assert(names.at(1) == "one");
-        assert(version.get() == 1);
+        MDBXC_TEST_ASSERT(names.at(1) == "one");
+        MDBXC_TEST_ASSERT(version.get() == 1);
     }
 
     {
         auto read_txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
-        assert(names.at(1, read_txn) == "one");
-        assert(version.get(read_txn) == 1);
+        MDBXC_TEST_ASSERT(names.at(1, read_txn) == "one");
+        MDBXC_TEST_ASSERT(version.get(read_txn) == 1);
         read_txn.commit();
 
         names.insert_or_assign(2, "two");
-        assert(names.at(2) == "two");
+        MDBXC_TEST_ASSERT(names.at(2) == "two");
     }
 
     {
@@ -66,7 +66,7 @@ int main() {
 
         names.insert_or_assign(key, "rolled back");
         names.rollback();
-        assert(!names.contains(key));
+        MDBXC_TEST_ASSERT(!names.contains(key));
     }
 
     {
@@ -77,7 +77,7 @@ int main() {
         txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
         names.insert_or_assign(key, "rolled back");
         txn.rollback();
-        assert(!names.contains(key));
+        MDBXC_TEST_ASSERT(!names.contains(key));
     }
 
     {
@@ -97,8 +97,8 @@ int main() {
         read_only_cfg.read_only = true;
         auto read_conn = mdbxc::Connection::create(read_only_cfg);
         mdbxc::KeyValueTable<int, std::string> read_table(read_conn, "readonly_names");
-        assert(read_table.at(1) == "one");
-        assert(read_table.contains(1));
+        MDBXC_TEST_ASSERT(read_table.at(1) == "one");
+        MDBXC_TEST_ASSERT(read_table.contains(1));
 
         bool write_failed = false;
         try {
@@ -106,8 +106,8 @@ int main() {
         } catch (const mdbxc::MdbxException&) {
             write_failed = true;
         }
-        assert(write_failed);
-        assert(!read_table.contains(2));
+        MDBXC_TEST_ASSERT(write_failed);
+        MDBXC_TEST_ASSERT(!read_table.contains(2));
     }
 
     {
@@ -120,8 +120,8 @@ int main() {
         auto cleanup_conn = mdbxc::Connection::create(cleanup_cfg);
         cleanup_conn->begin(mdbxc::TransactionMode::WRITABLE);
         std::shared_ptr<mdbxc::Transaction> held_txn = cleanup_conn->current_txn();
-        assert(held_txn);
-        assert(held_txn->handle());
+        MDBXC_TEST_ASSERT(held_txn);
+        MDBXC_TEST_ASSERT(held_txn->handle());
 
         bool disconnect_failed = false;
         try {
@@ -129,17 +129,17 @@ int main() {
         } catch (const mdbxc::MdbxException& ex) {
             disconnect_failed = ex.error_code() == MDBX_BUSY;
         }
-        assert(disconnect_failed);
-        assert(cleanup_conn->is_connected());
-        assert(held_txn->handle());
+        MDBXC_TEST_ASSERT(disconnect_failed);
+        MDBXC_TEST_ASSERT(cleanup_conn->is_connected());
+        MDBXC_TEST_ASSERT(held_txn->handle());
 
         cleanup_conn->rollback();
-        assert(!held_txn->handle());
+        MDBXC_TEST_ASSERT(!held_txn->handle());
         cleanup_conn->disconnect();
-        assert(!cleanup_conn->is_connected());
+        MDBXC_TEST_ASSERT(!cleanup_conn->is_connected());
 
         cleanup_conn->connect();
-        assert(cleanup_conn->is_connected());
+        MDBXC_TEST_ASSERT(cleanup_conn->is_connected());
         cleanup_conn->disconnect();
     }
 
@@ -156,9 +156,9 @@ int main() {
 
         {
             auto read_txn = reset_read_conn->transaction(mdbxc::TransactionMode::READ_ONLY);
-            assert(reset_read_table.at(1, read_txn) == "one");
+            MDBXC_TEST_ASSERT(reset_read_table.at(1, read_txn) == "one");
             read_txn.commit();
-            assert(read_txn.handle());
+            MDBXC_TEST_ASSERT(read_txn.handle());
 
             bool disconnect_failed = false;
             try {
@@ -166,7 +166,7 @@ int main() {
             } catch (const mdbxc::MdbxException& ex) {
                 disconnect_failed = ex.error_code() == MDBX_BUSY;
             }
-            assert(disconnect_failed);
+            MDBXC_TEST_ASSERT(disconnect_failed);
 
             bool shutdown_failed = false;
             try {
@@ -174,11 +174,11 @@ int main() {
             } catch (const std::logic_error&) {
                 shutdown_failed = true;
             }
-            assert(shutdown_failed);
+            MDBXC_TEST_ASSERT(shutdown_failed);
         }
 
         reset_read_conn->disconnect();
-        assert(!reset_read_conn->is_connected());
+        MDBXC_TEST_ASSERT(!reset_read_conn->is_connected());
     }
 
     {
@@ -229,8 +229,8 @@ int main() {
         }
 
         bool closed = shutdown_conn->shutdown_for(std::chrono::milliseconds(50));
-        assert(!closed);
-        assert(shutdown_conn->is_connected());
+        MDBXC_TEST_ASSERT(!closed);
+        MDBXC_TEST_ASSERT(shutdown_conn->is_connected());
 
         bool new_txn_blocked = false;
         try {
@@ -239,7 +239,7 @@ int main() {
         } catch (const std::logic_error&) {
             new_txn_blocked = true;
         }
-        assert(new_txn_blocked);
+        MDBXC_TEST_ASSERT(new_txn_blocked);
 
         {
             std::lock_guard<std::mutex> lock(sync_mutex);
@@ -256,13 +256,13 @@ int main() {
         worker.join();
 
         closed = shutdown_conn->shutdown_for(std::chrono::seconds(2));
-        assert(closed);
-        assert(!shutdown_conn->is_connected());
+        MDBXC_TEST_ASSERT(closed);
+        MDBXC_TEST_ASSERT(!shutdown_conn->is_connected());
 
         shutdown_conn->connect();
-        assert(shutdown_conn->is_connected());
+        MDBXC_TEST_ASSERT(shutdown_conn->is_connected());
         shutdown_conn->shutdown();
-        assert(!shutdown_conn->is_connected());
+        MDBXC_TEST_ASSERT(!shutdown_conn->is_connected());
     }
 
     std::cout << "Transaction test passed.\n";

--- a/tests/utils_test.cpp
+++ b/tests/utils_test.cpp
@@ -1,3 +1,4 @@
+#include "test_assert.hpp"
 #include <iostream>
 #include <mdbx_containers/common.hpp>
 
@@ -13,7 +14,7 @@ MDBX_val empty_value() {
 template<typename T>
 void assert_deserializes_empty() {
     T out = mdbxc::deserialize_value<T>(empty_value());
-    assert(out.empty());
+    MDBXC_TEST_ASSERT(out.empty());
 }
 
 template<typename T>
@@ -32,7 +33,7 @@ void assert_rejects_oversized_string_length() {
     } catch (const std::runtime_error&) {
         thrown = true;
     }
-    assert(thrown);
+    MDBXC_TEST_ASSERT(thrown);
 }
 
 template<typename T>
@@ -50,20 +51,20 @@ T deserialize_unaligned_uint32_values() {
 
 template<typename T>
 void assert_ordered_uint32_values(const T& out) {
-    assert(out.size() == 3);
+    MDBXC_TEST_ASSERT(out.size() == 3);
     typename T::const_iterator it = out.begin();
-    assert(*it == 1u);
+    MDBXC_TEST_ASSERT(*it == 1u);
     ++it;
-    assert(*it == 2u);
+    MDBXC_TEST_ASSERT(*it == 2u);
     ++it;
-    assert(*it == 3u);
+    MDBXC_TEST_ASSERT(*it == 3u);
 }
 
 void assert_unordered_uint32_values(const std::unordered_set<std::uint32_t>& out) {
-    assert(out.size() == 3);
-    assert(out.find(1u) != out.end());
-    assert(out.find(2u) != out.end());
-    assert(out.find(3u) != out.end());
+    MDBXC_TEST_ASSERT(out.size() == 3);
+    MDBXC_TEST_ASSERT(out.find(1u) != out.end());
+    MDBXC_TEST_ASSERT(out.find(2u) != out.end());
+    MDBXC_TEST_ASSERT(out.find(3u) != out.end());
 }
 
 } // namespace

--- a/tests/value_table_test.cpp
+++ b/tests/value_table_test.cpp
@@ -1,4 +1,4 @@
-#include <cassert>
+#include "test_assert.hpp"
 #include <cstring>
 #include <iostream>
 #include <stdexcept>
@@ -48,14 +48,14 @@ int main() {
         mdbxc::ValueTable<int> table(conn, "integer_state");
         table.clear();
 
-        assert(table.empty());
-        assert(!table.has_value());
-        assert(table.count() == 0);
-        assert(table.get_or(7) == 7);
+        MDBXC_TEST_ASSERT(table.empty());
+        MDBXC_TEST_ASSERT(!table.has_value());
+        MDBXC_TEST_ASSERT(table.count() == 0);
+        MDBXC_TEST_ASSERT(table.get_or(7) == 7);
 
         int out = 0;
-        assert(!table.try_get(out));
-        assert(!table.erase());
+        MDBXC_TEST_ASSERT(!table.try_get(out));
+        MDBXC_TEST_ASSERT(!table.erase());
 
         bool threw = false;
         try {
@@ -63,42 +63,42 @@ int main() {
         } catch (const std::out_of_range&) {
             threw = true;
         }
-        assert(threw);
+        MDBXC_TEST_ASSERT(threw);
 
-        assert(table.insert(10));
-        assert(!table.insert(20));
-        assert(table.has_value());
-        assert(!table.empty());
-        assert(table.count() == 1);
-        assert(table.get() == 10);
-        assert(table.try_get(out) && out == 10);
+        MDBXC_TEST_ASSERT(table.insert(10));
+        MDBXC_TEST_ASSERT(!table.insert(20));
+        MDBXC_TEST_ASSERT(table.has_value());
+        MDBXC_TEST_ASSERT(!table.empty());
+        MDBXC_TEST_ASSERT(table.count() == 1);
+        MDBXC_TEST_ASSERT(table.get() == 10);
+        MDBXC_TEST_ASSERT(table.try_get(out) && out == 10);
 
         table.set(30);
-        assert(table.get() == 30);
+        MDBXC_TEST_ASSERT(table.get() == 30);
 
         bool updated = table.update([](int& value) {
             value += 1;
         });
-        assert(updated);
-        assert(table.get() == 31);
+        MDBXC_TEST_ASSERT(updated);
+        MDBXC_TEST_ASSERT(table.get() == 31);
 
 #if __cplusplus >= 201703L
         auto found = table.find();
-        assert(found && *found == 31);
+        MDBXC_TEST_ASSERT(found && *found == 31);
 #else
         auto found = table.find();
-        assert(found.first && found.second == 31);
+        MDBXC_TEST_ASSERT(found.first && found.second == 31);
 #endif
 
         std::pair<bool, int> compat = table.find_compat();
-        assert(compat.first && compat.second == 31);
+        MDBXC_TEST_ASSERT(compat.first && compat.second == 31);
 
-        assert(table.erase());
-        assert(!table.erase());
-        assert(!table.update([](int& value) {
+        MDBXC_TEST_ASSERT(table.erase());
+        MDBXC_TEST_ASSERT(!table.erase());
+        MDBXC_TEST_ASSERT(!table.update([](int& value) {
             value += 1;
         }));
-        assert(table.count() == 0);
+        MDBXC_TEST_ASSERT(table.count() == 0);
     }
 
     {
@@ -111,19 +111,19 @@ int main() {
         table.set(expected);
 
         StoredState loaded = table.get();
-        assert(loaded == expected);
+        MDBXC_TEST_ASSERT(loaded == expected);
 
-        assert(table.update([](StoredState& value) {
+        MDBXC_TEST_ASSERT(table.update([](StoredState& value) {
             value.id += 1;
             value.score += 0.5;
         }));
 
         StoredState changed = table.get();
-        assert(changed.id == 43);
-        assert(changed.score == 4.0);
+        MDBXC_TEST_ASSERT(changed.id == 43);
+        MDBXC_TEST_ASSERT(changed.score == 4.0);
 
         table.clear();
-        assert(!table.has_value());
+        MDBXC_TEST_ASSERT(!table.has_value());
     }
 
     {
@@ -131,22 +131,22 @@ int main() {
         table.clear();
 
         auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
-        assert(table.insert(5, txn));
+        MDBXC_TEST_ASSERT(table.insert(5, txn));
         txn.commit();
 
         auto read_txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
-        assert(table.has_value(read_txn));
-        assert(table.count(read_txn) == 1);
-        assert(table.get(read_txn) == 5);
+        MDBXC_TEST_ASSERT(table.has_value(read_txn));
+        MDBXC_TEST_ASSERT(table.count(read_txn) == 1);
+        MDBXC_TEST_ASSERT(table.get(read_txn) == 5);
         read_txn.commit();
 
         auto update_txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
-        assert(table.update([](int& value) {
+        MDBXC_TEST_ASSERT(table.update([](int& value) {
             value *= 2;
         }, update_txn));
         update_txn.commit();
 
-        assert(table.get() == 10);
+        MDBXC_TEST_ASSERT(table.get() == 10);
     }
 
     {
@@ -159,7 +159,7 @@ int main() {
         mdbxc::ValueTable<std::string> table(standalone_cfg, "config_value");
         table.clear();
         table.set("ready");
-        assert(table.get() == "ready");
+        MDBXC_TEST_ASSERT(table.get() == "ready");
     }
 
     std::cout << "ValueTable test passed.\n";


### PR DESCRIPTION
## Summary
- Add ordered key-based range streaming, filtering, bounds, edge, reverse scan, range metadata, and range erasure APIs for KeyValueTable, KeyTable, and KeyMultiValueTable.
- Add KeyValueTable update(), find_many(), and find_many_vector() helpers.
- Fix cursor-bound edge cases found during review: exact-key upper_bound serialization, Multi upper_bound skipping duplicate values, C++11 same-name pair-style wrappers, and meaningful assertions in the new tests.
- Update table docs, mainpage, and README API notes.

## Verification
- cmake -S . -B tmp/build-cpp17 -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=17
- cmake --build tmp/build-cpp17
- ctest --test-dir tmp/build-cpp17 --output-on-failure
- cmake -S . -B tmp/build-cpp11 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=11
- cmake --build tmp/build-cpp11
- ctest --test-dir tmp/build-cpp11 --output-on-failure
- git diff --check