### PR TITLE
docs(sync): add DESIGN.md and implementation-notes subsection

### DIFF
--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -169,3 +169,36 @@ exceeded.
 - Guard C++17-only facilities with the existing `__cplusplus >= 201703L`
   pattern or provide a C++11 fallback.
 - Avoid MSVC-specific assumptions; Windows CI targets MinGW.
+
+## Sync Subsystem
+
+The optional replication layer lives under `include/mdbx_containers/sync/`
+and is gated by `MDBXC_SYNC_ENABLED`. The full design record with
+endianness policy, store layouts, codec contract, and what is explicitly
+deferred to v0.2 lives in
+[`include/mdbx_containers/sync/DESIGN.md`](../include/mdbx_containers/sync/DESIGN.md).
+
+Operational rules:
+
+- Read `DESIGN.md` before changing any sync header, the `ChangeBatchCodec`
+  layout, or any store's key encoding. These are wire-format and on-disk
+  contracts; changes break data on disk and break other nodes.
+- Endianness policy (LE for payloads, BE only when a key participates in a
+  numeric range scan) is documented in `DESIGN.md`. Do not "fix" the BE
+  seq field in `ChangeLogStore::encode_key` back to LE — the change was
+  intentional and required for correct range scan order.
+- `IdentityIndexValue` is an opaque payload keyed by a length-prefixed
+  composite. Do not add length-prefixes inside the value — the value is
+  single-valued per key, so prefixes solve no collision there.
+- Tombstones in `IdentityIndexStore` use the `IDENTITY_TOMBSTONE` flag bit,
+  not `erase()`. Older incoming batches may still need to resolve the
+  logical key; real removal is explicit.
+- The four stores each have an `ensure_open()` guard on every public
+  method. Calling a method before `open()` throws `std::logic_error` rather
+  than silently writing to DBI 0. Do not weaken this guard.
+- `ConflictPolicy::Reject` is the v0.1 default. `LastWriterWins` exists
+  but only with deterministic tie-break (`max(time_unix_ns, origin_node_id)`
+  when no `revision_key` is supplied). `Custom` is deferred to v0.2.
+- `HashedKeyValueStore`, `KeyMultiValueTable`, and `AnyValueTable` are
+  not replicated in v0.1; their wire format is not defined. Do not add
+  `record_op()` paths for them without first extending `DESIGN.md`.

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -187,18 +187,22 @@ Operational rules:
   numeric range scan) is documented in `DESIGN.md`. Do not "fix" the BE
   seq field in `ChangeLogStore::encode_key` back to LE — the change was
   intentional and required for correct range scan order.
-- `IdentityIndexValue` is an opaque payload keyed by a length-prefixed
-  composite. Do not add length-prefixes inside the value — the value is
-  single-valued per key, so prefixes solve no collision there.
+- `IdentityIndexValue` is an opaque structured payload keyed by a
+  length-prefixed composite. Variable-size fields inside the value
+  (`storage_key`, `revision_key`) are themselves length-prefixed for
+  decoding. Do **not** add an extra outer MDBX-value prefix — the value is
+  single-valued per key, so an outer prefix would solve no collision there.
 - Tombstones in `IdentityIndexStore` use the `IDENTITY_TOMBSTONE` flag bit,
   not `erase()`. Older incoming batches may still need to resolve the
   logical key; real removal is explicit.
 - The four stores each have an `ensure_open()` guard on every public
   method. Calling a method before `open()` throws `std::logic_error` rather
   than silently writing to DBI 0. Do not weaken this guard.
-- `ConflictPolicy::Reject` is the v0.1 default. `LastWriterWins` exists
-  but only with deterministic tie-break (`max(time_unix_ns, origin_node_id)`
-  when no `revision_key` is supplied). `Custom` is deferred to v0.2.
+- `ConflictPolicy::Reject` is the v0.1 default. `LastWriterWins` is
+  opt-in and must be deterministic. Prefer `revision_key` when present; if
+  no `revision_key` exists, the exact fallback must be defined in
+  `SyncEngine` and documented before use. `time_unix_ns` is metadata, not
+  a reliable conflict authority. `Custom` is deferred to v0.2.
 - `HashedKeyValueStore`, `KeyMultiValueTable`, and `AnyValueTable` are
   not replicated in v0.1; their wire format is not defined. Do not add
   `record_op()` paths for them without first extending `DESIGN.md`.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -189,19 +189,24 @@ when the current key compares greater than `hi` (or when the cursor runs
 out of records). This is the only documented way; alternatives either
 don't exist or fail on the first record.
 
-## Why `IdentityIndexValue` does not get length-prefixed fields
+## Why `IdentityIndexValue` does not get an extra outer value prefix
 
-Only the **key** is subject to MDBX bytewise uniqueness — different keys
-can hash to the same key bytes, in which case they collide in the DBI.
-The **value** for a given key is single-valued and never compares against
-any other value (codec-level equality, not identity). Adding length-prefix
-inside the value would inflate every record without solving a real problem,
-and would force every consumer to know two parallel encodings instead of
-one structured payload.
+Only the **key** is subject to MDBX bytewise uniqueness — different logical
+keys can collapse to the same key bytes if the composite key is not encoded
+unambiguously. That is why the identity-index key uses:
 
-When HLC or similar lands in v0.2, it goes in as **opaque bytes inside
-`revision_key`** — already a structured payload field, no length-prefix
-needed.
+    u32 dbi_name_len le ‖ dbi_name bytes ‖ identity_key bytes
+
+The **value** for a given key is single-valued and never participates in MDBX
+key comparison. It is still a structured payload, so variable-size fields
+inside the value (`storage_key`, `revision_key`) are length-prefixed where
+needed for decoding.
+
+Do not add an extra outer MDBX-value prefix around `IdentityIndexValue`;
+the MDBX value length is already known from `MDBX_val::iov_len`.
+
+When HLC or similar lands in v0.2, it goes in as opaque bytes inside
+`revision_key`.
 
 ## Deferred to v0.2 with no open issue yet
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1,28 +1,39 @@
-# Sync Subsystem Design (v0.1)
+# Sync Subsystem Design (target: v0.1)
 
 > Reading order for any agent considering changes to the sync subsystem.
-> v0.1 is the foundation layer: types, codec, stores, change capture. The
-> actual sync algorithm (`SyncEngine`, transports) lands in later commits.
+> This document locks in decisions that have wire- or disk-format consequences
+> so future agents do not silently change them. It also distinguishes
+> **already implemented** from **planned for v0.1** to keep the contract
+> honest as the codebase evolves.
 
 ## Scope
 
 Multi-master replication of logical MDBX tables between node-local envs.
 Wire is transport-agnostic, codec is versioned, storage is four named DBIs.
-This document locks in decisions that have wire- or disk-format consequences
-so future agents do not silently change them.
 
-## What v0.1 covers
+## Already implemented (merged into main)
 
-- Four stores: `MetaStore`, `ChangeLogStore`, `AppliedStore`, `IdentityIndexStore`.
-- `ChangeBatchCodec` with strict versioned wire format (magic, codec version,
-  batch version, batch flags, then payload).
+- Public types in `include/mdbx_containers/sync/`:
+  `Common`, `ChangeBatch`, `ChangeOp`, `CodecFlags`, `CodecBounds`,
+  `Protocol`, `SyncCursor`, `ConflictPolicy`, `ISyncPeer`,
+  `IdentityProvider`, `ChangeBatchCodec`.
+- Four system stores under `include/mdbx_containers/sync/stores/`:
+  `MetaStore`, `ChangeLogStore`, `AppliedStore`, `IdentityIndexStore`.
+- `ChangeBatchCodec` strict versioned wire format (magic, codec version,
+  batch version, batch flags, then payload); rejects unknown mandatory
+  flags and version mismatches at both encode and decode.
+
+## Planned before v0.1 release (NOT YET implemented)
+
 - Change capture: pre-commit hook in `Transaction::commit` writes a
   `ChangeBatch` to `ChangeLogStore` inside the same write transaction.
-- `SyncEngine` + `DirectSyncPeer` for in-process replication.
-- Full export/import via `seq=0, BATCH_HAS_MORE` chunks.
-- `ConflictPolicy::Reject` default, `LastWriterWins` opt-in.
-- Replicated tables: `KeyValueTable`, `KeyTable`, `ValueTable`, `SequenceTable`
-  (single-writer for `append`; `insert_or_assign`/`set`/`erase`/`clear` normal).
+- `SyncEngine` (pull/push/apply protocol logic, gap handling).
+- `DirectSyncPeer` for in-process tests of `SyncEngine`.
+- Full export/import via `seq=0, BATCH_HAS_MORE` chunks for empty replicas.
+- Replicated table operation coverage: `KeyValueTable`, `KeyTable`,
+  `ValueTable`, `SequenceTable` (single-writer for `append`;
+  `insert_or_assign`/`set`/`erase`/`clear` normal).
+- `ConflictPolicy::Reject` is the default; `LastWriterWins` is opt-in.
 
 ## What v0.1 does NOT cover (deferred to v0.2)
 
@@ -33,8 +44,10 @@ so future agents do not silently change them.
 - `IdentityProvider` integration in `BaseTable` — declared in v0.1, no
   write path until HashedKeyValueStore.
 - Automatic remap of physical `storage_key` from logical `identity_key`.
-- HLC for `LastWriterWins` ties — `time_unix_ns` is metadata only; tie-break
-  currently falls back to `origin_node_id` if no `revision_key` is supplied.
+- HLC for `LastWriterWins` — `time_unix_ns` is metadata only, not a reliable
+  conflict authority. The exact tie-break rule (revision_key priority,
+  fallback when no revision_key is supplied) must be defined in `SyncEngine`
+  and documented before `LastWriterWins` is used in a non-test path.
 - `Custom` conflict resolver — schema-level callback; deferred until the
   first real consumer needs it.
 - HTTP and WebSocket transports (`Simple-Web-Server`,
@@ -124,7 +137,7 @@ contract:
 - Decoder rejects trailing bytes when called with `bytes_read == nullptr`
   or via `decode_exact`.
 
-## Sync flow
+## Sync flow (planned v0.1 behavior, not yet implemented)
 
 Default round shape, single-writer friendly and the base case for
 multi-master:

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1,0 +1,203 @@
+# Sync Subsystem Design (v0.1)
+
+> Reading order for any agent considering changes to the sync subsystem.
+> v0.1 is the foundation layer: types, codec, stores, change capture. The
+> actual sync algorithm (`SyncEngine`, transports) lands in later commits.
+
+## Scope
+
+Multi-master replication of logical MDBX tables between node-local envs.
+Wire is transport-agnostic, codec is versioned, storage is four named DBIs.
+This document locks in decisions that have wire- or disk-format consequences
+so future agents do not silently change them.
+
+## What v0.1 covers
+
+- Four stores: `MetaStore`, `ChangeLogStore`, `AppliedStore`, `IdentityIndexStore`.
+- `ChangeBatchCodec` with strict versioned wire format (magic, codec version,
+  batch version, batch flags, then payload).
+- Change capture: pre-commit hook in `Transaction::commit` writes a
+  `ChangeBatch` to `ChangeLogStore` inside the same write transaction.
+- `SyncEngine` + `DirectSyncPeer` for in-process replication.
+- Full export/import via `seq=0, BATCH_HAS_MORE` chunks.
+- `ConflictPolicy::Reject` default, `LastWriterWins` opt-in.
+- Replicated tables: `KeyValueTable`, `KeyTable`, `ValueTable`, `SequenceTable`
+  (single-writer for `append`; `insert_or_assign`/`set`/`erase`/`clear` normal).
+
+## What v0.1 does NOT cover (deferred to v0.2)
+
+- `HashedKeyValueStore` — internal hash index layout complicates the wire
+  format; deferred until an explicit identity-mapping scheme lands.
+- `KeyMultiValueTable` — DUPSORT values need per-value length prefixes.
+- `AnyValueTable` — heterogeneous values need type-tag propagation on the wire.
+- `IdentityProvider` integration in `BaseTable` — declared in v0.1, no
+  write path until HashedKeyValueStore.
+- Automatic remap of physical `storage_key` from logical `identity_key`.
+- HLC for `LastWriterWins` ties — `time_unix_ns` is metadata only; tie-break
+  currently falls back to `origin_node_id` if no `revision_key` is supplied.
+- `Custom` conflict resolver — schema-level callback; deferred until the
+  first real consumer needs it.
+- HTTP and WebSocket transports (`Simple-Web-Server`,
+  `Simple-WebSocket-Server`) — guarded build flags; first adapter lands
+  after `DirectSyncPeer` integration test.
+- `zstd` compression — reserved flag, encoder throws, decoder rejects.
+
+## Endianness policy (do not change)
+
+| Layer | Endianness | Reason |
+|-------|------------|--------|
+| Payload integer fields | little-endian | Native on Windows/Linux/ARM; round-trip is platform-agnostic and cheap. |
+| Wire magic, codec version, batch version | ASCII (`MDBXCSYN`) | Independent of byte order. |
+| Codec integer fields (`codec_version`, `batch_version`, `batch_flags`, `seq` field, `time_unix_ns`, `ops_count`, op fields) | little-endian | Never sorted on the wire. |
+| `ChangeLogStore` key `seq` part | **big-endian** | Range scans (`prune_up_to`, future gap detection) must preserve numeric order under MDBX bytewise compare. LE would sort 256 before 1. |
+| `IdentityIndexStore` length prefix `u32 dbi_name_len` | little-endian | Read and written as a single u32, never sorted. |
+| All other key bytes (origins, raw `storage_key`, raw `identity_key`, dbi_name bytes) | opaque bytes | Layout defined by the application, not by the codec. |
+
+If you add a new ordered numeric key in the future: big-endian. If you add
+any new payload integer: little-endian.
+
+## Stores
+
+### `_mdbxc_meta` (MetaStore)
+
+| Tag | Field | Type | Notes |
+|-----|-------|------|-------|
+| `0x01` | `db_uuid` | 16 bytes | Stable for the lifetime of this logical database. |
+| `0x02` | `node_id` | 16 bytes | Stable for the lifetime of this replication node. |
+| `0x03` | `schema_version` | u32 LE | Bumped only when `ChangeBatch` layout or semantics change incompatibly. |
+| `0x04` | `local_seq` | u64 LE | Monotonic per-node counter; `increment_local_seq` is the only mutator. |
+| `0x05` | `created_at_ms` | u64 LE | Wall-clock metadata, not authority for any conflict. |
+
+### `_mdbxc_changelog` (ChangeLogStore)
+
+| | |
+|---|---|
+| Key | `origin_node_id (16 raw) ‖ seq (8 BE)` |
+| Value | raw `ChangeBatchCodec::encode()` bytes, opaque to this store |
+| Insertion | `MDBX_NOOVERWRITE` so accidental `(origin, seq)` reuse throws |
+| Retention | explicit `prune_up_to(origin, up_to)` removes records where `seq <= up_to` |
+
+`prune_up_to` opens a cursor, walks from `(origin, 0)` until `mdbx_cmp > (origin, up_to)`,
+deletes each hit, then closes. The boundary comparison is on the bytewise
+key, which is why `seq` is big-endian in the key.
+
+### `_mdbxc_applied` (AppliedStore)
+
+| | |
+|---|---|
+| Key | `origin_node_id` (16 raw bytes) |
+| Value | u64 LE — last contiguous applied `seq` |
+
+`SyncEngine` invariant: writes to this store are always contiguous. If
+`incoming.seq > last + 1`, the receiver keeps the incoming batch pending
+until the gap closes. If `incoming.seq <= last`, the batch is a redundant
+replay and is skipped.
+
+### `_mdbxc_identity_index` (IdentityIndexStore) — declared in v0.1, write path deferred
+
+| | |
+|---|---|
+| Key | `u32 dbi_name_len le ‖ dbi_name bytes ‖ identity_key bytes` |
+| Value | `IdentityIndexValue { storage_key, origin_node_id, seq, revision_key, flags }` |
+
+Length-prefix on `dbi_name` is mandatory: without it, `("ab","c")` and
+`("a","bc")` collide on the same record. The value layout is opaque and
+must contain enough metadata to resolve an `(dbi, identity_key)` entry
+back to a physical `storage_key` without re-reading the user table.
+
+`IDENTITY_TOMBSTONE` flag bit marks deleted logical records while keeping
+the row readable for older incoming batches that still reference the key.
+Real removal is explicit via `erase()`.
+
+## Codec — `ChangeBatchCodec`
+
+See `ChangeBatchCodec.hpp` layout comment for the full byte layout. Locked
+contract:
+
+- Magic: 8 bytes `MDBXCSYN`.
+- Mandatory unknown batch flag bits → decoder throws.
+- `BATCH_COMPRESSED_ZSTD` is reserved and rejected at both encode and
+  decode paths in v0.1.
+- Encoder rejects `ChangeBatch::version != 1`, `op_type > ClearTable`,
+  unknown op flag bits, `OP_TOMBSTONE` with non-empty value, and the
+  `OP_HAS_*_KEY` flags with empty payloads.
+- Decoder rejects trailing bytes when called with `bytes_read == nullptr`
+  or via `decode_exact`.
+
+## Sync flow
+
+Default round shape, single-writer friendly and the base case for
+multi-master:
+
+```
+origin A writes
+    -> Transaction::commit pre-commit hook
+        -> ChangeAccumulator.flush (writes ChangeLogStore + IdentityIndexStore)
+            -> mdbx_txn_commit() — changes land atomically
+
+receiver B
+    -> pull / push via ISyncPeer
+        -> SyncEngine.handle_push / handle_pull
+            -> begin write txn
+                if already_applied(origin, seq): commit no-op
+                for op in batch.ops: apply raw dbi_op
+                mark_applied(origin, seq)
+            -> commit
+```
+
+Multi-master initial sync of an empty replica:
+
+```
+B: empty cursor
+    -> pull request, have = empty
+A: detects request_full_snapshot
+    -> streams ChangeBatches with seq=0 and BATCH_HAS_MORE until done
+B: applies each batch as above
+    -> onward sync is incremental pull-from-have
+```
+
+## Why `prune_up_to` uses cursor walk + `MDBX_NEXT`
+
+MDBX has no batch "delete by key range" primitive. The supported pattern
+for walking and deleting a range is:
+
+```
+cursor open
+cursor get(MDBX_SET_RANGE, lo) -> k
+while cmp(k, hi) <= 0:
+    cursor_del(MDBX_CURRENT)
+    cursor get(MDBX_NEXT) -> k
+cursor close
+```
+
+After `cursor_del`, the cursor stays logically on the deleted position; the
+next `MDBX_NEXT` advances to the next live record. The loop terminates
+when the current key compares greater than `hi` (or when the cursor runs
+out of records). This is the only documented way; alternatives either
+don't exist or fail on the first record.
+
+## Why `IdentityIndexValue` does not get length-prefixed fields
+
+Only the **key** is subject to MDBX bytewise uniqueness — different keys
+can hash to the same key bytes, in which case they collide in the DBI.
+The **value** for a given key is single-valued and never compares against
+any other value (codec-level equality, not identity). Adding length-prefix
+inside the value would inflate every record without solving a real problem,
+and would force every consumer to know two parallel encodings instead of
+one structured payload.
+
+When HLC or similar lands in v0.2, it goes in as **opaque bytes inside
+`revision_key`** — already a structured payload field, no length-prefix
+needed.
+
+## Deferred to v0.2 with no open issue yet
+
+- `meta_schema_version()` currently returns 1; bump rule + migration
+  procedure not defined.
+- `SyncEngine` API surface (`SyncEngine(Connection&)` vs factory,
+  pull/push ordering, per-batch txn commit semantics).
+- SyncEngine ownership model relative to `Connection` — currently
+  `Connection::attach_sync_engine(SyncEngine*)` is the design direction,
+  non-owning, lifetime explicitly documented.
+- `PeerRegistry` for multi-peer fan-out — single peer per sync invocation
+  in v0.1.


### PR DESCRIPTION
Lock in design decisions for the sync subsystem before more code lands.

include/mdbx_containers/sync/DESIGN.md captures v0.1 scope, explicit v0.2 deferrals, the endianness policy, per-store key/value layouts, codec contract, and rationale notes (why cursor_del + MDBX_NEXT for prune_up_to, why IdentityIndexValue is not length-prefixed).

guides/implementation-notes.md gains a 'Sync Subsystem' subsection pointing to DESIGN.md and listing operational rules for future agents.

Docs only. No code, no API surface change. Ctest 21/21 still passes.