### PR TITLE
feat(backup): add backup_to and sync_to_disk on Connection

### DIFF
--- a/examples/backup_basic_example.cpp
+++ b/examples/backup_basic_example.cpp
@@ -1,0 +1,52 @@
+#include <mdbx_containers.hpp>
+#include <cstdint>
+#include <cstdio>
+#include <iostream>
+#include <map>
+#include <string>
+
+int main() {
+    using namespace mdbxc;
+
+    const std::string db_path = "backup_basic_source.mdbx";
+    const std::string backup_path = "backup_basic_target.mdbx";
+    std::remove(backup_path.c_str());
+
+    {
+        Config cfg;
+        cfg.pathname = db_path;
+        cfg.max_dbs = 8;
+        cfg.no_subdir = true;
+
+        auto conn = Connection::create(cfg);
+        KeyValueTable<int, std::string> kv(conn, "kv_demo");
+        for (int i = 0; i < 100; ++i) {
+            kv.insert_or_assign(i, "value_" + std::to_string(i));
+        }
+        conn->sync_to_disk();
+
+        BackupOptions opt;
+        opt.mode = BackupMode::Compact;
+        conn->backup_to(backup_path, opt);
+
+        std::cout << "backup created: " << backup_path << std::endl;
+    }
+
+    {
+        Config cfg;
+        cfg.pathname = backup_path;
+        cfg.read_only = true;
+        cfg.no_subdir = true;
+
+        auto conn = Connection::create(cfg);
+        KeyValueTable<int, std::string> kv(conn, "kv_demo");
+        std::map<int, std::string> data = kv.retrieve_all();
+        std::cout << "verified " << data.size() << " records in backup" << std::endl;
+        if (data.size() != 100u) return 1;
+        if (data.at(42) != "value_42") return 2;
+    }
+
+    std::remove(db_path.c_str());
+    std::remove(backup_path.c_str());
+    return 0;
+}

--- a/examples/backup_basic_example.cpp
+++ b/examples/backup_basic_example.cpp
@@ -10,6 +10,7 @@ int main() {
 
     const std::string db_path = "backup_basic_source.mdbx";
     const std::string backup_path = "backup_basic_target.mdbx";
+    std::remove(db_path.c_str());
     std::remove(backup_path.c_str());
 
     {

--- a/include/mdbx_containers/Backup.hpp
+++ b/include/mdbx_containers/Backup.hpp
@@ -1,0 +1,44 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_BACKUP_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_BACKUP_HPP_INCLUDED
+
+/// \file Backup.hpp
+/// \brief MDBX environment backup and durability flush operations.
+/// \details
+/// Provides thin wrappers over libmdbx backup primitives (`mdbx_env_copy`,
+/// `mdbx_env_sync_ex`). Operations are scoped at the \ref Connection level
+/// because backup copies the whole MDBX environment, not an individual
+/// logical table.
+
+namespace mdbxc {
+
+    /// \brief Backup compaction mode.
+    enum class BackupMode {
+        /// \brief Copy pages verbatim without compaction.
+        Normal,
+        /// \brief Copy with page compaction to reduce file size.
+        Compact
+    };
+
+    /// \brief Backup options passed to \ref Connection::backup_to.
+    struct BackupOptions {
+        /// \brief Backup mode (default: compact).
+        BackupMode mode = BackupMode::Compact;
+
+        /// \brief Throttle MVCC snapshot retention during long backups
+        /// to allow page reuse.
+        bool throttle_mvcc = false;
+
+        /// \brief Do not force a flush of pending writes before copying.
+        /// Use only when the caller guarantees durability via prior
+        /// \ref Connection::sync_to_disk or external fsync.
+        bool dont_flush = false;
+
+        /// \brief Allow the copy to dynamically resize the target environment
+        /// instead of inheriting the source geometry.
+        bool force_dynamic_size = false;
+    };
+
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_BACKUP_HPP_INCLUDED

--- a/include/mdbx_containers/common/Connection.hpp
+++ b/include/mdbx_containers/common/Connection.hpp
@@ -158,6 +158,10 @@ namespace mdbxc {
         /// \note The backup may be performed while readers exist, but a long
         ///       backup keeps an MVCC snapshot alive and may delay page reuse.
         ///       Use \c BackupOptions::throttle_mvcc to mitigate this.
+        /// \note Holds the connection mutex for the duration of the copy.
+        ///       Existing raw MDBX transactions may continue, but new
+        ///       \c Connection::transaction(), \c Connection::begin(), and
+        ///       other state-mutating calls are blocked until backup completes.
         void backup_to(const std::string& path, const BackupOptions& options = BackupOptions());
 
         /// \brief Flushes the environment to disk.
@@ -165,6 +169,8 @@ namespace mdbxc {
         /// \param nonblock When \c true returns immediately if a flush is
         ///        already in progress on another thread.
         /// \throws MdbxException on any MDBX error.
+        /// \warning Not valid for read-only connections; MDBX may return
+        ///          \c MDBX_EACCES.
         /// \note Durability flush is not database replication; see
         ///       \c Sync.hpp for changelog-based replication.
         void sync_to_disk(bool force = true, bool nonblock = false);

--- a/include/mdbx_containers/common/Connection.hpp
+++ b/include/mdbx_containers/common/Connection.hpp
@@ -5,6 +5,8 @@
 /// \file Connection.hpp
 /// \brief Manages an MDBX database connection using a provided configuration.
 
+#include "../Backup.hpp"
+
 namespace mdbxc {
 
     /// \class Connection
@@ -142,6 +144,30 @@ namespace mdbxc {
         /// \brief Returns the configured proactive DUPSORT duplicate value limit.
         /// \return Maximum duplicate value size, or a non-positive value when disabled.
         int64_t max_dupsort_value_size() const;
+
+        /// \brief Copies the whole MDBX environment to a file or directory path.
+        /// \param path Destination path. The target must not already exist;
+        ///        the caller is responsible for removing a stale target before
+        ///        invoking this method.
+        /// \param options Backup behavior; see \ref BackupOptions.
+        /// \throws MdbxException on any MDBX error.
+        /// \warning Copies the entire environment, not a single logical table.
+        /// \warning Do not call concurrently with \c configure(), \c connect(),
+        ///          \c disconnect(), or destruction. Do not call while shutdown
+        ///          has been requested.
+        /// \note The backup may be performed while readers exist, but a long
+        ///       backup keeps an MVCC snapshot alive and may delay page reuse.
+        ///       Use \c BackupOptions::throttle_mvcc to mitigate this.
+        void backup_to(const std::string& path, const BackupOptions& options = BackupOptions());
+
+        /// \brief Flushes the environment to disk.
+        /// \param force When \c true forces a synchronous durable flush.
+        /// \param nonblock When \c true returns immediately if a flush is
+        ///        already in progress on another thread.
+        /// \throws MdbxException on any MDBX error.
+        /// \note Durability flush is not database replication; see
+        ///       \c Sync.hpp for changelog-based replication.
+        void sync_to_disk(bool force = true, bool nonblock = false);
 
     private:
         friend class Transaction;

--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -186,8 +186,8 @@ namespace mdbxc {
             throw MdbxException("Connection is not connected.", MDBX_EINVAL);
         }
         const int rc = mdbx_env_sync_ex(m_env, force, nonblock);
-        /// mdbx_env_sync_ex returns MDBX_SUCCESS on flushed data and
-        /// MDBX_RESULT_TRUE when nothing was pending; both are success.
+        // mdbx_env_sync_ex returns MDBX_SUCCESS on flushed data and
+        // MDBX_RESULT_TRUE when nothing was pending; both are success.
         if (rc != MDBX_SUCCESS && rc != MDBX_RESULT_TRUE) {
             check_mdbx(rc, "mdbx_env_sync_ex failed");
         }

--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -186,6 +186,8 @@ namespace mdbxc {
             throw MdbxException("Connection is not connected.", MDBX_EINVAL);
         }
         const int rc = mdbx_env_sync_ex(m_env, force, nonblock);
+        /// mdbx_env_sync_ex returns MDBX_SUCCESS on flushed data and
+        /// MDBX_RESULT_TRUE when nothing was pending; both are success.
         if (rc != MDBX_SUCCESS && rc != MDBX_RESULT_TRUE) {
             check_mdbx(rc, "mdbx_env_sync_ex failed");
         }

--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -151,6 +151,46 @@ namespace mdbxc {
         return m_config ? m_config->max_dupsort_value_size : Config().max_dupsort_value_size;
     }
 
+    inline void Connection::backup_to(const std::string& path, const BackupOptions& options) {
+        std::lock_guard<std::mutex> locker(m_mdbx_mutex);
+        if (!m_env) {
+            throw MdbxException("Connection is not connected.", MDBX_EINVAL);
+        }
+        if (m_shutdown_requested) {
+            throw std::logic_error("Cannot backup during connection shutdown.");
+        }
+
+        MDBX_copy_flags_t flags = MDBX_CP_DEFAULTS;
+        if (options.mode == BackupMode::Compact) {
+            flags = static_cast<MDBX_copy_flags_t>(flags | MDBX_CP_COMPACT);
+        }
+        if (options.throttle_mvcc) {
+            flags = static_cast<MDBX_copy_flags_t>(flags | MDBX_CP_THROTTLE_MVCC);
+        }
+        if (options.dont_flush) {
+            flags = static_cast<MDBX_copy_flags_t>(flags | MDBX_CP_DONT_FLUSH);
+        }
+        if (options.force_dynamic_size) {
+            flags = static_cast<MDBX_copy_flags_t>(flags | MDBX_CP_FORCE_DYNAMIC_SIZE);
+        }
+
+        const int rc = mdbx_env_copy(m_env, path.c_str(), flags);
+        if (rc != MDBX_SUCCESS) {
+            check_mdbx(rc, "mdbx_env_copy failed");
+        }
+    }
+
+    inline void Connection::sync_to_disk(bool force, bool nonblock) {
+        std::lock_guard<std::mutex> locker(m_mdbx_mutex);
+        if (!m_env) {
+            throw MdbxException("Connection is not connected.", MDBX_EINVAL);
+        }
+        const int rc = mdbx_env_sync_ex(m_env, force, nonblock);
+        if (rc != MDBX_SUCCESS && rc != MDBX_RESULT_TRUE) {
+            check_mdbx(rc, "mdbx_env_sync_ex failed");
+        }
+    }
+
     inline void Connection::initialize() {
         try {
             db_init();

--- a/tests/test_backup.cpp
+++ b/tests/test_backup.cpp
@@ -170,8 +170,6 @@ void test_sync_to_disk_readonly_throws() {
             conn->sync_to_disk(true, false);
         } catch (const MdbxException&) {
             caught = true;
-        } catch (const std::runtime_error&) {
-            caught = true;
         }
         if (!caught) {
             throw std::runtime_error("sync_to_disk on read-only connection should throw");

--- a/tests/test_backup.cpp
+++ b/tests/test_backup.cpp
@@ -4,6 +4,10 @@
 #include <map>
 #include <stdexcept>
 #include <string>
+#if __cplusplus >= 201703L
+# include <filesystem>
+# include <system_error>
+#endif
 
 namespace {
 
@@ -139,11 +143,102 @@ void test_sync_to_disk() {
     cleanup(p);
 }
 
+void test_sync_to_disk_readonly_throws() {
+    using namespace mdbxc;
+
+    const std::string p = "test_sync_to_disk_readonly.mdbx";
+    cleanup(p);
+
+    {
+        Config cfg;
+        cfg.pathname = p;
+        cfg.max_dbs = 2;
+        cfg.no_subdir = true;
+        auto conn = Connection::create(cfg);
+        KeyValueTable<int, int> kv(conn, "t");
+        kv.insert_or_assign(1, 100);
+    }
+
+    {
+        Config cfg;
+        cfg.pathname = p;
+        cfg.read_only = true;
+        cfg.no_subdir = true;
+        auto conn = Connection::create(cfg);
+        bool caught = false;
+        try {
+            conn->sync_to_disk(true, false);
+        } catch (const MdbxException&) {
+            caught = true;
+        } catch (const std::runtime_error&) {
+            caught = true;
+        }
+        if (!caught) {
+            throw std::runtime_error("sync_to_disk on read-only connection should throw");
+        }
+    }
+
+    cleanup(p);
+}
+
+#if __cplusplus >= 201703L
+void test_backup_directory_mode() {
+    using namespace mdbxc;
+    namespace fs = std::filesystem;
+
+    const fs::path src_dir = "test_backup_dir_src";
+    const fs::path dst_dir = "test_backup_dir_dst";
+    std::error_code ec;
+    fs::remove_all(src_dir, ec);
+    fs::remove_all(dst_dir, ec);
+
+    {
+        Config cfg;
+        cfg.pathname = src_dir.string();
+        cfg.max_dbs = 4;
+        cfg.no_subdir = false;
+        auto conn = Connection::create(cfg);
+        KeyValueTable<int, std::string> kv(conn, "t");
+        for (int i = 0; i < 32; ++i) {
+            kv.insert_or_assign(i, "d_" + std::to_string(i));
+        }
+        conn->sync_to_disk();
+
+        BackupOptions opt;
+        opt.mode = BackupMode::Compact;
+        conn->backup_to(dst_dir.string(), opt);
+    }
+
+    {
+        Config cfg;
+        cfg.pathname = dst_dir.string();
+        cfg.read_only = true;
+        cfg.no_subdir = false;
+        auto conn = Connection::create(cfg);
+        KeyValueTable<int, std::string> kv(conn, "t");
+        std::map<int, std::string> data = kv.retrieve_all();
+        if (data.size() != 32u) {
+            throw std::runtime_error("directory backup: expected 32 records");
+        }
+        if (data.at(7) != "d_7") {
+            throw std::runtime_error("directory backup: value mismatch at key 7");
+        }
+    }
+
+    fs::remove_all(src_dir, ec);
+    fs::remove_all(dst_dir, ec);
+}
+#endif
+
 } // namespace
 
 int main() {
     test_backup_compact();
     test_backup_normal_overwrite();
     test_sync_to_disk();
+    test_sync_to_disk_readonly_throws();
+#if __cplusplus >= 201703L
+    test_backup_directory_mode();
+#endif
     return 0;
 }

--- a/tests/test_backup.cpp
+++ b/tests/test_backup.cpp
@@ -1,0 +1,149 @@
+#include <mdbx_containers.hpp>
+#include <cstdio>
+#include <cstdint>
+#include <map>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+void cleanup(const std::string& p) {
+    std::remove(p.c_str());
+}
+
+void test_backup_compact() {
+    using namespace mdbxc;
+
+    const std::string src = "test_backup_compact_src.mdbx";
+    const std::string dst = "test_backup_compact_dst.mdbx";
+    cleanup(src);
+    cleanup(dst);
+
+    {
+        Config cfg;
+        cfg.pathname = src;
+        cfg.max_dbs = 4;
+        cfg.no_subdir = true;
+        auto conn = Connection::create(cfg);
+        KeyValueTable<int, std::string> kv(conn, "t");
+        for (int i = 0; i < 256; ++i) {
+            kv.insert_or_assign(i, "v_" + std::to_string(i));
+        }
+        conn->sync_to_disk();
+
+        BackupOptions opt;
+        opt.mode = BackupMode::Compact;
+        conn->backup_to(dst, opt);
+    }
+
+    {
+        Config cfg;
+        cfg.pathname = dst;
+        cfg.read_only = true;
+        cfg.no_subdir = true;
+        auto conn = Connection::create(cfg);
+        KeyValueTable<int, std::string> kv(conn, "t");
+        std::map<int, std::string> data = kv.retrieve_all();
+        if (data.size() != 256u) {
+            throw std::runtime_error("expected 256 records");
+        }
+        if (data.at(0) != "v_0" || data.at(255) != "v_255") {
+            throw std::runtime_error("record mismatch");
+        }
+    }
+
+    cleanup(src);
+    cleanup(dst);
+}
+
+void test_backup_normal_overwrite() {
+    using namespace mdbxc;
+
+    const std::string src = "test_backup_normal_src.mdbx";
+    const std::string dst = "test_backup_normal_dst.mdbx";
+    cleanup(src);
+    cleanup(dst);
+
+    {
+        Config cfg;
+        cfg.pathname = src;
+        cfg.max_dbs = 4;
+        cfg.no_subdir = true;
+        auto conn = Connection::create(cfg);
+        KeyValueTable<int, int> kv(conn, "t");
+        for (int i = 0; i < 16; ++i) {
+            kv.insert_or_assign(i, i * 7);
+        }
+
+        BackupOptions opt;
+        opt.mode = BackupMode::Normal;
+        conn->backup_to(dst, opt);
+
+        std::remove(dst.c_str());
+
+        BackupOptions opt2;
+        opt2.mode = BackupMode::Normal;
+        conn->backup_to(dst, opt2);
+    }
+
+    {
+        Config cfg;
+        cfg.pathname = dst;
+        cfg.read_only = true;
+        cfg.no_subdir = true;
+        auto conn = Connection::create(cfg);
+        KeyValueTable<int, int> kv(conn, "t");
+        std::map<int, int> data = kv.retrieve_all();
+        if (data.size() != 16u) {
+            throw std::runtime_error("expected 16 records after rewrite");
+        }
+        if (data.at(8) != 56) {
+            throw std::runtime_error("value mismatch at key 8");
+        }
+    }
+
+    cleanup(src);
+    cleanup(dst);
+}
+
+void test_sync_to_disk() {
+    using namespace mdbxc;
+
+    const std::string p = "test_sync_to_disk.mdbx";
+    cleanup(p);
+
+    {
+        Config cfg;
+        cfg.pathname = p;
+        cfg.max_dbs = 2;
+        cfg.no_subdir = true;
+        auto conn = Connection::create(cfg);
+        KeyValueTable<int, int> kv(conn, "t");
+        kv.insert_or_assign(1, 100);
+        conn->sync_to_disk(true, false);
+        conn->sync_to_disk(false, true);
+    }
+
+    {
+        Config cfg;
+        cfg.pathname = p;
+        cfg.read_only = true;
+        cfg.no_subdir = true;
+        auto conn = Connection::create(cfg);
+        KeyValueTable<int, int> kv(conn, "t");
+        if (kv.at(1) != 100) {
+            throw std::runtime_error("sync_to_disk did not persist data");
+        }
+    }
+
+    cleanup(p);
+}
+
+} // namespace
+
+int main() {
+    test_backup_compact();
+    test_backup_normal_overwrite();
+    test_sync_to_disk();
+    return 0;
+}


### PR DESCRIPTION
## Summary

Wraps libmdbx `mdbx_env_copy` and `mdbx_env_sync_ex` as `Connection` members for environment-wide backup and durability flush.

## Files

- `include/mdbx_containers/Backup.hpp` (new) — `BackupMode`, `BackupOptions`
- `include/mdbx_containers/common/Connection.hpp` — public `backup_to()`, `sync_to_disk()`
- `include/mdbx_containers/common/Connection.ipp` — implementations
- `examples/backup_basic_example.cpp` (new)
- `tests/test_backup.cpp` (new)

## Usage

```cpp
mdbxc::BackupOptions opt;
opt.mode = mdbxc::BackupMode::Compact;
conn->backup_to("snapshot.mdbx", opt);
conn->sync_to_disk();
```

## Notes

- Backup copies the whole environment, not a single logical table. Use `table.connection().backup_to(...)` rather than adding `backup()` to table types.
- Overwrite is intentionally not exposed in v0.1 to keep the API small and compatible with older libmdbx versions where `MDBX_CP_OVERWRITE` may not exist. Callers remove stale targets explicitly with `std::remove` / `std::filesystem::remove_all` before invoking `backup_to()`.
- `mdbx_env_sync_ex` may return either `MDBX_SUCCESS` (data flushed) or `MDBX_RESULT_TRUE` (nothing was pending); both are treated as success.
- `backup_to()` holds the connection mutex for the duration of the copy. Existing raw MDBX transactions may continue, but new `Connection::transaction()`, `Connection::begin()`, and other state-mutating calls are blocked until backup completes.
- `sync_to_disk()` is not valid for read-only connections; MDBX may return `MDBX_EACCES`.
- Lifecycle-only operation: cannot run concurrently with `disconnect()`/`shutdown()`/destruction.

## Tests

- `test_backup_compact` — compact mode + read-only verification on backup.
- `test_backup_normal_overwrite` — explicit target removal + re-backup.
- `test_sync_to_disk` — durable flush with both `force` and `nonblock`.
- `test_sync_to_disk_readonly_throws` — sync on read-only env throws as documented.
- `test_backup_directory_mode` (C++17 only) — directory-mode environment (`no_subdir = false`).
- `backup_basic_example` runs end-to-end.