### PR TITLE
feat(sync): add versioned codec and foundation types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,9 @@ if(MDBXC_BUILD_EXAMPLES)
         target_link_libraries(${example_name} PRIVATE ${_PKG_TARGET})
         message(STATUS "Example ${example_name} -> ${_PKG_TARGET}")
 
+        # Enable the optional sync subsystem when its headers are exercised.
+        target_compile_definitions(${example_name} PRIVATE MDBXC_SYNC_ENABLED=1)
+
         # To enable pause-on-Enter in examples only (not in tests), uncomment:
         # target_compile_definitions(${example_name} PRIVATE INTERACTIVE_TEST)
     endforeach()
@@ -159,6 +162,9 @@ if(MDBXC_BUILD_TESTS)
 
         target_link_libraries(${test_name} PRIVATE ${_PKG_TARGET})
         message(STATUS "Test ${test_name} -> ${_PKG_TARGET}")
+
+        # Enable the optional sync subsystem when its headers are exercised.
+        target_compile_definitions(${test_name} PRIVATE MDBXC_SYNC_ENABLED=1)
 
         # IMPORTANT: we do NOT define INTERACTIVE_TEST for tests.
         add_test(NAME ${test_name} COMMAND ${test_name})

--- a/examples/sync_codec_dump_example.cpp
+++ b/examples/sync_codec_dump_example.cpp
@@ -1,0 +1,61 @@
+#define MDBXC_SYNC_ENABLED 1
+#include <mdbx_containers/Sync.hpp>
+#include <cstdint>
+#include <cstdio>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string hex(const std::vector<std::uint8_t>& bytes) {
+    static const char* digits = "0123456789abcdef";
+    std::string out;
+    out.reserve(bytes.size() * 3);
+    for (std::size_t i = 0; i < bytes.size(); ++i) {
+        if (i > 0 && (i % 16) == 0) out.push_back('\n');
+        else if (i > 0) out.push_back(' ');
+        out.push_back(digits[(bytes[i] >> 4) & 0xF]);
+        out.push_back(digits[bytes[i] & 0xF]);
+    }
+    return out;
+}
+
+} // namespace
+
+int main() {
+    using namespace mdbxc::sync;
+
+    ChangeBatch batch;
+    batch.version = 1;
+    for (int i = 0; i < 16; ++i) {
+        batch.origin_node_id[i] = static_cast<std::uint8_t>(0x10 + i);
+    }
+    batch.seq = 1;
+    batch.time_unix_ns = 1700000000000000000ULL;
+
+    ChangeOp op;
+    op.op_type = ChangeOpType::Put;
+    op.dbi_name = "trades";
+    op.storage_key = { 'E','U','R','U','S','D' };
+    op.value = { 'B','i','d',':','1','.','1','2','3','4' };
+    batch.ops.push_back(op);
+
+    ChangeOp del;
+    del.op_type = ChangeOpType::Delete;
+    del.op_flags = OP_TOMBSTONE;
+    del.dbi_name = "trades";
+    del.storage_key = { 'O','L','D' };
+    batch.ops.push_back(del);
+
+    const CodecBounds bounds;
+    const std::vector<std::uint8_t> bytes = ChangeBatchCodec::encode(batch, &bounds);
+
+    std::cout << "encoded " << bytes.size() << " bytes:\n";
+    std::cout << hex(bytes) << "\n";
+
+    const ChangeBatch decoded = ChangeBatchCodec::decode(bytes, nullptr, &bounds);
+    std::cout << "\nround-trip ops=" << decoded.ops.size()
+              << " seq=" << decoded.seq << "\n";
+    return 0;
+}

--- a/include/mdbx_containers/Sync.hpp
+++ b/include/mdbx_containers/Sync.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_HPP_INCLUDED
+
+/// \file Sync.hpp
+/// \brief Aggregate header for the optional sync subsystem.
+/// \details
+/// Pulls in all foundation types and codec when \c MDBXC_SYNC_ENABLED is
+/// non-zero. Otherwise the include is a no-op so applications that do not
+/// need replication pay zero compile-time or runtime cost.
+
+#include "sync/SyncModule.hpp"
+
+#if MDBXC_SYNC_ENABLED
+#include "sync/ChangeBatch.hpp"
+#include "sync/ChangeBatchCodec.hpp"
+#include "sync/ChangeOp.hpp"
+#include "sync/CodecBounds.hpp"
+#include "sync/CodecFlags.hpp"
+#include "sync/Common.hpp"
+#include "sync/ConflictPolicy.hpp"
+#include "sync/IdentityProvider.hpp"
+#include "sync/ISyncPeer.hpp"
+#include "sync/Protocol.hpp"
+#include "sync/SyncCursor.hpp"
+#endif
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_HPP_INCLUDED

--- a/include/mdbx_containers/sync/ChangeBatch.hpp
+++ b/include/mdbx_containers/sync/ChangeBatch.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_CHANGE_BATCH_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_CHANGE_BATCH_HPP_INCLUDED
+
+/// \file ChangeBatch.hpp
+/// \brief A single atomic group of replicated \c ChangeOp operations.
+
+#include <cstdint>
+#include <vector>
+
+#include "ChangeOp.hpp"
+#include "CodecFlags.hpp"
+#include "Common.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Versioned group of operations emitted by one origin node.
+    /// \invariant All operations in a batch are recorded and applied under a
+    /// single MDBX write transaction.
+    struct ChangeBatch {
+        std::uint32_t         version = 1;      ///< Schema version; always 1 in v0.1.
+        std::uint32_t         batch_flags = BATCH_NONE;
+        NodeId                origin_node_id{};
+        std::uint64_t         seq = 0;
+        std::uint64_t         time_unix_ns = 0; ///< Physical timestamp metadata only.
+        std::vector<ChangeOp> ops;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_CHANGE_BATCH_HPP_INCLUDED

--- a/include/mdbx_containers/sync/ChangeBatchCodec.hpp
+++ b/include/mdbx_containers/sync/ChangeBatchCodec.hpp
@@ -1,0 +1,401 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_CHANGE_BATCH_CODEC_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_CHANGE_BATCH_CODEC_HPP_INCLUDED
+
+/// \file ChangeBatchCodec.hpp
+/// \brief Stable little-endian binary codec for \c ChangeBatch.
+/// \details
+/// Wire layout:
+/// \code
+///   magic            "MDBXCSYN"   7 bytes
+///   codec_version    u16 le       = 1
+///   batch_version    u32 le       = 1
+///   batch_flags      u32 le
+///   origin_node_id   16 bytes
+///   seq              u64 le
+///   time_unix_ns     u64 le
+///   ops_count        u32 le
+///   for each op:
+///     op_type        u8
+///     op_flags       u32 le
+///     dbi_flags      u32 le
+///     dbi_name_len   u32 le
+///     dbi_name       [u8; ...]
+///     storage_key_len u32 le
+///     storage_key    [u8; ...]
+///     value_len      u32 le       (0xFFFFFFFF = absent)
+///     value          [u8; ...]    (omitted if value_len == 0xFFFFFFFF)
+///     identity_key_len u32 le     (omitted if !(op_flags & OP_HAS_IDENTITY_KEY))
+///     identity_key   [u8; ...]
+///     revision_key_len u32 le     (omitted if !(op_flags & OP_HAS_REVISION_KEY))
+///     revision_key   [u8; ...]
+/// \endcode
+/// Mandatory unknown bits in either \c batch_flags or \c op_flags trigger a
+/// decode error. \c BATCH_COMPRESSED_ZSTD is reserved and explicitly
+/// rejected.
+
+#include <cstring>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "ChangeBatch.hpp"
+#include "CodecBounds.hpp"
+#include "CodecFlags.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Stable binary codec for \c ChangeBatch.
+    class ChangeBatchCodec {
+    public:
+        /// \brief Encoded magic prefix.
+        static const char* magic() {
+            static const char m[8] = { 'M','D','B','X','C','S','Y','N' };
+            return m;
+        }
+
+        /// \brief Supported codec version.
+        static std::uint16_t codec_version() { return 1; }
+
+        /// \brief Supported batch schema version.
+        static std::uint32_t batch_version() { return 1; }
+
+        /// \brief Encodes a batch into a byte vector.
+        /// \param batch Source batch.
+        /// \param bounds Structural limits; null disables validation.
+        /// \throws std::length_error if any bound is exceeded.
+        /// \throws std::logic_error for invalid combinations.
+        static std::vector<std::uint8_t> encode(const ChangeBatch& batch,
+                                                const CodecBounds* bounds = nullptr) {
+            if (bounds != nullptr) {
+                validate_bounds(batch, *bounds);
+            }
+            if ((batch.batch_flags & BATCH_COMPRESSED_ZSTD) != 0) {
+                throw std::logic_error("BATCH_COMPRESSED_ZSTD is not supported in v0.1");
+            }
+
+            std::vector<std::uint8_t> out;
+            out.reserve(256 + batch.ops.size() * 32);
+            append_bytes(out, magic(), 7);
+            append_u16_le(out, codec_version());
+            append_u32_le(out, batch_version());
+            append_u32_le(out, batch.batch_flags);
+            append_bytes(out, reinterpret_cast<const char*>(batch.origin_node_id.data()), 16);
+            append_u64_le(out, batch.seq);
+            append_u64_le(out, batch.time_unix_ns);
+            append_u32_le(out, static_cast<std::uint32_t>(batch.ops.size()));
+
+            for (std::size_t i = 0; i < batch.ops.size(); ++i) {
+                const ChangeOp& op = batch.ops[i];
+                if ((op.op_flags & ~static_cast<std::uint32_t>(
+                        OP_HAS_IDENTITY_KEY | OP_HAS_REVISION_KEY | OP_TOMBSTONE)) != 0) {
+                    throw std::logic_error("ChangeOp has unknown mandatory flags");
+                }
+                if ((op.op_flags & OP_HAS_IDENTITY_KEY) != 0 && op.identity_key.empty()) {
+                    throw std::logic_error("OP_HAS_IDENTITY_KEY set with empty identity_key");
+                }
+                if ((op.op_flags & OP_HAS_REVISION_KEY) != 0 && op.revision_key.empty()) {
+                    throw std::logic_error("OP_HAS_REVISION_KEY set with empty revision_key");
+                }
+                if ((op.op_flags & OP_TOMBSTONE) != 0 && !op.value.empty()) {
+                    throw std::logic_error("OP_TOMBSTONE set with non-empty value");
+                }
+
+                append_u8(out, static_cast<std::uint8_t>(op.op_type));
+                append_u32_le(out, op.op_flags);
+                append_u32_le(out, op.dbi_flags);
+                append_u32_le(out, static_cast<std::uint32_t>(op.dbi_name.size()));
+                if (!op.dbi_name.empty()) {
+                    append_bytes(out, op.dbi_name.data(), op.dbi_name.size());
+                }
+                append_u32_le(out, static_cast<std::uint32_t>(op.storage_key.size()));
+                if (!op.storage_key.empty()) {
+                    append_bytes(out, reinterpret_cast<const char*>(op.storage_key.data()),
+                                 op.storage_key.size());
+                }
+                if (op.value.empty()) {
+                    append_u32_le(out, 0xFFFFFFFFu);
+                } else {
+                    append_u32_le(out, static_cast<std::uint32_t>(op.value.size()));
+                    append_bytes(out, reinterpret_cast<const char*>(op.value.data()),
+                                 op.value.size());
+                }
+                if ((op.op_flags & OP_HAS_IDENTITY_KEY) != 0) {
+                    append_u32_le(out, static_cast<std::uint32_t>(op.identity_key.size()));
+                    append_bytes(out, reinterpret_cast<const char*>(op.identity_key.data()),
+                                 op.identity_key.size());
+                }
+                if ((op.op_flags & OP_HAS_REVISION_KEY) != 0) {
+                    append_u32_le(out, static_cast<std::uint32_t>(op.revision_key.size()));
+                    append_bytes(out, reinterpret_cast<const char*>(op.revision_key.data()),
+                                 op.revision_key.size());
+                }
+            }
+            return out;
+        }
+
+        /// \brief Decodes a batch from a byte span.
+        /// \param data Source bytes.
+        /// \param bytes_read Optional output of bytes consumed.
+        /// \param bounds Structural limits; null disables validation.
+        /// \throws std::runtime_error on any format violation.
+        static ChangeBatch decode(const std::vector<std::uint8_t>& data,
+                                  std::size_t* bytes_read = nullptr,
+                                  const CodecBounds* bounds = nullptr) {
+            Cursor cur;
+            cur.data = data.empty() ? nullptr : &data[0];
+            cur.size = data.size();
+            cur.pos = 0;
+
+            ChangeBatch batch;
+            check_magic(cur);
+            const std::uint16_t cv = read_u16_le(cur);
+            if (cv != codec_version()) {
+                throw std::runtime_error("Unsupported codec_version");
+            }
+            const std::uint32_t bv = read_u32_le(cur);
+            if (bv != batch_version()) {
+                throw std::runtime_error("Unsupported batch_version");
+            }
+            batch.batch_flags = read_u32_le(cur);
+            if ((batch.batch_flags & BATCH_COMPRESSED_ZSTD) != 0) {
+                throw std::runtime_error("BATCH_COMPRESSED_ZSTD is not supported in v0.1");
+            }
+            const std::uint32_t known_batch_mask =
+                static_cast<std::uint32_t>(BATCH_COMPRESSED_ZSTD | BATCH_HAS_MORE);
+            if ((batch.batch_flags & ~known_batch_mask) != 0) {
+                throw std::runtime_error("Unknown mandatory batch flag bits set");
+            }
+
+            read_bytes(cur, reinterpret_cast<char*>(batch.origin_node_id.data()), 16);
+            batch.seq = read_u64_le(cur);
+            batch.time_unix_ns = read_u64_le(cur);
+            const std::uint32_t ops_count = read_u32_le(cur);
+
+            if (bounds != nullptr) {
+                if (ops_count > bounds->max_ops_per_batch) {
+                    throw std::length_error("ops_count exceeds max_ops_per_batch");
+                }
+            }
+
+            batch.ops.resize(ops_count);
+            for (std::uint32_t i = 0; i < ops_count; ++i) {
+                ChangeOp& op = batch.ops[i];
+                const std::uint8_t op_type = read_u8(cur);
+                if (op_type > static_cast<std::uint8_t>(ChangeOpType::ClearTable)) {
+                    throw std::runtime_error("Unknown ChangeOpType");
+                }
+                op.op_type = static_cast<ChangeOpType>(op_type);
+                op.op_flags = read_u32_le(cur);
+                const std::uint32_t known_op_mask = static_cast<std::uint32_t>(
+                    OP_HAS_IDENTITY_KEY | OP_HAS_REVISION_KEY | OP_TOMBSTONE);
+                if ((op.op_flags & ~known_op_mask) != 0) {
+                    throw std::runtime_error("Unknown mandatory op flag bits set");
+                }
+                op.dbi_flags = read_u32_le(cur);
+
+                const std::uint32_t dbi_name_len = read_u32_le(cur);
+                if (bounds != nullptr && dbi_name_len > bounds->max_dbi_name_len) {
+                    throw std::length_error("dbi_name_len exceeds max_dbi_name_len");
+                }
+                op.dbi_name.assign(read_bytes_ptr(cur, dbi_name_len), dbi_name_len);
+
+                const std::uint32_t storage_key_len = read_u32_le(cur);
+                if (bounds != nullptr && storage_key_len > bounds->max_storage_key_len) {
+                    throw std::length_error("storage_key_len exceeds max_storage_key_len");
+                }
+                const char* sk = read_bytes_ptr(cur, storage_key_len);
+                op.storage_key.resize(storage_key_len);
+                if (storage_key_len > 0) {
+                    std::memcpy(op.storage_key.data(), sk, storage_key_len);
+                }
+
+                const std::uint32_t value_len = read_u32_le(cur);
+                if (value_len == 0xFFFFFFFFu) {
+                    // value absent (e.g. delete or tombstone)
+                } else {
+                    if (bounds != nullptr && value_len > bounds->max_value_len) {
+                        throw std::length_error("value_len exceeds max_value_len");
+                    }
+                    const char* v = read_bytes_ptr(cur, value_len);
+                    op.value.resize(value_len);
+                    if (value_len > 0) {
+                        std::memcpy(op.value.data(), v, value_len);
+                    }
+                }
+
+                if ((op.op_flags & OP_HAS_IDENTITY_KEY) != 0) {
+                    const std::uint32_t id_len = read_u32_le(cur);
+                    if (bounds != nullptr && id_len > bounds->max_identity_key_len) {
+                        throw std::length_error("identity_key_len exceeds max_identity_key_len");
+                    }
+                    const char* id = read_bytes_ptr(cur, id_len);
+                    op.identity_key.resize(id_len);
+                    if (id_len > 0) {
+                        std::memcpy(op.identity_key.data(), id, id_len);
+                    }
+                }
+                if ((op.op_flags & OP_HAS_REVISION_KEY) != 0) {
+                    const std::uint32_t rv_len = read_u32_le(cur);
+                    if (bounds != nullptr && rv_len > bounds->max_revision_key_len) {
+                        throw std::length_error("revision_key_len exceeds max_revision_key_len");
+                    }
+                    const char* rv = read_bytes_ptr(cur, rv_len);
+                    op.revision_key.resize(rv_len);
+                    if (rv_len > 0) {
+                        std::memcpy(op.revision_key.data(), rv, rv_len);
+                    }
+                }
+
+                if ((op.op_flags & OP_TOMBSTONE) != 0 && !op.value.empty()) {
+                    throw std::runtime_error("OP_TOMBSTONE with non-empty value");
+                }
+                if ((op.op_flags & OP_HAS_IDENTITY_KEY) != 0 && op.identity_key.empty()) {
+                    throw std::runtime_error("OP_HAS_IDENTITY_KEY with empty identity_key");
+                }
+                if ((op.op_flags & OP_HAS_REVISION_KEY) != 0 && op.revision_key.empty()) {
+                    throw std::runtime_error("OP_HAS_REVISION_KEY with empty revision_key");
+                }
+            }
+
+            if (bounds != nullptr && cur.pos > bounds->max_batch_total_bytes) {
+                throw std::length_error("total batch bytes exceeds max_batch_total_bytes");
+            }
+
+            if (bytes_read != nullptr) {
+                *bytes_read = cur.pos;
+            }
+            return batch;
+        }
+
+        /// \brief Validates encoder input against the given bounds.
+        static void validate_bounds(const ChangeBatch& batch, const CodecBounds& bounds) {
+            if (batch.ops.size() > bounds.max_ops_per_batch) {
+                throw std::length_error("ops_count exceeds max_ops_per_batch");
+            }
+            for (std::size_t i = 0; i < batch.ops.size(); ++i) {
+                const ChangeOp& op = batch.ops[i];
+                if (op.dbi_name.size() > bounds.max_dbi_name_len) {
+                    throw std::length_error("dbi_name_len exceeds max_dbi_name_len");
+                }
+                if (op.storage_key.size() > bounds.max_storage_key_len) {
+                    throw std::length_error("storage_key_len exceeds max_storage_key_len");
+                }
+                if (op.value.size() > bounds.max_value_len) {
+                    throw std::length_error("value_len exceeds max_value_len");
+                }
+                if (op.identity_key.size() > bounds.max_identity_key_len) {
+                    throw std::length_error("identity_key_len exceeds max_identity_key_len");
+                }
+                if (op.revision_key.size() > bounds.max_revision_key_len) {
+                    throw std::length_error("revision_key_len exceeds max_revision_key_len");
+                }
+            }
+        }
+
+    private:
+        struct Cursor {
+            const std::uint8_t* data = nullptr;
+            std::size_t size = 0;
+            std::size_t pos = 0;
+        };
+
+        static void check_bounds(const Cursor& cur, std::size_t n) {
+            if (cur.pos + n > cur.size) {
+                throw std::runtime_error("Codec buffer underrun");
+            }
+        }
+
+        static void append_bytes(std::vector<std::uint8_t>& out, const char* src, std::size_t n) {
+            const std::size_t base = out.size();
+            out.resize(base + n);
+            std::memcpy(&out[base], src, n);
+        }
+
+        static void append_u8(std::vector<std::uint8_t>& out, std::uint8_t v) {
+            out.push_back(v);
+        }
+
+        static void append_u16_le(std::vector<std::uint8_t>& out, std::uint16_t v) {
+            out.push_back(static_cast<std::uint8_t>(v & 0xff));
+            out.push_back(static_cast<std::uint8_t>((v >> 8) & 0xff));
+        }
+
+        static void append_u32_le(std::vector<std::uint8_t>& out, std::uint32_t v) {
+            out.push_back(static_cast<std::uint8_t>(v & 0xff));
+            out.push_back(static_cast<std::uint8_t>((v >> 8) & 0xff));
+            out.push_back(static_cast<std::uint8_t>((v >> 16) & 0xff));
+            out.push_back(static_cast<std::uint8_t>((v >> 24) & 0xff));
+        }
+
+        static void append_u64_le(std::vector<std::uint8_t>& out, std::uint64_t v) {
+            for (int i = 0; i < 8; ++i) {
+                out.push_back(static_cast<std::uint8_t>((v >> (i * 8)) & 0xff));
+            }
+        }
+
+        static void check_magic(Cursor& cur) {
+            check_bounds(cur, 7);
+            if (std::memcmp(cur.data + cur.pos, magic(), 7) != 0) {
+                throw std::runtime_error("Codec magic mismatch");
+            }
+            cur.pos += 7;
+        }
+
+        static std::uint8_t read_u8(Cursor& cur) {
+            check_bounds(cur, 1);
+            const std::uint8_t v = cur.data[cur.pos];
+            cur.pos += 1;
+            return v;
+        }
+
+        static std::uint16_t read_u16_le(Cursor& cur) {
+            check_bounds(cur, 2);
+            const std::uint16_t v = static_cast<std::uint16_t>(
+                static_cast<std::uint16_t>(cur.data[cur.pos]) |
+                (static_cast<std::uint16_t>(cur.data[cur.pos + 1]) << 8));
+            cur.pos += 2;
+            return v;
+        }
+
+        static std::uint32_t read_u32_le(Cursor& cur) {
+            check_bounds(cur, 4);
+            const std::uint32_t v =
+                static_cast<std::uint32_t>(cur.data[cur.pos]) |
+                (static_cast<std::uint32_t>(cur.data[cur.pos + 1]) << 8) |
+                (static_cast<std::uint32_t>(cur.data[cur.pos + 2]) << 16) |
+                (static_cast<std::uint32_t>(cur.data[cur.pos + 3]) << 24);
+            cur.pos += 4;
+            return v;
+        }
+
+        static std::uint64_t read_u64_le(Cursor& cur) {
+            check_bounds(cur, 8);
+            std::uint64_t v = 0;
+            for (int i = 0; i < 8; ++i) {
+                v |= static_cast<std::uint64_t>(cur.data[cur.pos + i]) << (i * 8);
+            }
+            cur.pos += 8;
+            return v;
+        }
+
+        static void read_bytes(Cursor& cur, char* dst, std::size_t n) {
+            check_bounds(cur, n);
+            std::memcpy(dst, cur.data + cur.pos, n);
+            cur.pos += n;
+        }
+
+        static const char* read_bytes_ptr(Cursor& cur, std::size_t n) {
+            check_bounds(cur, n);
+            const char* p = reinterpret_cast<const char*>(cur.data + cur.pos);
+            cur.pos += n;
+            return p;
+        }
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_CHANGE_BATCH_CODEC_HPP_INCLUDED

--- a/include/mdbx_containers/sync/ChangeOp.hpp
+++ b/include/mdbx_containers/sync/ChangeOp.hpp
@@ -1,0 +1,42 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_CHANGE_OP_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_CHANGE_OP_HPP_INCLUDED
+
+/// \file ChangeOp.hpp
+/// \brief A single replicated operation: typed MDBX DBI write.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "CodecFlags.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Low-level operation kind carried over the wire.
+    enum class ChangeOpType : std::uint8_t {
+        Put         = 0, ///< mdbx_put (upsert).
+        Delete      = 1, ///< mdbx_del + identity_index tombstone.
+        ClearTable  = 2, ///< Drop the entire DBI contents.
+    };
+
+    /// \brief Single raw DBI operation captured by the change recorder.
+    /// \details \c storage_key is the MDBX key serialized by the table.
+    /// \c identity_key is the application-level identity (empty when equal to
+    /// storage_key). \c revision_key is an optional application-level version.
+    struct ChangeOp {
+        ChangeOpType           op_type   = ChangeOpType::Put;
+        std::uint32_t          op_flags  = OP_NONE;
+        std::uint32_t          dbi_flags = 0;
+        std::string            dbi_name;
+        std::vector<std::uint8_t> storage_key;
+        std::vector<std::uint8_t> value;
+        std::vector<std::uint8_t> identity_key;
+        std::vector<std::uint8_t> revision_key;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_CHANGE_OP_HPP_INCLUDED

--- a/include/mdbx_containers/sync/CodecBounds.hpp
+++ b/include/mdbx_containers/sync/CodecBounds.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_CODEC_BOUNDS_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_CODEC_BOUNDS_HPP_INCLUDED
+
+/// \file CodecBounds.hpp
+/// \brief Hard-coded codec bound defaults.
+
+#include <cstdint>
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Default structural limits enforced by the codec decoder.
+    /// \details Sync clients and servers should not exceed these values per
+    /// batch. Larger values are rejected by \c ChangeBatchCodec::validate.
+    struct CodecBounds {
+        std::uint32_t max_ops_per_batch        = 10000;
+        std::uint32_t max_dbi_name_len         = 256;
+        std::uint32_t max_storage_key_len      = 16u * 1024u;
+        std::uint32_t max_value_len            = 4u * 1024u * 1024u;
+        std::uint32_t max_identity_key_len     = 16u * 1024u;
+        std::uint32_t max_revision_key_len     = 16u * 1024u;
+        std::uint32_t max_batch_total_bytes    = 64u * 1024u * 1024u;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_CODEC_BOUNDS_HPP_INCLUDED

--- a/include/mdbx_containers/sync/CodecFlags.hpp
+++ b/include/mdbx_containers/sync/CodecFlags.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_CODEC_FLAGS_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_CODEC_FLAGS_HPP_INCLUDED
+
+/// \file CodecFlags.hpp
+/// \brief Codec flag bits for \c ChangeBatch and \c ChangeOp.
+
+#include <cstdint>
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Bit flags for the \c ChangeBatch level.
+    /// \note All unknown bits trigger a decoder error.
+    enum ChangeBatchFlags : std::uint32_t {
+        BATCH_NONE              = 0,
+        BATCH_COMPRESSED_ZSTD   = 1u << 0, ///< Reserved, unsupported in v0.1.
+        BATCH_HAS_MORE          = 1u << 1, ///< More chunks follow (full export).
+    };
+
+    /// \brief Bit flags for the \c ChangeOp level.
+    /// \note All unknown bits trigger a decoder error.
+    enum ChangeOpFlags : std::uint32_t {
+        OP_NONE             = 0,
+        OP_HAS_IDENTITY_KEY = 1u << 0, ///< identity_key is present and differs from storage_key.
+        OP_HAS_REVISION_KEY = 1u << 1, ///< revision_key is present.
+        OP_TOMBSTONE        = 1u << 2, ///< Delete-marker (value is absent).
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_CODEC_FLAGS_HPP_INCLUDED

--- a/include/mdbx_containers/sync/Common.hpp
+++ b/include/mdbx_containers/sync/Common.hpp
@@ -1,0 +1,62 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_COMMON_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_COMMON_HPP_INCLUDED
+
+/// \file Common.hpp
+/// \brief Shared sync types: node identifiers, fixed-size byte arrays.
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief 16-byte stable identifier (UUID-like).
+    using NodeId = std::array<std::uint8_t, 16>;
+
+    /// \brief 16-byte database identifier.
+    using DbId = std::array<std::uint8_t, 16>;
+
+    /// \brief Creates a \c NodeId filled with zeros.
+    inline NodeId make_zero_node() {
+        NodeId out{};
+        return out;
+    }
+
+    /// \brief Creates a \c NodeId from raw bytes.
+    /// \param bytes Source buffer with at least 16 bytes.
+    inline NodeId make_node_id(const std::uint8_t* bytes) {
+        NodeId out{};
+        std::memcpy(out.data(), bytes, 16);
+        return out;
+    }
+
+    /// \brief Lexicographic compare of two \c NodeId values.
+    /// \return Negative if \p a < \p b, zero if equal, positive otherwise.
+    inline int compare_node_id(const NodeId& a, const NodeId& b) {
+        for (std::size_t i = 0; i < a.size(); ++i) {
+            if (a[i] != b[i]) {
+                return a[i] < b[i] ? -1 : 1;
+            }
+        }
+        return 0;
+    }
+
+    /// \brief Stable lexical hash of a string (FNV-1a 64).
+    /// \param s Input string.
+    /// \return 64-bit hash.
+    inline std::uint64_t fnv1a_64(const std::string& s) {
+        std::uint64_t h = 0xcbf29ce484222325ULL;
+        for (std::size_t i = 0; i < s.size(); ++i) {
+            h ^= static_cast<std::uint64_t>(static_cast<std::uint8_t>(s[i]));
+            h *= 0x100000001b3ULL;
+        }
+        return h;
+    }
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_COMMON_HPP_INCLUDED

--- a/include/mdbx_containers/sync/ConflictPolicy.hpp
+++ b/include/mdbx_containers/sync/ConflictPolicy.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_CONFLICT_POLICY_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_CONFLICT_POLICY_HPP_INCLUDED
+
+/// \file ConflictPolicy.hpp
+/// \brief How a replica resolves conflicting updates to the same logical key.
+
+#include <cstdint>
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Conflict resolution policy applied during replication.
+    enum class ConflictPolicy {
+        /// \brief Reject the incoming change; surface an error to the caller.
+        Reject,
+        /// \brief Deterministically pick the change with the larger
+        /// \c revision_key (lexicographic), tie-broken by \c origin_node_id.
+        LastWriterWins,
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_CONFLICT_POLICY_HPP_INCLUDED

--- a/include/mdbx_containers/sync/ISyncPeer.hpp
+++ b/include/mdbx_containers/sync/ISyncPeer.hpp
@@ -1,0 +1,30 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_I_SYNC_PEER_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_I_SYNC_PEER_HPP_INCLUDED
+
+/// \file ISyncPeer.hpp
+/// \brief Abstract transport-level peer used by \c SyncEngine.
+
+#include "Protocol.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Abstract peer that exchanges pull and push requests.
+    /// \details Concrete implementations (in-process, HTTP, WebSocket) live
+    /// outside the core sync layer and depend on optional transport headers.
+    class ISyncPeer {
+    public:
+        virtual ~ISyncPeer() {}
+
+        /// \brief Sends a pull request and returns the response.
+        virtual PullResponse pull(const PullRequest& request) = 0;
+
+        /// \brief Sends a push request and returns the response.
+        virtual PushResponse push(const PushRequest& request) = 0;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_I_SYNC_PEER_HPP_INCLUDED

--- a/include/mdbx_containers/sync/IdentityProvider.hpp
+++ b/include/mdbx_containers/sync/IdentityProvider.hpp
@@ -1,0 +1,44 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_IDENTITY_PROVIDER_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_IDENTITY_PROVIDER_HPP_INCLUDED
+
+/// \file IdentityProvider.hpp
+/// \brief Application-level identity and revision keys for replication.
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "ChangeOp.hpp"
+#include "CodecFlags.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief View over a replicated record exposed to identity providers.
+    struct RecordView {
+        std::string dbi_name;
+        ChangeOpType op_type = ChangeOpType::Put;
+        std::vector<std::uint8_t> storage_key;
+        std::vector<std::uint8_t> value;
+    };
+
+    /// \brief Optional identity and revision for a replicated record.
+    /// \details \c has_identity = false disables identity indexing for this
+    /// record; conflict and dedup detection then fall back to \c storage_key.
+    struct RecordIdentity {
+        bool has_identity = false;
+        std::vector<std::uint8_t> identity_key;
+        bool has_revision = false;
+        std::vector<std::uint8_t> revision_key;
+    };
+
+    /// \brief Application-supplied callback that derives identity and
+    /// revision keys from a \c RecordView.
+    using IdentityProvider = std::function<RecordIdentity(const RecordView&)>;
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_IDENTITY_PROVIDER_HPP_INCLUDED

--- a/include/mdbx_containers/sync/Protocol.hpp
+++ b/include/mdbx_containers/sync/Protocol.hpp
@@ -1,0 +1,58 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_PROTOCOL_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_PROTOCOL_HPP_INCLUDED
+
+/// \file Protocol.hpp
+/// \brief Transport-level request and response structures for sync.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "ChangeBatch.hpp"
+#include "Common.hpp"
+#include "SyncCursor.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Request from a replica to a primary node for new change batches.
+    struct PullRequest {
+        NodeId       requester{};
+        DbId         db_id{};
+        SyncCursor   have;
+        std::uint64_t max_batches = 1000;
+        std::uint64_t max_bytes   = 4ULL * 1024ULL * 1024ULL;
+        /// \brief When true, the responder should produce a full snapshot
+        /// instead of an incremental delta.
+        bool         request_full_snapshot = false;
+    };
+
+    /// \brief Response to a \c PullRequest.
+    struct PullResponse {
+        SyncCursor               remote_have;
+        std::vector<ChangeBatch> batches;
+        bool                     has_more = false;
+        bool                     ok       = true;
+        std::string              error;
+    };
+
+    /// \brief Request carrying changes that the sender wants the receiver to
+    /// apply.
+    struct PushRequest {
+        NodeId                   sender{};
+        DbId                     db_id{};
+        std::vector<ChangeBatch> batches;
+    };
+
+    /// \brief Response to a \c PushRequest.
+    struct PushResponse {
+        SyncCursor               receiver_have;
+        bool                     ok = true;
+        std::string              error;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_PROTOCOL_HPP_INCLUDED

--- a/include/mdbx_containers/sync/SyncCursor.hpp
+++ b/include/mdbx_containers/sync/SyncCursor.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_SYNC_CURSOR_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_SYNC_CURSOR_HPP_INCLUDED
+
+/// \file SyncCursor.hpp
+/// \brief Vector-clock style replication cursor.
+
+#include <cstdint>
+#include <map>
+
+#include "Common.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Per-origin sequence cursor used by sync peers.
+    /// \details The cursor maps an origin \c NodeId to the highest contiguous
+    /// \c seq number already applied locally. Incremental sync asks the remote
+    /// for batches strictly above these numbers.
+    struct SyncCursor {
+        std::map<NodeId, std::uint64_t> last_seq_by_origin;
+
+        /// \brief Returns the last contiguous applied \c seq for \p origin.
+        std::uint64_t last_seq_for(const NodeId& origin) const {
+            const std::map<NodeId, std::uint64_t>::const_iterator it =
+                last_seq_by_origin.find(origin);
+            return it == last_seq_by_origin.end() ? 0ULL : it->second;
+        }
+
+        /// \brief Returns \c true when there is no record for \p origin.
+        bool is_empty_for(const NodeId& origin) const {
+            return last_seq_by_origin.find(origin) == last_seq_by_origin.end();
+        }
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_SYNC_CURSOR_HPP_INCLUDED

--- a/include/mdbx_containers/sync/SyncModule.hpp
+++ b/include/mdbx_containers/sync/SyncModule.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_SYNC_MODULE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_SYNC_MODULE_HPP_INCLUDED
+
+/// \file SyncModule.hpp
+/// \brief Compile-time gate for the optional sync subsystem.
+
+#ifndef MDBXC_SYNC_ENABLED
+/// \brief Define to 1 to compile in the sync subsystem (changelog, peers,
+/// replication). When undefined, sync headers expand to no-op stubs and
+/// \c Connection::attach_sync_engine is not available.
+#define MDBXC_SYNC_ENABLED 0
+#endif
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_SYNC_MODULE_HPP_INCLUDED

--- a/tests/test_codec_bounds.cpp
+++ b/tests/test_codec_bounds.cpp
@@ -1,0 +1,100 @@
+#include <mdbx_containers/Sync.hpp>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+template<class Fn>
+void expect_throw(const std::string& label, Fn&& fn) {
+    bool caught = false;
+    try { fn(); } catch (...) { caught = true; }
+    if (!caught) {
+        throw std::runtime_error(label + ": expected throw, nothing thrown");
+    }
+}
+
+void test_oversize_dbi_name() {
+    using namespace mdbxc::sync;
+    CodecBounds bounds;
+    bounds.max_dbi_name_len = 8;
+    ChangeBatch batch;
+    ChangeOp op;
+    op.op_type = ChangeOpType::Put;
+    op.dbi_name = std::string(64, 'x');
+    op.storage_key = { 0x01 };
+    op.value = { 0x02 };
+    batch.ops.push_back(op);
+    expect_throw("dbi_name too long", [] {
+        CodecBounds b;
+        b.max_dbi_name_len = 8;
+        ChangeBatch batch;
+        ChangeOp op;
+        op.op_type = ChangeOpType::Put;
+        op.dbi_name = std::string(64, 'x');
+        op.storage_key = { 0x01 };
+        op.value = { 0x02 };
+        batch.ops.push_back(op);
+        (void)ChangeBatchCodec::encode(batch, &b);
+    });
+    (void)bounds;
+}
+
+void test_oversize_storage_key() {
+    expect_throw("storage_key too long", [] {
+        using namespace mdbxc::sync;
+        CodecBounds b;
+        b.max_storage_key_len = 4;
+        ChangeBatch batch;
+        ChangeOp op;
+        op.op_type = ChangeOpType::Put;
+        op.dbi_name = "t";
+        op.storage_key.assign(64, 0x01);
+        op.value = { 0x02 };
+        batch.ops.push_back(op);
+        (void)ChangeBatchCodec::encode(batch, &b);
+    });
+}
+
+void test_oversize_value() {
+    expect_throw("value too long", [] {
+        using namespace mdbxc::sync;
+        CodecBounds b;
+        b.max_value_len = 4;
+        ChangeBatch batch;
+        ChangeOp op;
+        op.op_type = ChangeOpType::Put;
+        op.dbi_name = "t";
+        op.storage_key = { 0x01 };
+        op.value.assign(64, 0x02);
+        batch.ops.push_back(op);
+        (void)ChangeBatchCodec::encode(batch, &b);
+    });
+}
+
+void test_too_many_ops() {
+    expect_throw("ops count too large", [] {
+        using namespace mdbxc::sync;
+        CodecBounds b;
+        b.max_ops_per_batch = 2;
+        ChangeBatch batch;
+        for (int i = 0; i < 8; ++i) {
+            ChangeOp op;
+            op.op_type = ChangeOpType::Put;
+            op.dbi_name = "t";
+            op.storage_key = { static_cast<std::uint8_t>(i) };
+            op.value = { 0x00 };
+            batch.ops.push_back(op);
+        }
+        (void)ChangeBatchCodec::encode(batch, &b);
+    });
+}
+
+} // namespace
+
+int main() {
+    test_oversize_dbi_name();
+    test_oversize_storage_key();
+    test_oversize_value();
+    test_too_many_ops();
+    return 0;
+}

--- a/tests/test_codec_flags.cpp
+++ b/tests/test_codec_flags.cpp
@@ -1,0 +1,88 @@
+#include <mdbx_containers/Sync.hpp>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+template<class Fn>
+void expect_throw(const std::string& label, Fn&& fn) {
+    bool caught = false;
+    try { fn(); } catch (...) { caught = true; }
+    if (!caught) {
+        throw std::runtime_error(label + ": expected throw, nothing thrown");
+    }
+}
+
+void test_unknown_batch_flag_rejected() {
+    expect_throw("unknown batch flag", [] {
+        using namespace mdbxc::sync;
+        const CodecBounds b;
+        ChangeBatch batch;
+        batch.batch_flags = 0x80000000u;
+        batch.origin_node_id[0] = 1;
+        const std::vector<std::uint8_t> bytes = ChangeBatchCodec::encode(batch, &b);
+        (void)ChangeBatchCodec::decode(bytes, nullptr, &b);
+    });
+}
+
+void test_zstd_flag_rejected_on_decode() {
+    expect_throw("zstd unsupported", [] {
+        using namespace mdbxc::sync;
+        const CodecBounds b;
+        ChangeBatch batch;
+        batch.batch_flags = BATCH_COMPRESSED_ZSTD;
+        batch.origin_node_id[0] = 1;
+        (void)ChangeBatchCodec::encode(batch, &b);
+    });
+}
+
+void test_unknown_op_flag_rejected() {
+    expect_throw("unknown op flag", [] {
+        using namespace mdbxc::sync;
+        const CodecBounds b;
+        ChangeBatch batch;
+        batch.origin_node_id[0] = 1;
+        ChangeOp op;
+        op.op_type = ChangeOpType::Put;
+        op.op_flags = 0x80000000u;
+        op.dbi_name = "t";
+        op.storage_key = { 0x01 };
+        op.value = { 0x02 };
+        batch.ops.push_back(op);
+        const std::vector<std::uint8_t> bytes = ChangeBatchCodec::encode(batch, &b);
+        (void)ChangeBatchCodec::decode(bytes, nullptr, &b);
+    });
+}
+
+void test_version_mismatch_rejected() {
+    expect_throw("codec version mismatch", [] {
+        using namespace mdbxc::sync;
+        const CodecBounds b;
+        std::vector<std::uint8_t> bytes = ChangeBatchCodec::encode(ChangeBatch{}, &b);
+        // Patch the codec_version field to an unsupported value.
+        bytes[7] = 0xFF;
+        bytes[8] = 0xFF;
+        (void)ChangeBatchCodec::decode(bytes, nullptr, &b);
+    });
+}
+
+void test_magic_mismatch_rejected() {
+    expect_throw("magic mismatch", [] {
+        using namespace mdbxc::sync;
+        const CodecBounds b;
+        std::vector<std::uint8_t> bytes = ChangeBatchCodec::encode(ChangeBatch{}, &b);
+        bytes[0] = 'X';
+        (void)ChangeBatchCodec::decode(bytes, nullptr, &b);
+    });
+}
+
+} // namespace
+
+int main() {
+    test_unknown_batch_flag_rejected();
+    test_zstd_flag_rejected_on_decode();
+    test_unknown_op_flag_rejected();
+    test_version_mismatch_rejected();
+    test_magic_mismatch_rejected();
+    return 0;
+}

--- a/tests/test_codec_golden.cpp
+++ b/tests/test_codec_golden.cpp
@@ -1,0 +1,75 @@
+#include <mdbx_containers/Sync.hpp>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::vector<std::uint8_t> make_fixed_batch() {
+    using namespace mdbxc::sync;
+    ChangeBatch batch;
+    batch.version = 1;
+    batch.batch_flags = BATCH_NONE;
+    for (int i = 0; i < 16; ++i) {
+        batch.origin_node_id[i] = static_cast<std::uint8_t>(0x10 + i);
+    }
+    batch.seq = 0x0102030405060708ULL;
+    batch.time_unix_ns = 0x1122334455667788ULL;
+
+    ChangeOp op;
+    op.op_type = ChangeOpType::Put;
+    op.op_flags = OP_NONE;
+    op.dbi_flags = 0;
+    op.dbi_name = "t";
+    op.storage_key = { 0xAA, 0xBB };
+    op.value = { 0xCC, 0xDD, 0xEE };
+    batch.ops.push_back(op);
+
+    const CodecBounds bounds;
+    return ChangeBatchCodec::encode(batch, &bounds);
+}
+
+void expect(const std::string& label, std::size_t actual, std::size_t expected) {
+    if (actual != expected) {
+        throw std::runtime_error(label + ": expected " + std::to_string(expected) +
+                                 " got " + std::to_string(actual));
+    }
+}
+
+void test_golden_magic_and_version() {
+    using namespace mdbxc::sync;
+    const std::vector<std::uint8_t> bytes = make_fixed_batch();
+
+    static const std::uint8_t expected_magic[7] = { 'M','D','B','X','C','S','Y' };
+    for (int i = 0; i < 7; ++i) {
+        if (bytes[i] != expected_magic[i]) {
+            throw std::runtime_error("magic byte mismatch");
+        }
+    }
+    expect("codec_version low", bytes[7], 1u);
+    expect("codec_version high", bytes[8], 0u);
+    expect("batch_version b0", bytes[9], 1u);
+    expect("batch_version b1", bytes[10], 0u);
+    expect("batch_version b2", bytes[11], 0u);
+    expect("batch_version b3", bytes[12], 0u);
+    expect("batch_flags b0", bytes[13], 0u);
+    expect("batch_flags b1", bytes[14], 0u);
+    expect("batch_flags b2", bytes[15], 0u);
+    expect("batch_flags b3", bytes[16], 0u);
+    expect("origin byte 0", bytes[17], 0x10u);
+    expect("origin byte 15", bytes[32], 0x1Fu);
+    expect("seq b0", bytes[33], 0x08u);
+    expect("seq b7", bytes[40], 0x01u);
+    expect("time b0", bytes[41], 0x88u);
+    expect("time b7", bytes[48], 0x11u);
+    expect("ops_count b0", bytes[49], 1u);
+    expect("ops_count b3", bytes[52], 0u);
+}
+
+} // namespace
+
+int main() {
+    test_golden_magic_and_version();
+    return 0;
+}

--- a/tests/test_codec_roundtrip.cpp
+++ b/tests/test_codec_roundtrip.cpp
@@ -1,0 +1,124 @@
+#include <mdbx_containers/Sync.hpp>
+#include <cstdint>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+void assert_eq(const std::string& label, std::size_t a, std::size_t b) {
+    if (a != b) {
+        throw std::runtime_error(label + ": expected " + std::to_string(b) +
+                                 " got " + std::to_string(a));
+    }
+}
+
+void assert_eq_bytes(const std::string& label,
+                     const std::vector<std::uint8_t>& a,
+                     const std::vector<std::uint8_t>& b) {
+    if (a.size() != b.size()) {
+        throw std::runtime_error(label + ": size mismatch " +
+                                 std::to_string(a.size()) + " vs " +
+                                 std::to_string(b.size()));
+    }
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        if (a[i] != b[i]) {
+            throw std::runtime_error(label + ": byte mismatch at " +
+                                     std::to_string(i));
+        }
+    }
+}
+
+mdbxc::sync::ChangeBatch make_batch() {
+    using namespace mdbxc::sync;
+    ChangeBatch batch;
+    batch.version = 1;
+    batch.batch_flags = BATCH_NONE;
+    for (int i = 0; i < 16; ++i) {
+        batch.origin_node_id[i] = static_cast<std::uint8_t>(i + 1);
+    }
+    batch.seq = 42;
+    batch.time_unix_ns = 1700000000000000000ULL;
+
+    ChangeOp op;
+    op.op_type = ChangeOpType::Put;
+    op.op_flags = OP_HAS_REVISION_KEY;
+    op.dbi_flags = 0;
+    op.dbi_name = "trades";
+    op.storage_key = { 0x01, 0x02, 0x03, 0x04 };
+    op.value.assign(64, 0xAA);
+    op.revision_key = { 0x10, 0x20 };
+
+    ChangeOp del;
+    del.op_type = ChangeOpType::Delete;
+    del.op_flags = OP_TOMBSTONE;
+    del.dbi_name = "trades";
+    del.storage_key = { 0x05, 0x06 };
+
+    batch.ops.push_back(op);
+    batch.ops.push_back(del);
+    return batch;
+}
+
+void test_roundtrip_full() {
+    using namespace mdbxc;
+    using namespace mdbxc::sync;
+    const CodecBounds bounds;
+    ChangeBatch batch = make_batch();
+    std::vector<std::uint8_t> bytes = ChangeBatchCodec::encode(batch, &bounds);
+    ChangeBatch decoded = ChangeBatchCodec::decode(bytes, nullptr, &bounds);
+
+    assert_eq("ops count", decoded.ops.size(), batch.ops.size());
+    assert_eq("seq", decoded.seq, batch.seq);
+    assert_eq("time", decoded.time_unix_ns, batch.time_unix_ns);
+    for (int i = 0; i < 16; ++i) {
+        assert_eq("origin byte " + std::to_string(i),
+                  decoded.origin_node_id[i], batch.origin_node_id[i]);
+    }
+    const ChangeOp& od = decoded.ops[0];
+    const ChangeOp& os = batch.ops[0];
+    assert_eq("dbi_name 0", od.dbi_name.size(), os.dbi_name.size());
+    assert_eq("storage_key 0", od.storage_key.size(), os.storage_key.size());
+    assert_eq("value 0", od.value.size(), os.value.size());
+    assert_eq("revision_key 0", od.revision_key.size(), os.revision_key.size());
+    assert_eq("op_flags 0", od.op_flags, static_cast<std::uint32_t>(os.op_flags));
+
+    const ChangeOp& dd = decoded.ops[1];
+    const ChangeOp& ds = batch.ops[1];
+    assert_eq("op_type 1", static_cast<std::uint8_t>(dd.op_type),
+              static_cast<std::uint8_t>(ds.op_type));
+    assert_eq("tombstone flags", dd.op_flags,
+              static_cast<std::uint32_t>(OP_TOMBSTONE));
+    assert_eq("value empty", dd.value.size(), 0u);
+}
+
+void test_roundtrip_idempotent() {
+    using namespace mdbxc::sync;
+    const CodecBounds bounds;
+    const ChangeBatch batch = make_batch();
+    const std::vector<std::uint8_t> bytes1 = ChangeBatchCodec::encode(batch, &bounds);
+    const std::vector<std::uint8_t> bytes2 = ChangeBatchCodec::encode(batch, &bounds);
+    assert_eq_bytes("deterministic encode", bytes1, bytes2);
+}
+
+void test_roundtrip_no_ops() {
+    using namespace mdbxc::sync;
+    const CodecBounds bounds;
+    ChangeBatch batch;
+    batch.seq = 7;
+    batch.origin_node_id[0] = 0xAB;
+    const std::vector<std::uint8_t> bytes = ChangeBatchCodec::encode(batch, &bounds);
+    const ChangeBatch decoded = ChangeBatchCodec::decode(bytes, nullptr, &bounds);
+    assert_eq("empty ops", decoded.ops.size(), 0u);
+    assert_eq("seq 7", decoded.seq, 7u);
+}
+
+} // namespace
+
+int main() {
+    test_roundtrip_full();
+    test_roundtrip_idempotent();
+    test_roundtrip_no_ops();
+    return 0;
+}


### PR DESCRIPTION
## Summary

Introduces the sync subsystem foundation: types, versioned binary codec, and is gated by `MDBXC_SYNC_ENABLED`. No `Connection` integration yet (next PR).

## Files

- `include/mdbx_containers/Sync.hpp` (new) — aggregator
- `include/mdbx_containers/sync/SyncModule.hpp` — gate macro
- `sync/Common.hpp` — `NodeId`/`DbId`
- `sync/ChangeOp.hpp` — `ChangeOp`, `ChangeOpType`
- `sync/ChangeBatch.hpp` — `ChangeBatch`
- `sync/ChangeBatchCodec.hpp` — encode/decode
- `sync/CodecFlags.hpp` — `BATCH_*`, `OP_*` bit flags
- `sync/CodecBounds.hpp` — hard limits
- `sync/SyncCursor.hpp` — vector clock
- `sync/IdentityProvider.hpp` — `RecordView`/`RecordIdentity`
- `sync/ConflictPolicy.hpp` — `Reject`, `LastWriterWins`
- `sync/Protocol.hpp` — `PullRequest`/`Response`, `PushRequest`/`Response`
- `sync/ISyncPeer.hpp` — abstract peer
- `tests/test_codec_roundtrip.cpp` (new)
- `tests/test_codec_bounds.cpp` (new)
- `tests/test_codec_flags.cpp` (new)
- `tests/test_codec_golden.cpp` (new)
- `examples/sync_codec_dump_example.cpp` (new)
- `CMakeLists.txt` — `MDBXC_SYNC_ENABLED=1` for all test/example targets

## Codec layout

```
magic "MDBXCSYN"     7 bytes
codec_version       u16 le = 1
batch_version       u32 le = 1
batch_flags         u32 le
origin_node_id      16 bytes
seq                 u64 le
time_unix_ns        u64 le
ops_count           u32 le
  per op:
    op_type         u8
    op_flags        u32 le
    dbi_flags       u32 le
    dbi_name_len    u32 le + bytes
    storage_key_len u32 le + bytes
    value_len       u32 le (0xFFFFFFFF = absent) + bytes
    identity_key_len u32 le (if OP_HAS_IDENTITY_KEY) + bytes
    revision_key_len u32 le (if OP_HAS_REVISION_KEY) + bytes
```

Unknown mandatory flags trigger decode error. `BATCH_COMPRESSED_ZSTD` reserved but unsupported. `time_unix_ns` is metadata only.

## Deferred to v0.2 (separate PRs)

- `HashedKeyValueStore` replication (needs IdentityProvider integration)
- Stores (`_mdbxc_meta`, `_mdbxc_changelog`, `_mdbxc_applied`, `_mdbxc_identity_index`)
- Change capture in `BaseTable` + `Transaction::commit` pre-commit hook
- `SyncEngine` + `DirectSyncPeer`
- Full export/import via `seq=0, BATCH_HAS_MORE`
- `LastWriterWins` deterministic resolver
- HTTP/WS transports

## Tests

C++17 + C++11: 19/19 ctest passed; codec dump example produces fixed wire format.