### PR TITLE
[codex] Add embedded vector store MVP

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -40,6 +40,8 @@
 - Проверка type-tag prefix в `AnyValueTable` включается явно через
   `set_type_tag_check(true)` и по умолчанию выключена для совместимости с уже
   существующими raw-записями.
+- `VectorStore` — MVP embedded vector store для локального RAG: persistent
+  MDBX-хранилище с точным in-memory `FlatVectorIndex`.
 
 ### 🔁 Сериализация
 - Автоматическая сериализация trivially copyable типов.
@@ -164,6 +166,39 @@ auto unique_values = table.range_values<std::set>(10, 20);
 `filter_range()` как тонкий collecting-helper, `lower_bound()`/`upper_bound()`,
 `first()`/`last()`, `min_key()`/`max_key()`, `range_reverse()`,
 `contains_range()`, `count_range()` и `erase_range()`.
+
+### Embedded vector store
+
+`VectorStore` сохраняет embeddings, text и metadata в MDBX-таблицах и
+пересобирает точный RAM-индекс при открытии. Это MVP для локального RAG: поиск
+точный `O(N * dim)`, все embeddings загружаются в RAM, а ANN/HNSW,
+metadata filtering и генерация embeddings не входят в область MVP.
+
+```cpp
+#include <mdbx_containers/vector.hpp>
+#include <iostream>
+
+mdbxc::Config cfg;
+cfg.pathname = "rag.mdbx";
+cfg.max_dbs = 8;
+
+mdbxc::VectorStore store(cfg, "docs");
+
+mdbxc::Embedding e1;
+e1.dim = 3;
+e1.values = {1.0f, 0.0f, 0.0f};
+
+uint64_t id = store.add(e1, "Hello world", "{\"source\":\"test\"}");
+
+mdbxc::Embedding query;
+query.dim = 3;
+query.values = {1.0f, 0.1f, 0.0f};
+
+auto results = store.search(query, 5);
+for (const auto& r : results) {
+    std::cout << r.id << " " << r.score << " " << r.text << "\n";
+}
+```
 
 ### Hash-indexed key-value store
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 - `KeyMultiValueTable<K, V>` stores multiple values per key with a `std::multimap`-like API, streaming and materialized key-range scans, reverse scans, range erasure, and repeated identical `(key, value)` pair preservation.
 - `SequenceTable<ValueT>` stores values by stable uint64_t id with append-only semantics and sparse index support. Append returns a stable id; erase does not reindex following records.
 - `AnyValueTable` type-tag prefix verification is opt-in via `set_type_tag_check(true)` and is disabled by default for compatibility with existing raw records.
+- `VectorStore` is an MVP embedded vector store for local RAG: persistent MDBX
+  storage with an exact in-memory `FlatVectorIndex`.
 
 ### 🔁 Serialization
 - Automatic serialization of trivially copyable types.
@@ -134,6 +136,39 @@ Ordered key-based tables also provide `for_each_range()` for streaming scans,
 `filter_range()` as a thin collecting helper, `lower_bound()`/`upper_bound()`,
 `first()`/`last()`, `min_key()`/`max_key()`, `range_reverse()`,
 `contains_range()`, `count_range()`, and `erase_range()`.
+
+### Embedded vector store
+
+`VectorStore` persists embeddings, text, and metadata in MDBX tables and rebuilds
+an exact RAM index on open. It is intended as a local RAG MVP: search is exact
+`O(N * dim)`, all embeddings are loaded into RAM, and ANN/HNSW, metadata
+filtering, and generated embeddings are out of scope.
+
+```cpp
+#include <mdbx_containers/vector.hpp>
+#include <iostream>
+
+mdbxc::Config cfg;
+cfg.pathname = "rag.mdbx";
+cfg.max_dbs = 8;
+
+mdbxc::VectorStore store(cfg, "docs");
+
+mdbxc::Embedding e1;
+e1.dim = 3;
+e1.values = {1.0f, 0.0f, 0.0f};
+
+uint64_t id = store.add(e1, "Hello world", "{\"source\":\"test\"}");
+
+mdbxc::Embedding query;
+query.dim = 3;
+query.values = {1.0f, 0.1f, 0.0f};
+
+auto results = store.search(query, 5);
+for (const auto& r : results) {
+    std::cout << r.id << " " << r.score << " " << r.text << "\n";
+}
+```
 
 ### Hash-indexed key-value store
 

--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -20,6 +20,8 @@ Key features:
   helpers, reverse scans, range metadata, and range erasure.
 - `KeyValueTable` includes read-modify-write `update()` and batch point lookup
   helpers.
+- `VectorStore` provides persistent local vector storage with an exact
+  in-memory index for MVP RAG workflows.
 - Automatic serialization of trivially copyable types and custom `to_bytes()`/`from_bytes()` support.
 - Multiple logical tables inside one MDBX environment.
 - Read-only configuration for inspecting existing DBIs without creating tables.
@@ -165,6 +167,26 @@ mdbxc::ValueTable<int> schema_version(conn, "schema_version");
 schema_version.set(1);
 int version = schema_version.get_or(0);
 ```
+
+\subsection ex_vector_store Embedded vector store
+```cpp
+mdbxc::Config cfg; cfg.pathname = "rag.mdbx"; cfg.max_dbs = 8;
+mdbxc::VectorStore store(cfg, "docs");
+
+mdbxc::Embedding emb;
+emb.dim = 3;
+emb.values = {1.0f, 0.0f, 0.0f};
+uint64_t id = store.add(emb, "Hello world", "{\"source\":\"test\"}");
+
+mdbxc::Embedding query;
+query.dim = 3;
+query.values = {1.0f, 0.1f, 0.0f};
+std::vector<mdbxc::SearchResult> results = store.search(query, 5);
+```
+
+\note Vector search is exact \c O(N*dim), the index is held in RAM, and ANN,
+metadata filtering, embedding generation, and automatic chunking are not part
+of the MVP. See \subpage vector_store_page.
 
 \section build_sec Building
 Use CMake or simply include the headers and link with libmdbx.

--- a/docs/vector_store.dox
+++ b/docs/vector_store.dox
@@ -1,0 +1,66 @@
+/*! \page vector_store_page Embedded Vector Store
+\tableofcontents
+
+The vector module provides an MVP local RAG storage layer on top of
+mdbx-containers. Include it with:
+
+```cpp
+#include <mdbx_containers/vector.hpp>
+```
+
+\ref mdbxc::VectorStore persists embeddings, text, and metadata in MDBX tables
+and rebuilds an exact in-memory \ref mdbxc::FlatVectorIndex when opened. The
+MDBX tables are named from the sanitized collection name, for example
+`vectors_default_embeddings`, `vectors_default_texts`, and
+`vectors_default_metadata`.
+
+## Example
+
+```cpp
+mdbxc::Config cfg;
+cfg.pathname = "rag.mdbx";
+cfg.max_dbs = 8;
+
+mdbxc::VectorStore store(cfg, "docs");
+
+mdbxc::Embedding e1;
+e1.dim = 3;
+e1.values = {1.0f, 0.0f, 0.0f};
+
+uint64_t id = store.add(e1, "Hello world", "{\"source\":\"test\"}");
+
+mdbxc::Embedding query;
+query.dim = 3;
+query.values = {1.0f, 0.1f, 0.0f};
+
+std::vector<mdbxc::SearchResult> results = store.search(query, 5);
+```
+
+## Data Model
+
+\ref mdbxc::Embedding stores a dense `std::vector<float>` with an explicit
+dimension. It serializes as:
+
+```text
+uint32_t dim
+uint32_t reserved = 0
+float[dim]
+```
+
+\ref mdbxc::VectorStore stores each logical record across separate typed
+tables: `id -> Embedding`, `id -> text`, and `id -> metadata_json`.
+\ref mdbxc::SequenceTable is used only as the id allocator; embeddings are the
+source of truth for `count()` and index rebuild.
+
+## Search
+
+\ref mdbxc::FlatVectorIndex supports \ref mdbxc::VectorMetric::COSINE,
+\ref mdbxc::VectorMetric::DOT, and \ref mdbxc::VectorMetric::L2. L2 search
+returns negative squared distance so larger scores are always better.
+
+\warning Search is exact \c O(N*dim), all embeddings are loaded into RAM, and
+mutable index synchronization is caller-managed.
+
+\note The MVP does not include ANN/HNSW, quantization, metadata filters,
+distributed mode, HTTP APIs, embedding generation, or automatic chunking.
+*/

--- a/include/mdbx_containers/vector.hpp
+++ b/include/mdbx_containers/vector.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#ifndef _MDBX_CONTAINERS_VECTOR_HPP_INCLUDED
+#define _MDBX_CONTAINERS_VECTOR_HPP_INCLUDED
+
+#include "common.hpp"
+#include "vector/VectorMetric.hpp"
+#include "vector/Embedding.hpp"
+#include "vector/VectorRecord.hpp"
+#include "vector/SearchResult.hpp"
+#include "vector/FlatVectorIndex.hpp"
+#include "vector/VectorStore.hpp"
+
+#endif // _MDBX_CONTAINERS_VECTOR_HPP_INCLUDED

--- a/include/mdbx_containers/vector/Embedding.hpp
+++ b/include/mdbx_containers/vector/Embedding.hpp
@@ -1,0 +1,94 @@
+#pragma once
+#ifndef _MDBX_CONTAINERS_VECTOR_EMBEDDING_HPP_INCLUDED
+#define _MDBX_CONTAINERS_VECTOR_EMBEDDING_HPP_INCLUDED
+
+#include <vector>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+
+namespace mdbxc {
+
+    /// \brief Dense float vector persisted by the vector store.
+    ///
+    /// Serialized format is little-endian \c uint32_t dimension, little-endian
+    /// reserved \c uint32_t set to zero, followed by \c dim raw \c float values.
+    struct Embedding {
+        uint32_t dim = 0; ///< Number of float components.
+        std::vector<float> values; ///< Dense vector values.
+
+        /// \brief Returns whether the value array is empty.
+        bool empty() const noexcept {
+            return values.empty();
+        }
+
+        /// \brief Validates basic embedding invariants.
+        /// \throws std::invalid_argument if \c dim is zero or does not match \c values.size().
+        void validate() const {
+            if (dim == 0) {
+                throw std::invalid_argument("Embedding dimension is zero");
+            }
+            if (values.size() != static_cast<std::size_t>(dim)) {
+                throw std::invalid_argument("Embedding dimension does not match values size");
+            }
+        }
+
+        /// \brief Serializes the embedding for MDBX storage.
+        /// \return Binary representation suitable for table values.
+        /// \throws std::invalid_argument if the embedding invariants are invalid.
+        std::vector<uint8_t> to_bytes() const {
+            validate();
+            std::vector<uint8_t> result;
+            result.reserve(8 + dim * sizeof(float));
+            result.resize(8 + dim * sizeof(float));
+            result[0] = static_cast<uint8_t>(dim & 0xFF);
+            result[1] = static_cast<uint8_t>((dim >> 8) & 0xFF);
+            result[2] = static_cast<uint8_t>((dim >> 16) & 0xFF);
+            result[3] = static_cast<uint8_t>((dim >> 24) & 0xFF);
+            result[4] = result[5] = result[6] = result[7] = 0;
+            std::memcpy(result.data() + 8, values.data(), dim * sizeof(float));
+            return result;
+        }
+
+        /// \brief Deserializes an embedding from MDBX storage bytes.
+        /// \param data Pointer to serialized bytes.
+        /// \param len Serialized byte length.
+        /// \return Restored embedding.
+        /// \throws std::runtime_error if the binary format is invalid.
+        static Embedding from_bytes(const void* data, std::size_t len) {
+            if (data == nullptr) {
+                throw std::runtime_error("Embedding binary format data is null");
+            }
+            if (len < 8) {
+                throw std::runtime_error("Embedding binary format too short");
+            }
+            const uint8_t* p = static_cast<const uint8_t*>(data);
+            uint32_t dim = static_cast<uint32_t>(p[0])
+                         | (static_cast<uint32_t>(p[1]) << 8)
+                         | (static_cast<uint32_t>(p[2]) << 16)
+                         | (static_cast<uint32_t>(p[3]) << 24);
+            uint32_t reserved = static_cast<uint32_t>(p[4])
+                              | (static_cast<uint32_t>(p[5]) << 8)
+                              | (static_cast<uint32_t>(p[6]) << 16)
+                              | (static_cast<uint32_t>(p[7]) << 24);
+            if (reserved != 0) {
+                throw std::runtime_error("Embedding binary format reserved field is non-zero");
+            }
+            std::size_t expected_payload = static_cast<std::size_t>(dim) * sizeof(float);
+            if (len != 8 + expected_payload) {
+                throw std::runtime_error("Embedding binary format size mismatch");
+            }
+            if (dim == 0) {
+                throw std::runtime_error("Embedding dimension is zero in binary format");
+            }
+            Embedding e;
+            e.dim = dim;
+            e.values.resize(dim);
+            std::memcpy(e.values.data(), p + 8, expected_payload);
+            return e;
+        }
+    };
+
+} // namespace mdbxc
+
+#endif // _MDBX_CONTAINERS_VECTOR_EMBEDDING_HPP_INCLUDED

--- a/include/mdbx_containers/vector/FlatVectorIndex.hpp
+++ b/include/mdbx_containers/vector/FlatVectorIndex.hpp
@@ -67,8 +67,6 @@ namespace mdbxc {
 
 } // namespace mdbxc
 
-#ifdef MDBX_CONTAINERS_HEADER_ONLY
 #include "FlatVectorIndex.ipp"
-#endif
 
 #endif // _MDBX_CONTAINERS_VECTOR_FLAT_VECTOR_INDEX_HPP_INCLUDED

--- a/include/mdbx_containers/vector/FlatVectorIndex.hpp
+++ b/include/mdbx_containers/vector/FlatVectorIndex.hpp
@@ -1,0 +1,74 @@
+#pragma once
+#ifndef _MDBX_CONTAINERS_VECTOR_FLAT_VECTOR_INDEX_HPP_INCLUDED
+#define _MDBX_CONTAINERS_VECTOR_FLAT_VECTOR_INDEX_HPP_INCLUDED
+
+#include "Embedding.hpp"
+#include "VectorMetric.hpp"
+#include <vector>
+#include <cstdint>
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+namespace mdbxc {
+
+    /// \brief Lightweight id/score pair returned by \ref FlatVectorIndex.
+    struct VectorMatch {
+        uint64_t id = 0; ///< Matched vector id.
+        float score = 0.0f; ///< Metric score; larger values rank first.
+    };
+
+    /// \brief In-memory exact vector index.
+    ///
+    /// \warning Search is exact \c O(N*dim). All vectors are held in RAM.
+    /// The class does not synchronize concurrent mutation and search.
+    class FlatVectorIndex {
+    public:
+        /// \brief Creates an empty index for the given metric.
+        /// \param metric Scoring metric used for all vectors.
+        explicit FlatVectorIndex(VectorMetric metric = VectorMetric::COSINE);
+
+        /// \brief Removes all vectors and resets the index dimension.
+        void clear();
+
+        /// \brief Adds a vector id to the index.
+        /// \param id Caller-owned stable id.
+        /// \param embedding Dense embedding to index.
+        /// \throws std::invalid_argument if the embedding is invalid or has a mismatched dimension.
+        void add(uint64_t id, const Embedding& embedding);
+
+        /// \brief Removes a vector id from the index.
+        /// \param id Id to remove.
+        /// \return \c true if the id was present.
+        bool erase(uint64_t id);
+
+        /// \brief Searches the index and returns the best matches.
+        /// \param query Query embedding.
+        /// \param top_k Maximum number of matches to return.
+        /// \return Matches ordered by descending score.
+        /// \throws std::invalid_argument if the query is invalid or has a mismatched dimension.
+        std::vector<VectorMatch> search(const Embedding& query, std::size_t top_k) const;
+
+        /// \brief Returns the number of indexed vectors.
+        std::size_t size() const noexcept;
+
+        /// \brief Returns the active index dimension, or zero when empty.
+        uint32_t dim() const noexcept;
+
+    private:
+        VectorMetric m_metric;
+        uint32_t m_dim = 0;
+        std::vector<uint64_t> m_ids;
+        std::vector<float> m_vectors;
+
+        void check_dim(const Embedding& embedding);
+        float compute_score(const float* query_vec, const float* candidate_vec) const;
+    };
+
+} // namespace mdbxc
+
+#ifdef MDBX_CONTAINERS_HEADER_ONLY
+#include "FlatVectorIndex.ipp"
+#endif
+
+#endif // _MDBX_CONTAINERS_VECTOR_FLAT_VECTOR_INDEX_HPP_INCLUDED

--- a/include/mdbx_containers/vector/FlatVectorIndex.ipp
+++ b/include/mdbx_containers/vector/FlatVectorIndex.ipp
@@ -1,0 +1,155 @@
+#pragma once
+#ifndef _MDBX_CONTAINERS_VECTOR_FLAT_VECTOR_INDEX_IPP_INCLUDED
+#define _MDBX_CONTAINERS_VECTOR_FLAT_VECTOR_INDEX_IPP_INCLUDED
+
+#include <cstring>
+#include <cmath>
+#include <algorithm>
+#include <stdexcept>
+
+namespace mdbxc {
+
+    inline FlatVectorIndex::FlatVectorIndex(VectorMetric metric)
+        : m_metric(metric) {}
+
+    inline void FlatVectorIndex::clear() {
+        m_ids.clear();
+        m_vectors.clear();
+        m_dim = 0;
+    }
+
+    inline void FlatVectorIndex::check_dim(const Embedding& embedding) {
+        embedding.validate();
+        if (m_dim == 0) {
+            m_dim = embedding.dim;
+        } else if (embedding.dim != m_dim) {
+            throw std::invalid_argument("Embedding dimension does not match index dimension");
+        }
+    }
+
+    inline void FlatVectorIndex::add(uint64_t id, const Embedding& embedding) {
+        check_dim(embedding);
+        std::vector<float> stored(m_dim);
+        if (m_metric == VectorMetric::COSINE) {
+            float norm = 0.0f;
+            for (std::size_t i = 0; i < embedding.values.size(); ++i) {
+                norm += embedding.values[i] * embedding.values[i];
+            }
+            norm = std::sqrt(norm);
+            if (norm > 0.0f) {
+                for (std::size_t i = 0; i < m_dim; ++i) {
+                    stored[i] = embedding.values[i] / norm;
+                }
+            } else {
+                std::fill(stored.begin(), stored.end(), 0.0f);
+            }
+        } else {
+            std::memcpy(stored.data(), embedding.values.data(), m_dim * sizeof(float));
+        }
+        m_ids.reserve(m_ids.size() + 1);
+        m_vectors.reserve(m_vectors.size() + m_dim);
+        m_ids.push_back(id);
+        m_vectors.insert(m_vectors.end(), stored.begin(), stored.end());
+    }
+
+    inline bool FlatVectorIndex::erase(uint64_t id) {
+        for (std::size_t i = 0; i < m_ids.size(); ++i) {
+            if (m_ids[i] == id) {
+                std::size_t last = m_ids.size() - 1;
+                if (i != last) {
+                    m_ids[i] = m_ids[last];
+                    std::memcpy(&m_vectors[i * m_dim], &m_vectors[last * m_dim], m_dim * sizeof(float));
+                }
+                m_ids.pop_back();
+                m_vectors.resize(m_vectors.size() - m_dim);
+                if (m_ids.empty()) {
+                    m_dim = 0;
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    inline float FlatVectorIndex::compute_score(const float* query_vec,
+                                                  const float* candidate_vec) const {
+        if (m_metric == VectorMetric::COSINE || m_metric == VectorMetric::DOT) {
+            float dot = 0.0f;
+            for (std::size_t i = 0; i < m_dim; ++i) {
+                dot += query_vec[i] * candidate_vec[i];
+            }
+            return dot;
+        }
+        // L2: score = -squared_distance (higher is better)
+        float sq_dist = 0.0f;
+        for (std::size_t i = 0; i < m_dim; ++i) {
+            float diff = query_vec[i] - candidate_vec[i];
+            sq_dist += diff * diff;
+        }
+        return -sq_dist;
+    }
+
+    inline std::vector<VectorMatch> FlatVectorIndex::search(const Embedding& query,
+                                                              std::size_t top_k) const {
+        query.validate();
+        if (top_k == 0) {
+            return std::vector<VectorMatch>();
+        }
+        if (m_dim == 0 || m_ids.empty()) {
+            return std::vector<VectorMatch>();
+        }
+        if (query.dim != m_dim) {
+            throw std::invalid_argument("Query dimension does not match index dimension");
+        }
+
+        // Prepare query vector (normalize for COSINE)
+        std::vector<float> query_vec(m_dim);
+        if (m_metric == VectorMetric::COSINE) {
+            float norm = 0.0f;
+            for (std::size_t i = 0; i < query.values.size(); ++i) {
+                norm += query.values[i] * query.values[i];
+            }
+            norm = std::sqrt(norm);
+            if (norm > 0.0f) {
+                for (std::size_t i = 0; i < m_dim; ++i) {
+                    query_vec[i] = query.values[i] / norm;
+                }
+            } else {
+                std::fill(query_vec.begin(), query_vec.end(), 0.0f);
+            }
+        } else {
+            std::memcpy(query_vec.data(), query.values.data(), m_dim * sizeof(float));
+        }
+
+        std::size_t n = m_ids.size();
+        std::vector<VectorMatch> matches;
+        matches.reserve(n);
+        for (std::size_t i = 0; i < n; ++i) {
+            VectorMatch m;
+            m.id = m_ids[i];
+            m.score = compute_score(query_vec.data(), &m_vectors[i * m_dim]);
+            matches.push_back(m);
+        }
+
+        if (top_k > n) {
+            top_k = n;
+        }
+        std::partial_sort(matches.begin(), matches.begin() + top_k, matches.end(),
+            [](const VectorMatch& a, const VectorMatch& b) {
+                return a.score > b.score;
+            });
+        matches.resize(top_k);
+        return matches;
+    }
+
+    inline std::size_t FlatVectorIndex::size() const noexcept {
+        return m_ids.size();
+    }
+
+    inline uint32_t FlatVectorIndex::dim() const noexcept {
+        return m_dim;
+    }
+
+} // namespace mdbxc
+
+#endif // _MDBX_CONTAINERS_VECTOR_FLAT_VECTOR_INDEX_IPP_INCLUDED

--- a/include/mdbx_containers/vector/SearchResult.hpp
+++ b/include/mdbx_containers/vector/SearchResult.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#ifndef _MDBX_CONTAINERS_VECTOR_SEARCH_RESULT_HPP_INCLUDED
+#define _MDBX_CONTAINERS_VECTOR_SEARCH_RESULT_HPP_INCLUDED
+
+#include <string>
+#include <cstdint>
+
+namespace mdbxc {
+
+    /// \brief Result row returned by \ref VectorStore::search().
+    struct SearchResult {
+        uint64_t id = 0; ///< Matched record id.
+        float score = 0.0f; ///< Metric score; larger values rank first.
+        std::string collection; ///< Collection that produced the match.
+        std::string text; ///< Stored text payload.
+        std::string metadata_json; ///< Stored metadata JSON text.
+    };
+
+} // namespace mdbxc
+
+#endif // _MDBX_CONTAINERS_VECTOR_SEARCH_RESULT_HPP_INCLUDED

--- a/include/mdbx_containers/vector/VectorMetric.hpp
+++ b/include/mdbx_containers/vector/VectorMetric.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#ifndef _MDBX_CONTAINERS_VECTOR_VECTOR_METRIC_HPP_INCLUDED
+#define _MDBX_CONTAINERS_VECTOR_VECTOR_METRIC_HPP_INCLUDED
+
+namespace mdbxc {
+    /// \brief Similarity/distance metric used by vector search.
+    enum class VectorMetric {
+        COSINE, ///< Cosine similarity; higher score is better.
+        DOT,    ///< Raw dot product; higher score is better.
+        L2      ///< Negative squared L2 distance; higher score is better.
+    };
+} // namespace mdbxc
+
+#endif // _MDBX_CONTAINERS_VECTOR_VECTOR_METRIC_HPP_INCLUDED

--- a/include/mdbx_containers/vector/VectorRecord.hpp
+++ b/include/mdbx_containers/vector/VectorRecord.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#ifndef _MDBX_CONTAINERS_VECTOR_VECTOR_RECORD_HPP_INCLUDED
+#define _MDBX_CONTAINERS_VECTOR_VECTOR_RECORD_HPP_INCLUDED
+
+#include "Embedding.hpp"
+#include <string>
+#include <cstdint>
+
+namespace mdbxc {
+
+    /// \brief Complete logical vector record.
+    ///
+    /// \note The MVP \ref VectorStore persists this record across separate
+    /// tables rather than serializing \c VectorRecord as one blob.
+    struct VectorRecord {
+        uint64_t id = 0; ///< Stable record id.
+        std::string collection; ///< Collection name.
+        Embedding embedding; ///< Dense embedding.
+        std::string text; ///< Caller payload text.
+        std::string metadata_json; ///< Caller metadata encoded as JSON text.
+    };
+
+} // namespace mdbxc
+
+#endif // _MDBX_CONTAINERS_VECTOR_VECTOR_RECORD_HPP_INCLUDED

--- a/include/mdbx_containers/vector/VectorStore.hpp
+++ b/include/mdbx_containers/vector/VectorStore.hpp
@@ -20,6 +20,9 @@ namespace mdbxc {
     ///
     /// \warning Search is exact \c O(N*dim), all embeddings are loaded into RAM,
     /// and mutable index synchronization is caller-managed.
+    ///
+    /// \note Non-empty collections have a single active dimension established by
+    /// the first successfully added embedding.
     class VectorStore {
     public:
         /// \brief Opens a vector store using a new MDBX connection.
@@ -94,8 +97,6 @@ namespace mdbxc {
 
 } // namespace mdbxc
 
-#ifdef MDBX_CONTAINERS_HEADER_ONLY
 #include "VectorStore.ipp"
-#endif
 
 #endif // _MDBX_CONTAINERS_VECTOR_VECTOR_STORE_HPP_INCLUDED

--- a/include/mdbx_containers/vector/VectorStore.hpp
+++ b/include/mdbx_containers/vector/VectorStore.hpp
@@ -1,0 +1,101 @@
+#pragma once
+#ifndef _MDBX_CONTAINERS_VECTOR_VECTOR_STORE_HPP_INCLUDED
+#define _MDBX_CONTAINERS_VECTOR_VECTOR_STORE_HPP_INCLUDED
+
+#include "../common.hpp"
+#include "../SequenceTable.hpp"
+#include "../KeyValueTable.hpp"
+#include "FlatVectorIndex.hpp"
+#include "VectorRecord.hpp"
+#include "SearchResult.hpp"
+#include <string>
+#include <memory>
+
+namespace mdbxc {
+
+    /// \brief Persistent local vector store with an exact in-memory search index.
+    ///
+    /// The store persists embeddings, text, and metadata in MDBX tables, then
+    /// rebuilds a \ref FlatVectorIndex when opened.
+    ///
+    /// \warning Search is exact \c O(N*dim), all embeddings are loaded into RAM,
+    /// and mutable index synchronization is caller-managed.
+    class VectorStore {
+    public:
+        /// \brief Opens a vector store using a new MDBX connection.
+        /// \param config MDBX environment configuration.
+        /// \param collection Logical collection name; invalid table-name characters are replaced by \c _.
+        /// \param metric Metric used by the in-memory index.
+        /// \throws std::invalid_argument if \c collection is empty.
+        VectorStore(const Config& config,
+                    std::string collection = "default",
+                    VectorMetric metric = VectorMetric::COSINE);
+
+        /// \brief Opens a vector store using an existing connection.
+        /// \param connection Shared MDBX connection.
+        /// \param collection Logical collection name; invalid table-name characters are replaced by \c _.
+        /// \param metric Metric used by the in-memory index.
+        /// \throws std::invalid_argument if \c connection is null or \c collection is empty.
+        VectorStore(std::shared_ptr<Connection> connection,
+                    std::string collection = "default",
+                    VectorMetric metric = VectorMetric::COSINE);
+
+        /// \brief Adds a record and updates the RAM index after commit.
+        /// \param embedding Dense embedding.
+        /// \param text Text payload.
+        /// \param metadata_json Metadata encoded as JSON text.
+        /// \return Stable generated id.
+        /// \throws std::invalid_argument if \c embedding is invalid.
+        /// \throws MdbxException if a database error occurs.
+        uint64_t add(const Embedding& embedding,
+                     const std::string& text,
+                     const std::string& metadata_json = "{}");
+
+        /// \brief Searches the RAM index and loads payloads for matches.
+        /// \param query Query embedding.
+        /// \param top_k Maximum number of matches.
+        /// \return Search results ordered by descending score.
+        /// \throws std::invalid_argument if \c query is invalid.
+        /// \throws std::runtime_error if persisted payload rows are missing.
+        std::vector<SearchResult> search(const Embedding& query,
+                                         std::size_t top_k) const;
+
+        /// \brief Removes a record from persistent tables and the RAM index.
+        /// \param id Record id.
+        /// \return \c true if any persisted row existed.
+        bool erase(uint64_t id);
+
+        /// \brief Clears all persistent tables and the RAM index.
+        void clear();
+
+        /// \brief Rebuilds the RAM index from persisted embeddings.
+        void rebuild_index();
+
+        /// \brief Returns the number of persisted embeddings.
+        std::size_t count() const;
+
+        /// \brief Returns the sanitized collection name.
+        const std::string& collection() const noexcept;
+
+    private:
+        std::string m_collection;
+        VectorMetric m_metric;
+        std::shared_ptr<Connection> m_connection;
+        SequenceTable<uint64_t> m_ids;
+        KeyValueTable<uint64_t, Embedding> m_embeddings;
+        KeyValueTable<uint64_t, std::string> m_texts;
+        KeyValueTable<uint64_t, std::string> m_metadata;
+        FlatVectorIndex m_index;
+
+        static std::shared_ptr<Connection> require_connection(std::shared_ptr<Connection> connection);
+        static std::string sanitize_collection_name(const std::string& name);
+        static std::string make_table_name(const std::string& collection, const std::string& suffix);
+    };
+
+} // namespace mdbxc
+
+#ifdef MDBX_CONTAINERS_HEADER_ONLY
+#include "VectorStore.ipp"
+#endif
+
+#endif // _MDBX_CONTAINERS_VECTOR_VECTOR_STORE_HPP_INCLUDED

--- a/include/mdbx_containers/vector/VectorStore.ipp
+++ b/include/mdbx_containers/vector/VectorStore.ipp
@@ -73,6 +73,9 @@ namespace mdbxc {
                                        const std::string& text,
                                        const std::string& metadata_json) {
         embedding.validate();
+        if (m_index.dim() != 0 && embedding.dim != m_index.dim()) {
+            throw std::invalid_argument("Embedding dimension does not match index dimension");
+        }
 
         auto txn = m_connection->transaction(TransactionMode::WRITABLE);
         uint64_t id = m_ids.append(uint64_t(0), txn);

--- a/include/mdbx_containers/vector/VectorStore.ipp
+++ b/include/mdbx_containers/vector/VectorStore.ipp
@@ -1,0 +1,156 @@
+#pragma once
+#ifndef _MDBX_CONTAINERS_VECTOR_VECTOR_STORE_IPP_INCLUDED
+#define _MDBX_CONTAINERS_VECTOR_VECTOR_STORE_IPP_INCLUDED
+
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace mdbxc {
+
+    inline std::shared_ptr<Connection> VectorStore::require_connection(std::shared_ptr<Connection> connection) {
+        if (!connection) {
+            throw std::invalid_argument("VectorStore connection cannot be null");
+        }
+        return connection;
+    }
+
+    inline std::string VectorStore::sanitize_collection_name(const std::string& name) {
+        if (name.empty()) {
+            throw std::invalid_argument("Collection name cannot be empty");
+        }
+        std::string result;
+        result.reserve(name.size());
+        for (std::size_t i = 0; i < name.size(); ++i) {
+            char c = name[i];
+            if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+                (c >= '0' && c <= '9') || c == '_' || c == '-') {
+                result.push_back(c);
+            } else {
+                result.push_back('_');
+            }
+        }
+        return result;
+    }
+
+    inline std::string VectorStore::make_table_name(const std::string& collection,
+                                                      const std::string& suffix) {
+        return "vectors_" + collection + "_" + suffix;
+    }
+
+    inline VectorStore::VectorStore(const Config& config,
+                                      std::string collection,
+                                      VectorMetric metric)
+        : m_collection(sanitize_collection_name(collection))
+        , m_metric(metric)
+        , m_connection(Connection::create(config))
+        , m_ids(m_connection, make_table_name(m_collection, "ids"))
+        , m_embeddings(m_connection, make_table_name(m_collection, "embeddings"))
+        , m_texts(m_connection, make_table_name(m_collection, "texts"))
+        , m_metadata(m_connection, make_table_name(m_collection, "metadata"))
+        , m_index(metric)
+    {
+        rebuild_index();
+    }
+
+    inline VectorStore::VectorStore(std::shared_ptr<Connection> connection,
+                                      std::string collection,
+                                      VectorMetric metric)
+        : m_collection(sanitize_collection_name(collection))
+        , m_metric(metric)
+        , m_connection(require_connection(std::move(connection)))
+        , m_ids(m_connection, make_table_name(m_collection, "ids"))
+        , m_embeddings(m_connection, make_table_name(m_collection, "embeddings"))
+        , m_texts(m_connection, make_table_name(m_collection, "texts"))
+        , m_metadata(m_connection, make_table_name(m_collection, "metadata"))
+        , m_index(metric)
+    {
+        rebuild_index();
+    }
+
+    inline uint64_t VectorStore::add(const Embedding& embedding,
+                                       const std::string& text,
+                                       const std::string& metadata_json) {
+        embedding.validate();
+
+        auto txn = m_connection->transaction(TransactionMode::WRITABLE);
+        uint64_t id = m_ids.append(uint64_t(0), txn);
+        m_embeddings.insert_or_assign(id, embedding, txn);
+        m_texts.insert_or_assign(id, text, txn);
+        m_metadata.insert_or_assign(id, metadata_json, txn);
+        txn.commit();
+
+        m_index.add(id, embedding);
+        return id;
+    }
+
+    inline std::vector<SearchResult> VectorStore::search(const Embedding& query,
+                                                           std::size_t top_k) const {
+        query.validate();
+
+        std::vector<VectorMatch> matches = m_index.search(query, top_k);
+        std::vector<SearchResult> results;
+        results.reserve(matches.size());
+        for (std::size_t i = 0; i < matches.size(); ++i) {
+            std::pair<bool, std::string> text_res = m_texts.find_compat(matches[i].id);
+            if (!text_res.first) {
+                throw std::runtime_error("VectorStore integrity error: text missing for id");
+            }
+            std::pair<bool, std::string> meta_res = m_metadata.find_compat(matches[i].id);
+            if (!meta_res.first) {
+                throw std::runtime_error("VectorStore integrity error: metadata missing for id");
+            }
+            SearchResult sr;
+            sr.id = matches[i].id;
+            sr.score = matches[i].score;
+            sr.collection = m_collection;
+            sr.text = text_res.second;
+            sr.metadata_json = meta_res.second;
+            results.push_back(sr);
+        }
+        return results;
+    }
+
+    inline bool VectorStore::erase(uint64_t id) {
+        auto txn = m_connection->transaction(TransactionMode::WRITABLE);
+        bool emb_ok = m_embeddings.erase(id, txn);
+        bool txt_ok = m_texts.erase(id, txn);
+        bool meta_ok = m_metadata.erase(id, txn);
+        txn.commit();
+
+        m_index.erase(id);
+        return emb_ok || txt_ok || meta_ok;
+    }
+
+    inline void VectorStore::clear() {
+        auto txn = m_connection->transaction(TransactionMode::WRITABLE);
+        m_ids.clear(txn);
+        m_embeddings.clear(txn);
+        m_texts.clear(txn);
+        m_metadata.clear(txn);
+        txn.commit();
+        m_index.clear();
+    }
+
+    inline void VectorStore::rebuild_index() {
+        m_index.clear();
+        std::vector<std::pair<uint64_t, Embedding>> entries;
+        m_embeddings.load(entries);
+        for (std::size_t i = 0; i < entries.size(); ++i) {
+            entries[i].second.validate();
+            m_index.add(entries[i].first, entries[i].second);
+        }
+    }
+
+    inline std::size_t VectorStore::count() const {
+        return m_embeddings.count();
+    }
+
+    inline const std::string& VectorStore::collection() const noexcept {
+        return m_collection;
+    }
+
+} // namespace mdbxc
+
+#endif // _MDBX_CONTAINERS_VECTOR_VECTOR_STORE_IPP_INCLUDED

--- a/tests/vector_store_test.cpp
+++ b/tests/vector_store_test.cpp
@@ -205,7 +205,37 @@ int main() {
         MDBXC_TEST_ASSERT(l2_index.dim() == 0);
     }
 
-    // --- 9. Embedding serialization validation ---
+    // --- 9. Failed add does not persist ---
+    {
+        mdbxc::Config cfg;
+        cfg.pathname = "data/vector_store_test_9.mdbx";
+        cfg.max_dbs = 10;
+        cfg.no_subdir = true;
+        cfg.relative_to_exe = true;
+
+        {
+            mdbxc::VectorStore store(cfg, "failed_add");
+            store.clear();
+            store.add(make_embedding({1.0f, 0.0f, 0.0f}), "dim3");
+            bool threw = false;
+            try {
+                store.add(make_embedding({1.0f, 0.0f}), "dim2");
+            } catch (const std::invalid_argument&) {
+                threw = true;
+            }
+            MDBXC_TEST_ASSERT(threw);
+            MDBXC_TEST_ASSERT(store.count() == 1);
+        }
+        {
+            mdbxc::VectorStore store(cfg, "failed_add");
+            mdbxc::Embedding query = make_embedding({1.0f, 0.0f, 0.0f});
+            auto results = store.search(query, 1);
+            MDBXC_TEST_ASSERT(results.size() == 1);
+            MDBXC_TEST_ASSERT(results[0].text == "dim3");
+        }
+    }
+
+    // --- 10. Embedding serialization validation ---
     {
         mdbxc::Embedding embedding = make_embedding({1.0f, 2.0f});
         std::vector<uint8_t> bytes = embedding.to_bytes();

--- a/tests/vector_store_test.cpp
+++ b/tests/vector_store_test.cpp
@@ -1,0 +1,239 @@
+#include "test_assert.hpp"
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mdbx_containers/vector.hpp>
+
+static mdbxc::Embedding make_embedding(const std::vector<float>& vals) {
+    mdbxc::Embedding e;
+    e.dim = static_cast<uint32_t>(vals.size());
+    e.values = vals;
+    return e;
+}
+
+int main() {
+    // --- 1. Add and search ---
+    {
+        mdbxc::Config cfg;
+        cfg.pathname = "data/vector_store_test_1.mdbx";
+        cfg.max_dbs = 10;
+        cfg.no_subdir = true;
+        cfg.relative_to_exe = true;
+
+        mdbxc::VectorStore store(cfg, "test1");
+        store.clear();
+
+        mdbxc::Embedding e1 = make_embedding({1.0f, 0.0f, 0.0f});
+        mdbxc::Embedding e2 = make_embedding({0.0f, 1.0f, 0.0f});
+        store.add(e1, "A", "{\"source\":\"unit\"}");
+        store.add(e2, "B");
+
+        mdbxc::Embedding query = make_embedding({1.0f, 0.0f, 0.0f});
+        std::vector<mdbxc::SearchResult> results = store.search(query, 1);
+        MDBXC_TEST_ASSERT(results.size() == 1);
+        MDBXC_TEST_ASSERT(results[0].text == "A");
+        MDBXC_TEST_ASSERT(results[0].metadata_json == "{\"source\":\"unit\"}");
+    }
+
+    // --- 2. Top-k order ---
+    {
+        mdbxc::Config cfg;
+        cfg.pathname = "data/vector_store_test_2.mdbx";
+        cfg.max_dbs = 10;
+        cfg.no_subdir = true;
+        cfg.relative_to_exe = true;
+
+        mdbxc::VectorStore store(cfg, "test2");
+        store.clear();
+
+        mdbxc::Embedding e1 = make_embedding({1.0f, 0.0f});
+        mdbxc::Embedding e2 = make_embedding({0.8f, 0.2f});
+        mdbxc::Embedding e3 = make_embedding({0.0f, 1.0f});
+        uint64_t id1 = store.add(e1, "first");
+        store.add(e2, "second");
+        store.add(e3, "third");
+
+        mdbxc::Embedding query = make_embedding({1.0f, 0.0f});
+        std::vector<mdbxc::SearchResult> results = store.search(query, 2);
+        MDBXC_TEST_ASSERT(results.size() == 2);
+        MDBXC_TEST_ASSERT(results[0].id == id1);
+    }
+
+    // --- 3. Persistence rebuild ---
+    {
+        mdbxc::Config cfg;
+        cfg.pathname = "data/vector_store_test_3.mdbx";
+        cfg.max_dbs = 10;
+        cfg.no_subdir = true;
+        cfg.relative_to_exe = true;
+
+        {
+            mdbxc::VectorStore store(cfg, "persist");
+            store.clear();
+            mdbxc::Embedding e1 = make_embedding({1.0f, 0.0f});
+            store.add(e1, "persisted");
+        }
+
+        {
+            mdbxc::VectorStore store(cfg, "persist");
+            mdbxc::Embedding query = make_embedding({1.0f, 0.0f});
+            std::vector<mdbxc::SearchResult> results = store.search(query, 1);
+            MDBXC_TEST_ASSERT(results.size() == 1);
+            MDBXC_TEST_ASSERT(results[0].text == "persisted");
+        }
+    }
+
+    // --- 4. Erase ---
+    {
+        mdbxc::Config cfg;
+        cfg.pathname = "data/vector_store_test_4.mdbx";
+        cfg.max_dbs = 10;
+        cfg.no_subdir = true;
+        cfg.relative_to_exe = true;
+
+        mdbxc::VectorStore store(cfg, "erase_test");
+        store.clear();
+
+        mdbxc::Embedding e1 = make_embedding({1.0f, 0.0f});
+        mdbxc::Embedding e2 = make_embedding({0.0f, 1.0f});
+        store.add(e1, "keep");
+        uint64_t id2 = store.add(e2, "remove");
+
+        MDBXC_TEST_ASSERT(store.erase(id2));
+
+        mdbxc::Embedding query = make_embedding({0.0f, 1.0f});
+        std::vector<mdbxc::SearchResult> results = store.search(query, 10);
+        for (std::size_t i = 0; i < results.size(); ++i) {
+            MDBXC_TEST_ASSERT(results[i].id != id2);
+        }
+    }
+
+    // --- 5. Dimension mismatch ---
+    {
+        mdbxc::Config cfg;
+        cfg.pathname = "data/vector_store_test_5.mdbx";
+        cfg.max_dbs = 10;
+        cfg.no_subdir = true;
+        cfg.relative_to_exe = true;
+
+        mdbxc::VectorStore store(cfg, "dim_test");
+        store.clear();
+
+        mdbxc::Embedding e3 = make_embedding({1.0f, 0.0f, 0.0f});
+        store.add(e3, "dim3");
+
+        mdbxc::Embedding query2 = make_embedding({1.0f, 0.0f});
+        bool threw = false;
+        try {
+            store.search(query2, 1);
+        } catch (const std::invalid_argument&) {
+            threw = true;
+        }
+        MDBXC_TEST_ASSERT(threw);
+    }
+
+    // --- 6. Empty embedding ---
+    {
+        mdbxc::Config cfg;
+        cfg.pathname = "data/vector_store_test_6.mdbx";
+        cfg.max_dbs = 10;
+        cfg.no_subdir = true;
+        cfg.relative_to_exe = true;
+
+        mdbxc::VectorStore store(cfg, "empty_test");
+        store.clear();
+
+        mdbxc::Embedding empty_e;
+        bool threw = false;
+        try {
+            store.add(empty_e, "bad");
+        } catch (const std::invalid_argument&) {
+            threw = true;
+        }
+        MDBXC_TEST_ASSERT(threw);
+    }
+
+    // --- 7. Collections isolation ---
+    {
+        mdbxc::Config cfg;
+        cfg.pathname = "data/vector_store_test_7.mdbx";
+        cfg.max_dbs = 20;
+        cfg.no_subdir = true;
+        cfg.relative_to_exe = true;
+
+        auto conn = mdbxc::Connection::create(cfg);
+
+        mdbxc::VectorStore storeA(conn, "docs");
+        mdbxc::VectorStore storeB(conn, "code/raw");
+        storeA.clear();
+        storeB.clear();
+        MDBXC_TEST_ASSERT(storeB.collection() == "code_raw");
+
+        mdbxc::Embedding e1 = make_embedding({1.0f, 0.0f});
+        storeA.add(e1, "document");
+
+        mdbxc::Embedding query = make_embedding({1.0f, 0.0f});
+        std::vector<mdbxc::SearchResult> resultsB = storeB.search(query, 1);
+        MDBXC_TEST_ASSERT(resultsB.empty());
+    }
+
+    // --- 8. FlatVectorIndex metrics and top_k=0 ---
+    {
+        mdbxc::FlatVectorIndex dot_index(mdbxc::VectorMetric::DOT);
+        dot_index.add(10, make_embedding({2.0f, 0.0f}));
+        dot_index.add(11, make_embedding({0.0f, 1.0f}));
+        std::vector<mdbxc::VectorMatch> dot_results =
+            dot_index.search(make_embedding({1.0f, 0.0f}), 1);
+        MDBXC_TEST_ASSERT(dot_results.size() == 1);
+        MDBXC_TEST_ASSERT(dot_results[0].id == 10);
+        MDBXC_TEST_ASSERT(dot_results[0].score == 2.0f);
+        MDBXC_TEST_ASSERT(dot_index.search(make_embedding({1.0f, 0.0f}), 0).empty());
+
+        mdbxc::FlatVectorIndex l2_index(mdbxc::VectorMetric::L2);
+        l2_index.add(20, make_embedding({1.0f, 0.0f}));
+        l2_index.add(21, make_embedding({3.0f, 0.0f}));
+        std::vector<mdbxc::VectorMatch> l2_results =
+            l2_index.search(make_embedding({2.5f, 0.0f}), 2);
+        MDBXC_TEST_ASSERT(l2_results.size() == 2);
+        MDBXC_TEST_ASSERT(l2_results[0].id == 21);
+        MDBXC_TEST_ASSERT(l2_index.erase(20));
+        MDBXC_TEST_ASSERT(l2_index.erase(21));
+        MDBXC_TEST_ASSERT(l2_index.dim() == 0);
+    }
+
+    // --- 9. Embedding serialization validation ---
+    {
+        mdbxc::Embedding embedding = make_embedding({1.0f, 2.0f});
+        std::vector<uint8_t> bytes = embedding.to_bytes();
+        mdbxc::Embedding restored = mdbxc::Embedding::from_bytes(bytes.data(), bytes.size());
+        MDBXC_TEST_ASSERT(restored.dim == 2);
+        MDBXC_TEST_ASSERT(restored.values == embedding.values);
+
+        bool threw = false;
+        try {
+            mdbxc::Embedding invalid;
+            invalid.dim = 3;
+            invalid.values.push_back(1.0f);
+            invalid.to_bytes();
+        } catch (const std::invalid_argument&) {
+            threw = true;
+        }
+        MDBXC_TEST_ASSERT(threw);
+
+        threw = false;
+        bytes[4] = 1;
+        try {
+            mdbxc::Embedding::from_bytes(bytes.data(), bytes.size());
+        } catch (const std::runtime_error&) {
+            threw = true;
+        }
+        MDBXC_TEST_ASSERT(threw);
+    }
+
+    std::cout << "VectorStore test passed.\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add the `mdbx_containers/vector.hpp` aggregate header and vector domain types
- implement `Embedding` binary serialization, `FlatVectorIndex`, and `VectorStore`
- add vector store tests plus README/Doxygen coverage for the MVP RAG workflow

## Notes
- search is exact `O(N * dim)` and keeps embeddings in RAM
- no ANN/HNSW, metadata filtering, embedding generation, or network API in this MVP

## Validation
- `cmake -S . -B tmp/build-cpp17 -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=17`
- `cmake -S . -B tmp/build-cpp11 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=11`
- `cmake --build tmp/build-cpp17`
- `cmake --build tmp/build-cpp11`
- `ctest --test-dir tmp/build-cpp17 --output-on-failure`
- `ctest --test-dir tmp/build-cpp11 --output-on-failure`
- `git diff --cached --check`