### PR TITLE
[codex] Avoid deprecated UTF-8 path conversion in Connection

### DIFF
--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -5,11 +5,6 @@
 #include <unordered_map>
 #include <cassert>
 
-#if __cplusplus < 202002L
-# include <codecvt>
-# include <locale>
-#endif
-
 #if __cplusplus >= 201703L
 # include <filesystem>
 #endif
@@ -271,8 +266,7 @@ namespace mdbxc {
 #       if __cplusplus >= 202002L
         fs::path file_path = fs::u8path(pathname);
 #       else
-        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-        std::wstring wide_path = converter.from_bytes(pathname);
+        std::wstring wide_path = utf8_to_wide(pathname);
         fs::path file_path = fs::path(wide_path);
 #       endif
         file_path = file_path.lexically_normal();
@@ -282,8 +276,7 @@ namespace mdbxc {
         );
 #   else
         pathname = lexically_normal_compat(pathname);
-        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-        std::wstring wide_path = converter.from_bytes(pathname);
+        std::wstring wide_path = utf8_to_wide(pathname);
         check_mdbx(
             mdbx_env_openW(m_env, wide_path.c_str(), env_flags, 0664),
             "Failed to open environment"

--- a/tests/connection_unicode_path_test.cpp
+++ b/tests/connection_unicode_path_test.cpp
@@ -1,0 +1,104 @@
+#include "test_assert.hpp"
+
+#include <mdbx_containers/common.hpp>
+
+#include <ctime>
+#include <cstdio>
+#include <string>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+namespace {
+
+std::string unicode_dir_name() {
+    return "\xD0\xB1\xD0\xB0\xD0\xB7\xD0\xB0"
+           "_\xE6\xB5\x8B\xE8\xAF\x95"
+           "_\xF0\x9F\x98\x80";
+}
+
+#ifdef _WIN32
+std::string temp_dir() {
+    std::wstring buffer(MAX_PATH, L'\0');
+    DWORD size = GetTempPathW(static_cast<DWORD>(buffer.size()), &buffer[0]);
+    MDBXC_TEST_ASSERT(size > 0);
+    MDBXC_TEST_ASSERT(size < buffer.size());
+    buffer.resize(size);
+    return mdbxc::wide_to_utf8(buffer);
+}
+
+std::string suffix() {
+    char buf[64];
+    std::snprintf(buf, sizeof(buf), "%lu_%lu",
+                  static_cast<unsigned long>(GetCurrentProcessId()),
+                  static_cast<unsigned long>(GetTickCount()));
+    return buf;
+}
+
+void remove_file_if_exists(const std::string& path) {
+    DeleteFileW(mdbxc::utf8_to_wide(path).c_str());
+}
+
+void remove_dir_if_exists(const std::string& path) {
+    RemoveDirectoryW(mdbxc::utf8_to_wide(path).c_str());
+}
+#else
+std::string temp_dir() {
+    return "/tmp/";
+}
+
+std::string suffix() {
+    char buf[64];
+    std::snprintf(buf, sizeof(buf), "%ld_%ld",
+                  static_cast<long>(getpid()),
+                  static_cast<long>(std::time(nullptr)));
+    return buf;
+}
+
+void remove_file_if_exists(const std::string& path) {
+    unlink(path.c_str());
+}
+
+void remove_dir_if_exists(const std::string& path) {
+    rmdir(path.c_str());
+}
+#endif
+
+void open_and_close(const std::string& db_path) {
+    mdbxc::Config config;
+    config.pathname = db_path;
+    config.relative_to_exe = false;
+    config.no_subdir = true;
+    config.max_dbs = 2;
+
+    mdbxc::Connection connection;
+    connection.connect(config);
+    connection.disconnect();
+}
+
+} // namespace
+
+int main() {
+    const std::string root = temp_dir() + "mdbxc_connection_unicode_" + suffix();
+    const std::string unicode_dir = root + "/" + unicode_dir_name();
+    const std::string db_path = unicode_dir + "/data.mdbx";
+
+    remove_file_if_exists(db_path);
+    remove_file_if_exists(db_path + "-lck");
+    remove_dir_if_exists(unicode_dir);
+    remove_dir_if_exists(root);
+
+    open_and_close(db_path);
+    open_and_close(db_path);
+
+    remove_file_if_exists(db_path);
+    remove_file_if_exists(db_path + "-lck");
+    remove_dir_if_exists(unicode_dir);
+    remove_dir_if_exists(root);
+
+    return 0;
+}


### PR DESCRIPTION
﻿## Summary

- Replace `std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>` in `Connection::db_init()` with the existing Windows `utf8_to_wide()` helper.
- Remove now-unused `<codecvt>` / `<locale>` includes from `Connection.ipp`.
- Add `connection_unicode_path_test` that opens, closes, and reopens a database at a UTF-8 path containing Cyrillic, CJK, and emoji characters with `relative_to_exe=false`.

## Why

`std::wstring_convert` and `<codecvt>` are deprecated in C++17 and trigger warnings with modern MinGW/GCC when consumers include `Connection.ipp`. The project already has WinAPI-based UTF-8/UTF-16 helpers in `detail/path_utils.hpp`, so `Connection` can use the same conversion path as the rest of the Windows path utilities.

This keeps UTF-8 validation behavior strict through `MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, ...)` and avoids relying on deprecated standard-library conversion APIs. The new integration test verifies the full `Connection -> db_init -> mdbx_env_openW` path rather than only the standalone path utilities.

## Validation

- `cmake -G "MinGW Makefiles" -S . -B tmp/build-cpp17 -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=17`
- `cmake --build tmp/build-cpp17 --target connection_unicode_path_test -- -j1`
- `ctest --test-dir tmp/build-cpp17 -R connection_unicode_path_test --output-on-failure` - 1 passed
- `ctest --test-dir tmp/build-cpp17 --output-on-failure` - 16 passed
- `cmake -G "MinGW Makefiles" -S . -B tmp/build-cpp11 -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=11`
- `cmake --build tmp/build-cpp11 --target connection_unicode_path_test -- -j1`
- `ctest --test-dir tmp/build-cpp11 -R connection_unicode_path_test --output-on-failure` - 1 passed
- `ctest --test-dir tmp/build-cpp11 --output-on-failure` - 15 passed
- `git diff --check`
