### PR TITLE
test(sync): rename contract tests to match what they verify

### DIFF
--- a/tests/test_sync_randomized.cpp
+++ b/tests/test_sync_randomized.cpp
@@ -67,7 +67,7 @@ void seed_changelog(mdbxc::Connection& conn,
     txn.commit();
 }
 
-void run_state_equality_after_pull() {
+void run_pull_apply_data_and_replay() {
     using namespace mdbxc;
     using namespace mdbxc::sync;
 
@@ -155,7 +155,7 @@ void run_state_equality_after_pull() {
     cleanup(r_path);
 }
 
-void test_push_gap_returns_conflict() {
+void test_make_push_request_rejects_changelog_gap() {
     using namespace mdbxc;
     using namespace mdbxc::sync;
 
@@ -225,8 +225,9 @@ void test_push_gap_returns_conflict() {
 int main() {
     struct Case { const char* name; void (*fn)(); };
     const Case cases[] = {
-        { "test_state_equality_after_pull",  &run_state_equality_after_pull },
-        { "test_push_gap_returns_conflict",   &test_push_gap_returns_conflict },
+        { "test_pull_apply_data_and_replay",  &run_pull_apply_data_and_replay },
+        { "test_make_push_request_rejects_changelog_gap",
+                                             &test_make_push_request_rejects_changelog_gap },
     };
     int rc = 0;
     for (std::size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {


### PR DESCRIPTION
## Что

Follow-up к PR #71 review. Переименовывает два теста чтобы имена отражали то, что они реально проверяют:

* `test_state_equality_after_pull` → `test_pull_apply_data_and_replay`
* `test_push_gap_returns_conflict` → `test_make_push_request_rejects_changelog_gap`

## Чего здесь НЕТ

Data-equality extension (read kv on replica + assert bytes) — отложен в отдельный PR. Текущая структура теста (apply WRITABLE txn → READ_ONLY verify txn в той же функции) вызывает `MDBX_TXN_OVERLAPPING` на локальной Windows-тачке. Исправление требует другого test shape и должно идти вместе с разбором MDBX_BUSY.

## Тесты

Локально:
```
PASS test_pull_apply_data_and_replay
PASS test_make_push_request_rejects_changelog_gap
```

## Трейлеры

```
Constraint: rename only; no behavior change.
Rejected:  folding the data-equality check into this PR — would block on
           MDBX_TXN_OVERLAPPING debug.
Directive:  rename a test only when its name actually describes what
           it verifies; otherwise rewrite the test body too.
Scope-risk: narrow
Confidence: high
```