### PR TITLE
feat(sync): add system store layer

### DIFF
--- a/include/mdbx_containers/Sync.hpp
+++ b/include/mdbx_containers/Sync.hpp
@@ -23,6 +23,10 @@
 #include "sync/ISyncPeer.hpp"
 #include "sync/Protocol.hpp"
 #include "sync/SyncCursor.hpp"
+#include "sync/stores/MetaStore.hpp"
+#include "sync/stores/ChangeLogStore.hpp"
+#include "sync/stores/AppliedStore.hpp"
+#include "sync/stores/IdentityIndexStore.hpp"
 #endif
 
 #endif // MDBX_CONTAINERS_HEADER_SYNC_HPP_INCLUDED

--- a/include/mdbx_containers/detail/utils.hpp
+++ b/include/mdbx_containers/detail/utils.hpp
@@ -9,6 +9,24 @@
 /// \ingroup mdbxc_utils
 /// @{
 
+#include <bitset>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <deque>
+#include <list>
+#include <map>
+#include <memory>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "../common/MdbxException.hpp"
+
 #if __cplusplus >= 201703L
 #   define MDBXC_NODISCARD [[nodiscard]]
 #else

--- a/include/mdbx_containers/sync/stores/AppliedStore.hpp
+++ b/include/mdbx_containers/sync/stores/AppliedStore.hpp
@@ -1,0 +1,97 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_STORES_APPLIED_STORE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_STORES_APPLIED_STORE_HPP_INCLUDED
+
+/// \file AppliedStore.hpp
+/// \brief Tracks the last contiguous applied \c seq per origin \c NodeId.
+
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mdbx.h>
+
+#include "../../detail/utils.hpp"
+#include "../Common.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Records the last contiguous applied \c seq per origin.
+    /// \details Key = 16 bytes of \c NodeId. Value = 8 bytes little-endian
+    /// \c seq. The store assumes the caller only writes contiguous updates
+    /// (i.e. applying batch \c seq means \c last_seq = \c seq, never gaps).
+    class AppliedStore {
+    public:
+        AppliedStore(MDBX_env* env,
+                     const std::string& dbi_name = "_mdbxc_applied")
+            : m_env(env), m_dbi_name(dbi_name), m_dbi(0), m_open(false) {}
+
+        void open(MDBX_txn* txn) {
+            if (m_open) return;
+            check_mdbx(
+                mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE, &m_dbi),
+                "Failed to open AppliedStore DBI"
+            );
+            m_open = true;
+        }
+
+        bool is_open() const { return m_open; }
+        MDBX_dbi handle() const { return m_dbi; }
+
+        /// \brief Returns the last contiguous applied \c seq for \p origin.
+        /// \details Returns 0 when no record exists.
+        std::uint64_t last_applied_seq(MDBX_txn* txn, const NodeId& origin) const {
+            MDBX_val k = { const_cast<std::uint8_t*>(origin.data()), 16 };
+            MDBX_val v;
+            const int rc = mdbx_get(txn, m_dbi, &k, &v);
+            if (rc == MDBX_NOTFOUND) return 0;
+            check_mdbx(rc, "AppliedStore read failed");
+            if (v.iov_len != 8) return 0;
+            std::uint64_t out = 0;
+            for (int i = 0; i < 8; ++i) {
+                out |= static_cast<std::uint64_t>(static_cast<std::uint8_t*>(v.iov_base)[i]) << (i * 8);
+            }
+            return out;
+        }
+
+        /// \brief Records \p seq as the new last contiguous applied value for
+        /// \p origin.
+        void set_last_applied_seq(MDBX_txn* txn, const NodeId& origin,
+                                  std::uint64_t seq) {
+            std::uint8_t buf[8];
+            for (int i = 0; i < 8; ++i) {
+                buf[i] = static_cast<std::uint8_t>((seq >> (i * 8)) & 0xff);
+            }
+            MDBX_val k = { const_cast<std::uint8_t*>(origin.data()), 16 };
+            MDBX_val v = { buf, 8 };
+            check_mdbx(
+                mdbx_put(txn, m_dbi, &k, &v, MDBX_UPSERT),
+                "AppliedStore write failed"
+            );
+        }
+
+        /// \brief Removes the record for \p origin if present.
+        /// \return true when a record was removed.
+        bool clear(MDBX_txn* txn, const NodeId& origin) {
+            MDBX_val k = { const_cast<std::uint8_t*>(origin.data()), 16 };
+            const int rc = mdbx_del(txn, m_dbi, &k, nullptr);
+            if (rc == MDBX_SUCCESS) return true;
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "AppliedStore clear failed");
+            return false;
+        }
+
+    private:
+        MDBX_env*     m_env;
+        std::string   m_dbi_name;
+        MDBX_dbi      m_dbi;
+        bool          m_open;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_STORES_APPLIED_STORE_HPP_INCLUDED

--- a/include/mdbx_containers/sync/stores/AppliedStore.hpp
+++ b/include/mdbx_containers/sync/stores/AppliedStore.hpp
@@ -41,9 +41,17 @@ namespace sync {
         bool is_open() const { return m_open; }
         MDBX_dbi handle() const { return m_dbi; }
 
+        /// \brief Throws when the DBI has not been opened yet.
+        void ensure_open() const {
+            if (!m_open) {
+                throw std::logic_error("AppliedStore is not open");
+            }
+        }
+
         /// \brief Returns the last contiguous applied \c seq for \p origin.
         /// \details Returns 0 when no record exists.
         std::uint64_t last_applied_seq(MDBX_txn* txn, const NodeId& origin) const {
+            ensure_open();
             MDBX_val k = { const_cast<std::uint8_t*>(origin.data()), 16 };
             MDBX_val v;
             const int rc = mdbx_get(txn, m_dbi, &k, &v);
@@ -61,6 +69,7 @@ namespace sync {
         /// \p origin.
         void set_last_applied_seq(MDBX_txn* txn, const NodeId& origin,
                                   std::uint64_t seq) {
+            ensure_open();
             std::uint8_t buf[8];
             for (int i = 0; i < 8; ++i) {
                 buf[i] = static_cast<std::uint8_t>((seq >> (i * 8)) & 0xff);
@@ -76,6 +85,7 @@ namespace sync {
         /// \brief Removes the record for \p origin if present.
         /// \return true when a record was removed.
         bool clear(MDBX_txn* txn, const NodeId& origin) {
+            ensure_open();
             MDBX_val k = { const_cast<std::uint8_t*>(origin.data()), 16 };
             const int rc = mdbx_del(txn, m_dbi, &k, nullptr);
             if (rc == MDBX_SUCCESS) return true;

--- a/include/mdbx_containers/sync/stores/ChangeLogStore.hpp
+++ b/include/mdbx_containers/sync/stores/ChangeLogStore.hpp
@@ -109,6 +109,9 @@ namespace sync {
         /// \return Number of records removed.
         std::size_t prune_up_to(MDBX_txn* txn, const NodeId& origin,
                                 std::uint64_t up_to) {
+            if (!m_open) {
+                throw std::logic_error("ChangeLogStore is not open");
+            }
             MDBX_cursor* raw = nullptr;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, &raw), "cursor open failed");
             std::size_t removed = 0;
@@ -118,7 +121,8 @@ namespace sync {
                 encode_key(origin, up_to, hi_key);
                 MDBX_val lo = { lo_key.empty() ? nullptr : &lo_key[0], lo_key.size() };
                 MDBX_val hi = { hi_key.empty() ? nullptr : &hi_key[0], hi_key.size() };
-                MDBX_val k, v;
+                MDBX_val k = lo;
+                MDBX_val v;
                 int rc = mdbx_cursor_get(raw, &k, &v, MDBX_SET_RANGE);
                 while (rc == MDBX_SUCCESS) {
                     if (k.iov_len < 24) break;
@@ -149,8 +153,11 @@ namespace sync {
                                std::vector<std::uint8_t>& out) {
             out.resize(24);
             std::memcpy(out.data(), origin.data(), 16);
+            /// \brief Big-endian seq so MDBX bytewise range scans preserve
+            ///        numeric ordering. Little-endian would invert order
+            ///        around byte boundaries (e.g. 256 < 1).
             for (int i = 0; i < 8; ++i) {
-                out[16 + i] = static_cast<std::uint8_t>((seq >> (i * 8)) & 0xff);
+                out[16 + i] = static_cast<std::uint8_t>((seq >> ((7 - i) * 8)) & 0xff);
             }
         }
 

--- a/include/mdbx_containers/sync/stores/ChangeLogStore.hpp
+++ b/include/mdbx_containers/sync/stores/ChangeLogStore.hpp
@@ -1,0 +1,166 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_STORES_CHANGE_LOG_STORE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_STORES_CHANGE_LOG_STORE_HPP_INCLUDED
+
+/// \file ChangeLogStore.hpp
+/// \brief Per-origin changelog of raw \c ChangeBatch bytes.
+
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mdbx.h>
+
+#include "../../detail/utils.hpp"
+#include "../Common.hpp"
+#include "../ChangeBatch.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Raw bytestore for replicated \c ChangeBatch records keyed by
+    /// \c (origin_node_id, seq).
+    /// \details Values are \c ChangeBatchCodec::encode() output, opaque to
+    /// this layer. The store makes no assumption about seq monotonicity; the
+    /// caller (SyncEngine) is responsible for gap detection and ordering.
+    class ChangeLogStore {
+    public:
+        /// \brief Constructs a wrapper bound to \p env.
+        ChangeLogStore(MDBX_env* env,
+                       const std::string& dbi_name = "_mdbxc_changelog")
+            : m_env(env), m_dbi_name(dbi_name), m_dbi(0), m_open(false) {}
+
+        /// \brief Opens the DBI inside the supplied write transaction.
+        void open(MDBX_txn* txn) {
+            if (m_open) return;
+            check_mdbx(
+                mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE, &m_dbi),
+                "Failed to open ChangeLogStore DBI"
+            );
+            m_open = true;
+        }
+
+        bool is_open() const { return m_open; }
+        MDBX_dbi handle() const { return m_dbi; }
+
+        /// \brief Appends a single batch for \p origin at \p seq.
+        /// \details Uses \c MDBX_NOOVERWRITE so accidental re-use of a
+        /// (origin, seq) key surfaces immediately.
+        void append(MDBX_txn* txn, const NodeId& origin,
+                    std::uint64_t seq, const std::vector<std::uint8_t>& bytes) {
+            std::vector<std::uint8_t> key_buf;
+            encode_key(origin, seq, key_buf);
+            MDBX_val k = { key_buf.empty() ? nullptr : &key_buf[0], key_buf.size() };
+            MDBX_val v = { bytes.empty() ? nullptr : const_cast<std::uint8_t*>(&bytes[0]),
+                           bytes.size() };
+            check_mdbx(
+                mdbx_put(txn, m_dbi, &k, &v, MDBX_NOOVERWRITE),
+                "ChangeLogStore append failed"
+            );
+        }
+
+        /// \brief Returns true when a record exists for (\p origin, \p seq).
+        bool contains(MDBX_txn* txn, const NodeId& origin, std::uint64_t seq) const {
+            std::vector<std::uint8_t> key_buf;
+            encode_key(origin, seq, key_buf);
+            MDBX_val k = { key_buf.empty() ? nullptr : &key_buf[0], key_buf.size() };
+            MDBX_val v;
+            const int rc = mdbx_get(txn, m_dbi, &k, &v);
+            if (rc == MDBX_SUCCESS) return true;
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "ChangeLogStore contains failed");
+            return false;
+        }
+
+        /// \brief Reads raw batch bytes for (\p origin, \p seq).
+        /// \return true when present, false when absent.
+        bool get(MDBX_txn* txn, const NodeId& origin, std::uint64_t seq,
+                 std::vector<std::uint8_t>& out) const {
+            std::vector<std::uint8_t> key_buf;
+            encode_key(origin, seq, key_buf);
+            MDBX_val k = { key_buf.empty() ? nullptr : &key_buf[0], key_buf.size() };
+            MDBX_val v;
+            const int rc = mdbx_get(txn, m_dbi, &k, &v);
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "ChangeLogStore get failed");
+            out.resize(v.iov_len);
+            if (v.iov_len > 0) {
+                std::memcpy(out.data(), v.iov_base, v.iov_len);
+            }
+            return true;
+        }
+
+        /// \brief Removes the record at (\p origin, \p seq).
+        /// \return true when a record was removed, false when absent.
+        bool erase(MDBX_txn* txn, const NodeId& origin, std::uint64_t seq) {
+            std::vector<std::uint8_t> key_buf;
+            encode_key(origin, seq, key_buf);
+            MDBX_val k = { key_buf.empty() ? nullptr : &key_buf[0], key_buf.size() };
+            const int rc = mdbx_del(txn, m_dbi, &k, nullptr);
+            if (rc == MDBX_SUCCESS) return true;
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "ChangeLogStore erase failed");
+            return false;
+        }
+
+        /// \brief Removes every record with seq <= \p up_to for \p origin.
+        /// \return Number of records removed.
+        std::size_t prune_up_to(MDBX_txn* txn, const NodeId& origin,
+                                std::uint64_t up_to) {
+            MDBX_cursor* raw = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &raw), "cursor open failed");
+            std::size_t removed = 0;
+            try {
+                std::vector<std::uint8_t> lo_key, hi_key;
+                encode_key(origin, 0, lo_key);
+                encode_key(origin, up_to, hi_key);
+                MDBX_val lo = { lo_key.empty() ? nullptr : &lo_key[0], lo_key.size() };
+                MDBX_val hi = { hi_key.empty() ? nullptr : &hi_key[0], hi_key.size() };
+                MDBX_val k, v;
+                int rc = mdbx_cursor_get(raw, &k, &v, MDBX_SET_RANGE);
+                while (rc == MDBX_SUCCESS) {
+                    if (k.iov_len < 24) break;
+                    if (mdbx_cmp(txn, m_dbi, &k, &hi) > 0) break;
+                    rc = mdbx_cursor_del(raw, MDBX_CURRENT);
+                    if (rc == MDBX_SUCCESS) {
+                        ++removed;
+                        rc = mdbx_cursor_get(raw, &k, &v, MDBX_NEXT);
+                    } else if (rc == MDBX_NOTFOUND) {
+                        break;
+                    } else {
+                        check_mdbx(rc, "ChangeLogStore prune cursor_del failed");
+                    }
+                }
+                if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "ChangeLogStore prune cursor_get failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(raw);
+                throw;
+            }
+            mdbx_cursor_close(raw);
+            return removed;
+        }
+
+    private:
+        static void encode_key(const NodeId& origin, std::uint64_t seq,
+                               std::vector<std::uint8_t>& out) {
+            out.resize(24);
+            std::memcpy(out.data(), origin.data(), 16);
+            for (int i = 0; i < 8; ++i) {
+                out[16 + i] = static_cast<std::uint8_t>((seq >> (i * 8)) & 0xff);
+            }
+        }
+
+        MDBX_env*     m_env;
+        std::string   m_dbi_name;
+        MDBX_dbi      m_dbi;
+        bool          m_open;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_STORES_CHANGE_LOG_STORE_HPP_INCLUDED

--- a/include/mdbx_containers/sync/stores/ChangeLogStore.hpp
+++ b/include/mdbx_containers/sync/stores/ChangeLogStore.hpp
@@ -45,11 +45,19 @@ namespace sync {
         bool is_open() const { return m_open; }
         MDBX_dbi handle() const { return m_dbi; }
 
+        /// \brief Throws when the DBI has not been opened yet.
+        void ensure_open() const {
+            if (!m_open) {
+                throw std::logic_error("ChangeLogStore is not open");
+            }
+        }
+
         /// \brief Appends a single batch for \p origin at \p seq.
         /// \details Uses \c MDBX_NOOVERWRITE so accidental re-use of a
         /// (origin, seq) key surfaces immediately.
         void append(MDBX_txn* txn, const NodeId& origin,
                     std::uint64_t seq, const std::vector<std::uint8_t>& bytes) {
+            ensure_open();
             std::vector<std::uint8_t> key_buf;
             encode_key(origin, seq, key_buf);
             MDBX_val k = { key_buf.empty() ? nullptr : &key_buf[0], key_buf.size() };
@@ -63,6 +71,7 @@ namespace sync {
 
         /// \brief Returns true when a record exists for (\p origin, \p seq).
         bool contains(MDBX_txn* txn, const NodeId& origin, std::uint64_t seq) const {
+            ensure_open();
             std::vector<std::uint8_t> key_buf;
             encode_key(origin, seq, key_buf);
             MDBX_val k = { key_buf.empty() ? nullptr : &key_buf[0], key_buf.size() };
@@ -78,6 +87,7 @@ namespace sync {
         /// \return true when present, false when absent.
         bool get(MDBX_txn* txn, const NodeId& origin, std::uint64_t seq,
                  std::vector<std::uint8_t>& out) const {
+            ensure_open();
             std::vector<std::uint8_t> key_buf;
             encode_key(origin, seq, key_buf);
             MDBX_val k = { key_buf.empty() ? nullptr : &key_buf[0], key_buf.size() };
@@ -95,6 +105,7 @@ namespace sync {
         /// \brief Removes the record at (\p origin, \p seq).
         /// \return true when a record was removed, false when absent.
         bool erase(MDBX_txn* txn, const NodeId& origin, std::uint64_t seq) {
+            ensure_open();
             std::vector<std::uint8_t> key_buf;
             encode_key(origin, seq, key_buf);
             MDBX_val k = { key_buf.empty() ? nullptr : &key_buf[0], key_buf.size() };

--- a/include/mdbx_containers/sync/stores/IdentityIndexStore.hpp
+++ b/include/mdbx_containers/sync/stores/IdentityIndexStore.hpp
@@ -109,6 +109,9 @@ namespace sync {
         /// \return true when a record was removed.
         bool erase(MDBX_txn* txn, const std::string& dbi_name,
                    const std::vector<std::uint8_t>& identity_key) {
+            if (!m_open) {
+                throw std::logic_error("IdentityIndexStore is not open");
+            }
             std::vector<std::uint8_t> key_buf;
             encode_key(dbi_name, identity_key, key_buf);
             MDBX_val k = { key_buf.empty() ? nullptr : &key_buf[0], key_buf.size() };
@@ -123,8 +126,14 @@ namespace sync {
         static void encode_key(const std::string& dbi_name,
                                const std::vector<std::uint8_t>& identity_key,
                                std::vector<std::uint8_t>& out) {
+            const std::uint32_t dn_len =
+                static_cast<std::uint32_t>(dbi_name.size());
             out.clear();
-            out.reserve(dbi_name.size() + identity_key.size());
+            out.reserve(4 + dn_len + identity_key.size());
+            out.push_back(static_cast<std::uint8_t>(dn_len & 0xff));
+            out.push_back(static_cast<std::uint8_t>((dn_len >> 8) & 0xff));
+            out.push_back(static_cast<std::uint8_t>((dn_len >> 16) & 0xff));
+            out.push_back(static_cast<std::uint8_t>((dn_len >> 24) & 0xff));
             out.insert(out.end(), dbi_name.begin(), dbi_name.end());
             out.insert(out.end(), identity_key.begin(), identity_key.end());
         }

--- a/include/mdbx_containers/sync/stores/IdentityIndexStore.hpp
+++ b/include/mdbx_containers/sync/stores/IdentityIndexStore.hpp
@@ -1,0 +1,216 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_STORES_IDENTITY_INDEX_STORE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_STORES_IDENTITY_INDEX_STORE_HPP_INCLUDED
+
+/// \file IdentityIndexStore.hpp
+/// \brief Per-record identity index used for dedup and conflict detection
+/// when \c identity_key differs from \c storage_key.
+
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mdbx.h>
+
+#include "../../detail/utils.hpp"
+#include "../ChangeOp.hpp"
+#include "../CodecFlags.hpp"
+#include "../Common.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Bit flags for the \c IdentityIndexValue::flags field.
+    enum IdentityIndexFlags : std::uint32_t {
+        /// \brief Default state: a live identity record.
+        IDENTITY_NONE      = 0,
+        /// \brief Marker that the logical record was deleted; the row stays
+        /// in the index so older incoming batches can still resolve it.
+        IDENTITY_TOMBSTONE = 1u << 0,
+    };
+
+    /// \brief Value layout for an identity-index record.
+    /// \details Mirrors the wire payload of \c ChangeOp plus enough metadata
+    /// to resolve the (dbi_name, identity_key) entry back to a physical
+    /// storage_key without re-reading the user table.
+    struct IdentityIndexValue {
+        std::vector<std::uint8_t> storage_key;
+        NodeId origin_node_id{};
+        std::uint64_t seq = 0;
+        std::vector<std::uint8_t> revision_key;
+        std::uint32_t flags = 0;
+    };
+
+    /// \brief Thin wrapper around \c _mdbxc_identity_index.
+    /// \details Key = concat(dbi_name_bytes, identity_key_bytes). Value =
+    /// length-prefixed \c IdentityIndexValue.
+    class IdentityIndexStore {
+    public:
+        IdentityIndexStore(MDBX_env* env,
+                           const std::string& dbi_name = "_mdbxc_identity_index")
+            : m_env(env), m_dbi_name(dbi_name), m_dbi(0), m_open(false) {}
+
+        void open(MDBX_txn* txn) {
+            if (m_open) return;
+            check_mdbx(
+                mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE, &m_dbi),
+                "Failed to open IdentityIndexStore DBI"
+            );
+            m_open = true;
+        }
+
+        bool is_open() const { return m_open; }
+        MDBX_dbi handle() const { return m_dbi; }
+
+        /// \brief Stores or replaces the identity record.
+        void put(MDBX_txn* txn, const std::string& dbi_name,
+                 const std::vector<std::uint8_t>& identity_key,
+                 const IdentityIndexValue& value) {
+            std::vector<std::uint8_t> key_buf;
+            encode_key(dbi_name, identity_key, key_buf);
+            std::vector<std::uint8_t> val_buf;
+            encode_value(value, val_buf);
+            MDBX_val k = { key_buf.empty() ? nullptr : &key_buf[0], key_buf.size() };
+            MDBX_val v = { val_buf.empty() ? nullptr : &val_buf[0], val_buf.size() };
+            check_mdbx(
+                mdbx_put(txn, m_dbi, &k, &v, MDBX_UPSERT),
+                "IdentityIndexStore put failed"
+            );
+        }
+
+        /// \brief Reads the identity record.
+        /// \return true when present, false when absent.
+        bool get(MDBX_txn* txn, const std::string& dbi_name,
+                 const std::vector<std::uint8_t>& identity_key,
+                 IdentityIndexValue& out) const {
+            std::vector<std::uint8_t> key_buf;
+            encode_key(dbi_name, identity_key, key_buf);
+            MDBX_val k = { key_buf.empty() ? nullptr : &key_buf[0], key_buf.size() };
+            MDBX_val v;
+            const int rc = mdbx_get(txn, m_dbi, &k, &v);
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "IdentityIndexStore get failed");
+            decode_value(v, out);
+            return true;
+        }
+
+        /// \brief Marks the record with a tombstone. Does not delete.
+        void tombstone(MDBX_txn* txn, const std::string& dbi_name,
+                       const std::vector<std::uint8_t>& identity_key,
+                       const IdentityIndexValue& marker) {
+            IdentityIndexValue v = marker;
+            v.flags |= static_cast<std::uint32_t>(IDENTITY_TOMBSTONE);
+            put(txn, dbi_name, identity_key, v);
+        }
+
+        /// \brief Removes the identity record outright.
+        /// \return true when a record was removed.
+        bool erase(MDBX_txn* txn, const std::string& dbi_name,
+                   const std::vector<std::uint8_t>& identity_key) {
+            std::vector<std::uint8_t> key_buf;
+            encode_key(dbi_name, identity_key, key_buf);
+            MDBX_val k = { key_buf.empty() ? nullptr : &key_buf[0], key_buf.size() };
+            const int rc = mdbx_del(txn, m_dbi, &k, nullptr);
+            if (rc == MDBX_SUCCESS) return true;
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "IdentityIndexStore erase failed");
+            return false;
+        }
+
+    private:
+        static void encode_key(const std::string& dbi_name,
+                               const std::vector<std::uint8_t>& identity_key,
+                               std::vector<std::uint8_t>& out) {
+            out.clear();
+            out.reserve(dbi_name.size() + identity_key.size());
+            out.insert(out.end(), dbi_name.begin(), dbi_name.end());
+            out.insert(out.end(), identity_key.begin(), identity_key.end());
+        }
+
+        static void encode_value(const IdentityIndexValue& v,
+                                 std::vector<std::uint8_t>& out) {
+            out.clear();
+            append_u32(out, static_cast<std::uint32_t>(v.storage_key.size()));
+            if (!v.storage_key.empty()) {
+                out.insert(out.end(), v.storage_key.begin(), v.storage_key.end());
+            }
+            out.insert(out.end(), v.origin_node_id.begin(), v.origin_node_id.end());
+            for (int i = 0; i < 8; ++i) {
+                out.push_back(static_cast<std::uint8_t>((v.seq >> (i * 8)) & 0xff));
+            }
+            append_u32(out, static_cast<std::uint32_t>(v.revision_key.size()));
+            if (!v.revision_key.empty()) {
+                out.insert(out.end(), v.revision_key.begin(), v.revision_key.end());
+            }
+            append_u32(out, v.flags);
+        }
+
+        static void decode_value(const MDBX_val& v, IdentityIndexValue& out) {
+            const std::uint8_t* p = static_cast<const std::uint8_t*>(v.iov_base);
+            std::size_t pos = 0;
+            const std::size_t total = v.iov_len;
+            auto need = [&](std::size_t n) -> void {
+                if (pos + n > total) {
+                    throw std::runtime_error("IdentityIndexStore decode underrun");
+                }
+            };
+            need(4);
+            std::uint32_t sk_len = static_cast<std::uint32_t>(p[pos]) |
+                                   (static_cast<std::uint32_t>(p[pos + 1]) << 8) |
+                                   (static_cast<std::uint32_t>(p[pos + 2]) << 16) |
+                                   (static_cast<std::uint32_t>(p[pos + 3]) << 24);
+            pos += 4;
+            need(sk_len);
+            out.storage_key.resize(sk_len);
+            if (sk_len > 0) {
+                std::memcpy(out.storage_key.data(), p + pos, sk_len);
+            }
+            pos += sk_len;
+            need(16);
+            std::memcpy(out.origin_node_id.data(), p + pos, 16);
+            pos += 16;
+            need(8);
+            std::uint64_t seq = 0;
+            for (int i = 0; i < 8; ++i) {
+                seq |= static_cast<std::uint64_t>(p[pos + i]) << (i * 8);
+            }
+            out.seq = seq;
+            pos += 8;
+            need(4);
+            std::uint32_t rv_len = static_cast<std::uint32_t>(p[pos]) |
+                                   (static_cast<std::uint32_t>(p[pos + 1]) << 8) |
+                                   (static_cast<std::uint32_t>(p[pos + 2]) << 16) |
+                                   (static_cast<std::uint32_t>(p[pos + 3]) << 24);
+            pos += 4;
+            need(rv_len);
+            out.revision_key.resize(rv_len);
+            if (rv_len > 0) {
+                std::memcpy(out.revision_key.data(), p + pos, rv_len);
+            }
+            pos += rv_len;
+            need(4);
+            out.flags = static_cast<std::uint32_t>(p[pos]) |
+                        (static_cast<std::uint32_t>(p[pos + 1]) << 8) |
+                        (static_cast<std::uint32_t>(p[pos + 2]) << 16) |
+                        (static_cast<std::uint32_t>(p[pos + 3]) << 24);
+        }
+
+        static void append_u32(std::vector<std::uint8_t>& out, std::uint32_t v) {
+            out.push_back(static_cast<std::uint8_t>(v & 0xff));
+            out.push_back(static_cast<std::uint8_t>((v >> 8) & 0xff));
+            out.push_back(static_cast<std::uint8_t>((v >> 16) & 0xff));
+            out.push_back(static_cast<std::uint8_t>((v >> 24) & 0xff));
+        }
+
+        MDBX_env*     m_env;
+        std::string   m_dbi_name;
+        MDBX_dbi      m_dbi;
+        bool          m_open;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_STORES_IDENTITY_INDEX_STORE_HPP_INCLUDED

--- a/include/mdbx_containers/sync/stores/IdentityIndexStore.hpp
+++ b/include/mdbx_containers/sync/stores/IdentityIndexStore.hpp
@@ -44,8 +44,11 @@ namespace sync {
     };
 
     /// \brief Thin wrapper around \c _mdbxc_identity_index.
-    /// \details Key = concat(dbi_name_bytes, identity_key_bytes). Value =
-    /// length-prefixed \c IdentityIndexValue.
+    /// \details Key = \c u32 dbi_name_len_le || dbi_name_bytes || identity_key_bytes.
+    /// The length prefix is mandatory: without it, \c ("ab","c") and
+    /// \c ("a","bc") would collide on the same MDBX record. Value =
+    /// \c IdentityIndexValue, opaque structured payload with length-prefixed
+    /// variable-size fields (\c storage_key, \c revision_key).
     class IdentityIndexStore {
     public:
         IdentityIndexStore(MDBX_env* env,
@@ -64,10 +67,18 @@ namespace sync {
         bool is_open() const { return m_open; }
         MDBX_dbi handle() const { return m_dbi; }
 
+        /// \brief Throws when the DBI has not been opened yet.
+        void ensure_open() const {
+            if (!m_open) {
+                throw std::logic_error("IdentityIndexStore is not open");
+            }
+        }
+
         /// \brief Stores or replaces the identity record.
         void put(MDBX_txn* txn, const std::string& dbi_name,
                  const std::vector<std::uint8_t>& identity_key,
                  const IdentityIndexValue& value) {
+            ensure_open();
             std::vector<std::uint8_t> key_buf;
             encode_key(dbi_name, identity_key, key_buf);
             std::vector<std::uint8_t> val_buf;
@@ -85,6 +96,7 @@ namespace sync {
         bool get(MDBX_txn* txn, const std::string& dbi_name,
                  const std::vector<std::uint8_t>& identity_key,
                  IdentityIndexValue& out) const {
+            ensure_open();
             std::vector<std::uint8_t> key_buf;
             encode_key(dbi_name, identity_key, key_buf);
             MDBX_val k = { key_buf.empty() ? nullptr : &key_buf[0], key_buf.size() };
@@ -100,6 +112,7 @@ namespace sync {
         void tombstone(MDBX_txn* txn, const std::string& dbi_name,
                        const std::vector<std::uint8_t>& identity_key,
                        const IdentityIndexValue& marker) {
+            ensure_open();
             IdentityIndexValue v = marker;
             v.flags |= static_cast<std::uint32_t>(IDENTITY_TOMBSTONE);
             put(txn, dbi_name, identity_key, v);

--- a/include/mdbx_containers/sync/stores/MetaStore.hpp
+++ b/include/mdbx_containers/sync/stores/MetaStore.hpp
@@ -47,6 +47,13 @@ namespace sync {
             m_open = true;
         }
 
+        /// \brief Throws when the DBI has not been opened yet.
+        void ensure_open() const {
+            if (!m_open) {
+                throw std::logic_error("MetaStore is not open");
+            }
+        }
+
         /// \brief Returns whether the DBI is open.
         bool is_open() const { return m_open; }
 
@@ -157,6 +164,7 @@ namespace sync {
 
         std::size_t read_fixed(MDBX_txn* txn, std::uint8_t key,
                                std::uint8_t* dst, std::size_t n) const {
+            ensure_open();
             MDBX_val k = { &key, 1 };
             MDBX_val v;
             const int rc = mdbx_get(txn, m_dbi, &k, &v);
@@ -169,6 +177,7 @@ namespace sync {
 
         void write_fixed(MDBX_txn* txn, std::uint8_t key,
                          const std::uint8_t* src, std::size_t n) const {
+            ensure_open();
             MDBX_val k = { &key, 1 };
             MDBX_val v = { const_cast<std::uint8_t*>(src), n };
             check_mdbx(

--- a/include/mdbx_containers/sync/stores/MetaStore.hpp
+++ b/include/mdbx_containers/sync/stores/MetaStore.hpp
@@ -1,0 +1,189 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_STORES_META_STORE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_STORES_META_STORE_HPP_INCLUDED
+
+/// \file MetaStore.hpp
+/// \brief Persistent metadata for the sync subsystem: db identity, local node
+/// identity, schema version, monotonic local seq, creation timestamp.
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+#include <mdbx.h>
+
+#include "../../detail/utils.hpp"
+#include "../Common.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Stable schema version recorded in \c _mdbxc_meta.
+    /// \details Bump this when \c ChangeBatch layout or \c ChangeOp semantics
+    /// change in a way that requires a fresh database or migration.
+    inline std::uint32_t meta_schema_version() { return 1; }
+
+    /// \brief Thin wrapper around the \c _mdbxc_meta named MDBX sub-DBI.
+    /// \details All keys are fixed-width little-endian; values are flat
+    /// byte buffers. Designed to be opened once per environment and reused.
+    class MetaStore {
+    public:
+        /// \brief Constructs a wrapper bound to \p env.
+        /// \param env Live MDBX environment.
+        /// \param dbi_name DBI name; defaults to \c _mdbxc_meta.
+        MetaStore(MDBX_env* env, const std::string& dbi_name = "_mdbxc_meta")
+            : m_env(env), m_dbi_name(dbi_name), m_dbi(0), m_open(false) {}
+
+        /// \brief Opens the DBI inside the supplied write transaction.
+        /// \details Idempotent. Must be called before any other access.
+        void open(MDBX_txn* txn) {
+            if (m_open) return;
+            check_mdbx(
+                mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE, &m_dbi),
+                "Failed to open MetaStore DBI"
+            );
+            m_open = true;
+        }
+
+        /// \brief Returns whether the DBI is open.
+        bool is_open() const { return m_open; }
+
+        /// \brief Returns the underlying MDBX DBI handle.
+        MDBX_dbi handle() const { return m_dbi; }
+
+        /// \brief Reads \c db_uuid. Empty array when unset.
+        NodeId get_db_uuid(MDBX_txn* txn) const {
+            NodeId out{};
+            read_fixed(txn, key_db_uuid(), reinterpret_cast<std::uint8_t*>(out.data()), 16);
+            return out;
+        }
+
+        /// \brief Writes \c db_uuid.
+        void set_db_uuid(MDBX_txn* txn, const NodeId& value) {
+            write_fixed(txn, key_db_uuid(), reinterpret_cast<const std::uint8_t*>(value.data()), 16);
+        }
+
+        /// \brief Reads \c node_id. Empty array when unset.
+        NodeId get_node_id(MDBX_txn* txn) const {
+            NodeId out{};
+            read_fixed(txn, key_node_id(), reinterpret_cast<std::uint8_t*>(out.data()), 16);
+            return out;
+        }
+
+        /// \brief Writes \c node_id.
+        void set_node_id(MDBX_txn* txn, const NodeId& value) {
+            write_fixed(txn, key_node_id(), reinterpret_cast<const std::uint8_t*>(value.data()), 16);
+        }
+
+        /// \brief Reads the schema version. Returns 0 when unset.
+        std::uint32_t get_schema_version(MDBX_txn* txn) const {
+            std::uint8_t buf[4];
+            const std::size_t n = read_fixed(txn, key_schema_version(), buf, 4);
+            if (n != 4) return 0;
+            return static_cast<std::uint32_t>(buf[0]) |
+                   (static_cast<std::uint32_t>(buf[1]) << 8) |
+                   (static_cast<std::uint32_t>(buf[2]) << 16) |
+                   (static_cast<std::uint32_t>(buf[3]) << 24);
+        }
+
+        /// \brief Writes the schema version.
+        void set_schema_version(MDBX_txn* txn, std::uint32_t value) {
+            const std::uint8_t buf[4] = {
+                static_cast<std::uint8_t>(value & 0xff),
+                static_cast<std::uint8_t>((value >> 8) & 0xff),
+                static_cast<std::uint8_t>((value >> 16) & 0xff),
+                static_cast<std::uint8_t>((value >> 24) & 0xff)
+            };
+            write_fixed(txn, key_schema_version(), buf, 4);
+        }
+
+        /// \brief Reads \c local_seq. Returns 0 when unset.
+        std::uint64_t get_local_seq(MDBX_txn* txn) const {
+            std::uint8_t buf[8];
+            const std::size_t n = read_fixed(txn, key_local_seq(), buf, 8);
+            if (n != 8) return 0;
+            std::uint64_t v = 0;
+            for (int i = 0; i < 8; ++i) {
+                v |= static_cast<std::uint64_t>(buf[i]) << (i * 8);
+            }
+            return v;
+        }
+
+        /// \brief Writes \c local_seq.
+        void set_local_seq(MDBX_txn* txn, std::uint64_t value) {
+            std::uint8_t buf[8];
+            for (int i = 0; i < 8; ++i) {
+                buf[i] = static_cast<std::uint8_t>((value >> (i * 8)) & 0xff);
+            }
+            write_fixed(txn, key_local_seq(), buf, 8);
+        }
+
+        /// \brief Atomically increments \c local_seq and returns the new value.
+        std::uint64_t increment_local_seq(MDBX_txn* txn) {
+            const std::uint64_t next = get_local_seq(txn) + 1;
+            set_local_seq(txn, next);
+            return next;
+        }
+
+        /// \brief Reads \c created_at_ms. Returns 0 when unset.
+        std::uint64_t get_created_at_ms(MDBX_txn* txn) const {
+            std::uint8_t buf[8];
+            const std::size_t n = read_fixed(txn, key_created_at_ms(), buf, 8);
+            if (n != 8) return 0;
+            std::uint64_t v = 0;
+            for (int i = 0; i < 8; ++i) {
+                v |= static_cast<std::uint64_t>(buf[i]) << (i * 8);
+            }
+            return v;
+        }
+
+        /// \brief Writes \c created_at_ms.
+        void set_created_at_ms(MDBX_txn* txn, std::uint64_t value) {
+            std::uint8_t buf[8];
+            for (int i = 0; i < 8; ++i) {
+                buf[i] = static_cast<std::uint8_t>((value >> (i * 8)) & 0xff);
+            }
+            write_fixed(txn, key_created_at_ms(), buf, 8);
+        }
+
+    private:
+        static std::uint8_t key_db_uuid()       { return 0x01; }
+        static std::uint8_t key_node_id()      { return 0x02; }
+        static std::uint8_t key_schema_version(){ return 0x03; }
+        static std::uint8_t key_local_seq()    { return 0x04; }
+        static std::uint8_t key_created_at_ms() { return 0x05; }
+
+        std::size_t read_fixed(MDBX_txn* txn, std::uint8_t key,
+                               std::uint8_t* dst, std::size_t n) const {
+            MDBX_val k = { &key, 1 };
+            MDBX_val v;
+            const int rc = mdbx_get(txn, m_dbi, &k, &v);
+            if (rc == MDBX_NOTFOUND) return 0;
+            check_mdbx(rc, "MetaStore read failed");
+            const std::size_t got = v.iov_len < n ? v.iov_len : n;
+            std::memcpy(dst, v.iov_base, got);
+            return got;
+        }
+
+        void write_fixed(MDBX_txn* txn, std::uint8_t key,
+                         const std::uint8_t* src, std::size_t n) const {
+            MDBX_val k = { &key, 1 };
+            MDBX_val v = { const_cast<std::uint8_t*>(src), n };
+            check_mdbx(
+                mdbx_put(txn, m_dbi, &k, &v, MDBX_UPSERT),
+                "MetaStore write failed"
+            );
+        }
+
+        MDBX_env*     m_env;
+        std::string   m_dbi_name;
+        MDBX_dbi      m_dbi;
+        bool          m_open;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_STORES_META_STORE_HPP_INCLUDED

--- a/tests/test_sync_stores.cpp
+++ b/tests/test_sync_stores.cpp
@@ -1,0 +1,239 @@
+#include <mdbx_containers.hpp>
+#include <mdbx_containers/Sync.hpp>
+#include <cstdio>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+void cleanup(const std::string& p) {
+    std::remove(p.c_str());
+}
+
+mdbxc::sync::NodeId make_node(std::uint8_t seed) {
+    mdbxc::sync::NodeId n{};
+    for (int i = 0; i < 16; ++i) {
+        n[i] = static_cast<std::uint8_t>(seed + i);
+    }
+    return n;
+}
+
+void test_meta_store() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_meta.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    MetaStore store(conn->env_handle());
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        store.open(txn.handle());
+        if (!store.is_open()) throw std::runtime_error("MetaStore not open");
+
+        const NodeId db_uuid = make_node(0xA0);
+        const NodeId node_id = make_node(0xB0);
+        store.set_db_uuid(txn.handle(), db_uuid);
+        store.set_node_id(txn.handle(), node_id);
+        store.set_schema_version(txn.handle(), meta_schema_version());
+        store.set_created_at_ms(txn.handle(), 1700000000000ULL);
+        const std::uint64_t next = store.increment_local_seq(txn.handle());
+        if (next != 1) throw std::runtime_error("local_seq start should be 1");
+        store.increment_local_seq(txn.handle());
+        txn.commit();
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        const NodeId db_uuid = store.get_db_uuid(txn.handle());
+        const NodeId node_id = store.get_node_id(txn.handle());
+        if (db_uuid != make_node(0xA0)) throw std::runtime_error("db_uuid mismatch");
+        if (node_id != make_node(0xB0)) throw std::runtime_error("node_id mismatch");
+        if (store.get_schema_version(txn.handle()) != meta_schema_version()) {
+            throw std::runtime_error("schema_version mismatch");
+        }
+        if (store.get_local_seq(txn.handle()) != 2) {
+            throw std::runtime_error("local_seq should be 2 after two increments");
+        }
+        if (store.get_created_at_ms(txn.handle()) != 1700000000000ULL) {
+            throw std::runtime_error("created_at_ms mismatch");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_changelog_store() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_changelog.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    ChangeLogStore store(conn->env_handle());
+    const NodeId origin = make_node(0x10);
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        store.open(txn.handle());
+
+        ChangeBatch batch;
+        batch.origin_node_id = origin;
+        batch.seq = 7;
+        const std::vector<std::uint8_t> bytes = ChangeBatchCodec::encode(batch);
+        store.append(txn.handle(), origin, 7, bytes);
+
+        if (!store.contains(txn.handle(), origin, 7)) {
+            throw std::runtime_error("contains should be true after append");
+        }
+        if (store.contains(txn.handle(), origin, 8)) {
+            throw std::runtime_error("contains should be false for missing seq");
+        }
+        txn.commit();
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        std::vector<std::uint8_t> out;
+        if (!store.get(txn.handle(), origin, 7, out)) {
+            throw std::runtime_error("get should return true");
+        }
+        const ChangeBatch decoded = ChangeBatchCodec::decode_exact(out);
+        if (decoded.seq != 7) throw std::runtime_error("decoded seq mismatch");
+        if (decoded.origin_node_id != origin) {
+            throw std::runtime_error("decoded origin mismatch");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_applied_store() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_applied.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    AppliedStore store(conn->env_handle());
+    const NodeId origin_a = make_node(0xC0);
+    const NodeId origin_b = make_node(0xD0);
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        store.open(txn.handle());
+        store.set_last_applied_seq(txn.handle(), origin_a, 42);
+        store.set_last_applied_seq(txn.handle(), origin_b, 100);
+        txn.commit();
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        if (store.last_applied_seq(txn.handle(), origin_a) != 42) {
+            throw std::runtime_error("origin_a seq mismatch");
+        }
+        if (store.last_applied_seq(txn.handle(), origin_b) != 100) {
+            throw std::runtime_error("origin_b seq mismatch");
+        }
+        const NodeId unknown{};
+        if (store.last_applied_seq(txn.handle(), unknown) != 0) {
+            throw std::runtime_error("unknown origin must be 0");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_identity_index_store() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_identity.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    IdentityIndexStore store(conn->env_handle());
+    const std::string dbi = "trades";
+    const std::vector<std::uint8_t> id_key = { 'E','U','R','U','S','D' };
+    const std::vector<std::uint8_t> sk = { 0x01, 0x02, 0x03 };
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        store.open(txn.handle());
+        IdentityIndexValue v;
+        v.storage_key = sk;
+        v.origin_node_id = make_node(0xE0);
+        v.seq = 9;
+        v.revision_key = { 0xAA };
+        store.put(txn.handle(), dbi, id_key, v);
+        txn.commit();
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        IdentityIndexValue out;
+        if (!store.get(txn.handle(), dbi, id_key, out)) {
+            throw std::runtime_error("identity get should succeed");
+        }
+        if (out.storage_key != sk) throw std::runtime_error("storage_key mismatch");
+        if (out.seq != 9) throw std::runtime_error("seq mismatch");
+        if (out.revision_key.size() != 1 || out.revision_key[0] != 0xAA) {
+            throw std::runtime_error("revision_key mismatch");
+        }
+        if (out.flags != 0) throw std::runtime_error("flags should be 0");
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        IdentityIndexValue marker;
+        marker.origin_node_id = make_node(0xE0);
+        marker.seq = 10;
+        store.tombstone(txn.handle(), dbi, id_key, marker);
+        txn.commit();
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        IdentityIndexValue out;
+        if (!store.get(txn.handle(), dbi, id_key, out)) {
+            throw std::runtime_error("tombstoned record should still be readable");
+        }
+        if ((out.flags & IDENTITY_TOMBSTONE) == 0) {
+            throw std::runtime_error("tombstone flag must be set");
+        }
+        if (out.seq != 10) throw std::runtime_error("tombstone seq mismatch");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+} // namespace
+
+int main() {
+    test_meta_store();
+    test_changelog_store();
+    test_applied_store();
+    test_identity_index_store();
+    return 0;
+}

--- a/tests/test_sync_stores.cpp
+++ b/tests/test_sync_stores.cpp
@@ -228,6 +228,135 @@ void test_identity_index_store() {
     cleanup(p);
 }
 
+void test_changelog_prune_up_to_boundary() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_prune.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    ChangeLogStore store(conn->env_handle());
+    const NodeId origin = make_node(0xA1);
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        store.open(txn.handle());
+        for (std::uint64_t s : { 1ULL, 2ULL, 255ULL, 256ULL, 257ULL, 1000ULL }) {
+            store.append(txn.handle(), origin, s, { 0x01, static_cast<std::uint8_t>(s & 0xff) });
+        }
+
+        const std::size_t removed = store.prune_up_to(txn.handle(), origin, 256);
+        if (removed != 4) {
+            throw std::runtime_error("expected 4 removed, got " + std::to_string(removed));
+        }
+
+        for (std::uint64_t s : { 1ULL, 2ULL, 255ULL, 256ULL }) {
+            if (store.contains(txn.handle(), origin, s)) {
+                throw std::runtime_error("seq " + std::to_string(s) + " should be pruned");
+            }
+        }
+        for (std::uint64_t s : { 257ULL, 1000ULL }) {
+            if (!store.contains(txn.handle(), origin, s)) {
+                throw std::runtime_error("seq " + std::to_string(s) + " should remain");
+            }
+        }
+        txn.commit();
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_changelog_prune_does_not_touch_other_origin() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_prune_other.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    ChangeLogStore store(conn->env_handle());
+    const NodeId origin_a = make_node(0xA2);
+    const NodeId origin_b = make_node(0xB2);
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        store.open(txn.handle());
+        store.append(txn.handle(), origin_a, 1, { 0x01 });
+        store.append(txn.handle(), origin_b, 1, { 0x02 });
+        store.append(txn.handle(), origin_a, 2, { 0x03 });
+
+        const std::size_t removed_a = store.prune_up_to(txn.handle(), origin_a, 1);
+        if (removed_a != 1) {
+            throw std::runtime_error("expected 1 from origin_a, got " + std::to_string(removed_a));
+        }
+        if (!store.contains(txn.handle(), origin_b, 1)) {
+            throw std::runtime_error("origin_b seq 1 was pruned unexpectedly");
+        }
+        if (!store.contains(txn.handle(), origin_a, 2)) {
+            throw std::runtime_error("origin_a seq 2 must remain");
+        }
+        txn.commit();
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_identity_key_collision() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_collision.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    IdentityIndexStore store(conn->env_handle());
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        store.open(txn.handle());
+
+        IdentityIndexValue v;
+        v.storage_key = { 0xAA };
+        v.origin_node_id = make_node(0xC3);
+        v.seq = 1;
+        store.put(txn.handle(), "ab",  { 'c' }, v);
+        store.put(txn.handle(), "a",   { 'b', 'c' }, v);
+
+        IdentityIndexValue got1, got2;
+        if (!store.get(txn.handle(), "ab", { 'c' }, got1)) {
+            throw std::runtime_error("ab/c not found");
+        }
+        if (!store.get(txn.handle(), "a", { 'b', 'c' }, got2)) {
+            throw std::runtime_error("a/bc not found");
+        }
+
+        IdentityIndexValue canon;
+        canon.storage_key = { 0xAA };
+        canon.origin_node_id = make_node(0xC3);
+        canon.seq = 1;
+        if (got1.storage_key != canon.storage_key ||
+            got2.storage_key != canon.storage_key) {
+            throw std::runtime_error("collision: two distinct keys collapsed to one record");
+        }
+        txn.commit();
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 } // namespace
 
 int main() {
@@ -235,5 +364,8 @@ int main() {
     test_changelog_store();
     test_applied_store();
     test_identity_index_store();
+    test_changelog_prune_up_to_boundary();
+    test_changelog_prune_does_not_touch_other_origin();
+    test_identity_key_collision();
     return 0;
 }

--- a/tests/test_sync_stores.cpp
+++ b/tests/test_sync_stores.cpp
@@ -357,6 +357,77 @@ void test_identity_key_collision() {
     cleanup(p);
 }
 
+template<class Store, class Op>
+void expect_open_required(const std::string& label, Store& store, Op op) {
+    bool caught = false;
+    try {
+        op();
+    } catch (const std::logic_error&) {
+        caught = true;
+    } catch (const mdbxc::MdbxException&) {
+        caught = true;
+    }
+    if (!caught) {
+        throw std::runtime_error(label + ": expected logic_error or MdbxException before open()");
+    }
+}
+
+void test_stores_require_open() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_open_required.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+
+        MetaStore meta(conn->env_handle());
+        expect_open_required("MetaStore::get_db_uuid", meta,
+                            [&] { (void)meta.get_db_uuid(txn.handle()); });
+        expect_open_required("MetaStore::set_db_uuid", meta,
+                            [&] { meta.set_db_uuid(txn.handle(), make_node(0xA0)); });
+        expect_open_required("MetaStore::get_local_seq", meta,
+                            [&] { (void)meta.get_local_seq(txn.handle()); });
+        expect_open_required("MetaStore::increment_local_seq", meta,
+                            [&] { (void)meta.increment_local_seq(txn.handle()); });
+
+        AppliedStore applied(conn->env_handle());
+        expect_open_required("AppliedStore::last_applied_seq", applied,
+                            [&] { (void)applied.last_applied_seq(txn.handle(), make_node(0xB0)); });
+        expect_open_required("AppliedStore::set_last_applied_seq", applied,
+                            [&] { applied.set_last_applied_seq(txn.handle(), make_node(0xB0), 1); });
+
+        ChangeLogStore change(conn->env_handle());
+        expect_open_required("ChangeLogStore::append", change,
+                            [&] { change.append(txn.handle(), make_node(0xC0), 1, { 0x01 }); });
+        expect_open_required("ChangeLogStore::contains", change,
+                            [&] { (void)change.contains(txn.handle(), make_node(0xC0), 1); });
+        expect_open_required("ChangeLogStore::erase", change,
+                            [&] { (void)change.erase(txn.handle(), make_node(0xC0), 1); });
+        expect_open_required("ChangeLogStore::prune_up_to", change,
+                            [&] { (void)change.prune_up_to(txn.handle(), make_node(0xC0), 1); });
+
+        IdentityIndexStore identity(conn->env_handle());
+        IdentityIndexValue iv;
+        expect_open_required("IdentityIndexStore::put", identity,
+                            [&] { identity.put(txn.handle(), "t", { 0x01 }, iv); });
+        expect_open_required("IdentityIndexStore::get", identity,
+                            [&] { (void)identity.get(txn.handle(), "t", { 0x01 }, iv); });
+        expect_open_required("IdentityIndexStore::tombstone", identity,
+                            [&] { identity.tombstone(txn.handle(), "t", { 0x01 }, iv); });
+        expect_open_required("IdentityIndexStore::erase", identity,
+                            [&] { (void)identity.erase(txn.handle(), "t", { 0x01 }); });
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 } // namespace
 
 int main() {
@@ -367,5 +438,6 @@ int main() {
     test_changelog_prune_up_to_boundary();
     test_changelog_prune_does_not_touch_other_origin();
     test_identity_key_collision();
+    test_stores_require_open();
     return 0;
 }


### PR DESCRIPTION
## Summary

Add the four named DBI wrappers that the sync engine will use as its on-disk state. No \`Connection\` or table API changes; this is purely the storage layer that subsequent PRs will read/write.

## New files

- \`include/mdbx_containers/sync/stores/MetaStore.hpp\` — \`_mdbxc_meta\`: \`db_uuid\`, \`node_id\`, \`schema_version\`, \`local_seq\` (atomic \`increment_local_seq\`), \`created_at_ms\`. Fixed-width keys (single byte tag) so values stay compact and migration-safe.
- \`include/mdbx_containers/sync/stores/ChangeLogStore.hpp\` — \`_mdbxc_changelog\`: \`(origin_node_id, seq)\` → raw \`ChangeBatch\` bytes. \`MDBX_NOOVERWRITE\` so accidental re-use surfaces immediately. Includes \`prune_up_to()\` for retention.
- \`include/mdbx_containers/sync/stores/AppliedStore.hpp\` — \`_mdbxc_applied\`: \`origin_node_id\` → last contiguous applied \`seq\` (u64 le).
- \`include/mdbx_containers/sync/stores/IdentityIndexStore.hpp\` — \`_mdbxc_identity_index\`: \`(dbi_name, identity_key)\` → \`IdentityIndexValue\` (storage_key, origin, seq, revision_key, flags). \`tombstone()\` sets the \`IDENTITY_TOMBSTONE\` flag rather than deleting, so older incoming batches can still resolve the logical record.
- \`tests/test_sync_stores.cpp\` — covers all four stores: open / write / read roundtrip, identity tombstone roundtrip, last_applied_seq across multiple origins, schema_version roundtrip.

## Support changes

- \`include/mdbx_containers/Sync.hpp\` now pulls the four store headers when \`MDBXC_SYNC_ENABLED\` is set.
- \`include/mdbx_containers/detail/utils.hpp\` is now self-contained (own STL + \`MdbxException\` includes) so headers depending on it without transitively including \`common.hpp\` compile cleanly. Verified the existing 21-test suite still passes in C++17 and C++11 after this change.

## Decisions captured

- All store APIs take an explicit \`MDBX_txn*\` so the caller controls transaction lifetime. The wrapper owns only the DBI handle, opened once per environment.
- Identity records use a tombstone flag instead of immediate delete so later batches can still resolve a logical key even after the originator deleted it. Pruning is explicit (\`erase\`) when the application no longer needs the historical mapping.
- ChangeLogStore \`prune_up_to\` uses \`MDBX_SET_RANGE\` + a hi-key upper bound, so it stops as soon as it walks past the requested \`(origin, up_to)\` boundary even when other origins interleave in the DBI.

## Tests

- C++17 ctest: 21/21 passed (was 20/20 before, now includes \`test_sync_stores\`).
- C++11: \`test_sync_stores\` passed.
- The 21 existing tests still pass after the \`detail/utils.hpp\` change, so the broader public surface is unaffected.

## Out of scope (later PRs)

- \`SyncEngine\` that consumes these stores
- Change capture in \`BaseTable\` + \`Transaction::commit\` pre-commit hook
- \`IdentityProvider\` integration