### PR TITLE
[codex] Reuse parent-provided MDBX targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
       matrix:
         target_case:
           - mdbx
+          - mdbx-bare
           - libmdbx
+          - libmdbx-bare
           - mdbx-static
           - mdbx-static-bare
           - libmdbx-static

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  parent-targets:
+    name: Parent MDBX target smoke (${{ matrix.target_case }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target_case:
+          - mdbx
+          - libmdbx
+          - mdbx-static
+          - libmdbx-static
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build
+
+      - name: Configure parent-target smoke
+        run: |
+          set -euo pipefail
+          cmake -S tests/cmake/parent_targets -B "build-parent-${{ matrix.target_case }}" -G "Ninja" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_STANDARD=17 \
+            -DMDBXC_PARENT_TARGET_CASE="${{ matrix.target_case }}" \
+            -Wno-dev
+
+      - name: Build parent-target smoke
+        run: |
+          set -euo pipefail
+          cmake --build "build-parent-${{ matrix.target_case }}" --parallel
+
   windows:
     name: Windows MinGW64 (C++${{ matrix.std }})
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,9 @@ jobs:
           - mdbx
           - libmdbx
           - mdbx-static
+          - mdbx-static-bare
           - libmdbx-static
+          - libmdbx-static-bare
 
     steps:
       - name: Checkout repository

--- a/README-RU.md
+++ b/README-RU.md
@@ -93,7 +93,8 @@
    проект подключён как subproject, уже существующий parent target
    `mdbx::mdbx`, `mdbx::mdbx-static`, `libmdbx::mdbx` или
    `libmdbx::mdbx-static` переиспользуется до поиска пакета, submodule или
-   FetchContent.
+   FetchContent. Parent targets имеют приоритет над `MDBXC_DEPS_MODE`, включая
+   `BUNDLED`.
 3. Используйте компилятор с поддержкой C++11 или новее.
 
 ### Сборка через CMake

--- a/README-RU.md
+++ b/README-RU.md
@@ -89,7 +89,11 @@
    submodule.
 2. Убедитесь, что `libmdbx` доступна вашей системе сборки. Установите
    `MDBXC_DEPS_MODE=BUNDLED`, чтобы использовать bundled submodule в
-   `external/libmdbx`, или `SYSTEM`/`AUTO` для установленного пакета.
+   `external/libmdbx`, или `SYSTEM`/`AUTO` для установленного пакета. Если
+   проект подключён как subproject, уже существующий parent target
+   `mdbx::mdbx`, `mdbx::mdbx-static`, `libmdbx::mdbx` или
+   `libmdbx::mdbx-static` переиспользуется до поиска пакета, submodule или
+   FetchContent.
 3. Используйте компилятор с поддержкой C++11 или новее.
 
 ### Сборка через CMake

--- a/README.md
+++ b/README.md
@@ -62,7 +62,13 @@
 ## 🛠️ Installation
 
 1. Copy the `include/` directory into your project or add this repository as a submodule.
-2. Ensure `libmdbx` is available to your build system. Set `MDBXC_DEPS_MODE=BUNDLED` to use the bundled submodule at `external/libmdbx`, or use `SYSTEM`/`AUTO` for an installed package.
+2. Ensure `libmdbx` is available to your build system. Set
+   `MDBXC_DEPS_MODE=BUNDLED` to use the bundled submodule at
+   `external/libmdbx`, or use `SYSTEM`/`AUTO` for an installed package. When
+   this project is added as a subproject, an existing parent-provided
+   `mdbx::mdbx`, `mdbx::mdbx-static`, `libmdbx::mdbx`, or
+   `libmdbx::mdbx-static` target is reused before package, submodule, or
+   FetchContent lookup.
 3. Use a C++11 (or later) compiler.
 
 ### Build with CMake

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@
    this project is added as a subproject, an existing parent-provided
    `mdbx::mdbx`, `mdbx::mdbx-static`, `libmdbx::mdbx`, or
    `libmdbx::mdbx-static` target is reused before package, submodule, or
-   FetchContent lookup.
+   FetchContent lookup. Parent-provided targets take precedence over
+   `MDBXC_DEPS_MODE`, including `BUNDLED`.
 3. Use a C++11 (or later) compiler.
 
 ### Build with CMake

--- a/cmake/deps/mdbx.cmake
+++ b/cmake/deps/mdbx.cmake
@@ -16,6 +16,9 @@
 #       OUT_TARGET_SHARED <var>     # returns 'mdbx::mdbx' (shared if system provided; bundled path -> static alias)
 #   )
 #
+# NOTE: Existing parent-provided targets take precedence over MODE, including
+#       BUNDLED.  MODE only controls fallback lookup after parent targets.
+#
 # NOTE: We intentionally keep bundled builds STATIC (MDBX_BUILD_SHARED_LIBRARY=OFF),
 #       to preserve existing CI behavior and Windows/MSYS quirks you had.
 
@@ -51,6 +54,14 @@ function(_mdbx_make_aliases _maybe_shared _maybe_static)
         if(TARGET ${_static_target} AND NOT TARGET mdbx::mdbx-static)
             add_library(mdbx::mdbx-static ALIAS ${_static_target})
             message(STATUS "[mdbx] Aliased '${_maybe_static}' -> mdbx::mdbx-static")
+        endif()
+    endif()
+
+    if(NOT TARGET mdbx::mdbx AND TARGET mdbx::mdbx-static)
+        _mdbx_resolve_alias(_static_target_for_shared "mdbx::mdbx-static")
+        if(TARGET ${_static_target_for_shared})
+            add_library(mdbx::mdbx ALIAS ${_static_target_for_shared})
+            message(STATUS "[mdbx] Aliased 'mdbx::mdbx-static' -> mdbx::mdbx")
         endif()
     endif()
 endfunction()

--- a/cmake/deps/mdbx.cmake
+++ b/cmake/deps/mdbx.cmake
@@ -1,8 +1,9 @@
 # cmake/deps/mdbx.cmake
 # Provides libmdbx targets with minimal, robust logic:
-#   1) SYSTEM/AUTO: try find_package (CONFIG/MODULE, various names)
-#   2) BUNDLED/AUTO: try submodule at external/libmdbx (with Windows/MSYS quirks)
-#   3) fallback: FetchContent from upstream
+#   1) use an existing parent-provided target, if available
+#   2) SYSTEM/AUTO: try find_package (CONFIG/MODULE, various names)
+#   3) BUNDLED/AUTO: try submodule at external/libmdbx (with Windows/MSYS quirks)
+#   4) fallback: FetchContent from upstream
 #
 # Canonical aliases produced:
 #   mdbx::mdbx        - "the" MDBX target (shared if system provides; otherwise static alias)
@@ -24,16 +25,31 @@ set(MDBX_GIT_TAG "v0.13.12" CACHE STRING "libmdbx release tag")
 
 # -------- internals ----------------------------------------------------------
 
+function(_mdbx_resolve_alias out_target target_name)
+    set(_resolved_target "${target_name}")
+
+    if(TARGET ${target_name})
+        get_target_property(_aliased_target ${target_name} ALIASED_TARGET)
+        if(_aliased_target)
+            set(_resolved_target "${_aliased_target}")
+        endif()
+    endif()
+
+    set(${out_target} "${_resolved_target}" PARENT_SCOPE)
+endfunction()
+
 function(_mdbx_make_aliases _maybe_shared _maybe_static)
     if(DEFINED _maybe_shared AND NOT "${_maybe_shared}" STREQUAL "")
-        if(TARGET ${_maybe_shared} AND NOT TARGET mdbx::mdbx)
-            add_library(mdbx::mdbx ALIAS ${_maybe_shared})
+        _mdbx_resolve_alias(_shared_target "${_maybe_shared}")
+        if(TARGET ${_shared_target} AND NOT TARGET mdbx::mdbx)
+            add_library(mdbx::mdbx ALIAS ${_shared_target})
             message(STATUS "[mdbx] Aliased '${_maybe_shared}' -> mdbx::mdbx")
         endif()
     endif()
     if(DEFINED _maybe_static AND NOT "${_maybe_static}" STREQUAL "")
-        if(TARGET ${_maybe_static} AND NOT TARGET mdbx::mdbx-static)
-            add_library(mdbx::mdbx-static ALIAS ${_maybe_static})
+        _mdbx_resolve_alias(_static_target "${_maybe_static}")
+        if(TARGET ${_static_target} AND NOT TARGET mdbx::mdbx-static)
+            add_library(mdbx::mdbx-static ALIAS ${_static_target})
             message(STATUS "[mdbx] Aliased '${_maybe_static}' -> mdbx::mdbx-static")
         endif()
     endif()
@@ -76,6 +92,17 @@ function(_mdbx_detect_and_alias out_ok)
 
     if(_found_shared OR _found_static)
         _mdbx_make_aliases("${_found_shared}" "${_found_static}")
+        set(${out_ok} TRUE PARENT_SCOPE)
+        return()
+    endif()
+endfunction()
+
+function(_mdbx_try_existing_target out_ok)
+    set(${out_ok} FALSE PARENT_SCOPE)
+
+    _mdbx_detect_and_alias(_ok)
+    if(_ok)
+        message(STATUS "[mdbx] Using existing CMake target")
         set(${out_ok} TRUE PARENT_SCOPE)
         return()
     endif()
@@ -241,7 +268,9 @@ function(mdbx_provide)
 
     set(_ok FALSE)
 
-    if(MX_MODE_UP STREQUAL "SYSTEM" OR MX_MODE_UP STREQUAL "AUTO")
+    _mdbx_try_existing_target(_ok)
+
+    if(NOT _ok AND (MX_MODE_UP STREQUAL "SYSTEM" OR MX_MODE_UP STREQUAL "AUTO"))
         _mdbx_try_find_package(_ok)
     endif()
 
@@ -255,9 +284,9 @@ function(mdbx_provide)
 
     if(NOT _ok)
         if(MX_MODE_UP STREQUAL "SYSTEM")
-            message(FATAL_ERROR "[mdbx] SYSTEM mode requested, but no package found.")
+            message(FATAL_ERROR "[mdbx] SYSTEM mode requested, but no existing target or package found.")
         else()
-            message(FATAL_ERROR "[mdbx] Failed to provide MDBX (find_package, submodule, FetchContent all failed).")
+            message(FATAL_ERROR "[mdbx] Failed to provide MDBX (existing target, find_package, submodule, FetchContent all failed).")
         endif()
     endif()
 

--- a/guides/build-and-test.md
+++ b/guides/build-and-test.md
@@ -21,7 +21,8 @@ All project options use the `MDBXC_` prefix.
 When `mdbx-containers` is added as a subproject, existing parent-provided
 `mdbx::mdbx`, `mdbx::mdbx-static`, `libmdbx::mdbx`, and
 `libmdbx::mdbx-static` targets are reused before package, submodule, or
-FetchContent lookup.
+FetchContent lookup. Parent-provided targets take precedence over
+`MDBXC_DEPS_MODE`, including `BUNDLED`.
 
 ## Baseline Commands
 

--- a/guides/build-and-test.md
+++ b/guides/build-and-test.md
@@ -18,6 +18,11 @@ All project options use the `MDBXC_` prefix.
 | `MDBXC_BUILD_TESTS` | `ON` | Build tests from `tests/` and register them with CTest. |
 | `MDBXC_USE_ASAN` | `ON` | Enable AddressSanitizer for tests/examples when supported. |
 
+When `mdbx-containers` is added as a subproject, existing parent-provided
+`mdbx::mdbx`, `mdbx::mdbx-static`, `libmdbx::mdbx`, and
+`libmdbx::mdbx-static` targets are reused before package, submodule, or
+FetchContent lookup.
+
 ## Baseline Commands
 
 Use `tmp/` inside the repository for local verification builds, installs,

--- a/tests/cmake/parent_targets/CMakeLists.txt
+++ b/tests/cmake/parent_targets/CMakeLists.txt
@@ -5,7 +5,9 @@ project(mdbxc_parent_targets_smoke LANGUAGES CXX)
 set(MDBXC_PARENT_TARGET_CASE "" CACHE STRING "Parent-provided MDBX target case")
 set_property(CACHE MDBXC_PARENT_TARGET_CASE PROPERTY STRINGS
     mdbx
+    mdbx-bare
     libmdbx
+    libmdbx-bare
     mdbx-static
     mdbx-static-bare
     libmdbx-static
@@ -13,15 +15,19 @@ set_property(CACHE MDBXC_PARENT_TARGET_CASE PROPERTY STRINGS
 )
 
 if(MDBXC_PARENT_TARGET_CASE STREQUAL "")
-    message(FATAL_ERROR "Set MDBXC_PARENT_TARGET_CASE to one of: mdbx, libmdbx, mdbx-static, mdbx-static-bare, libmdbx-static, libmdbx-static-bare")
+    message(FATAL_ERROR "Set MDBXC_PARENT_TARGET_CASE to one of: mdbx, mdbx-bare, libmdbx, libmdbx-bare, mdbx-static, mdbx-static-bare, libmdbx-static, libmdbx-static-bare")
 endif()
 
 if(MDBXC_PARENT_TARGET_CASE STREQUAL "mdbx")
     add_library(parent_mdbx INTERFACE)
     add_library(mdbx::mdbx ALIAS parent_mdbx)
+elseif(MDBXC_PARENT_TARGET_CASE STREQUAL "mdbx-bare")
+    add_library(mdbx INTERFACE)
 elseif(MDBXC_PARENT_TARGET_CASE STREQUAL "libmdbx")
     add_library(parent_libmdbx INTERFACE)
     add_library(libmdbx::mdbx ALIAS parent_libmdbx)
+elseif(MDBXC_PARENT_TARGET_CASE STREQUAL "libmdbx-bare")
+    add_library(libmdbx INTERFACE)
 elseif(MDBXC_PARENT_TARGET_CASE STREQUAL "mdbx-static")
     add_library(parent_mdbx_static INTERFACE)
     add_library(mdbx::mdbx-static ALIAS parent_mdbx_static)

--- a/tests/cmake/parent_targets/CMakeLists.txt
+++ b/tests/cmake/parent_targets/CMakeLists.txt
@@ -7,11 +7,13 @@ set_property(CACHE MDBXC_PARENT_TARGET_CASE PROPERTY STRINGS
     mdbx
     libmdbx
     mdbx-static
+    mdbx-static-bare
     libmdbx-static
+    libmdbx-static-bare
 )
 
 if(MDBXC_PARENT_TARGET_CASE STREQUAL "")
-    message(FATAL_ERROR "Set MDBXC_PARENT_TARGET_CASE to one of: mdbx, libmdbx, mdbx-static, libmdbx-static")
+    message(FATAL_ERROR "Set MDBXC_PARENT_TARGET_CASE to one of: mdbx, libmdbx, mdbx-static, mdbx-static-bare, libmdbx-static, libmdbx-static-bare")
 endif()
 
 if(MDBXC_PARENT_TARGET_CASE STREQUAL "mdbx")
@@ -23,9 +25,13 @@ elseif(MDBXC_PARENT_TARGET_CASE STREQUAL "libmdbx")
 elseif(MDBXC_PARENT_TARGET_CASE STREQUAL "mdbx-static")
     add_library(parent_mdbx_static INTERFACE)
     add_library(mdbx::mdbx-static ALIAS parent_mdbx_static)
+elseif(MDBXC_PARENT_TARGET_CASE STREQUAL "mdbx-static-bare")
+    add_library(mdbx-static INTERFACE)
 elseif(MDBXC_PARENT_TARGET_CASE STREQUAL "libmdbx-static")
     add_library(parent_libmdbx_static INTERFACE)
     add_library(libmdbx::mdbx-static ALIAS parent_libmdbx_static)
+elseif(MDBXC_PARENT_TARGET_CASE STREQUAL "libmdbx-static-bare")
+    add_library(libmdbx-static INTERFACE)
 else()
     message(FATAL_ERROR "Unsupported MDBXC_PARENT_TARGET_CASE='${MDBXC_PARENT_TARGET_CASE}'")
 endif()

--- a/tests/cmake/parent_targets/CMakeLists.txt
+++ b/tests/cmake/parent_targets/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.18)
+
+project(mdbxc_parent_targets_smoke LANGUAGES CXX)
+
+set(MDBXC_PARENT_TARGET_CASE "" CACHE STRING "Parent-provided MDBX target case")
+set_property(CACHE MDBXC_PARENT_TARGET_CASE PROPERTY STRINGS
+    mdbx
+    libmdbx
+    mdbx-static
+    libmdbx-static
+)
+
+if(MDBXC_PARENT_TARGET_CASE STREQUAL "")
+    message(FATAL_ERROR "Set MDBXC_PARENT_TARGET_CASE to one of: mdbx, libmdbx, mdbx-static, libmdbx-static")
+endif()
+
+if(MDBXC_PARENT_TARGET_CASE STREQUAL "mdbx")
+    add_library(parent_mdbx INTERFACE)
+    add_library(mdbx::mdbx ALIAS parent_mdbx)
+elseif(MDBXC_PARENT_TARGET_CASE STREQUAL "libmdbx")
+    add_library(parent_libmdbx INTERFACE)
+    add_library(libmdbx::mdbx ALIAS parent_libmdbx)
+elseif(MDBXC_PARENT_TARGET_CASE STREQUAL "mdbx-static")
+    add_library(parent_mdbx_static INTERFACE)
+    add_library(mdbx::mdbx-static ALIAS parent_mdbx_static)
+elseif(MDBXC_PARENT_TARGET_CASE STREQUAL "libmdbx-static")
+    add_library(parent_libmdbx_static INTERFACE)
+    add_library(libmdbx::mdbx-static ALIAS parent_libmdbx_static)
+else()
+    message(FATAL_ERROR "Unsupported MDBXC_PARENT_TARGET_CASE='${MDBXC_PARENT_TARGET_CASE}'")
+endif()
+
+set(MDBXC_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(MDBXC_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(MDBXC_USE_ASAN OFF CACHE BOOL "" FORCE)
+set(MDBXC_DEPS_MODE BUNDLED CACHE STRING "" FORCE)
+
+add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../../.." mdbx-containers-build)
+
+if(NOT TARGET mdbx_containers::mdbx_containers)
+    message(FATAL_ERROR "mdbx_containers::mdbx_containers target was not created")
+endif()
+
+if(NOT TARGET mdbx::mdbx)
+    message(FATAL_ERROR "Canonical mdbx::mdbx target was not created")
+endif()
+
+if(MDBXC_PARENT_TARGET_CASE MATCHES "static" AND NOT TARGET mdbx::mdbx-static)
+    message(FATAL_ERROR "Canonical mdbx::mdbx-static target was not created")
+endif()
+
+add_executable(parent_target_smoke main.cpp)
+target_link_libraries(parent_target_smoke PRIVATE mdbx_containers::mdbx_containers)

--- a/tests/cmake/parent_targets/main.cpp
+++ b/tests/cmake/parent_targets/main.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Reuse existing parent-provided MDBX CMake targets before `find_package`, bundled submodule, or FetchContent lookup.
- Resolve parent aliases before creating canonical `mdbx::mdbx` / `mdbx::mdbx-static` aliases.
- Keep the canonical `mdbx::mdbx` alias available when the parent project provides only a static MDBX target.
- Document that parent-provided MDBX targets take precedence over `MDBXC_DEPS_MODE`, including `BUNDLED`.
- Add a Linux CI CMake smoke matrix for every parent target spelling checked by the dependency helper: `mdbx`, bare `mdbx`, `libmdbx`, bare `libmdbx`, `mdbx-static`, bare `mdbx-static`, `libmdbx-static`, and bare `libmdbx-static`.

## Validation

- `cmake -S tests/cmake/parent_targets -B tmp/agent-work/parent-target-mdbx -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DMDBXC_PARENT_TARGET_CASE=mdbx -Wno-dev`
- `cmake --build tmp/agent-work/parent-target-mdbx --parallel 8`
- `cmake -S tests/cmake/parent_targets -B tmp/agent-work/parent-target-mdbx-bare -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DMDBXC_PARENT_TARGET_CASE=mdbx-bare -Wno-dev`
- `cmake --build tmp/agent-work/parent-target-mdbx-bare --parallel 8`
- `cmake -S tests/cmake/parent_targets -B tmp/agent-work/parent-target-libmdbx -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DMDBXC_PARENT_TARGET_CASE=libmdbx -Wno-dev`
- `cmake --build tmp/agent-work/parent-target-libmdbx --parallel 8`
- `cmake -S tests/cmake/parent_targets -B tmp/agent-work/parent-target-libmdbx-bare -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DMDBXC_PARENT_TARGET_CASE=libmdbx-bare -Wno-dev`
- `cmake --build tmp/agent-work/parent-target-libmdbx-bare --parallel 8`
- `cmake -S tests/cmake/parent_targets -B tmp/agent-work/parent-target-mdbx-static -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DMDBXC_PARENT_TARGET_CASE=mdbx-static -Wno-dev`
- `cmake --build tmp/agent-work/parent-target-mdbx-static --parallel 8`
- `cmake -S tests/cmake/parent_targets -B tmp/agent-work/parent-target-mdbx-static-bare -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DMDBXC_PARENT_TARGET_CASE=mdbx-static-bare -Wno-dev`
- `cmake --build tmp/agent-work/parent-target-mdbx-static-bare --parallel 8`
- `cmake -S tests/cmake/parent_targets -B tmp/agent-work/parent-target-libmdbx-static -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DMDBXC_PARENT_TARGET_CASE=libmdbx-static -Wno-dev`
- `cmake --build tmp/agent-work/parent-target-libmdbx-static --parallel 8`
- `cmake -S tests/cmake/parent_targets -B tmp/agent-work/parent-target-libmdbx-static-bare -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DMDBXC_PARENT_TARGET_CASE=libmdbx-static-bare -Wno-dev`
- `cmake --build tmp/agent-work/parent-target-libmdbx-static-bare --parallel 8`
- `cmake -S . -B tmp/agent-work/build-cpp17-bundled -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=OFF -DMDBXC_BUILD_EXAMPLES=OFF -DMDBXC_USE_ASAN=OFF`
- `cmake --build tmp/agent-work/build-cpp17-bundled --parallel 8`
- `git diff --check`
