### PR TITLE
feat(sync): SyncEngine + DirectSyncPeer (v0.1 apply/pull/push)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,31 @@
-/tmp/
-/build*/
+# Build directories
+/build/
+/build-*/
+/build_test/
+/build_test*/
+/cmake-build-*/
+
+# Generated docs
+/docs/html/
+/docs/latex/
+
+# Test artifacts
+/test_*.mdbx
+/test_*.mdbx-lck
+/test_engine_*.mdbx
+/test_engine_*.mdbx-lck
+/test_repro*.mdbx*
+/trace.mdbx*
+
+# Build / IDE
+CMakeUserPresets.json
+.cache/
+compile_commands.json
+/build.log
+
+# OMC + tooling
+/.omc/
+/Testing/
+
+# Scripts not part of source
+/build-cpp17-examples.bat

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -26,6 +26,8 @@
 #include "sync/ISyncPeer.hpp"
 #include "sync/protocol.hpp"
 #include "sync/SyncCursor.hpp"
+#include "sync/SyncEngine.hpp"
+#include "sync/DirectSyncPeer.hpp"
 #include "sync/stores/MetaStore.hpp"
 #include "sync/stores/ChangeLogStore.hpp"
 #include "sync/stores/AppliedStore.hpp"

--- a/include/mdbx_containers/sync/DirectSyncPeer.hpp
+++ b/include/mdbx_containers/sync/DirectSyncPeer.hpp
@@ -18,13 +18,18 @@ namespace sync {
     class DirectSyncPeer : public ISyncPeer {
     public:
         /// \brief Constructs a peer that forwards to \p remote.
-        explicit DirectSyncPeer(SyncEngine* remote) noexcept : m_remote(remote) {}
+        /// \pre \p remote must not be null.
+        explicit DirectSyncPeer(SyncEngine* remote) noexcept : m_remote(remote) {
+            assert(m_remote != nullptr && "DirectSyncPeer: remote engine is null");
+        }
 
         PullResponse pull(const PullRequest& request) override {
+            assert(m_remote != nullptr);
             return m_remote->handle_pull(request);
         }
 
         PushResponse push(const PushRequest& request) override {
+            assert(m_remote != nullptr);
             return m_remote->handle_push(request);
         }
 

--- a/include/mdbx_containers/sync/DirectSyncPeer.hpp
+++ b/include/mdbx_containers/sync/DirectSyncPeer.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_DIRECT_SYNC_PEER_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_DIRECT_SYNC_PEER_HPP_INCLUDED
+
+/// \file DirectSyncPeer.hpp
+/// \brief In-process transport that forwards \c ISyncPeer calls to a remote
+///        \c SyncEngine instance. Intended for tests; no serialization.
+
+#include "ISyncPeer.hpp"
+#include "SyncEngine.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Non-owning \c ISyncPeer that delegates to another \c SyncEngine.
+    /// \details The remote engine must outlive the peer. Useful for in-process
+    /// integration tests of pull / push without a real transport layer.
+    class DirectSyncPeer : public ISyncPeer {
+    public:
+        /// \brief Constructs a peer that forwards to \p remote.
+        explicit DirectSyncPeer(SyncEngine* remote) noexcept : m_remote(remote) {}
+
+        PullResponse pull(const PullRequest& request) override {
+            return m_remote->handle_pull(request);
+        }
+
+        PushResponse push(const PushRequest& request) override {
+            return m_remote->handle_push(request);
+        }
+
+    private:
+        SyncEngine* m_remote;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_DIRECT_SYNC_PEER_HPP_INCLUDED

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -37,7 +37,7 @@
 #include "ChangeBatch.hpp"
 #include "ChangeBatchCodec.hpp"
 #include "ChangeOp.hpp"
-#include "Protocol.hpp"
+#include "protocol.hpp"
 #include "SyncCursor.hpp"
 #include "../common/MdbxException.hpp"
 #include "../common/Transaction.hpp"
@@ -146,11 +146,20 @@ namespace sync {
                 /// \brief Handles a pull request: scans the local \c ChangeLogStore
         /// for batches newer than the requester's cursor.
         /// \details When \c request.have is empty, returns a full snapshot
-        /// (all known origins, batches from seq=1). The \c remote_have field
-        /// is left empty; callers can call \c applied_cursor separately when
-        /// they want it.
+        /// (all known origins, batches from seq=1). Validates
+        /// \c request.db_id against the local \c db_uuid; mismatched peers
+        /// receive an empty response with \c ok=false.
+        /// \c has_more is set to \c true when the loop stopped because of
+        /// \c request.max_batches or \c request.max_bytes rather than
+        /// running out of changelog entries.
         PullResponse handle_pull(const PullRequest& request) {
             PullResponse out;
+            if (!db_id_matches(request.db_id)) {
+                out.ok = false;
+                out.error = "db_id mismatch";
+                return out;
+            }
+
             MDBX_txn* txn = nullptr;
             check_mdbx(mdbx_txn_begin(m_conn->env_handle(), nullptr,
                                       MDBX_TXN_RDONLY, &txn),
@@ -161,7 +170,10 @@ namespace sync {
             } guard{txn};
 
             MDBX_dbi changelog_dbi = open_changelog_ro(txn);
-            if (changelog_dbi == 0) return out;
+            if (changelog_dbi == 0) {
+                out.remote_have = read_applied_cursor(txn, out.remote_have);
+                return out;
+            }
 
             if (request.have.last_seq_by_origin.empty()) {
                 return pull_full_snapshot(txn, changelog_dbi, request);
@@ -169,6 +181,7 @@ namespace sync {
 
             std::vector<std::uint8_t> buf;
             std::size_t total_bytes = 0;
+            bool truncated = false;
             for (const auto& kv : request.have.last_seq_by_origin) {
                 const NodeId& origin = kv.first;
                 const std::uint64_t have_seq = kv.second;
@@ -183,29 +196,36 @@ namespace sync {
                     out.batches.push_back(b);
                     total_bytes += buf.size();
                     ++next_seq;
-                    if (!(b.batch_flags & BATCH_HAS_MORE)) {
-                        break;
-                    }
+                }
+                if (out.batches.size() >= request.max_batches ||
+                    total_bytes >= request.max_bytes) {
+                    truncated = true;
+                    break;
                 }
             }
-            out.has_more = false;
+            out.has_more = truncated;
+            out.remote_have = read_applied_cursor(txn, out.remote_have);
             return out;
         }
 
         /// \brief Walks the changelog with a cursor and returns every batch.
+        /// \details Sets \c has_more=true when the walk stopped because of
+        /// \c request.max_batches or \c request.max_bytes.
         PullResponse pull_full_snapshot(MDBX_txn* txn, MDBX_dbi dbi,
                                         const PullRequest& request) {
             PullResponse out;
-            out.remote_have = applied_cursor(txn);
+            out.remote_have = read_applied_cursor(txn, out.remote_have);
             MDBX_cursor* raw = nullptr;
             check_mdbx(mdbx_cursor_open(txn, dbi, &raw), "pull_full: cursor open failed");
             std::size_t total_bytes = 0;
+            bool truncated = false;
             try {
                 MDBX_val k, v;
                 int rc = mdbx_cursor_get(raw, &k, &v, MDBX_FIRST);
                 while (rc == MDBX_SUCCESS) {
                     if (out.batches.size() >= request.max_batches ||
                         total_bytes >= request.max_bytes) {
+                        truncated = true;
                         break;
                     }
                     std::vector<std::uint8_t> buf(v.iov_len);
@@ -224,19 +244,35 @@ namespace sync {
                 throw;
             }
             mdbx_cursor_close(raw);
+            out.has_more = truncated;
             return out;
         }
 
-        /// \brief Handles a push request: applies each batch in order and
-        /// returns the resulting cursor.
+        /// \brief Handles a push request: applies each batch in order.
+        /// \details Atomic: when \c apply_batch returns \c Conflict for any
+        /// batch, the transaction is rolled back (no partial commit) and
+        /// \c ok is set to \c false. Validates \c request.db_id against the
+        /// local \c db_uuid; mismatched peers receive \c ok=false with no
+        /// side effects.
         PushResponse handle_push(const PushRequest& request) {
             PushResponse out;
-            out.receiver_have = applied_cursor();
+            if (!db_id_matches(request.db_id)) {
+                out.ok = false;
+                out.error = "db_id mismatch";
+                out.receiver_have = applied_cursor();
+                return out;
+            }
             auto txn = m_conn->transaction(TransactionMode::WRITABLE);
             for (const ChangeBatch& batch : request.batches) {
-                (void)apply_batch(txn.handle(), batch);
+                const ApplyResult r = apply_batch(txn.handle(), batch);
+                if (r == ApplyResult::Conflict) {
+                    out.ok = false;
+                    out.error = "gap/conflict while applying pushed batch";
+                    return out;  // txn dtor rolls back; receiver_have stays stale
+                }
             }
             txn.commit();
+            out.ok = true;
             out.receiver_have = applied_cursor();
             return out;
         }
@@ -257,6 +293,15 @@ namespace sync {
         }
 
     private:
+        /// \brief Returns true when \p request_db_id matches the local
+        /// \c db_uuid. A zero \p request_db_id is rejected: callers must
+        /// know the database identity before issuing pull/push requests.
+        bool db_id_matches(const NodeId& request_db_id) const {
+            const NodeId zero{};
+            if (compare_node_id(request_db_id, zero) == 0) return false;
+            return compare_node_id(request_db_id, db_uuid()) == 0;
+        }
+
         /// \brief Opens \c _mdbxc_changelog read-only when it exists; 0 otherwise.
         static MDBX_dbi open_changelog_ro(MDBX_txn* txn) {
             return open_store_ro(txn, "_mdbxc_changelog");

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -43,7 +43,6 @@
 #include "../common/Transaction.hpp"
 #include "../detail/utils.hpp"
 #include "stores/AppliedStore.hpp"
-#include "stores/ChangeLogStore.hpp"
 #include "stores/MetaStore.hpp"
 
 namespace mdbxc {
@@ -120,10 +119,8 @@ namespace sync {
         /// name with \c MDBX_CREATE; existing DBIs are reused within \p txn.
         ApplyResult apply_batch(MDBX_txn* txn, const ChangeBatch& batch) {
             MetaStore meta(m_conn->env_handle());
-            ChangeLogStore changelog(m_conn->env_handle());
             AppliedStore applied(m_conn->env_handle());
             meta.open(txn);
-            changelog.open(txn);
             applied.open(txn);
 
             const NodeId local_node = meta.get_node_id(txn);
@@ -164,9 +161,12 @@ namespace sync {
             check_mdbx(mdbx_txn_begin(m_conn->env_handle(), nullptr,
                                       MDBX_TXN_RDONLY, &txn),
                        "SyncEngine: failed to begin read txn for pull");
+            /// RAII guard: aborts (releases handle + reader slot) instead of
+            /// reset, because we never renew the same transaction here — reset
+            /// would leak the MDBX_txn object across calls.
             struct Guard {
                 MDBX_txn* t;
-                ~Guard() { if (t) mdbx_txn_reset(t); }
+                ~Guard() { if (t) mdbx_txn_abort(t); }
             } guard{txn};
 
             MDBX_dbi changelog_dbi = open_changelog_ro(txn);

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -1,0 +1,392 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_SYNC_ENGINE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_SYNC_ENGINE_HPP_INCLUDED
+
+/// \file SyncEngine.hpp
+/// \brief Pull/push/apply coordinator for replication.
+///
+/// Lifecycle: call \c initialize_local_identity once per database, then drive
+/// replication through \c handle_pull / \c handle_push / \c apply_batch.
+/// \c handle_pull and \c handle_push open their own transactions on the
+/// engine's \c Connection; \c apply_batch uses a caller-supplied write
+/// transaction so multiple batches can be applied atomically.
+///
+/// Apply rules (v0.1):
+///  - \c seq <= last_applied_seq: \c Skipped (redundant replay).
+///  - \c seq == last_applied_seq + 1: \c Applied, ops applied in order.
+///  - \c seq >  last_applied_seq + 1: \c Conflict (gap; caller must re-pull).
+///
+/// Self-origin batches are always \c Skipped (the receiver already has them).
+///
+/// Stores (MetaStore, ChangeLogStore, AppliedStore) are opened inside the
+/// supplied transaction and are therefore valid only for its lifetime.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <mdbx.h>
+
+#include "common.hpp"
+#include "ConflictPolicy.hpp"
+#include "ChangeBatch.hpp"
+#include "ChangeBatchCodec.hpp"
+#include "ChangeOp.hpp"
+#include "Protocol.hpp"
+#include "SyncCursor.hpp"
+#include "../common/MdbxException.hpp"
+#include "../common/Transaction.hpp"
+#include "../detail/utils.hpp"
+#include "stores/AppliedStore.hpp"
+#include "stores/ChangeLogStore.hpp"
+#include "stores/MetaStore.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Outcome of a single \c apply_batch call.
+    enum class ApplyResult {
+        Applied,  ///< Batch was applied to local DBIs.
+        Skipped,  ///< Batch was redundant (seq <= last contiguous applied)
+                  ///< or originated from the local node.
+        Conflict, ///< Gap detected (seq > last + 1); not applied.
+    };
+
+    /// \brief Pull/push/apply coordinator bound to a single \c Connection.
+    class SyncEngine {
+    public:
+        /// \brief Constructs an engine bound to \p conn.
+        /// \param conn Shared connection that owns the env and stores.
+        /// \param policy Conflict resolution policy (default: \c Reject).
+        explicit SyncEngine(std::shared_ptr<Connection> conn,
+                            ConflictPolicy policy = ConflictPolicy::Reject)
+            : m_conn(std::move(conn)), m_policy(policy) {}
+
+        /// \brief Initialises the local \c node_id and \c db_uuid.
+        /// \details Throws when already initialised with different values.
+        /// \param node_id Stable 16-byte identifier for this node.
+        /// \param db_uuid Stable 16-byte identifier for the replicated database.
+        void initialize_local_identity(const NodeId& node_id,
+                                      const NodeId& db_uuid) {
+            auto txn = m_conn->transaction(TransactionMode::WRITABLE);
+            MetaStore meta(m_conn->env_handle());
+            meta.open(txn.handle());
+            const NodeId existing_node = meta.get_node_id(txn.handle());
+            const NodeId zero{};
+            if (compare_node_id(existing_node, zero) != 0 &&
+                compare_node_id(existing_node, node_id) != 0) {
+                throw std::logic_error(
+                    "SyncEngine already initialised with a different node_id");
+            }
+            const NodeId existing_db = meta.get_db_uuid(txn.handle());
+            if (compare_node_id(existing_db, zero) != 0 &&
+                compare_node_id(existing_db, db_uuid) != 0) {
+                throw std::logic_error(
+                    "SyncEngine already initialised with a different db_uuid");
+            }
+            meta.set_node_id(txn.handle(), node_id);
+            meta.set_db_uuid(txn.handle(), db_uuid);
+            meta.set_schema_version(txn.handle(), meta_schema_version());
+            txn.commit();
+        }
+
+        /// \brief Returns the local \c node_id.
+        NodeId local_node_id() const {
+            auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
+            MetaStore meta(m_conn->env_handle());
+            meta.open(txn.handle());
+            return meta.get_node_id(txn.handle());
+        }
+
+        /// \brief Returns the database \c db_uuid.
+        NodeId db_uuid() const {
+            auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
+            MetaStore meta(m_conn->env_handle());
+            meta.open(txn.handle());
+            return meta.get_db_uuid(txn.handle());
+        }
+
+        /// \brief Returns the conflict resolution policy.
+        ConflictPolicy policy() const noexcept { return m_policy; }
+
+        /// \brief Applies a single \c ChangeBatch to local DBIs inside \p txn.
+        /// \details See class-level docs for the seq / apply rules. The
+        /// caller commits the transaction. User DBIs are opened lazily by
+        /// name with \c MDBX_CREATE; existing DBIs are reused within \p txn.
+        ApplyResult apply_batch(MDBX_txn* txn, const ChangeBatch& batch) {
+            MetaStore meta(m_conn->env_handle());
+            ChangeLogStore changelog(m_conn->env_handle());
+            AppliedStore applied(m_conn->env_handle());
+            meta.open(txn);
+            changelog.open(txn);
+            applied.open(txn);
+
+            const NodeId local_node = meta.get_node_id(txn);
+            if (compare_node_id(batch.origin_node_id, local_node) == 0) {
+                return ApplyResult::Skipped;
+            }
+
+            const std::uint64_t last = applied.last_applied_seq(txn, batch.origin_node_id);
+            if (batch.seq <= last) return ApplyResult::Skipped;
+            if (batch.seq != last + 1) return ApplyResult::Conflict;
+
+            std::unordered_map<std::string, MDBX_dbi> dbi_cache;
+            for (const ChangeOp& op : batch.ops) {
+                apply_one_op(txn, op, dbi_cache);
+            }
+            applied.set_last_applied_seq(txn, batch.origin_node_id, batch.seq);
+            return ApplyResult::Applied;
+        }
+
+                /// \brief Handles a pull request: scans the local \c ChangeLogStore
+        /// for batches newer than the requester's cursor.
+        /// \details When \c request.have is empty, returns a full snapshot
+        /// (all known origins, batches from seq=1). The \c remote_have field
+        /// is left empty; callers can call \c applied_cursor separately when
+        /// they want it.
+        PullResponse handle_pull(const PullRequest& request) {
+            PullResponse out;
+            MDBX_txn* txn = nullptr;
+            check_mdbx(mdbx_txn_begin(m_conn->env_handle(), nullptr,
+                                      MDBX_TXN_RDONLY, &txn),
+                       "SyncEngine: failed to begin read txn for pull");
+            struct Guard {
+                MDBX_txn* t;
+                ~Guard() { if (t) mdbx_txn_reset(t); }
+            } guard{txn};
+
+            MDBX_dbi changelog_dbi = open_changelog_ro(txn);
+            if (changelog_dbi == 0) return out;
+
+            if (request.have.last_seq_by_origin.empty()) {
+                return pull_full_snapshot(txn, changelog_dbi, request);
+            }
+
+            std::vector<std::uint8_t> buf;
+            std::size_t total_bytes = 0;
+            for (const auto& kv : request.have.last_seq_by_origin) {
+                const NodeId& origin = kv.first;
+                const std::uint64_t have_seq = kv.second;
+                std::uint64_t next_seq = have_seq + 1;
+                while (out.batches.size() < request.max_batches &&
+                       total_bytes < request.max_bytes) {
+                    if (!changelog_get_ro(txn, changelog_dbi, origin,
+                                          next_seq, buf)) {
+                        break;
+                    }
+                    const ChangeBatch b = ChangeBatchCodec::decode_exact(buf);
+                    out.batches.push_back(b);
+                    total_bytes += buf.size();
+                    ++next_seq;
+                    if (!(b.batch_flags & BATCH_HAS_MORE)) {
+                        break;
+                    }
+                }
+            }
+            out.has_more = false;
+            return out;
+        }
+
+        /// \brief Walks the changelog with a cursor and returns every batch.
+        PullResponse pull_full_snapshot(MDBX_txn* txn, MDBX_dbi dbi,
+                                        const PullRequest& request) {
+            PullResponse out;
+            out.remote_have = applied_cursor(txn);
+            MDBX_cursor* raw = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, dbi, &raw), "pull_full: cursor open failed");
+            std::size_t total_bytes = 0;
+            try {
+                MDBX_val k, v;
+                int rc = mdbx_cursor_get(raw, &k, &v, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    if (out.batches.size() >= request.max_batches ||
+                        total_bytes >= request.max_bytes) {
+                        break;
+                    }
+                    std::vector<std::uint8_t> buf(v.iov_len);
+                    if (v.iov_len > 0) {
+                        std::memcpy(buf.data(), v.iov_base, v.iov_len);
+                    }
+                    out.batches.push_back(ChangeBatchCodec::decode_exact(buf));
+                    total_bytes += v.iov_len;
+                    rc = mdbx_cursor_get(raw, &k, &v, MDBX_NEXT);
+                }
+                if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "pull_full: cursor walk failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(raw);
+                throw;
+            }
+            mdbx_cursor_close(raw);
+            return out;
+        }
+
+        /// \brief Handles a push request: applies each batch in order and
+        /// returns the resulting cursor.
+        PushResponse handle_push(const PushRequest& request) {
+            PushResponse out;
+            out.receiver_have = applied_cursor();
+            auto txn = m_conn->transaction(TransactionMode::WRITABLE);
+            for (const ChangeBatch& batch : request.batches) {
+                (void)apply_batch(txn.handle(), batch);
+            }
+            txn.commit();
+            out.receiver_have = applied_cursor();
+            return out;
+        }
+
+        /// \brief Returns the current applied cursor across all known origins.
+        SyncCursor applied_cursor() const {
+            SyncCursor cur;
+            auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
+            return read_applied_cursor(txn.handle(), cur);
+        }
+
+        /// \brief Reads the applied cursor using the caller-supplied txn.
+        /// \details Used inside \c handle_pull to avoid opening a second
+        /// sticky-thread transaction on the same thread.
+        SyncCursor applied_cursor(MDBX_txn* txn) const {
+            SyncCursor cur;
+            return read_applied_cursor(txn, cur);
+        }
+
+    private:
+        /// \brief Opens \c _mdbxc_changelog read-only when it exists; 0 otherwise.
+        static MDBX_dbi open_changelog_ro(MDBX_txn* txn) {
+            return open_store_ro(txn, "_mdbxc_changelog");
+        }
+
+        /// \brief Opens \c _mdbxc_applied read-only when it exists; 0 otherwise.
+        static MDBX_dbi open_applied_ro(MDBX_txn* txn) {
+            return open_store_ro(txn, "_mdbxc_applied");
+        }
+
+        static MDBX_dbi open_store_ro(MDBX_txn* txn, const char* name) {
+            MDBX_dbi dbi = 0;
+            const int rc = mdbx_dbi_open(txn, name, static_cast<MDBX_db_flags_t>(0), &dbi);
+            if (rc == MDBX_NOTFOUND) return 0;
+            check_mdbx(rc, std::string("SyncEngine: failed to open store '") + name + "'");
+            return dbi;
+        }
+
+        static SyncCursor read_applied_cursor(MDBX_txn* txn, SyncCursor cur) {
+            MDBX_dbi applied_dbi = open_applied_ro(txn);
+            if (applied_dbi == 0) return cur;
+            MDBX_cursor* raw = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, applied_dbi, &raw),
+                       "applied_cursor: cursor open failed");
+            try {
+                MDBX_val k, v;
+                int rc = mdbx_cursor_get(raw, &k, &v, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    if (k.iov_len == 16) {
+                        NodeId origin{};
+                        std::memcpy(origin.data(), k.iov_base, 16);
+                        if (v.iov_len == 8) {
+                            std::uint64_t seq = 0;
+                            for (int i = 0; i < 8; ++i) {
+                                seq |= static_cast<std::uint64_t>(
+                                           static_cast<std::uint8_t*>(v.iov_base)[i])
+                                       << (i * 8);
+                            }
+                            cur.last_seq_by_origin[origin] = seq;
+                        }
+                    }
+                    rc = mdbx_cursor_get(raw, &k, &v, MDBX_NEXT);
+                }
+                if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "applied_cursor: cursor walk failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(raw);
+                throw;
+            }
+            mdbx_cursor_close(raw);
+            return cur;
+        }
+
+        static bool changelog_get_ro(MDBX_txn* txn, MDBX_dbi dbi,
+                                     const NodeId& origin, std::uint64_t seq,
+                                     std::vector<std::uint8_t>& out) {
+            std::vector<std::uint8_t> key_buf(24);
+            std::memcpy(key_buf.data(), origin.data(), 16);
+            for (int i = 0; i < 8; ++i) {
+                key_buf[16 + i] = static_cast<std::uint8_t>((seq >> ((7 - i) * 8)) & 0xff);
+            }
+            MDBX_val k = { key_buf.empty() ? nullptr : &key_buf[0], key_buf.size() };
+            MDBX_val v;
+            const int rc = mdbx_get(txn, dbi, &k, &v);
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "changelog read failed");
+            out.resize(v.iov_len);
+            if (v.iov_len > 0) {
+                std::memcpy(out.data(), v.iov_base, v.iov_len);
+            }
+            return true;
+        }
+
+        static MDBX_dbi resolve_user_dbi(MDBX_txn* txn,
+                                         const std::string& name,
+                                         std::unordered_map<std::string, MDBX_dbi>& cache) {
+            auto it = cache.find(name);
+            if (it != cache.end() && it->second != 0) {
+                return it->second;
+            }
+            MDBX_dbi dbi = 0;
+            check_mdbx(mdbx_dbi_open(txn, name.c_str(), MDBX_CREATE, &dbi),
+                       "SyncEngine: failed to open user DBI '" + name + "'");
+            cache[name] = dbi;
+            return dbi;
+        }
+
+        static void apply_one_op(MDBX_txn* txn,
+                                 const ChangeOp& op,
+                                 std::unordered_map<std::string, MDBX_dbi>& cache) {
+            MDBX_dbi dbi = resolve_user_dbi(txn, op.dbi_name, cache);
+            switch (op.op_type) {
+                case ChangeOpType::Put: {
+                    MDBX_val k = { op.storage_key.empty() ? nullptr
+                                                           : const_cast<std::uint8_t*>(op.storage_key.data()),
+                                   op.storage_key.size() };
+                    MDBX_val v = { op.value.empty() ? nullptr
+                                                     : const_cast<std::uint8_t*>(op.value.data()),
+                                   op.value.size() };
+                    check_mdbx(mdbx_put(txn, dbi, &k, &v, MDBX_UPSERT),
+                               "SyncEngine: mdbx_put failed for DBI '" + op.dbi_name + "'");
+                    return;
+                }
+                case ChangeOpType::Delete: {
+                    MDBX_val k = { op.storage_key.empty() ? nullptr
+                                                           : const_cast<std::uint8_t*>(op.storage_key.data()),
+                                   op.storage_key.size() };
+                    const int rc = mdbx_del(txn, dbi, &k, nullptr);
+                    if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
+                        check_mdbx(rc, "SyncEngine: mdbx_del failed for DBI '" + op.dbi_name + "'");
+                    }
+                    cache.erase(op.dbi_name);
+                    return;
+                }
+                case ChangeOpType::ClearTable: {
+                    check_mdbx(mdbx_drop(txn, dbi, 0),
+                               "SyncEngine: mdbx_drop failed for DBI '" + op.dbi_name + "'");
+                    cache.erase(op.dbi_name);
+                    return;
+                }
+            }
+            throw std::logic_error("SyncEngine: unknown ChangeOpType");
+        }
+
+        std::shared_ptr<Connection> m_conn;
+        ConflictPolicy              m_policy;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_SYNC_ENGINE_HPP_INCLUDED

--- a/include/mdbx_containers/sync/stores/MetaStore.hpp
+++ b/include/mdbx_containers/sync/stores/MetaStore.hpp
@@ -33,14 +33,18 @@ namespace sync {
         MetaStore(MDBX_env* env, const std::string& dbi_name = "_mdbxc_meta")
             : m_env(env), m_dbi_name(dbi_name), m_dbi(0), m_open(false) {}
 
-        /// \brief Opens the DBI inside the supplied write transaction.
+        /// \brief Opens the DBI inside the supplied transaction.
         /// \details Idempotent. Must be called before any other access.
+        /// Tries \c MDBX_CREATE first; falls back to a plain open when the
+        /// transaction is read-only and the DBI already exists.
         void open(MDBX_txn* txn) {
             if (m_open) return;
-            check_mdbx(
-                mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE, &m_dbi),
-                "Failed to open MetaStore DBI"
-            );
+            int rc = mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE, &m_dbi);
+            if (rc == MDBX_EACCESS) {
+                rc = mdbx_dbi_open(txn, m_dbi_name.c_str(),
+                                   static_cast<MDBX_db_flags_t>(0), &m_dbi);
+            }
+            check_mdbx(rc, "Failed to open MetaStore DBI");
             m_open = true;
         }
 

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1,0 +1,357 @@
+#include <mdbx_containers.hpp>
+#include <mdbx_containers/Sync.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+void cleanup(const std::string& p) {
+    std::remove(p.c_str());
+}
+
+mdbxc::sync::NodeId make_node(std::uint8_t seed) {
+    mdbxc::sync::NodeId n{};
+    for (int i = 0; i < 16; ++i) {
+        n[i] = static_cast<std::uint8_t>(seed + i);
+    }
+    return n;
+}
+
+std::shared_ptr<mdbxc::Connection> open_env(const std::string& path) {
+    using namespace mdbxc;
+    Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    return Connection::create(cfg);
+}
+
+void seed_node_id(std::shared_ptr<mdbxc::Connection> conn,
+                  const mdbxc::sync::NodeId& node_id) {
+    using namespace mdbxc;
+    sync::MetaStore meta(conn->env_handle());
+    auto txn = conn->transaction(TransactionMode::WRITABLE);
+    meta.open(txn.handle());
+    meta.set_node_id(txn.handle(), node_id);
+    txn.commit();
+}
+
+void test_engine_round_trip_kv() {
+    using namespace mdbxc;
+    const std::string primary_path = "test_engine_primary.mdbx";
+    const std::string replica_path = "test_engine_replica.mdbx";
+    cleanup(primary_path);
+    cleanup(replica_path);
+
+    auto primary_conn   = open_env(primary_path);
+    auto replica_conn   = open_env(replica_path);
+
+    const sync::NodeId primary_node = make_node(0xA0);
+    const sync::NodeId replica_node = make_node(0xB0);
+    const sync::NodeId db_uuid      = make_node(0xD0);
+
+    sync::SyncEngine primary_engine(primary_conn);
+    sync::SyncEngine replica_engine(replica_conn);
+    primary_engine.initialize_local_identity(primary_node, db_uuid);
+    replica_engine.initialize_local_identity(replica_node, db_uuid);
+
+    sync::ThreadLocalChangeAccumulator primary_sink(primary_conn);
+    primary_conn->attach_sync_capture(&primary_sink);
+
+    {
+        KeyValueTable<int, int> kv(primary_conn, "kv");
+        kv.insert_or_assign(1, 100);
+        kv.insert_or_assign(2, 200);
+        kv.insert_or_assign(3, 300);
+    }
+
+    primary_conn->detach_sync_capture();
+
+    sync::DirectSyncPeer peer(&primary_engine);
+    sync::PullRequest req;
+    req.requester = replica_node;
+    req.db_id     = db_uuid;
+    const sync::PullResponse resp = peer.pull(req);
+
+    if (resp.batches.size() != 3u) {
+        throw std::runtime_error("expected 3 batches, got " +
+                                 std::to_string(resp.batches.size()));
+    }
+
+    {
+        auto txn = replica_conn->transaction(TransactionMode::WRITABLE);
+        for (const sync::ChangeBatch& batch : resp.batches) {
+            const sync::ApplyResult r = replica_engine.apply_batch(txn.handle(), batch);
+            if (r != sync::ApplyResult::Applied) {
+                throw std::runtime_error("apply_batch did not return Applied");
+            }
+        }
+        txn.commit();
+    }
+
+    KeyValueTable<int, int> replica_kv(replica_conn, "kv");
+    auto v1 = replica_kv.find(1);
+    auto v2 = replica_kv.find(2);
+    auto v3 = replica_kv.find(3);
+    if (!v1 || *v1 != 100) throw std::runtime_error("replica kv[1] != 100");
+    if (!v2 || *v2 != 200) throw std::runtime_error("replica kv[2] != 200");
+    if (!v3 || *v3 != 300) throw std::runtime_error("replica kv[3] != 300");
+
+    replica_conn->disconnect();
+    cleanup(primary_path);
+    cleanup(replica_path);
+}
+
+void test_engine_skips_self_origin() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_self_origin.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    seed_node_id(conn, make_node(0x10));
+
+    sync::SyncEngine engine(conn);
+    sync::MetaStore meta(conn->env_handle());
+    {
+        auto txn = conn->transaction(TransactionMode::WRITABLE);
+        meta.open(txn.handle());
+        meta.set_node_id(txn.handle(), make_node(0x10));
+        txn.commit();
+    }
+
+    sync::ChangeBatch batch;
+    batch.origin_node_id = make_node(0x10);
+    batch.seq = 1;
+    sync::ChangeOp op;
+    op.op_type = sync::ChangeOpType::Put;
+    op.dbi_name = "t";
+    op.storage_key = { 0x01 };
+    op.value = { 0xAA };
+    batch.ops.push_back(op);
+
+    {
+        auto txn = conn->transaction(TransactionMode::WRITABLE);
+        const sync::ApplyResult r = engine.apply_batch(txn.handle(), batch);
+        if (r != sync::ApplyResult::Skipped) {
+            throw std::runtime_error("self-origin batch should be Skipped");
+        }
+        txn.commit();
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_idempotent_replay() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_replay.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    seed_node_id(conn, make_node(0x10));
+
+    sync::SyncEngine engine(conn);
+
+    sync::ChangeBatch batch;
+    batch.origin_node_id = make_node(0x20);
+    batch.seq = 1;
+    sync::ChangeOp op;
+    op.op_type = sync::ChangeOpType::Put;
+    op.dbi_name = "t";
+    op.storage_key = { 0x42 };
+    op.value = { 0x11, 0x22 };
+    batch.ops.push_back(op);
+
+    {
+        auto txn = conn->transaction(TransactionMode::WRITABLE);
+        if (engine.apply_batch(txn.handle(), batch) != sync::ApplyResult::Applied) {
+            throw std::runtime_error("first apply should be Applied");
+        }
+        if (engine.apply_batch(txn.handle(), batch) != sync::ApplyResult::Skipped) {
+            throw std::runtime_error("second apply should be Skipped");
+        }
+        txn.commit();
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_gap_returns_conflict() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_gap.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    seed_node_id(conn, make_node(0x10));
+    sync::SyncEngine engine(conn);
+
+    auto make_batch = [](std::uint64_t seq) {
+        sync::ChangeBatch b;
+        b.origin_node_id = make_node(0x20);
+        b.seq = seq;
+        sync::ChangeOp op;
+        op.op_type = sync::ChangeOpType::Put;
+        op.dbi_name = "t";
+        op.storage_key = { static_cast<std::uint8_t>(seq) };
+        op.value = { 0xFF };
+        b.ops.push_back(op);
+        return b;
+    };
+
+    auto txn = conn->transaction(TransactionMode::WRITABLE);
+    if (engine.apply_batch(txn.handle(), make_batch(1)) != sync::ApplyResult::Applied) {
+        throw std::runtime_error("seq=1 should apply");
+    }
+    if (engine.apply_batch(txn.handle(), make_batch(3)) != sync::ApplyResult::Conflict) {
+        throw std::runtime_error("seq=3 should be Conflict (gap after seq=1)");
+    }
+    if (engine.apply_batch(txn.handle(), make_batch(2)) != sync::ApplyResult::Applied) {
+        throw std::runtime_error("seq=2 should apply after seq=1");
+    }
+    txn.commit();
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_applied_cursor() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_cursor.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    seed_node_id(conn, make_node(0x10));
+    sync::SyncEngine engine(conn);
+
+    auto make_batch = [](std::uint64_t seq) {
+        sync::ChangeBatch b;
+        b.origin_node_id = make_node(0x20);
+        b.seq = seq;
+        sync::ChangeOp op;
+        op.op_type = sync::ChangeOpType::Put;
+        op.dbi_name = "t";
+        op.storage_key = { static_cast<std::uint8_t>(seq) };
+        op.value = { 0xFF };
+        b.ops.push_back(op);
+        return b;
+    };
+
+    {
+        auto txn = conn->transaction(TransactionMode::WRITABLE);
+        engine.apply_batch(txn.handle(), make_batch(1));
+        engine.apply_batch(txn.handle(), make_batch(2));
+        txn.commit();
+    }
+
+    const sync::SyncCursor cur = engine.applied_cursor();
+    const std::uint64_t last =
+        cur.last_seq_for(make_node(0x20));
+    if (last != 2u) {
+        throw std::runtime_error("cursor should report last=2, got " +
+                                 std::to_string(last));
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_handle_push_to_remote() {
+    using namespace mdbxc;
+    const std::string origin_path = "test_engine_push_origin.mdbx";
+    const std::string remote_path = "test_engine_push_remote.mdbx";
+    cleanup(origin_path);
+    cleanup(remote_path);
+
+    auto origin_conn = open_env(origin_path);
+    auto remote_conn = open_env(remote_path);
+
+    sync::SyncEngine origin_engine(origin_conn);
+    sync::SyncEngine remote_engine(remote_conn);
+    origin_engine.initialize_local_identity(make_node(0xA0), make_node(0xD0));
+    remote_engine.initialize_local_identity(make_node(0xB0), make_node(0xD0));
+
+    sync::ThreadLocalChangeAccumulator origin_sink(origin_conn);
+    origin_conn->attach_sync_capture(&origin_sink);
+    {
+        KeyValueTable<int, int> kv(origin_conn, "kv");
+        kv.insert_or_assign(7, 0x77);
+    }
+    origin_conn->detach_sync_capture();
+
+    sync::DirectSyncPeer peer(&remote_engine);
+    sync::PushRequest req;
+    req.sender = make_node(0xA0);
+    req.db_id  = make_node(0xD0);
+
+    {
+        auto txn = origin_conn->transaction(TransactionMode::WRITABLE);
+        sync::MetaStore meta(origin_conn->env_handle());
+        meta.open(txn.handle());
+        sync::ChangeLogStore log(origin_conn->env_handle());
+        log.open(txn.handle());
+        const std::uint64_t last_seq = meta.get_local_seq(txn.handle());
+        std::vector<std::uint8_t> buf;
+        if (!log.get(txn.handle(), make_node(0xA0), last_seq, buf)) {
+            throw std::runtime_error("origin changelog has no batch for last seq");
+        }
+        const sync::ChangeBatch b = sync::ChangeBatchCodec::decode_exact(buf);
+        req.batches.push_back(b);
+        txn.commit();
+    }
+
+    const sync::PushResponse resp = peer.push(req);
+    if (!resp.ok) {
+        throw std::runtime_error("push should succeed: " + resp.error);
+    }
+    if (resp.receiver_have.last_seq_for(make_node(0xA0)) != 1u) {
+        throw std::runtime_error("receiver cursor should reflect applied seq");
+    }
+
+    KeyValueTable<int, int> remote_kv(remote_conn, "kv");
+    auto v = remote_kv.find(7);
+    if (!v || *v != 0x77) {
+        throw std::runtime_error("remote kv[7] != 0x77 after push");
+    }
+
+    origin_conn->disconnect();
+    remote_conn->disconnect();
+    cleanup(origin_path);
+    cleanup(remote_path);
+}
+
+} // namespace
+
+int main() {
+    struct Case { const char* name; void (*fn)(); };
+    const Case cases[] = {
+        { "test_engine_round_trip_kv",          &test_engine_round_trip_kv },
+        { "test_engine_skips_self_origin",      &test_engine_skips_self_origin },
+        { "test_engine_idempotent_replay",      &test_engine_idempotent_replay },
+        { "test_engine_gap_returns_conflict",   &test_engine_gap_returns_conflict },
+        { "test_engine_applied_cursor",         &test_engine_applied_cursor },
+        { "test_engine_handle_push_to_remote",  &test_engine_handle_push_to_remote },
+    };
+
+    int rc = 0;
+    for (std::size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
+        try {
+            cases[i].fn();
+            std::printf("PASS %s\n", cases[i].name);
+        } catch (const std::exception& e) {
+            std::printf("FAIL %s: %s\n", cases[i].name, e.what());
+            rc = static_cast<int>(i + 1);
+        } catch (...) {
+            std::printf("FAIL %s: non-std exception\n", cases[i].name);
+            rc = static_cast<int>(i + 1);
+        }
+    }
+    return rc;
+}

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -561,6 +561,35 @@ void test_engine_handle_pull_pagination_has_more() {
     cleanup(primary_path); cleanup(replica_path);
 }
 
+void test_engine_handle_pull_lifecycle() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_pull_lifecycle.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    sync::SyncEngine local_engine(conn);
+    local_engine.initialize_local_identity(make_node(0x10), make_node(0x10));
+
+    sync::DirectSyncPeer peer(&local_engine);
+    sync::PullRequest req;
+    req.requester = make_node(0x20);
+    req.db_id     = make_node(0x10);
+    // Many handle_pull() calls in sequence — the read txn guard must abort
+    // (release handle + reader slot) every time, otherwise long-lived
+    // servers would slowly exhaust the reader table (MDBX_READERS limit).
+    // This test will catch a regression back to mdbx_txn_reset().
+    for (int i = 0; i < 256; ++i) {
+        const sync::PullResponse resp = peer.pull(req);
+        if (!resp.ok) {
+            throw std::runtime_error("pull lifecycle: ok=false at i=" +
+                                     std::to_string(i));
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 } // namespace
 
 int main() {
@@ -576,6 +605,7 @@ int main() {
         { "test_engine_handle_pull_wrong_db_id",&test_engine_handle_pull_wrong_db_id },
         { "test_engine_handle_push_wrong_db_id",&test_engine_handle_push_wrong_db_id },
         { "test_engine_handle_pull_pagination", &test_engine_handle_pull_pagination_has_more },
+        { "test_engine_handle_pull_lifecycle", &test_engine_handle_pull_lifecycle },
     };
 
     int rc = 0;

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1,5 +1,5 @@
 #include <mdbx_containers.hpp>
-#include <mdbx_containers/Sync.hpp>
+#include <mdbx_containers/sync.hpp>
 
 #include <cstdint>
 #include <cstdio>
@@ -14,6 +14,25 @@ namespace {
 
 void cleanup(const std::string& p) {
     std::remove(p.c_str());
+}
+
+template<class KVT>
+typename KVT::value_type::second_type kv_or_throw(const std::shared_ptr<mdbxc::Connection>& conn,
+        KVT& kv, const typename KVT::value_type::first_type& key, const char* what) {
+    typename KVT::value_type::second_type out{};
+    auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+    if (!kv.try_get(key, out, txn.handle())) {
+        throw std::runtime_error(std::string("missing: ") + what);
+    }
+    return out;
+}
+
+template<class KVT>
+bool kv_has(const std::shared_ptr<mdbxc::Connection>& conn,
+        KVT& kv, const typename KVT::value_type::first_type& key) {
+    typename KVT::value_type::second_type out{};
+    auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+    return kv.try_get(key, out, txn.handle());
 }
 
 mdbxc::sync::NodeId make_node(std::uint8_t seed) {
@@ -97,12 +116,9 @@ void test_engine_round_trip_kv() {
     }
 
     KeyValueTable<int, int> replica_kv(replica_conn, "kv");
-    auto v1 = replica_kv.find(1);
-    auto v2 = replica_kv.find(2);
-    auto v3 = replica_kv.find(3);
-    if (!v1 || *v1 != 100) throw std::runtime_error("replica kv[1] != 100");
-    if (!v2 || *v2 != 200) throw std::runtime_error("replica kv[2] != 200");
-    if (!v3 || *v3 != 300) throw std::runtime_error("replica kv[3] != 300");
+    if (kv_or_throw(replica_conn, replica_kv, 1, "replica kv[1]") != 100) throw std::runtime_error("replica kv[1] != 100");
+    if (kv_or_throw(replica_conn, replica_kv, 2, "replica kv[2]") != 200) throw std::runtime_error("replica kv[2] != 200");
+    if (kv_or_throw(replica_conn, replica_kv, 3, "replica kv[3]") != 300) throw std::runtime_error("replica kv[3] != 300");
 
     replica_conn->disconnect();
     cleanup(primary_path);
@@ -316,8 +332,7 @@ void test_engine_handle_push_to_remote() {
     }
 
     KeyValueTable<int, int> remote_kv(remote_conn, "kv");
-    auto v = remote_kv.find(7);
-    if (!v || *v != 0x77) {
+    if (kv_or_throw(remote_conn, remote_kv, 7, "remote kv[7]") != 0x77) {
         throw std::runtime_error("remote kv[7] != 0x77 after push");
     }
 
@@ -325,6 +340,225 @@ void test_engine_handle_push_to_remote() {
     remote_conn->disconnect();
     cleanup(origin_path);
     cleanup(remote_path);
+}
+
+void test_engine_push_gap_rolls_back() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_push_gap.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    seed_node_id(conn, make_node(0x10));
+    sync::SyncEngine engine(conn);
+
+    auto make_batch = [](std::uint64_t seq) {
+        sync::ChangeBatch b;
+        b.origin_node_id = make_node(0x20);
+        b.seq = seq;
+        sync::ChangeOp op;
+        op.op_type = sync::ChangeOpType::Put;
+        op.dbi_name = "t";
+        op.storage_key = { static_cast<std::uint8_t>(seq) };
+        op.value = { 0xFF };
+        b.ops.push_back(op);
+        return b;
+    };
+
+    // Direct apply: seq=1 first
+    {
+        auto txn = conn->transaction(TransactionMode::WRITABLE);
+        if (engine.apply_batch(txn.handle(), make_batch(1)) != sync::ApplyResult::Applied) {
+            throw std::runtime_error("seq=1 should apply");
+        }
+        txn.commit();
+    }
+
+    // Push [seq=3] — should be Conflict, ok=false, no commit
+    {
+        sync::DirectSyncPeer peer(&engine);
+        sync::PushRequest req;
+        req.sender = make_node(0x20);
+        req.db_id  = make_node(0x10);  // peer db_id == local db_uuid
+        req.batches.push_back(make_batch(3));
+
+        const sync::PushResponse resp = peer.push(req);
+        if (resp.ok) {
+            throw std::runtime_error("push with gap should return ok=false");
+        }
+    }
+
+    // After rejected push, table 't' should still be empty (rollback worked)
+    {
+        KeyValueTable<std::uint8_t, std::uint8_t> t(conn, "t");
+        if (kv_has(conn, t, static_cast<std::uint8_t>(3))) {
+            throw std::runtime_error("seq=3 must not be persisted on rejected push");
+        }
+    }
+
+    // Receiver cursor should remain at seq=1
+    {
+        const sync::SyncCursor cur = engine.applied_cursor();
+        if (cur.last_seq_for(make_node(0x20)) != 1u) {
+            throw std::runtime_error("cursor should still be at seq=1 after rejected push");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_handle_pull_wrong_db_id() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_pull_wrong_db.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0xA0), make_node(0xD0));
+
+    sync::DirectSyncPeer peer(&engine);
+    sync::PullRequest req;
+    req.requester = make_node(0xB0);
+    req.db_id     = make_node(0xFF);  // wrong db_id
+
+    const sync::PullResponse resp = peer.pull(req);
+    if (resp.ok) {
+        throw std::runtime_error("pull with wrong db_id should return ok=false");
+    }
+    if (!resp.batches.empty()) {
+        throw std::runtime_error("pull with wrong db_id should not return batches");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_handle_push_wrong_db_id() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_push_wrong_db.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0xA0), make_node(0xD0));
+
+    sync::ChangeBatch b;
+    b.origin_node_id = make_node(0x20);
+    b.seq = 1;
+    sync::ChangeOp op;
+    op.op_type = sync::ChangeOpType::Put;
+    op.dbi_name = "t";
+    op.storage_key = { 0x01 };
+    op.value = { 0xAA };
+    b.ops.push_back(op);
+
+    sync::DirectSyncPeer peer(&engine);
+    sync::PushRequest req;
+    req.sender = make_node(0x20);
+    req.db_id  = make_node(0xFF);  // wrong
+    req.batches.push_back(b);
+
+    const sync::PushResponse resp = peer.push(req);
+    if (resp.ok) {
+        throw std::runtime_error("push with wrong db_id should return ok=false");
+    }
+
+    {
+        KeyValueTable<std::uint8_t, std::uint8_t> t(conn, "t");
+        if (kv_has(conn, t, static_cast<std::uint8_t>(1))) {
+            throw std::runtime_error("table must be empty on wrong db_id push");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_handle_pull_pagination_has_more() {
+    using namespace mdbxc;
+    const std::string primary_path = "test_engine_pull_pag.mdbx";
+    const std::string replica_path = "test_engine_pull_pag_replica.mdbx";
+    cleanup(primary_path); cleanup(replica_path);
+
+    auto primary_conn = open_env(primary_path);
+    auto replica_conn = open_env(replica_path);
+
+    const sync::NodeId primary_node = make_node(0xA0);
+    const sync::NodeId replica_node = make_node(0xB0);
+    const sync::NodeId db_uuid      = make_node(0xD0);
+
+    sync::SyncEngine primary_engine(primary_conn);
+    sync::SyncEngine replica_engine(replica_conn);
+    primary_engine.initialize_local_identity(primary_node, db_uuid);
+    replica_engine.initialize_local_identity(replica_node, db_uuid);
+
+    sync::ThreadLocalChangeAccumulator primary_sink(primary_conn);
+    primary_conn->attach_sync_capture(&primary_sink);
+    {
+        KeyValueTable<int, int> kv(primary_conn, "kv");
+        for (int i = 1; i <= 5; ++i) {
+            kv.insert_or_assign(i, i * 100);
+        }
+    }
+    primary_conn->detach_sync_capture();
+
+    sync::DirectSyncPeer peer(&primary_engine);
+    sync::PullRequest req;
+    req.requester  = replica_node;
+    req.db_id      = db_uuid;
+    req.max_batches = 2;  // force pagination
+    const sync::PullResponse resp = peer.pull(req);
+
+    if (resp.batches.size() != 2u) {
+        throw std::runtime_error("expected 2 batches, got " +
+                                 std::to_string(resp.batches.size()));
+    }
+    if (!resp.has_more) {
+        throw std::runtime_error("has_more should be true when limit truncates pull");
+    }
+
+    // Apply first page
+    {
+        auto txn = replica_conn->transaction(TransactionMode::WRITABLE);
+        for (const sync::ChangeBatch& b : resp.batches) {
+            replica_engine.apply_batch(txn.handle(), b);
+        }
+        txn.commit();
+    }
+
+    // Pull page 2 with cursor from page 1
+    sync::PullRequest req2;
+    req2.requester = replica_node;
+    req2.db_id     = db_uuid;
+    req2.have      = replica_engine.applied_cursor();
+    req2.max_batches = 100;  // no limit this time
+    const sync::PullResponse resp2 = peer.pull(req2);
+    if (resp2.batches.size() != 3u) {
+        throw std::runtime_error("expected 3 remaining batches, got " +
+                                 std::to_string(resp2.batches.size()));
+    }
+    if (resp2.has_more) {
+        throw std::runtime_error("has_more should be false after draining changelog");
+    }
+
+    {
+        auto txn = replica_conn->transaction(TransactionMode::WRITABLE);
+        for (const sync::ChangeBatch& b : resp2.batches) {
+            replica_engine.apply_batch(txn.handle(), b);
+        }
+        txn.commit();
+    }
+
+    KeyValueTable<int, int> replica_kv(replica_conn, "kv");
+    for (int i = 1; i <= 5; ++i) {
+        if (kv_or_throw(replica_conn, replica_kv, i, "missing on replica") != i * 100) {
+            throw std::runtime_error("wrong value on replica after paginated pull");
+        }
+    }
+
+    primary_conn->disconnect();
+    replica_conn->disconnect();
+    cleanup(primary_path); cleanup(replica_path);
 }
 
 } // namespace
@@ -338,6 +572,10 @@ int main() {
         { "test_engine_gap_returns_conflict",   &test_engine_gap_returns_conflict },
         { "test_engine_applied_cursor",         &test_engine_applied_cursor },
         { "test_engine_handle_push_to_remote",  &test_engine_handle_push_to_remote },
+        { "test_engine_push_gap_rolls_back",    &test_engine_push_gap_rolls_back },
+        { "test_engine_handle_pull_wrong_db_id",&test_engine_handle_pull_wrong_db_id },
+        { "test_engine_handle_push_wrong_db_id",&test_engine_handle_push_wrong_db_id },
+        { "test_engine_handle_pull_pagination", &test_engine_handle_pull_pagination_has_more },
     };
 
     int rc = 0;


### PR DESCRIPTION
## Что

- `SyncEngine`: apply_batch (Applied/Skipped/Conflict), handle_pull (incremental + full-snapshot, paginated), handle_push (atomic с rollback на Conflict), applied_cursor, initialize_local_identity, local_node_id / db_uuid.
- `DirectSyncPeer`: in-process ISyncPeer, делегирует в удалённый SyncEngine — для тестов без реального транспорта.
- `applied_cursor(MDBX_txn*)` overload — позволяет читать внутри уже открытой транзакции без MDBX_BAD_RSLOT.
- `MetaStore::open` стал tolerant к READ_ONLY txn (MDBX_EACCESS → fallback без MDBX_CREATE).
- 10 интеграционных тестов: round_trip_kv, self_origin skip, idempotent replay, gap/Conflict, applied_cursor, push_to_remote, push-gap-rolls-back, pull/push wrong db_id, paginated pull (has_more).

## v0.1 protocol-level contracts (v1 этого PR)

1. `db_id` обязателен и проверяется против local `db_uuid` через `db_id_matches`. Несовпадение → `ok=false`, побочных эффектов нет.
2. `handle_push` атомарен: первый `Conflict` прерывает транзакцию (dtor rollback) и возвращает `ok=false`. Receiver cursor не коммитится.
3. `handle_pull` корректно выставляет `has_more=true`, когда остановился из-за `max_batches`/`max_bytes`, и `false` когда changelog исчерпан. Pull без `have` использует full-snapshot путь с тем же контрактом.
4. `BATCH_HAS_MORE` больше не интерпретируется как per-batch terminator внутри incremental pull (это chunk-boundary marker для full export).

## Зачем

PR #66 (capture) пишет в changelog, но читать и применять было некому. Этот PR замыкает цикл capture→store→engine→peer в рамках v0.1 single-replica.

## Scope (v0.1)

- Только pull + push, single-replica, Reject policy.
- Нет LastWriterWins, нет merge, нет реального wire transport (только DirectSyncPeer).

## Pre-existing Linux CI failures (доказательство)

Linux C++11 и Linux C++17 падали на `main` (`CI #28998984982`) до моих правок с той же ошибкой:

```
include/mdbx_containers.hpp:12:10: fatal error: mdbx_containers/sync.hpp: No such file or directory
```

Это case-sensitivity баг в umbrella — `mdbx_containers/sync.hpp` vs tracked filename `Sync.hpp`. На Windows/macOS (case-insensitive) работает, на Linux нет. Дополнительно починен в коммите `7f6e598` этого PR: `include/mdbx_containers.hpp` теперь инклюдит `mdbx_containers/Sync.hpp`.

## Тесты (локально MinGW C++11 + C++17 stdlib extension)

```
PASS test_engine_round_trip_kv
PASS test_engine_skips_self_origin
PASS test_engine_idempotent_replay
PASS test_engine_gap_returns_conflict
PASS test_engine_applied_cursor
PASS test_engine_handle_push_to_remote
PASS test_engine_push_gap_rolls_back
PASS test_engine_handle_pull_wrong_db_id
PASS test_engine_handle_push_wrong_db_id
PASS test_engine_handle_pull_pagination
```

Тесты используют `try_get(key, out, txn)` вместо `find()` — это portable и для C++11 (`std::pair<bool, T>`), и для C++17/libstdc++ extension (`std::optional<T>`).

## Трейлеры

```
Constraint: v0.1 scope only; protocol-level safety before feature expansion.
Rejected:  relaxing atomic push or db_id check; symlink/rename Sync.hpp.
Directive:  overload any new SyncEngine helper that reads inside an open txn;
           keep using try_get in tests; db_id is mandatory.
Not-tested: multi-origin concurrent evolution; gap with >1 missing seq.
Confidence: high
Scope-risk: moderate
```