### PR TITLE
feat(vector): embedded vector store MVP

### DIFF
--- a/include/mdbx_containers/vector/FlatVectorIndex.hpp
+++ b/include/mdbx_containers/vector/FlatVectorIndex.hpp
@@ -59,6 +59,8 @@ namespace mdbxc {
         VectorMetric m_metric;
         uint32_t m_dim = 0;
         std::vector<uint64_t> m_ids;
+        /// \brief Contiguous row-major vector storage: [id0 dim floats][id1 dim floats]...
+        /// This layout is intentionally compatible with Eigen::Map and future SIMD backends.
         std::vector<float> m_vectors;
 
         void check_dim(const Embedding& embedding);


### PR DESCRIPTION
Implements MVP embedded vector store on top of mdbx-containers.

### Added
- VectorMetric enum (COSINE, DOT, L2)
- Embedding struct with binary serialization
- VectorRecord and SearchResult types
- FlatVectorIndex: in-memory exact flat search with cosine normalization
- VectorStore: persistent facade over SequenceTable + KeyValueTables + FlatVectorIndex
- Collection support with name sanitization
- Rebuild RAM index from MDBX on construction

### Tests
- add/search, top-k order, persistence/rebuild, erase
- dimension mismatch, empty embedding, collection isolation
- FlatVectorIndex metrics (DOT, L2) and serialization validation
- Failed add without persisted side effect

### Notes
- Search is exact O(N*dim); all embeddings loaded into RAM.
- No ANN/HNSW, no metadata filtering yet.
- Header-only; include via `<mdbx_containers/vector.hpp>`.