### PR TITLE
fix(sync): tighten codec wire contract

### DIFF
--- a/include/mdbx_containers/sync/ChangeBatchCodec.hpp
+++ b/include/mdbx_containers/sync/ChangeBatchCodec.hpp
@@ -7,7 +7,7 @@
 /// \details
 /// Wire layout:
 /// \code
-///   magic            "MDBXCSYN"   7 bytes
+///   magic            "MDBXCSYN"   8 bytes
 ///   codec_version    u16 le       = 1
 ///   batch_version    u32 le       = 1
 ///   batch_flags      u32 le
@@ -50,11 +50,14 @@ namespace sync {
     /// \brief Stable binary codec for \c ChangeBatch.
     class ChangeBatchCodec {
     public:
-        /// \brief Encoded magic prefix.
-        static const char* magic() {
-            static const char m[8] = { 'M','D','B','X','C','S','Y','N' };
+        /// \brief Encoded magic prefix (8 bytes, no NUL terminator).
+        static const std::uint8_t* magic() {
+            static const std::uint8_t m[8] = { 'M','D','B','X','C','S','Y','N' };
             return m;
         }
+
+        /// \brief Magic prefix length in bytes.
+        static std::size_t magic_size() { return 8; }
 
         /// \brief Supported codec version.
         static std::uint16_t codec_version() { return 1; }
@@ -72,13 +75,21 @@ namespace sync {
             if (bounds != nullptr) {
                 validate_bounds(batch, *bounds);
             }
+            if (batch.version != batch_version()) {
+                throw std::logic_error("Unsupported ChangeBatch::version");
+            }
             if ((batch.batch_flags & BATCH_COMPRESSED_ZSTD) != 0) {
                 throw std::logic_error("BATCH_COMPRESSED_ZSTD is not supported in v0.1");
+            }
+            const std::uint32_t known_batch_mask = static_cast<std::uint32_t>(
+                BATCH_COMPRESSED_ZSTD | BATCH_HAS_MORE);
+            if ((batch.batch_flags & ~known_batch_mask) != 0) {
+                throw std::logic_error("ChangeBatch has unknown mandatory batch flags");
             }
 
             std::vector<std::uint8_t> out;
             out.reserve(256 + batch.ops.size() * 32);
-            append_bytes(out, magic(), 7);
+            append_bytes(out, reinterpret_cast<const char*>(magic()), magic_size());
             append_u16_le(out, codec_version());
             append_u32_le(out, batch_version());
             append_u32_le(out, batch.batch_flags);
@@ -138,7 +149,9 @@ namespace sync {
 
         /// \brief Decodes a batch from a byte span.
         /// \param data Source bytes.
-        /// \param bytes_read Optional output of bytes consumed.
+        /// \param bytes_read Optional output of bytes consumed. When null, any
+        ///        trailing bytes after a valid batch cause a decode error; pass
+        ///        a non-null pointer to use \c decode() as a stream parser.
         /// \param bounds Structural limits; null disables validation.
         /// \throws std::runtime_error on any format violation.
         static ChangeBatch decode(const std::vector<std::uint8_t>& data,
@@ -159,6 +172,7 @@ namespace sync {
             if (bv != batch_version()) {
                 throw std::runtime_error("Unsupported batch_version");
             }
+            batch.version = bv;
             batch.batch_flags = read_u32_le(cur);
             if ((batch.batch_flags & BATCH_COMPRESSED_ZSTD) != 0) {
                 throw std::runtime_error("BATCH_COMPRESSED_ZSTD is not supported in v0.1");
@@ -266,6 +280,22 @@ namespace sync {
 
             if (bytes_read != nullptr) {
                 *bytes_read = cur.pos;
+            } else if (cur.pos != cur.size) {
+                throw std::runtime_error("Trailing bytes after ChangeBatch");
+            }
+            return batch;
+        }
+
+        /// \brief Strict decoder: the input buffer must contain exactly one
+        /// batch with no trailing bytes.
+        /// \throws std::runtime_error on any format violation, including
+        ///         trailing bytes.
+        static ChangeBatch decode_exact(const std::vector<std::uint8_t>& data,
+                                       const CodecBounds* bounds = nullptr) {
+            std::size_t consumed = 0;
+            ChangeBatch batch = decode(data, &consumed, bounds);
+            if (consumed != data.size()) {
+                throw std::runtime_error("Trailing bytes after ChangeBatch");
             }
             return batch;
         }
@@ -337,11 +367,11 @@ namespace sync {
         }
 
         static void check_magic(Cursor& cur) {
-            check_bounds(cur, 7);
-            if (std::memcmp(cur.data + cur.pos, magic(), 7) != 0) {
+            check_bounds(cur, magic_size());
+            if (std::memcmp(cur.data + cur.pos, magic(), magic_size()) != 0) {
                 throw std::runtime_error("Codec magic mismatch");
             }
-            cur.pos += 7;
+            cur.pos += magic_size();
         }
 
         static std::uint8_t read_u8(Cursor& cur) {

--- a/include/mdbx_containers/sync/ChangeBatchCodec.hpp
+++ b/include/mdbx_containers/sync/ChangeBatchCodec.hpp
@@ -100,6 +100,9 @@ namespace sync {
 
             for (std::size_t i = 0; i < batch.ops.size(); ++i) {
                 const ChangeOp& op = batch.ops[i];
+                if (op.op_type > ChangeOpType::ClearTable) {
+                    throw std::logic_error("Unknown ChangeOpType");
+                }
                 if ((op.op_flags & ~static_cast<std::uint32_t>(
                         OP_HAS_IDENTITY_KEY | OP_HAS_REVISION_KEY | OP_TOMBSTONE)) != 0) {
                     throw std::logic_error("ChangeOp has unknown mandatory flags");
@@ -154,6 +157,7 @@ namespace sync {
         ///        a non-null pointer to use \c decode() as a stream parser.
         /// \param bounds Structural limits; null disables validation.
         /// \throws std::runtime_error on any format violation.
+        /// \throws std::length_error when structural bounds are exceeded.
         static ChangeBatch decode(const std::vector<std::uint8_t>& data,
                                   std::size_t* bytes_read = nullptr,
                                   const CodecBounds* bounds = nullptr) {

--- a/tests/test_codec_golden.cpp
+++ b/tests/test_codec_golden.cpp
@@ -41,35 +41,117 @@ void test_golden_magic_and_version() {
     using namespace mdbxc::sync;
     const std::vector<std::uint8_t> bytes = make_fixed_batch();
 
-    static const std::uint8_t expected_magic[7] = { 'M','D','B','X','C','S','Y' };
-    for (int i = 0; i < 7; ++i) {
+    static const std::uint8_t expected_magic[8] = { 'M','D','B','X','C','S','Y','N' };
+    for (int i = 0; i < 8; ++i) {
         if (bytes[i] != expected_magic[i]) {
             throw std::runtime_error("magic byte mismatch");
         }
     }
-    expect("codec_version low", bytes[7], 1u);
-    expect("codec_version high", bytes[8], 0u);
-    expect("batch_version b0", bytes[9], 1u);
-    expect("batch_version b1", bytes[10], 0u);
-    expect("batch_version b2", bytes[11], 0u);
-    expect("batch_version b3", bytes[12], 0u);
-    expect("batch_flags b0", bytes[13], 0u);
-    expect("batch_flags b1", bytes[14], 0u);
-    expect("batch_flags b2", bytes[15], 0u);
-    expect("batch_flags b3", bytes[16], 0u);
-    expect("origin byte 0", bytes[17], 0x10u);
-    expect("origin byte 15", bytes[32], 0x1Fu);
-    expect("seq b0", bytes[33], 0x08u);
-    expect("seq b7", bytes[40], 0x01u);
-    expect("time b0", bytes[41], 0x88u);
-    expect("time b7", bytes[48], 0x11u);
-    expect("ops_count b0", bytes[49], 1u);
-    expect("ops_count b3", bytes[52], 0u);
+    expect("codec_version low", bytes[8], 1u);
+    expect("codec_version high", bytes[9], 0u);
+    expect("batch_version b0", bytes[10], 1u);
+    expect("batch_version b1", bytes[11], 0u);
+    expect("batch_version b2", bytes[12], 0u);
+    expect("batch_version b3", bytes[13], 0u);
+    expect("batch_flags b0", bytes[14], 0u);
+    expect("batch_flags b1", bytes[15], 0u);
+    expect("batch_flags b2", bytes[16], 0u);
+    expect("batch_flags b3", bytes[17], 0u);
+    expect("origin byte 0", bytes[18], 0x10u);
+    expect("origin byte 15", bytes[33], 0x1Fu);
+    expect("seq b0", bytes[34], 0x08u);
+    expect("seq b7", bytes[41], 0x01u);
+    expect("time b0", bytes[42], 0x88u);
+    expect("time b7", bytes[49], 0x11u);
+    expect("ops_count b0", bytes[50], 1u);
+    expect("ops_count b3", bytes[53], 0u);
+}
+
+void test_golden_trailing_bytes_rejected() {
+    using namespace mdbxc::sync;
+    const CodecBounds bounds;
+    ChangeBatch batch;
+    ChangeOp op;
+    op.op_type = ChangeOpType::Put;
+    op.dbi_name = "t";
+    op.storage_key = { 0x01 };
+    op.value = { 0x02 };
+    batch.ops.push_back(op);
+    std::vector<std::uint8_t> bytes = ChangeBatchCodec::encode(batch, &bounds);
+    bytes.push_back(0xFF);
+    bool caught = false;
+    try {
+        (void)ChangeBatchCodec::decode(bytes, nullptr, &bounds);
+    } catch (const std::runtime_error&) {
+        caught = true;
+    }
+    if (!caught) {
+        throw std::runtime_error("decode without bytes_read must reject trailing bytes");
+    }
+}
+
+void test_decode_exact_rejects_trailing() {
+    using namespace mdbxc::sync;
+    const CodecBounds bounds;
+    ChangeBatch batch;
+    ChangeOp op;
+    op.op_type = ChangeOpType::Put;
+    op.dbi_name = "t";
+    op.storage_key = { 0x01 };
+    op.value = { 0x02 };
+    batch.ops.push_back(op);
+    std::vector<std::uint8_t> bytes = ChangeBatchCodec::encode(batch, &bounds);
+    bytes.push_back(0xFF);
+    bool caught = false;
+    try {
+        (void)ChangeBatchCodec::decode_exact(bytes, &bounds);
+    } catch (const std::runtime_error&) {
+        caught = true;
+    }
+    if (!caught) {
+        throw std::runtime_error("decode_exact must reject trailing bytes");
+    }
+}
+
+void test_encoder_rejects_bad_batch_version() {
+    using namespace mdbxc::sync;
+    const CodecBounds bounds;
+    ChangeBatch batch;
+    batch.version = 999;
+    bool caught = false;
+    try {
+        (void)ChangeBatchCodec::encode(batch, &bounds);
+    } catch (const std::logic_error&) {
+        caught = true;
+    }
+    if (!caught) {
+        throw std::runtime_error("encoder must reject batch.version != 1");
+    }
+}
+
+void test_encoder_rejects_unknown_batch_flags() {
+    using namespace mdbxc::sync;
+    const CodecBounds bounds;
+    ChangeBatch batch;
+    batch.batch_flags = 0x80000000u;
+    bool caught = false;
+    try {
+        (void)ChangeBatchCodec::encode(batch, &bounds);
+    } catch (const std::logic_error&) {
+        caught = true;
+    }
+    if (!caught) {
+        throw std::runtime_error("encoder must reject unknown batch_flags");
+    }
 }
 
 } // namespace
 
 int main() {
     test_golden_magic_and_version();
+    test_golden_trailing_bytes_rejected();
+    test_decode_exact_rejects_trailing();
+    test_encoder_rejects_bad_batch_version();
+    test_encoder_rejects_unknown_batch_flags();
     return 0;
 }

--- a/tests/test_codec_golden.cpp
+++ b/tests/test_codec_golden.cpp
@@ -145,6 +145,45 @@ void test_encoder_rejects_unknown_batch_flags() {
     }
 }
 
+void test_encoder_rejects_unknown_op_type() {
+    using namespace mdbxc::sync;
+    const CodecBounds bounds;
+    ChangeBatch batch;
+    ChangeOp op;
+    op.op_type = static_cast<ChangeOpType>(99);
+    op.dbi_name = "t";
+    op.storage_key = { 0x01 };
+    op.value = { 0x02 };
+    batch.ops.push_back(op);
+    bool caught = false;
+    try {
+        (void)ChangeBatchCodec::encode(batch, &bounds);
+    } catch (const std::logic_error&) {
+        caught = true;
+    }
+    if (!caught) {
+        throw std::runtime_error("encoder must reject unknown ChangeOpType");
+    }
+}
+
+void test_batch_has_more_roundtrip() {
+    using namespace mdbxc::sync;
+    const CodecBounds bounds;
+    ChangeBatch batch;
+    batch.batch_flags = BATCH_HAS_MORE;
+    ChangeOp op;
+    op.op_type = ChangeOpType::Put;
+    op.dbi_name = "t";
+    op.storage_key = { 0x01 };
+    op.value = { 0x02 };
+    batch.ops.push_back(op);
+    const std::vector<std::uint8_t> bytes = ChangeBatchCodec::encode(batch, &bounds);
+    const ChangeBatch decoded = ChangeBatchCodec::decode_exact(bytes, &bounds);
+    if ((decoded.batch_flags & BATCH_HAS_MORE) == 0) {
+        throw std::runtime_error("BATCH_HAS_MORE must survive roundtrip");
+    }
+}
+
 } // namespace
 
 int main() {
@@ -153,5 +192,7 @@ int main() {
     test_decode_exact_rejects_trailing();
     test_encoder_rejects_bad_batch_version();
     test_encoder_rejects_unknown_batch_flags();
+    test_encoder_rejects_unknown_op_type();
+    test_batch_has_more_roundtrip();
     return 0;
 }

--- a/tests/test_codec_roundtrip.cpp
+++ b/tests/test_codec_roundtrip.cpp
@@ -69,6 +69,7 @@ void test_roundtrip_full() {
     std::vector<std::uint8_t> bytes = ChangeBatchCodec::encode(batch, &bounds);
     ChangeBatch decoded = ChangeBatchCodec::decode(bytes, nullptr, &bounds);
 
+    assert_eq("version", decoded.version, batch.version);
     assert_eq("ops count", decoded.ops.size(), batch.ops.size());
     assert_eq("seq", decoded.seq, batch.seq);
     assert_eq("time", decoded.time_unix_ns, batch.time_unix_ns);
@@ -91,6 +92,24 @@ void test_roundtrip_full() {
     assert_eq("tombstone flags", dd.op_flags,
               static_cast<std::uint32_t>(OP_TOMBSTONE));
     assert_eq("value empty", dd.value.size(), 0u);
+}
+
+void test_roundtrip_stream_mode() {
+    using namespace mdbxc::sync;
+    const CodecBounds bounds;
+    const ChangeBatch batch = make_batch();
+    std::vector<std::uint8_t> bytes = ChangeBatchCodec::encode(batch, &bounds);
+    const std::size_t expected_consumed = bytes.size();
+    bytes.push_back(0xFF);
+    bytes.push_back(0xEE);
+    bytes.push_back(0xDD);
+
+    std::size_t consumed = 0;
+    const ChangeBatch decoded = ChangeBatchCodec::decode(bytes, &consumed, &bounds);
+    assert_eq("stream consumed", consumed, expected_consumed);
+    assert_eq("stream ops", decoded.ops.size(), batch.ops.size());
+    assert_eq("stream seq", decoded.seq, batch.seq);
+    assert_eq("stream version", decoded.version, batch.version);
 }
 
 void test_roundtrip_idempotent() {
@@ -120,5 +139,6 @@ int main() {
     test_roundtrip_full();
     test_roundtrip_idempotent();
     test_roundtrip_no_ops();
+    test_roundtrip_stream_mode();
     return 0;
 }


### PR DESCRIPTION
## Summary

Follow-up to #61. Hardens the versioned codec before it becomes a public contract: magic is now the full 8 bytes, `ChangeBatch::version` is enforced, and `decode()` rejects trailing bytes by default.

## Changes

- **Magic**: now the full 8 bytes `MDBXCSYN`. `magic()` returns `const uint8_t*` and `magic_size()` returns 8. `encode`, `decode`, the layout doc comment, and the golden test all use the same length.
- **`ChangeBatch::version`**: part of the contract. `encode()` rejects any value != 1 with `std::logic_error`. `decode()` assigns the wire `batch_version` into `batch.version` so callers always see the actual schema version.
- **Unknown batch flags**: `encode()` now rejects unknown `batch_flags` the same way `decode()` does. `BATCH_COMPRESSED_ZSTD` is still rejected separately as unsupported.
- **Trailing bytes**: `decode()` with `bytes_read == nullptr` now throws on trailing bytes. Added `decode_exact()` as the explicit single-batch entry point.
- **Golden test**: offsets updated for the 8-byte magic; added 4 new test cases:
  - `test_golden_trailing_bytes_rejected`
  - `test_decode_exact_rejects_trailing`
  - `test_encoder_rejects_bad_batch_version`
  - `test_encoder_rejects_unknown_batch_flags`

## Why now

Before any consumer writes to `_mdbxc_changelog` or builds a transport on top of this codec, the wire format needs to be unambiguously defined. PR #61 left four asymmetries that would have caused silent data loss or version-mismatch bugs once data was on disk.

## Tests

- C++17: 20/20 ctest passed.
- C++11: all 4 codec tests passed.
- `sync_codec_dump_example` outputs 127 bytes (was 126; +1 from the extra magic byte).

## Notes

No changes to `ChangeBatch`, `ChangeOp`, `ConflictPolicy`, or the protocol structs — only the codec.