### PR TITLE
fix: preserve UTF-8 Windows paths

### DIFF
--- a/guides/coding-style.md
+++ b/guides/coding-style.md
@@ -21,6 +21,23 @@ Getter methods may omit `get_` when they behave like property accessors, such as
 `size()` or `empty()`. Use `get_` when the method performs computation or when
 omitting the prefix would be misleading.
 
+## Semantic Values And Literals
+
+- Avoid magic numbers: name non-obvious numeric values, including byte values
+  such as `0xD0`, when the domain meaning is not self-evident.
+- Avoid magic literals: name non-obvious strings, bytes, characters, regular
+  expressions, paths, flags, and test payloads.
+- Use intention-revealing names: prefer names that explain the role of a value,
+  for example `invalid_utf8_leading_byte` rather than `byte`.
+- Make invalid and edge cases explicit: test data for failure paths should state
+  which failure condition it represents.
+- Prefer named constants for semantic values: if a value has project or domain
+  meaning, bind that meaning to a local constant.
+- Separate data meaning from representation: `0xD0` is a representation;
+  "truncated UTF-8 leading byte" is the meaning.
+- Follow the Principle of Least Astonishment: readers should not need to infer
+  why a particular byte, flag, or literal was chosen.
+
 ## File Names
 
 - If a file contains one primary class, use `CamelCase`, for example

--- a/include/mdbx_containers/detail/path_utils.hpp
+++ b/include/mdbx_containers/detail/path_utils.hpp
@@ -19,10 +19,6 @@
 // For Windows systems
 #include <direct.h>
 #include <windows.h>
-#if __cplusplus < 202002L
-#include <locale>
-#include <codecvt>
-#endif
 #include <errno.h>
 #else
 // For POSIX systems
@@ -47,6 +43,28 @@ namespace mdbxc {
     /// \brief Converts a UTF-8 string with char8_t characters to std::string.
     inline std::string u8string_to_string(const std::u8string& s) {
         return std::string(s.begin(), s.end());
+    }
+#endif
+
+#ifdef _WIN32
+    /// \brief Converts a wide Windows string to a UTF-8 string.
+    inline std::string wide_to_utf8(const std::wstring& wide) {
+        if (wide.empty()) return std::string();
+        int size = WideCharToMultiByte(CP_UTF8, 0, wide.data(), static_cast<int>(wide.size()), NULL, 0, NULL, NULL);
+        if (size == 0) return std::string();
+        std::string utf8(static_cast<std::size_t>(size), '\0');
+        WideCharToMultiByte(CP_UTF8, 0, wide.data(), static_cast<int>(wide.size()), &utf8[0], size, NULL, NULL);
+        return utf8;
+    }
+
+    /// \brief Converts a UTF-8 string to a wide Windows string.
+    inline std::wstring utf8_to_wide(const std::string& utf8) {
+        if (utf8.empty()) return std::wstring();
+        int size = MultiByteToWideChar(CP_UTF8, 0, utf8.data(), static_cast<int>(utf8.size()), NULL, 0);
+        if (size == 0) return std::wstring();
+        std::wstring wide(static_cast<std::size_t>(size), L'\0');
+        MultiByteToWideChar(CP_UTF8, 0, utf8.data(), static_cast<int>(utf8.size()), &wide[0], size);
+        return wide;
     }
 #endif
 
@@ -124,15 +142,7 @@ namespace mdbxc {
             exe_path = exe_path.substr(0, pos);
         }
 
-#       if __cplusplus >= 202002L
-        fs::path path_wide = exe_path;
-        auto tmp = path_wide.u8string();
-        return u8string_to_string(tmp);
-#       else
-        // Convert from std::wstring (UTF-16) to std::string (UTF-8)
-        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-        return converter.to_bytes(exe_path);
-#       endif
+        return wide_to_utf8(exe_path);
 
 #       elif defined(__APPLE__)
         uint32_t size = 0;
@@ -200,28 +210,6 @@ namespace mdbxc {
 #       endif
     }
 
-    /// \brief Converts a UTF-8 string to an ANSI string (Windows-specific).
-    /// \param utf8 The UTF-8 encoded string.
-    /// \return The converted ANSI string.
-    inline std::string utf8_to_ansi(const std::string& utf8) noexcept {
-#ifdef _WIN32
-        int n_len = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, NULL, 0);
-        if (n_len == 0) return {};
-
-        std::wstring wide_string(n_len + 1, L'\0');
-        MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, &wide_string[0], n_len);
-
-        n_len = WideCharToMultiByte(CP_ACP, 0, wide_string.c_str(), -1, NULL, 0, NULL, NULL);
-        if (n_len == 0) return {};
-
-        std::string ansi_string(n_len - 1, '\0');
-        WideCharToMultiByte(CP_ACP, 0, wide_string.c_str(), -1, &ansi_string[0], n_len, NULL, NULL);
-        return ansi_string;
-#else
-        return utf8;
-#endif
-    }
-
 #if __cplusplus >= 201703L
 
     /// \brief Computes the relative path from base_path to file_path using C++17 std::filesystem.
@@ -251,14 +239,7 @@ namespace mdbxc {
     /// \throws std::runtime_error if the directories cannot be created.
       inline void create_directories(const std::string& path) {
 #   ifdef _WIN32
-#       if __cplusplus >= 202002L
-        fs::path parent_dir = fs::u8path(get_parent_path(path));
-#       else
-        // Convert UTF-8 string to wide string for Windows
-        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-        std::wstring wide_path = converter.from_bytes(get_parent_path(path));
-        fs::path parent_dir = fs::path(wide_path);
-#       endif
+        fs::path parent_dir = fs::path(utf8_to_wide(get_parent_path(path)));
 #   else
         fs::path parent_dir = fs::u8path(get_parent_path(path));
 #   endif
@@ -513,7 +494,7 @@ namespace mdbxc {
                 components[i] == "/" ||
                 components[i] == "~/") continue;
 #           ifdef _WIN32
-            int ret = _mkdir(utf8_to_ansi(current_path).c_str());
+            int ret = _wmkdir(utf8_to_wide(current_path).c_str());
 #           else
             int ret = mkdir(current_path.c_str(), 0755);
 #           endif

--- a/include/mdbx_containers/detail/path_utils.hpp
+++ b/include/mdbx_containers/detail/path_utils.hpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 #include <stdexcept>
+#include <cstring>
 #if __cplusplus >= 201703L
 #include <filesystem>
 #else
@@ -50,20 +51,38 @@ namespace mdbxc {
     /// \brief Converts a wide Windows string to a UTF-8 string.
     inline std::string wide_to_utf8(const std::wstring& wide) {
         if (wide.empty()) return std::string();
-        int size = WideCharToMultiByte(CP_UTF8, 0, wide.data(), static_cast<int>(wide.size()), NULL, 0, NULL, NULL);
-        if (size == 0) return std::string();
+        int size = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS,
+                                       wide.data(), static_cast<int>(wide.size()),
+                                       NULL, 0, NULL, NULL);
+        if (size == 0) {
+            throw std::runtime_error("Failed to convert UTF-16 path to UTF-8.");
+        }
         std::string utf8(static_cast<std::size_t>(size), '\0');
-        WideCharToMultiByte(CP_UTF8, 0, wide.data(), static_cast<int>(wide.size()), &utf8[0], size, NULL, NULL);
+        int written = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS,
+                                          wide.data(), static_cast<int>(wide.size()),
+                                          &utf8[0], size, NULL, NULL);
+        if (written == 0) {
+            throw std::runtime_error("Failed to convert UTF-16 path to UTF-8.");
+        }
         return utf8;
     }
 
     /// \brief Converts a UTF-8 string to a wide Windows string.
     inline std::wstring utf8_to_wide(const std::string& utf8) {
         if (utf8.empty()) return std::wstring();
-        int size = MultiByteToWideChar(CP_UTF8, 0, utf8.data(), static_cast<int>(utf8.size()), NULL, 0);
-        if (size == 0) return std::wstring();
+        int size = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+                                       utf8.data(), static_cast<int>(utf8.size()),
+                                       NULL, 0);
+        if (size == 0) {
+            throw std::runtime_error("Failed to convert UTF-8 path to UTF-16.");
+        }
         std::wstring wide(static_cast<std::size_t>(size), L'\0');
-        MultiByteToWideChar(CP_UTF8, 0, utf8.data(), static_cast<int>(utf8.size()), &wide[0], size);
+        int written = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+                                          utf8.data(), static_cast<int>(utf8.size()),
+                                          &wide[0], size);
+        if (written == 0) {
+            throw std::runtime_error("Failed to convert UTF-8 path to UTF-16.");
+        }
         return wide;
     }
 #endif
@@ -249,9 +268,11 @@ namespace mdbxc {
             if (!std::filesystem::create_directories(parent_dir, ec)) {
 #       if __cplusplus >= 202002L
                 auto p = parent_dir.u8string();
-                throw std::runtime_error("Failed to create directories for path: " + u8string_to_string(p));
+                throw std::runtime_error("Failed to create directories for path: " +
+                                         u8string_to_string(p) + ": " + ec.message());
 #       else
-                throw std::runtime_error("Failed to create directories for path: " + parent_dir.u8string());
+                throw std::runtime_error("Failed to create directories for path: " +
+                                         parent_dir.u8string() + ": " + ec.message());
 #       endif
             }
         }
@@ -500,7 +521,8 @@ namespace mdbxc {
 #           endif
             int errnum = errno;
             if (ret != 0 && errnum != EEXIST) {
-                throw std::runtime_error("Failed to create directory: " + current_path);
+                throw std::runtime_error("Failed to create directory: " + current_path +
+                                         ": " + std::string(strerror(errnum)));
             }
         }
     }

--- a/tests/path_utils_unicode_test.cpp
+++ b/tests/path_utils_unicode_test.cpp
@@ -14,9 +14,25 @@ const char* cyrillic_sample() {
     return "\xD0\xBA\xD0\xB8\xD1\x80\xD0\xB8\xD0\xBB\xD0\xBB\xD0\xB8\xD1\x86\xD0\xB0_\xD0\x81_\xD1\x82\xD0\xB5\xD1\x81\xD1\x82";
 }
 
+const char* ukrainian_sample() {
+    return "\xD1\x83\xD0\xBA\xD1\x80\xD0\xB0\xD1\x97\xD0\xBD\xD1\x81\xD1\x8C\xD0\xBA\xD0\xB0_\xD0\x84_\xD0\x87_\xD0\x86_\xD2\x90";
+}
+
+const char* exotic_sample() {
+    return "\xE0\xBA\x9E\xE0\xBA\xB2\xE0\xBA\xAA\xE0\xBA\xB2\xE0\xBA\xA5\xE0\xBA\xB2\xE0\xBA\xA7";
+}
+
 #ifdef _WIN32
 std::wstring wide_cyrillic_sample() {
     return L"\x043A\x0438\x0440\x0438\x043B\x043B\x0438\x0446\x0430_\x0401_\x0442\x0435\x0441\x0442";
+}
+
+std::wstring wide_ukrainian_sample() {
+    return L"\x0443\x043A\x0440\x0430\x0457\x043D\x0441\x044C\x043A\x0430_\x0404_\x0407_\x0406_\x0490";
+}
+
+std::wstring wide_exotic_sample() {
+    return L"\x0E9E\x0EB2\x0EAA\x0EB2\x0EA5\x0EB2\x0EA7";
 }
 
 std::wstring temp_dir() {
@@ -41,17 +57,33 @@ std::string suffix() {
 
 int main() {
 #ifdef _WIN32
-    const std::string utf8 = cyrillic_sample();
-    const std::wstring wide = wide_cyrillic_sample();
+    const std::string cyrillic = cyrillic_sample();
+    const std::string ukrainian = ukrainian_sample();
+    const std::string exotic = exotic_sample();
 
-    MDBXC_TEST_ASSERT(mdbxc::wide_to_utf8(wide) == utf8);
-    MDBXC_TEST_ASSERT(mdbxc::utf8_to_wide(utf8) == wide);
+    MDBXC_TEST_ASSERT(mdbxc::wide_to_utf8(wide_cyrillic_sample()) == cyrillic);
+    MDBXC_TEST_ASSERT(mdbxc::utf8_to_wide(cyrillic) == wide_cyrillic_sample());
+    MDBXC_TEST_ASSERT(mdbxc::wide_to_utf8(wide_ukrainian_sample()) == ukrainian);
+    MDBXC_TEST_ASSERT(mdbxc::utf8_to_wide(ukrainian) == wide_ukrainian_sample());
+    MDBXC_TEST_ASSERT(mdbxc::wide_to_utf8(wide_exotic_sample()) == exotic);
+    MDBXC_TEST_ASSERT(mdbxc::utf8_to_wide(exotic) == wide_exotic_sample());
+
+    bool failed = false;
+    try {
+        (void)mdbxc::utf8_to_wide(std::string("\xD0", 1));
+    } catch (const std::runtime_error&) {
+        failed = true;
+    }
+    MDBXC_TEST_ASSERT(failed);
 
     const std::string root = mdbxc::wide_to_utf8(temp_dir()) + "mdbxc_unicode_" + suffix();
-    const std::string first_parent = root + "\\" + utf8;
-    const std::string second_parent = first_parent + "\\" + utf8 + "_nested";
-    const std::string parent = second_parent + "\\" + utf8 + "_leaf";
+    const std::string first_parent = root + "\\" + cyrillic;
+    const std::string second_parent = first_parent + "\\" + ukrainian;
+    const std::string parent = second_parent + "\\" + exotic;
     const std::string db_path = parent + "\\db.mdbx";
+
+    MDBXC_TEST_ASSERT(mdbxc::get_file_name(db_path) == "db.mdbx");
+    MDBXC_TEST_ASSERT(mdbxc::get_parent_path(db_path) == parent);
 
     mdbxc::create_directories(db_path);
 
@@ -65,8 +97,11 @@ int main() {
     RemoveDirectoryW(mdbxc::utf8_to_wide(first_parent).c_str());
     RemoveDirectoryW(mdbxc::utf8_to_wide(root).c_str());
 #else
-    const std::string path = std::string("tmp/") + cyrillic_sample() + "/db.mdbx";
-    MDBXC_TEST_ASSERT(mdbxc::get_parent_path(path) == std::string("tmp/") + cyrillic_sample());
+    const std::string path = std::string("tmp/") + cyrillic_sample() + "/" +
+                             ukrainian_sample() + "/" + exotic_sample() + "/db.mdbx";
+    const std::string parent = std::string("tmp/") + cyrillic_sample() + "/" +
+                               ukrainian_sample() + "/" + exotic_sample();
+    MDBXC_TEST_ASSERT(mdbxc::get_parent_path(path) == parent);
     MDBXC_TEST_ASSERT(mdbxc::get_file_name(path) == "db.mdbx");
 #endif
 

--- a/tests/path_utils_unicode_test.cpp
+++ b/tests/path_utils_unicode_test.cpp
@@ -1,0 +1,74 @@
+#include "test_assert.hpp"
+#include <mdbx_containers/detail/path_utils.hpp>
+
+#include <cstdio>
+#include <string>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace {
+
+const char* cyrillic_sample() {
+    return "\xD0\xBA\xD0\xB8\xD1\x80\xD0\xB8\xD0\xBB\xD0\xBB\xD0\xB8\xD1\x86\xD0\xB0_\xD0\x81_\xD1\x82\xD0\xB5\xD1\x81\xD1\x82";
+}
+
+#ifdef _WIN32
+std::wstring wide_cyrillic_sample() {
+    return L"\x043A\x0438\x0440\x0438\x043B\x043B\x0438\x0446\x0430_\x0401_\x0442\x0435\x0441\x0442";
+}
+
+std::wstring temp_dir() {
+    std::wstring buffer(MAX_PATH, L'\0');
+    DWORD size = GetTempPathW(static_cast<DWORD>(buffer.size()), &buffer[0]);
+    MDBXC_TEST_ASSERT(size > 0);
+    MDBXC_TEST_ASSERT(size < buffer.size());
+    buffer.resize(size);
+    return buffer;
+}
+
+std::string suffix() {
+    char buf[64];
+    std::snprintf(buf, sizeof(buf), "%lu_%lu",
+                  static_cast<unsigned long>(GetCurrentProcessId()),
+                  static_cast<unsigned long>(GetTickCount()));
+    return buf;
+}
+#endif
+
+} // namespace
+
+int main() {
+#ifdef _WIN32
+    const std::string utf8 = cyrillic_sample();
+    const std::wstring wide = wide_cyrillic_sample();
+
+    MDBXC_TEST_ASSERT(mdbxc::wide_to_utf8(wide) == utf8);
+    MDBXC_TEST_ASSERT(mdbxc::utf8_to_wide(utf8) == wide);
+
+    const std::string root = mdbxc::wide_to_utf8(temp_dir()) + "mdbxc_unicode_" + suffix();
+    const std::string first_parent = root + "\\" + utf8;
+    const std::string second_parent = first_parent + "\\" + utf8 + "_nested";
+    const std::string parent = second_parent + "\\" + utf8 + "_leaf";
+    const std::string db_path = parent + "\\db.mdbx";
+
+    mdbxc::create_directories(db_path);
+
+    const std::wstring wide_parent = mdbxc::utf8_to_wide(parent);
+    DWORD attributes = GetFileAttributesW(wide_parent.c_str());
+    MDBXC_TEST_ASSERT(attributes != INVALID_FILE_ATTRIBUTES);
+    MDBXC_TEST_ASSERT((attributes & FILE_ATTRIBUTE_DIRECTORY) != 0);
+
+    RemoveDirectoryW(wide_parent.c_str());
+    RemoveDirectoryW(mdbxc::utf8_to_wide(second_parent).c_str());
+    RemoveDirectoryW(mdbxc::utf8_to_wide(first_parent).c_str());
+    RemoveDirectoryW(mdbxc::utf8_to_wide(root).c_str());
+#else
+    const std::string path = std::string("tmp/") + cyrillic_sample() + "/db.mdbx";
+    MDBXC_TEST_ASSERT(mdbxc::get_parent_path(path) == std::string("tmp/") + cyrillic_sample());
+    MDBXC_TEST_ASSERT(mdbxc::get_file_name(path) == "db.mdbx");
+#endif
+
+    return 0;
+}

--- a/tests/path_utils_unicode_test.cpp
+++ b/tests/path_utils_unicode_test.cpp
@@ -68,9 +68,10 @@ int main() {
     MDBXC_TEST_ASSERT(mdbxc::wide_to_utf8(wide_exotic_sample()) == exotic);
     MDBXC_TEST_ASSERT(mdbxc::utf8_to_wide(exotic) == wide_exotic_sample());
 
+    const std::string invalid_utf8(1, static_cast<char>(0xD0));
     bool failed = false;
     try {
-        (void)mdbxc::utf8_to_wide(std::string("\xD0", 1));
+        (void)mdbxc::utf8_to_wide(invalid_utf8);
     } catch (const std::runtime_error&) {
         failed = true;
     }


### PR DESCRIPTION
## Summary
- replace deprecated std::wstring_convert usage in Windows path helpers with Win32 UTF-8/UTF-16 APIs
- keep C++11 compatibility and avoid ACP conversion for Unicode directories
- add a test for Cyrillic UTF-8 round-trip and nested Cyrillic directory creation

## Verification
- cmake -S . -B tmp/build-cpp17-mingw -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=17
- cmake --build tmp/build-cpp17-mingw --target path_utils_unicode_test
- ctest --test-dir tmp/build-cpp17-mingw -R path_utils_unicode_test --output-on-failure
- cmake -S . -B tmp/build-cpp11-mingw -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=11
- cmake --build tmp/build-cpp11-mingw --target path_utils_unicode_test
- ctest --test-dir tmp/build-cpp11-mingw -R path_utils_unicode_test --output-on-failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)