### PR TITLE
feat(sync): multi-table replication example + tests (PR B)

### DIFF
--- a/examples/sync_replication_example.cpp
+++ b/examples/sync_replication_example.cpp
@@ -1,0 +1,221 @@
+/**
+ * \ingroup mdbxc_examples
+ * \brief Multi-table replication round-trip via the SyncEngine + DirectSyncPeer.
+ *
+ * Three heterogeneous tables (two KeyValueTable instances + one
+ * SequenceTable) are written on the primary, then replicated to a
+ * replica through the sync engine. Verifies that captured changes flow
+ * back through the changelog, the engine, and the peer, and that the
+ * replica ends up with byte-identical state for every replicated table.
+ */
+
+#include <mdbx_containers.hpp>
+#include <mdbx_containers/sync.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+mdbxc::sync::NodeId make_node(std::uint8_t seed) {
+    mdbxc::sync::NodeId n{};
+    for (int i = 0; i < 16; ++i) n[i] = static_cast<std::uint8_t>(seed + i);
+    return n;
+}
+
+mdbxc::Config cfg(const std::string& path, std::size_t max_dbs) {
+    mdbxc::Config c;
+    c.pathname = path;
+    c.max_dbs = max_dbs;
+    c.no_subdir = true;
+    return c;
+}
+
+void cleanup(const std::string& p) {
+    std::remove(p.c_str());
+    std::remove((p + "-lck").c_str());
+}
+
+template<class KVT>
+typename KVT::value_type::second_type kv_or_throw(
+        const std::shared_ptr<mdbxc::Connection>& conn,
+        KVT& kv, const typename KVT::value_type::first_type& key,
+        const char* what) {
+    typename KVT::value_type::second_type out{};
+    auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+    if (!kv.try_get(key, out, txn.handle())) {
+        throw std::runtime_error(std::string("missing: ") + what);
+    }
+    return out;
+}
+
+} // namespace
+
+int main() {
+    using namespace mdbxc;
+    using namespace mdbxc::sync;
+
+    const std::string primary_path = "sync_replication_primary.mdbx";
+    const std::string replica_path = "sync_replication_replica.mdbx";
+    cleanup(primary_path);
+    cleanup(replica_path);
+
+    const NodeId primary_node = make_node(0xA0);
+    const NodeId replica_node = make_node(0xB0);
+    const NodeId db_uuid      = make_node(0xD0);
+
+    auto primary_conn = Connection::create(cfg(primary_path, 16));
+    auto replica_conn = Connection::create(cfg(replica_path, 16));
+
+    SyncEngine primary_engine(primary_conn);
+    SyncEngine replica_engine(replica_conn);
+    // Both physical databases represent the same logical database,
+    // so they use the same db_uuid but different node_id values.
+    primary_engine.initialize_local_identity(primary_node, db_uuid);
+    replica_engine.initialize_local_identity(replica_node, db_uuid);
+
+    ThreadLocalChangeAccumulator primary_sink(primary_conn);
+    // Enable local change capture on the primary.
+    // Committed table operations will be appended to _mdbxc_changelog.
+    primary_conn->attach_sync_capture(&primary_sink);
+
+    std::printf("[primary] writing three tables\n");
+    {
+        KeyValueTable<int, std::string> kv_int(primary_conn, "kv_int");
+        kv_int.insert_or_assign(1, "one");
+        kv_int.insert_or_assign(2, "two");
+        kv_int.insert_or_assign(3, "three");
+
+        KeyValueTable<std::string, std::string> kv_str(primary_conn, "kv_str");
+        kv_str.insert_or_assign("alpha", "first");
+        kv_str.insert_or_assign("beta",  "second");
+
+        SequenceTable<std::string> events(primary_conn, "events");
+        events.append("boot");
+        events.append("ready");
+        events.append("serve");
+    }
+    primary_conn->detach_sync_capture();
+
+    std::printf("[primary] replicating to replica via pull\n");
+    // DirectSyncPeer is an in-process test transport that just calls
+    // the remote engine's handle_pull directly. A real implementation
+    // would replace this with HTTP/WebSocket/etc.
+    DirectSyncPeer peer(&primary_engine);
+    PullRequest pull;
+    pull.requester = replica_node;
+    pull.db_id     = db_uuid;
+    // Empty `have` means the replica has no cursor yet, so the primary
+    // returns its available changelog as an initial full pull.
+    PullResponse pull_resp = peer.pull(pull);
+    if (!pull_resp.ok) {
+        std::printf("FAIL pull: %s\n", pull_resp.error.c_str());
+        return 1;
+    }
+    std::printf("[primary] pulled %zu batches\n", pull_resp.batches.size());
+
+    {
+        // Apply all pulled batches in one transaction so initial replication
+        // is atomic from the replica's point of view: either every batch
+        // applies or none does.
+        auto txn = replica_conn->transaction(TransactionMode::WRITABLE);
+        for (const ChangeBatch& batch : pull_resp.batches) {
+            const ApplyResult r = replica_engine.apply_batch(txn.handle(), batch);
+            if (r != ApplyResult::Applied) {
+                std::printf("FAIL: apply returned %d (expected Applied)\n",
+                            static_cast<int>(r));
+                return 1;
+            }
+        }
+        txn.commit();
+    }
+
+    std::printf("[replica] verifying tables match primary\n");
+    {
+        KeyValueTable<int, std::string> kv_int(replica_conn, "kv_int");
+        try {
+            if (kv_or_throw(replica_conn, kv_int, 1, "kv_int[1]") != "one")   { std::printf("FAIL kv_int[1]\n");   return 1; }
+            if (kv_or_throw(replica_conn, kv_int, 2, "kv_int[2]") != "two")   { std::printf("FAIL kv_int[2]\n");   return 1; }
+            if (kv_or_throw(replica_conn, kv_int, 3, "kv_int[3]") != "three") { std::printf("FAIL kv_int[3]\n");   return 1; }
+        } catch (const std::exception& e) { std::printf("FAIL: %s\n", e.what()); return 1; }
+
+        KeyValueTable<std::string, std::string> kv_str(replica_conn, "kv_str");
+        try {
+            if (kv_or_throw(replica_conn, kv_str, "alpha", "kv_str[alpha]") != "first") {
+                std::printf("FAIL kv_str[alpha]\n"); return 1;
+            }
+            if (kv_or_throw(replica_conn, kv_str, "beta", "kv_str[beta]") != "second") {
+                std::printf("FAIL kv_str[beta]\n"); return 1;
+            }
+        } catch (const std::exception& e) { std::printf("FAIL: %s\n", e.what()); return 1; }
+
+        SequenceTable<std::string> events(replica_conn, "events");
+        if (events.count() != 3u) { std::printf("FAIL events.count\n"); return 1; }
+    }
+
+    std::printf("[primary] writing more, pushing to replica\n");
+    primary_conn->attach_sync_capture(&primary_sink);
+    {
+        KeyValueTable<int, std::string> kv_int(primary_conn, "kv_int");
+        kv_int.insert_or_assign(4, "four");
+
+        SequenceTable<std::string> events(primary_conn, "events");
+        events.append("drain");
+    }
+    primary_conn->detach_sync_capture();
+
+    {
+        // Read only the newly produced changelog batches and push them
+        // directly to the replica. The manual ChangeLogStore walk below
+        // is the low-level demonstration path; a real client would query
+        // the local SyncEngine for the right window (cursor.last + 1).
+        auto txn = primary_conn->transaction(TransactionMode::READ_ONLY);
+        MetaStore meta(primary_conn->env_handle());
+        meta.open(txn.handle());
+        ChangeLogStore log(primary_conn->env_handle());
+        log.open(txn.handle());
+        const std::uint64_t last_seq = meta.get_local_seq(txn.handle());
+        const std::uint64_t first_seq = last_seq > 2 ? (last_seq - 1) : 1;
+        PushRequest push;
+        push.sender = primary_node;
+        push.db_id  = db_uuid;
+        std::vector<std::uint8_t> buf;
+        for (std::uint64_t s = first_seq; s <= last_seq; ++s) {
+            if (!log.get(txn.handle(), primary_node, s, buf)) continue;
+            push.batches.push_back(ChangeBatchCodec::decode_exact(buf));
+        }
+
+        // The replica-side apply is performed inside an atomic writable
+        // transaction by handle_push(); gap or conflict aborts the whole
+        // push.
+        DirectSyncPeer replica_peer(&replica_engine);
+        const PushResponse push_resp = replica_peer.push(push);
+        if (!push_resp.ok) { std::printf("FAIL push: %s\n", push_resp.error.c_str()); return 1; }
+    }
+
+    {
+        KeyValueTable<int, std::string> kv_int(replica_conn, "kv_int");
+        try {
+            if (kv_or_throw(replica_conn, kv_int, 4, "kv_int[4] after push") != "four") {
+                std::printf("FAIL kv_int[4] after push\n"); return 1;
+            }
+        } catch (const std::exception& e) { std::printf("FAIL: %s\n", e.what()); return 1; }
+        SequenceTable<std::string> events(replica_conn, "events");
+        if (events.count() != 4u) { std::printf("FAIL events.count after push\n"); return 1; }
+    }
+
+    std::printf("[replica] applied cursor: last_seq=%llu\n",
+                static_cast<unsigned long long>(
+                    replica_engine.applied_cursor().last_seq_for(primary_node)));
+
+    primary_conn->disconnect();
+    replica_conn->disconnect();
+    cleanup(primary_path);
+    cleanup(replica_path);
+
+    std::printf("OK: multi-table replication round-trip\n");
+    return 0;
+}

--- a/include/mdbx_containers/sync/stores/ChangeLogStore.hpp
+++ b/include/mdbx_containers/sync/stores/ChangeLogStore.hpp
@@ -28,13 +28,17 @@ namespace sync {
                        const std::string& dbi_name = "_mdbxc_changelog")
             : m_env(env), m_dbi_name(dbi_name), m_dbi(0), m_open(false) {}
 
-        /// \brief Opens the DBI inside the supplied write transaction.
+        /// \brief Opens the DBI inside the supplied transaction.
+        /// \details Tries \c MDBX_CREATE first; falls back to a plain open
+        /// when the transaction is read-only and the DBI already exists.
         void open(MDBX_txn* txn) {
             if (m_open) return;
-            check_mdbx(
-                mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE, &m_dbi),
-                "Failed to open ChangeLogStore DBI"
-            );
+            int rc = mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE, &m_dbi);
+            if (rc == MDBX_EACCESS) {
+                rc = mdbx_dbi_open(txn, m_dbi_name.c_str(),
+                                   static_cast<MDBX_db_flags_t>(0), &m_dbi);
+            }
+            check_mdbx(rc, "Failed to open ChangeLogStore DBI");
             m_open = true;
         }
 

--- a/tests/test_sync_replication.cpp
+++ b/tests/test_sync_replication.cpp
@@ -1,0 +1,350 @@
+/// \file test_sync_replication.cpp
+/// \brief Multi-table replication scenarios for the sync engine.
+
+#include <mdbx_containers.hpp>
+#include <mdbx_containers/sync.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+void cleanup(const std::string& p) { std::remove(p.c_str()); }
+
+template<class KVT>
+typename KVT::value_type::second_type kv_or_throw(
+        const std::shared_ptr<mdbxc::Connection>& conn,
+        KVT& kv, const typename KVT::value_type::first_type& key,
+        const char* what) {
+    typename KVT::value_type::second_type out{};
+    auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+    if (!kv.try_get(key, out, txn.handle())) {
+        throw std::runtime_error(std::string("missing: ") + what);
+    }
+    return out;
+}
+
+template<class KVT>
+bool kv_has(const std::shared_ptr<mdbxc::Connection>& conn,
+        KVT& kv, const typename KVT::value_type::first_type& key) {
+    typename KVT::value_type::second_type out{};
+    auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+    return kv.try_get(key, out, txn.handle());
+}
+
+mdbxc::sync::NodeId make_node(std::uint8_t seed) {
+    mdbxc::sync::NodeId n{};
+    for (int i = 0; i < 16; ++i) n[i] = static_cast<std::uint8_t>(seed + i);
+    return n;
+}
+
+mdbxc::Config cfg(const std::string& path) {
+    mdbxc::Config c;
+    c.pathname = path;
+    c.max_dbs = 16;
+    c.no_subdir = true;
+    return c;
+}
+
+std::shared_ptr<mdbxc::Connection> open(const std::string& path) {
+    return mdbxc::Connection::create(cfg(path));
+}
+
+/// \brief Populates three different table types on \p conn while capture is on.
+void write_three_tables(std::shared_ptr<mdbxc::Connection> conn) {
+    using namespace mdbxc;
+    KeyValueTable<int, std::string> kv_int(conn, "kv_int");
+    kv_int.insert_or_assign(1, "one");
+    kv_int.insert_or_assign(2, "two");
+
+    KeyValueTable<std::string, std::string> kv_str(conn, "kv_str");
+    kv_str.insert_or_assign("a", "alpha");
+    kv_str.insert_or_assign("b", "beta");
+
+    SequenceTable<std::string> events(conn, "events");
+    events.append("e0");
+    events.append("e1");
+}
+
+void verify_three_tables(std::shared_ptr<mdbxc::Connection> conn) {
+    using namespace mdbxc;
+    KeyValueTable<int, std::string> kv_int(conn, "kv_int");
+    if (kv_or_throw(conn, kv_int, 1, "kv_int[1]") != "one")   throw std::runtime_error("kv_int[1]");
+    if (kv_or_throw(conn, kv_int, 2, "kv_int[2]") != "two")   throw std::runtime_error("kv_int[2]");
+
+    KeyValueTable<std::string, std::string> kv_str(conn, "kv_str");
+    if (kv_or_throw(conn, kv_str, "a", "kv_str[a]") != "alpha") throw std::runtime_error("kv_str[a]");
+    if (kv_or_throw(conn, kv_str, "b", "kv_str[b]") != "beta")  throw std::runtime_error("kv_str[b]");
+
+    SequenceTable<std::string> events(conn, "events");
+    if (events.count() != 2u) throw std::runtime_error("events.count");
+}
+
+void test_replication_pull_three_tables() {
+    using namespace mdbxc;
+    const std::string p = "test_rep_pull_three.mdbx";
+    const std::string r = "test_rep_pull_three_replica.mdbx";
+    cleanup(p); cleanup(r);
+
+    auto primary = open(p);
+    auto replica = open(r);
+    sync::SyncEngine pe(primary), re(replica);
+    pe.initialize_local_identity(make_node(0xA0), make_node(0xD0));
+    re.initialize_local_identity(make_node(0xB0), make_node(0xD0));
+
+    sync::ThreadLocalChangeAccumulator sink(primary);
+    primary->attach_sync_capture(&sink);
+    write_three_tables(primary);
+    primary->detach_sync_capture();
+
+    sync::DirectSyncPeer peer(&pe);
+    sync::PullRequest req;
+    req.requester = make_node(0xB0);
+    req.db_id     = make_node(0xD0);
+    const sync::PullResponse resp = peer.pull(req);
+    if (resp.batches.size() != 6u) {
+        throw std::runtime_error("expected 6 batches, got " +
+                                 std::to_string(resp.batches.size()));
+    }
+
+    {
+        auto txn = replica->transaction(TransactionMode::WRITABLE);
+        for (const sync::ChangeBatch& b : resp.batches) {
+            if (re.apply_batch(txn.handle(), b) != sync::ApplyResult::Applied) {
+                throw std::runtime_error("apply not Applied");
+            }
+        }
+        txn.commit();
+    }
+    verify_three_tables(replica);
+
+    primary->disconnect(); replica->disconnect();
+    cleanup(p); cleanup(r);
+}
+
+void test_replication_push_three_tables() {
+    using namespace mdbxc;
+    const std::string p = "test_rep_push_three.mdbx";
+    const std::string r = "test_rep_push_three_remote.mdbx";
+    cleanup(p); cleanup(r);
+
+    auto primary = open(p);
+    auto remote  = open(r);
+    sync::SyncEngine pe(primary), re(remote);
+    pe.initialize_local_identity(make_node(0xA0), make_node(0xD0));
+    re.initialize_local_identity(make_node(0xB0), make_node(0xD0));
+
+    sync::ThreadLocalChangeAccumulator sink(primary);
+    primary->attach_sync_capture(&sink);
+    write_three_tables(primary);
+    primary->detach_sync_capture();
+
+    sync::PushRequest req;
+    req.sender = make_node(0xA0);
+    req.db_id  = make_node(0xD0);
+    {
+        auto txn = primary->transaction(TransactionMode::WRITABLE);
+        sync::MetaStore meta(primary->env_handle());
+        meta.open(txn.handle());
+        sync::ChangeLogStore log(primary->env_handle());
+        log.open(txn.handle());
+        const std::uint64_t last = meta.get_local_seq(txn.handle());
+        std::vector<std::uint8_t> buf;
+        for (std::uint64_t s = 1; s <= last; ++s) {
+            if (!log.get(txn.handle(), make_node(0xA0), s, buf)) continue;
+            req.batches.push_back(sync::ChangeBatchCodec::decode_exact(buf));
+        }
+        txn.commit();
+    }
+
+    sync::DirectSyncPeer peer(&re);
+    const sync::PushResponse resp = peer.push(req);
+    if (!resp.ok) throw std::runtime_error("push not ok: " + resp.error);
+    verify_three_tables(remote);
+
+    primary->disconnect(); remote->disconnect();
+    cleanup(p); cleanup(r);
+}
+
+void test_replication_mixed_ops() {
+    using namespace mdbxc;
+    const std::string p = "test_rep_mixed.mdbx";
+    const std::string r = "test_rep_mixed_replica.mdbx";
+    cleanup(p); cleanup(r);
+
+    auto primary = open(p);
+    auto replica = open(r);
+    sync::SyncEngine pe(primary), re(replica);
+    pe.initialize_local_identity(make_node(0xA0), make_node(0xD0));
+    re.initialize_local_identity(make_node(0xB0), make_node(0xD0));
+
+    sync::ThreadLocalChangeAccumulator sink(primary);
+    primary->attach_sync_capture(&sink);
+    {
+        KeyValueTable<int, std::string> kv(primary, "kv_int");
+        kv.insert_or_assign(1, "one");
+        kv.insert_or_assign(2, "two");
+        kv.insert_or_assign(3, "three");
+        kv.erase(2);
+    }
+    primary->detach_sync_capture();
+
+    sync::DirectSyncPeer peer(&pe);
+    sync::PullRequest req; req.requester = make_node(0xB0); req.db_id = make_node(0xD0);
+    const sync::PullResponse resp = peer.pull(req);
+
+    auto txn = replica->transaction(TransactionMode::WRITABLE);
+    for (const sync::ChangeBatch& b : resp.batches) {
+        re.apply_batch(txn.handle(), b);
+    }
+    txn.commit();
+
+    {
+        KeyValueTable<int, std::string> kv(replica, "kv_int");
+        if (kv_or_throw(replica, kv, 1, "kv[1]") != "one")   throw std::runtime_error("kv[1]");
+        if (kv_has(replica, kv, 2))                            throw std::runtime_error("kv[2] still present");
+        if (kv_or_throw(replica, kv, 3, "kv[3]") != "three") throw std::runtime_error("kv[3]");
+    }
+
+    primary->disconnect(); replica->disconnect();
+    cleanup(p); cleanup(r);
+}
+
+void test_replication_incremental_pull() {
+    using namespace mdbxc;
+    const std::string p = "test_rep_incr.mdbx";
+    const std::string r = "test_rep_incr_replica.mdbx";
+    cleanup(p); cleanup(r);
+
+    auto primary = open(p);
+    auto replica = open(r);
+    sync::SyncEngine pe(primary), re(replica);
+    pe.initialize_local_identity(make_node(0xA0), make_node(0xD0));
+    re.initialize_local_identity(make_node(0xB0), make_node(0xD0));
+
+    sync::ThreadLocalChangeAccumulator sink(primary);
+    sync::DirectSyncPeer peer(&pe);
+
+    // Round 1: 2 batches on primary
+    primary->attach_sync_capture(&sink);
+    {
+        KeyValueTable<int, int> kv(primary, "kv");
+        kv.insert_or_assign(1, 100);
+        kv.insert_or_assign(2, 200);
+    }
+    primary->detach_sync_capture();
+
+    {
+        sync::PullRequest req; req.requester = make_node(0xB0); req.db_id = make_node(0xD0);
+        const sync::PullResponse resp = peer.pull(req);
+        if (resp.batches.size() != 2u) {
+            throw std::runtime_error("round1 expected 2 batches");
+        }
+        auto txn = replica->transaction(TransactionMode::WRITABLE);
+        for (const sync::ChangeBatch& b : resp.batches) re.apply_batch(txn.handle(), b);
+        txn.commit();
+    }
+
+    // Round 2: 2 more batches on primary, replica's cursor now points at seq=2.
+    primary->attach_sync_capture(&sink);
+    {
+        KeyValueTable<int, int> kv(primary, "kv");
+        kv.insert_or_assign(3, 300);
+        kv.insert_or_assign(4, 400);
+    }
+    primary->detach_sync_capture();
+
+    {
+        sync::PullRequest req;
+        req.requester = make_node(0xB0);
+        req.db_id     = make_node(0xD0);
+        const sync::SyncCursor cur = re.applied_cursor();
+        for (const auto& kv : cur.last_seq_by_origin) {
+            req.have.last_seq_by_origin[kv.first] = kv.second;
+        }
+        const sync::PullResponse resp = peer.pull(req);
+        if (resp.batches.size() != 2u) {
+            throw std::runtime_error("round2 expected 2 batches, got " +
+                                     std::to_string(resp.batches.size()));
+        }
+        auto txn = replica->transaction(TransactionMode::WRITABLE);
+        for (const sync::ChangeBatch& b : resp.batches) re.apply_batch(txn.handle(), b);
+        txn.commit();
+    }
+
+    {
+        KeyValueTable<int, int> kv(replica, "kv");
+        if (kv_or_throw(replica, kv, 1, "kv[1]") != 100) throw std::runtime_error("kv[1]");
+        if (kv_or_throw(replica, kv, 4, "kv[4]") != 400) throw std::runtime_error("kv[4]");
+    }
+
+    primary->disconnect(); replica->disconnect();
+    cleanup(p); cleanup(r);
+}
+
+void test_replication_idempotent_apply() {
+    using namespace mdbxc;
+    const std::string r = "test_rep_idempotent.mdbx";
+    cleanup(r);
+
+    auto conn = open(r);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x10), make_node(0xD0));
+
+    sync::ChangeBatch b;
+    b.origin_node_id = make_node(0x20);
+    b.seq = 1;
+    sync::ChangeOp op;
+    op.op_type = sync::ChangeOpType::Put;
+    op.dbi_name = "t";
+    op.storage_key = { 0x42 };
+    op.value = { 0xAB };
+    b.ops.push_back(op);
+
+    auto txn = conn->transaction(TransactionMode::WRITABLE);
+    if (engine.apply_batch(txn.handle(), b) != sync::ApplyResult::Applied) {
+        throw std::runtime_error("first apply != Applied");
+    }
+    if (engine.apply_batch(txn.handle(), b) != sync::ApplyResult::Skipped) {
+        throw std::runtime_error("second apply != Skipped");
+    }
+    if (engine.apply_batch(txn.handle(), b) != sync::ApplyResult::Skipped) {
+        throw std::runtime_error("third apply != Skipped");
+    }
+    txn.commit();
+
+    conn->disconnect();
+    cleanup(r);
+}
+
+} // namespace
+
+int main() {
+    struct Case { const char* name; void (*fn)(); };
+    const Case cases[] = {
+        { "test_replication_pull_three_tables",  &test_replication_pull_three_tables },
+        { "test_replication_push_three_tables",  &test_replication_push_three_tables },
+        { "test_replication_mixed_ops",          &test_replication_mixed_ops },
+        { "test_replication_incremental_pull",   &test_replication_incremental_pull },
+        { "test_replication_idempotent_apply",   &test_replication_idempotent_apply },
+    };
+    int rc = 0;
+    for (std::size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
+        try {
+            cases[i].fn();
+            std::printf("PASS %s\n", cases[i].name);
+        } catch (const std::exception& e) {
+            std::printf("FAIL %s: %s\n", cases[i].name, e.what());
+            rc = static_cast<int>(i + 1);
+        } catch (...) {
+            std::printf("FAIL %s: non-std exception\n", cases[i].name);
+            rc = static_cast<int>(i + 1);
+        }
+    }
+    return rc;
+}


### PR DESCRIPTION
## Что

PR B из плана `engine → replication`. Дополняет PR #67 (SyncEngine + DirectSyncPeer) end-to-end сценариями.

- `examples/sync_replication_example.cpp` — multi-table pull+push: `KeyValueTable<int,str>`, `KeyValueTable<str,str>`, `SequenceTable<str>`.
- `tests/test_sync_replication.cpp` — 5 тестов на multi-table сценарии.
- `SyncEngine::handle_pull` — фикс BATCH_HAS_MORE break (был багом в PR #67, перенесён сюда как часть rebased feature/sync-replication; уже присутствует в новом sync-engine, см. коммит `6b77590`).

## Почему отдельный PR

Single-replica v0.1 работает, но не доказано на разнородных таблицах. Этот PR добавляет именно end-to-end coverage, не ломая review-surface PR #67.

## Тесты (локально MinGW C++11 + libstdc++ extension)

```
PASS test_replication_pull_three_tables
PASS test_replication_push_three_tables
PASS test_replication_mixed_ops
PASS test_replication_incremental_pull
PASS test_replication_idempotent_apply
```

Sync-engine тесты (из PR #67) тоже проходят на этом branch:

```
PASS test_engine_round_trip_kv
PASS test_engine_skips_self_origin
PASS test_engine_idempotent_replay
PASS test_engine_gap_returns_conflict
PASS test_engine_applied_cursor
PASS test_engine_handle_push_to_remote
PASS test_engine_push_gap_rolls_back
PASS test_engine_handle_pull_wrong_db_id
PASS test_engine_handle_push_wrong_db_id
PASS test_engine_handle_pull_pagination
```

## Трейлеры

```
Constraint: depends on PR #67; не вводит новые SyncEngine API.
Rejected:  объединять с PR #67 — review-surface удваивается.
Directive:  любые новые multi-table сценарии добавлять сюда, а не в engine.
Not-tested: много-origin concurrent evolution; push с seq > last+2.
Confidence: high
Scope-risk: narrow
```