### PR TITLE
feat(sync): add SyncEngine::make_push_request helper

### DIFF
--- a/examples/sync_replication_example.cpp
+++ b/examples/sync_replication_example.cpp
@@ -175,7 +175,7 @@ int main() {
         const std::uint64_t from_seq =
             replica_engine.applied_cursor().last_seq_for(primary_node) + 1;
         const PushRequest push = primary_engine.make_push_request(
-            primary_node, from_seq, /*to_seq=*/0);
+            from_seq, /*to_seq=*/0);
 
         // The replica-side apply is performed inside an atomic writable
         // transaction by handle_push(); gap or conflict aborts the whole

--- a/examples/sync_replication_example.cpp
+++ b/examples/sync_replication_example.cpp
@@ -168,25 +168,14 @@ int main() {
     primary_conn->detach_sync_capture();
 
     {
-        // Read only the newly produced changelog batches and push them
-        // directly to the replica. The manual ChangeLogStore walk below
-        // is the low-level demonstration path; a real client would query
-        // the local SyncEngine for the right window (cursor.last + 1).
-        auto txn = primary_conn->transaction(TransactionMode::READ_ONLY);
-        MetaStore meta(primary_conn->env_handle());
-        meta.open(txn.handle());
-        ChangeLogStore log(primary_conn->env_handle());
-        log.open(txn.handle());
-        const std::uint64_t last_seq = meta.get_local_seq(txn.handle());
-        const std::uint64_t first_seq = last_seq > 2 ? (last_seq - 1) : 1;
-        PushRequest push;
-        push.sender = primary_node;
-        push.db_id  = db_uuid;
-        std::vector<std::uint8_t> buf;
-        for (std::uint64_t s = first_seq; s <= last_seq; ++s) {
-            if (!log.get(txn.handle(), primary_node, s, buf)) continue;
-            push.batches.push_back(ChangeBatchCodec::decode_exact(buf));
-        }
+        // Build a PushRequest that covers only the batches the replica has
+        // not seen yet. make_push_request opens its own short-lived read
+        // transaction on the bound connection, so it is safe to call right
+        // after a writable commit (no overlap with user's open txns).
+        const std::uint64_t from_seq =
+            replica_engine.applied_cursor().last_seq_for(primary_node) + 1;
+        const PushRequest push = primary_engine.make_push_request(
+            primary_node, from_seq, /*to_seq=*/0);
 
         // The replica-side apply is performed inside an atomic writable
         // transaction by handle_push(); gap or conflict aborts the whole

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -296,23 +296,27 @@ namespace sync {
         /// \c seq in \c [from_seq, to_seq] (inclusive).
         /// \details Hides the system stores from callers: example code and
         /// future transports can call this instead of touching
-        /// \c MetaStore / \c ChangeLogStore directly. Opens its own short-lived
-        /// read-only transaction on the bound connection; safe to call from
-        /// any context (including right after a writable commit).
-        /// \param sender_node_id Identity under which the batches were
-        /// appended locally.
+        /// \c MetaStore / \c ChangeLogStore directly. The sender is always
+        /// the local node id (derived from \c _mdbxc_meta); sending batches
+        /// of other origins is not supported at this layer.
+        ///
+        /// Opens its own short-lived read-only transaction on the bound
+        /// connection. The caller must not have another active transaction
+        /// for the same connection on the current thread (Mdbx would return
+        /// \c MDBX_BUSY). Right after a writable commit is fine.
         /// \param from_seq First \c seq to include (use 1 to send from the
         /// beginning; use the peer's \c applied_cursor + 1 to send a delta).
         /// \param to_seq Last \c seq to include (use 0 to send up to the
         /// current local tail, inclusive).
         /// \return A \c PushRequest ready to send to the peer. Empty
-        /// \c batches when the range is empty.
+        /// \c batches when the requested range is empty (or past the tail).
+        /// \throws std::runtime_error if the requested range is not
+        /// contiguous in the local changelog (a hole means pruning,
+        /// corruption, or a wrong origin).
         /// \throws MdbxException on database error.
-        PushRequest make_push_request(const NodeId& sender_node_id,
-                                      std::uint64_t from_seq,
+        PushRequest make_push_request(std::uint64_t from_seq,
                                       std::uint64_t to_seq) const {
             PushRequest req;
-            req.sender = sender_node_id;
             req.db_id  = db_uuid();
             if (to_seq != 0 && to_seq < from_seq) return req;
             auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
@@ -320,14 +324,21 @@ namespace sync {
             meta.open(txn.handle());
             ChangeLogStore log(m_conn->env_handle());
             log.open(txn.handle());
+            req.sender = meta.get_node_id(txn.handle());
             if (to_seq == 0) {
                 to_seq = meta.get_local_seq(txn.handle());
             }
             if (to_seq < from_seq) return req;
             std::vector<std::uint8_t> buf;
-            for (std::uint64_t s = from_seq; s <= to_seq; ++s) {
-                if (!log.get(txn.handle(), sender_node_id, s, buf)) continue;
+            for (std::uint64_t s = from_seq;; ++s) {
+                if (!log.get(txn.handle(), req.sender, s, buf)) {
+                    throw std::runtime_error(
+                        "SyncEngine::make_push_request: changelog gap at seq " +
+                        std::to_string(s) +
+                        " (pruning, corruption, or wrong origin)");
+                }
                 req.batches.push_back(ChangeBatchCodec::decode_exact(buf));
+                if (s == to_seq) break;
             }
             return req;
         }

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -292,6 +292,46 @@ namespace sync {
             return read_applied_cursor(txn, cur);
         }
 
+        /// \brief Builds a \c PushRequest that carries every local batch with
+        /// \c seq in \c [from_seq, to_seq] (inclusive).
+        /// \details Hides the system stores from callers: example code and
+        /// future transports can call this instead of touching
+        /// \c MetaStore / \c ChangeLogStore directly. Opens its own short-lived
+        /// read-only transaction on the bound connection; safe to call from
+        /// any context (including right after a writable commit).
+        /// \param sender_node_id Identity under which the batches were
+        /// appended locally.
+        /// \param from_seq First \c seq to include (use 1 to send from the
+        /// beginning; use the peer's \c applied_cursor + 1 to send a delta).
+        /// \param to_seq Last \c seq to include (use 0 to send up to the
+        /// current local tail, inclusive).
+        /// \return A \c PushRequest ready to send to the peer. Empty
+        /// \c batches when the range is empty.
+        /// \throws MdbxException on database error.
+        PushRequest make_push_request(const NodeId& sender_node_id,
+                                      std::uint64_t from_seq,
+                                      std::uint64_t to_seq) const {
+            PushRequest req;
+            req.sender = sender_node_id;
+            req.db_id  = db_uuid();
+            if (to_seq != 0 && to_seq < from_seq) return req;
+            auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
+            MetaStore meta(m_conn->env_handle());
+            meta.open(txn.handle());
+            ChangeLogStore log(m_conn->env_handle());
+            log.open(txn.handle());
+            if (to_seq == 0) {
+                to_seq = meta.get_local_seq(txn.handle());
+            }
+            if (to_seq < from_seq) return req;
+            std::vector<std::uint8_t> buf;
+            for (std::uint64_t s = from_seq; s <= to_seq; ++s) {
+                if (!log.get(txn.handle(), sender_node_id, s, buf)) continue;
+                req.batches.push_back(ChangeBatchCodec::decode_exact(buf));
+            }
+            return req;
+        }
+
     private:
         /// \brief Returns true when \p request_db_id matches the local
         /// \c db_uuid. A zero \p request_db_id is rejected: callers must

--- a/tests/test_sync_replication.cpp
+++ b/tests/test_sync_replication.cpp
@@ -312,7 +312,7 @@ void test_replication_make_push_request_helper() {
     // Empty range -> empty request.
     {
         const sync::PushRequest empty = pe.make_push_request(
-            make_node(0xA0), /*from_seq=*/100, /*to_seq=*/0);
+            /*from_seq=*/100, /*to_seq=*/0);
         if (!empty.batches.empty()) {
             throw std::runtime_error("empty range produced non-empty push");
         }
@@ -321,7 +321,7 @@ void test_replication_make_push_request_helper() {
     // Full window (from 1 to local tail).
     {
         const sync::PushRequest full = pe.make_push_request(
-            make_node(0xA0), /*from_seq=*/1, /*to_seq=*/0);
+            /*from_seq=*/1, /*to_seq=*/0);
         if (full.batches.size() != 3u) {
             throw std::runtime_error("full window wrong size: " +
                                      std::to_string(full.batches.size()));
@@ -342,7 +342,7 @@ void test_replication_make_push_request_helper() {
     // Partial window (from 2 to 3).
     {
         const sync::PushRequest mid = pe.make_push_request(
-            make_node(0xA0), /*from_seq=*/2, /*to_seq=*/3);
+            /*from_seq=*/2, /*to_seq=*/3);
         if (mid.batches.size() != 2u) {
             throw std::runtime_error("partial window wrong size: " +
                                      std::to_string(mid.batches.size()));
@@ -352,9 +352,40 @@ void test_replication_make_push_request_helper() {
     // Reversed range (to_seq < from_seq) -> empty.
     {
         const sync::PushRequest rev = pe.make_push_request(
-            make_node(0xA0), /*from_seq=*/5, /*to_seq=*/2);
+            /*from_seq=*/5, /*to_seq=*/2);
         if (!rev.batches.empty()) {
             throw std::runtime_error("reversed range produced non-empty push");
+        }
+    }
+
+    // Gap in changelog -> exception, not silent skip.
+    // Delete seq 2 directly via MDBX, then ask for [1, 3].
+    {
+        auto erase_txn = primary->transaction(mdbxc::TransactionMode::WRITABLE);
+        sync::ChangeLogStore log(primary->env_handle());
+        log.open(erase_txn.handle());
+        const sync::NodeId local = make_node(0xA0);
+        std::vector<std::uint8_t> key_buf(24);
+        std::memcpy(key_buf.data(), local.data(), 16);
+        const std::uint64_t seq = 2;
+        for (int i = 0; i < 8; ++i) {
+            key_buf[16 + i] = static_cast<std::uint8_t>((seq >> ((7 - i) * 8)) & 0xff);
+        }
+        MDBX_val k{ key_buf.data(), key_buf.size() };
+        const int del_rc = mdbx_del(erase_txn.handle(), log.handle(), &k, nullptr);
+        if (del_rc != MDBX_SUCCESS && del_rc != MDBX_NOTFOUND) {
+            throw std::runtime_error("test setup: mdbx_del failed");
+        }
+        erase_txn.commit();
+
+        bool threw = false;
+        try {
+            (void)pe.make_push_request(/*from_seq=*/1, /*to_seq=*/3);
+        } catch (const std::runtime_error&) {
+            threw = true;
+        }
+        if (!threw) {
+            throw std::runtime_error("gap in changelog did not throw");
         }
     }
 

--- a/tests/test_sync_replication.cpp
+++ b/tests/test_sync_replication.cpp
@@ -287,6 +287,81 @@ void test_replication_incremental_pull() {
     cleanup(p); cleanup(r);
 }
 
+void test_replication_make_push_request_helper() {
+    using namespace mdbxc;
+    const std::string p = "test_rep_make_push_helper.mdbx";
+    const std::string r = "test_rep_make_push_helper_replica.mdbx";
+    cleanup(p); cleanup(r);
+
+    auto primary = open(p);
+    auto replica = open(r);
+    sync::SyncEngine pe(primary), re(replica);
+    pe.initialize_local_identity(make_node(0xA0), make_node(0xD0));
+    re.initialize_local_identity(make_node(0xB0), make_node(0xD0));
+
+    sync::ThreadLocalChangeAccumulator sink(primary);
+    primary->attach_sync_capture(&sink);
+    {
+        KeyValueTable<int, std::string> kv(primary, "kv");
+        kv.insert_or_assign(1, "a");
+        kv.insert_or_assign(2, "b");
+        kv.insert_or_assign(3, "c");
+    }
+    primary->detach_sync_capture();
+
+    // Empty range -> empty request.
+    {
+        const sync::PushRequest empty = pe.make_push_request(
+            make_node(0xA0), /*from_seq=*/100, /*to_seq=*/0);
+        if (!empty.batches.empty()) {
+            throw std::runtime_error("empty range produced non-empty push");
+        }
+    }
+
+    // Full window (from 1 to local tail).
+    {
+        const sync::PushRequest full = pe.make_push_request(
+            make_node(0xA0), /*from_seq=*/1, /*to_seq=*/0);
+        if (full.batches.size() != 3u) {
+            throw std::runtime_error("full window wrong size: " +
+                                     std::to_string(full.batches.size()));
+        }
+        if (full.sender != make_node(0xA0) || full.db_id != make_node(0xD0)) {
+            throw std::runtime_error("push request header fields wrong");
+        }
+        // End-to-end: helper -> DirectSyncPeer -> replica engine -> kv.
+        sync::DirectSyncPeer peer(&re);
+        const sync::PushResponse resp = peer.push(full);
+        if (!resp.ok) { throw std::runtime_error("push via helper failed: " + resp.error); }
+        KeyValueTable<int, std::string> kv_re(replica, "kv");
+        if (kv_or_throw(replica, kv_re, 1, "kv[1] after helper push") != "a") throw std::runtime_error("kv[1] != a");
+        if (kv_or_throw(replica, kv_re, 2, "kv[2] after helper push") != "b") throw std::runtime_error("kv[2] != b");
+        if (kv_or_throw(replica, kv_re, 3, "kv[3] after helper push") != "c") throw std::runtime_error("kv[3] != c");
+    }
+
+    // Partial window (from 2 to 3).
+    {
+        const sync::PushRequest mid = pe.make_push_request(
+            make_node(0xA0), /*from_seq=*/2, /*to_seq=*/3);
+        if (mid.batches.size() != 2u) {
+            throw std::runtime_error("partial window wrong size: " +
+                                     std::to_string(mid.batches.size()));
+        }
+    }
+
+    // Reversed range (to_seq < from_seq) -> empty.
+    {
+        const sync::PushRequest rev = pe.make_push_request(
+            make_node(0xA0), /*from_seq=*/5, /*to_seq=*/2);
+        if (!rev.batches.empty()) {
+            throw std::runtime_error("reversed range produced non-empty push");
+        }
+    }
+
+    primary->disconnect(); replica->disconnect();
+    cleanup(p); cleanup(r);
+}
+
 void test_replication_idempotent_apply() {
     using namespace mdbxc;
     const std::string r = "test_rep_idempotent.mdbx";
@@ -332,6 +407,7 @@ int main() {
         { "test_replication_mixed_ops",          &test_replication_mixed_ops },
         { "test_replication_incremental_pull",   &test_replication_incremental_pull },
         { "test_replication_idempotent_apply",   &test_replication_idempotent_apply },
+        { "test_replication_make_push_request", &test_replication_make_push_request_helper },
     };
     int rc = 0;
     for (std::size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {


### PR DESCRIPTION
## Что

Удобный helper на `SyncEngine` для построения `PushRequest` из локального changelog'а без обращения к `MetaStore`/`ChangeLogStore` напрямую.

```cpp
const std::uint64_t from_seq =
    replica_engine.applied_cursor().last_seq_for(primary_node) + 1;
const PushRequest push =
    primary_engine.make_push_request(from_seq, /*to_seq=*/0);
peer.push(push);
```

`req.sender` подставляется внутри helper'а из локального `_mdbxc_meta.node_id` (v0.1 changelog локальный, чужие origin'ы этим слоем не поддерживаются).

## Зачем

В `sync_replication_example.cpp` push-блок делал manual `MetaStore` + `ChangeLogStore` walk с хардкодом `last_seq > 2 ? (last_seq - 1) : 1`. Это:
- утечка system-store API наружу (пример был единственным клиентом, который напрямую открывал `_mdbxc_changelog`),
- хрупкое (нужно знать `local_seq` смещение),
- недоступно другим клиентам без копипасты.

## Контракт

- `from_seq` — первый `seq` для включения (1 для initial pull; `replica.applied_cursor + 1` для дельты).
- `to_seq` — последний `seq` (0 = текущий локальный tail).
- Возвращает `PushRequest` с пустым `batches`, если диапазон пуст (или проскочил tail).
- Бросает `std::runtime_error` при дырке в changelog (pruning / corruption / wrong origin).
- Helper открывает собственную короткоживущую READ_ONLY транзакцию на bound connection. Caller не должен держать открытую транзакцию на том же connection/thread (Mdbx вернёт `MDBX_BUSY`).

## Скоуп

- Новый public метод `SyncEngine::make_push_request(from_seq, to_seq) const`.
- 4 строки удалено из `sync_replication_example.cpp` push-блока.
- Новый тест `test_replication_make_push_request` (5 сценариев: пустой / полный / частичный / обратный диапазон / end-to-end push + **gap → exception**).

## Чего здесь НЕТ

- Никаких изменений протокола (всё те же `PushRequest`/`PushResponse`).
- Никаких изменений в conflict-handling, atomic commit, has_more (это в PR #67).
- Multi-master foundation (cursor-per-origin + revision) — отдельный PR F.

## Тесты

```
PASS test_replication_pull_three_tables
PASS test_replication_push_three_tables
PASS test_replication_mixed_ops
PASS test_replication_incremental_pull
PASS test_replication_idempotent_apply
PASS test_replication_make_push_request
```

## Трейлеры

```
Constraint: same external behaviour for the contiguous case; throw on
           contract violation (gap, missing seq).
Rejected:  returning a SnapshotRequired status enum — exception is
           honest and matches the existing MdbxException throw-on-error
           style.
Rejected:  keeping sender_node_id — the v0.1 changelog is local-only;
           sending other origins is not supported at this layer.
Directive:  new helpers in the sync layer must throw on contract
           violation rather than skip silently.
Scope-risk: narrow
Confidence: high
Not-tested: ASan/Valgrind on lifecycle; concurrent calls from multiple
            threads; randomized state-model coverage (planned as a
            separate PR).
```