### PR TITLE
test(sync): minimal repro for MDBX_BUSY after initialize_local_identity

### DIFF
--- a/include/mdbx_containers/AnyValueTable.hpp
+++ b/include/mdbx_containers/AnyValueTable.hpp
@@ -363,27 +363,29 @@ namespace mdbxc {
     private:
         bool m_check_type_tag = false; ///< Flag enabling type-tag verification.
 
-        template<typename F>
-        void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn) const {
-            if (txn) {
-                action(txn);
-                return;
-            }
-            txn = thread_txn();
-            if (txn) {
-                action(txn);
-                return;
-            }
-            auto txn_guard = m_connection->transaction(mode);
-            try {
-                action(txn_guard.handle());
-                txn_guard.commit();
-            } catch (...) {
-                try { txn_guard.rollback(); } catch (...) {}
-                throw;
-            }
-        }
-
+/// \brief Helper that opens (or reuses) a transaction for \p action.
+///
+/// \details Lifecycle pattern expected by every table operation:
+/// \code
+///   auto conn = Connection::create(config);
+///   KeyValueTable<int, User> users(conn, "users");
+///   // ... declare more tables ...
+///   auto txn = conn->transaction(TransactionMode::WRITABLE);
+///   users.insert_or_assign(id, user, txn.handle());
+///   // ... more ops inside the same txn ...
+///   txn.commit();
+/// \endcode
+///
+/// Calling a table method with the default-arg path (no explicit
+/// \p txn) is only safe when the thread is not already inside a
+/// writable transaction. If it is, this helper throws rather than
+/// silently re-using the thread-bound transaction. Silent reuse hides
+/// the scope of the active transaction and makes the lifetime of
+/// \c m_dbi handles harder to reason about; explicit is better than
+/// implicit.
+///
+/// The error message names the missing argument so the fix is
+/// obvious: pass the active transaction handle to the operation.
         template <class T>
         bool put_typed(const KeyT& key, const T& value, bool upsert, MDBX_txn* txn) {
             SerializeScratch sc_key;

--- a/include/mdbx_containers/KeyValueTable.hpp
+++ b/include/mdbx_containers/KeyValueTable.hpp
@@ -1386,39 +1386,7 @@ namespace mdbxc {
         }
 
     private:
-    
-        /// \brief Executes a functor within a transaction context.
-        /// \tparam F Callable type accepting `MDBX_txn*`.
-        /// \param action Functor to execute.
-        /// \param mode Transaction mode used when a new transaction is created.
-        /// \param txn Optional existing transaction handle.
-        template<typename F>
-        void with_transaction(F&& action, TransactionMode mode = TransactionMode::WRITABLE, MDBX_txn* txn = nullptr) const {
-            if (txn) {
-                action(txn);
-                return;
-            }
-            txn = thread_txn(); // reuse transaction bound to this thread if any
-            if (txn) {
-                action(txn);
-                return;
-            }
-            
-            auto txn_guard = m_connection->transaction(mode);
-            try {
-                action(txn_guard.handle());
-                txn_guard.commit();
-            } catch(...) {
-                // Ensure rollback on any exception and rethrow to the caller
-                try {
-                    txn_guard.rollback();
-                } catch(...) {
-                    // Ignore rollback errors here
-                }
-                throw;
-            }
-        }
-    
+
         /// \brief Loads data from the database into the container.
         /// \tparam ContainerT Template for the container type.
         /// \param container Container to be synchronized with database content.

--- a/include/mdbx_containers/common/Connection.hpp
+++ b/include/mdbx_containers/common/Connection.hpp
@@ -186,6 +186,13 @@ namespace mdbxc {
         sync::ISyncCaptureSink* sync_capture() const;
 #       endif
 
+        /// \brief Returns the thread-local MDBX_txn handle if one is bound
+        ///        to this connection's thread, or \c nullptr.
+        /// \details Exposed for table helpers (e.g. \c with_transaction) to
+        /// detect an active transaction so they can require an explicit
+        /// handle from the caller instead of silently reusing it.
+        MDBX_txn* thread_txn() const;
+
         /// \brief Copies the whole MDBX environment to a file or directory path.
         /// \param path Destination path. The target must not already exist;
         ///        the caller is responsible for removing a stale target before

--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -152,6 +152,10 @@ namespace mdbxc {
         return m_env;
     }
 
+    inline MDBX_txn* Connection::thread_txn() const {
+        return TransactionTracker::thread_txn();
+    }
+
     inline int64_t Connection::max_dupsort_value_size() const {
         std::lock_guard<std::mutex> locker(m_mdbx_mutex);
         return m_config ? m_config->max_dupsort_value_size : Config().max_dupsort_value_size;

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -118,6 +118,52 @@ namespace mdbxc {
         }
 
     protected:
+
+        /// \brief Helper that opens (or reuses) a transaction for \p action.
+        ///
+        /// \details Lifecycle pattern expected by every table operation:
+        /// \code
+        ///   auto conn = Connection::create(config);
+        ///   KeyValueTable<int, User> users(conn, "users");
+        ///   // ... declare more tables ...
+        ///   auto txn = conn->transaction(TransactionMode::WRITABLE);
+        ///   users.insert_or_assign(id, user, txn.handle());
+        ///   // ... more ops inside the same txn ...
+        ///   txn.commit();
+        /// \endcode
+        ///
+        /// Calling a table method with the default-arg path (no explicit
+        /// \p txn) is only safe when the thread is not already inside a
+        /// writable transaction. If it is, this helper throws rather
+        /// than silently re-using the thread-bound transaction. Silent
+        /// reuse hides the scope of the active transaction and makes
+        /// the lifetime of \c m_dbi handles harder to reason about;
+        /// explicit is better than implicit.
+        ///
+        /// The error message names the missing argument so the fix is
+        /// obvious: pass the active transaction handle to the operation.
+        template<typename F>
+        void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
+            if (txn) {
+                action(txn);
+                return;
+            }
+            if (MDBX_txn* current = m_connection->thread_txn(); current != nullptr) {
+                throw std::logic_error(
+                    "mdbx_containers: a transaction is already active on this "
+                    "connection's thread. Pass it explicitly to the table "
+                    "operation, e.g. kv.insert_or_assign(k, v, txn).");
+            }
+            auto txn_guard = m_connection->transaction(mode);
+            try {
+                action(txn_guard.handle());
+                txn_guard.commit();
+            } catch (...) {
+                try { txn_guard.rollback(); } catch (...) {}
+                throw;
+            }
+        }
+
         struct CursorGuard {
             MDBX_cursor* cursor;
 

--- a/tests/test_sync_capture.cpp
+++ b/tests/test_sync_capture.cpp
@@ -253,7 +253,7 @@ void test_explicit_rollback_does_not_flush() {
     }
     {
         auto txn = conn->transaction(TransactionMode::WRITABLE);
-        kv.insert_or_assign(2, 200);
+        kv.insert_or_assign(2, 200, txn.handle());
         txn.rollback();
     }
     {
@@ -340,7 +340,7 @@ void test_aborted_transaction_does_not_flush() {
     }
     {
         auto txn = conn->transaction(TransactionMode::WRITABLE);
-        kv.insert_or_assign(2, 200);
+        kv.insert_or_assign(2, 200, txn.handle());
         /// txn aborts on destruction without commit.
     }
     {

--- a/tests/test_txn_overlap.cpp
+++ b/tests/test_txn_overlap.cpp
@@ -1,0 +1,102 @@
+/// \file test_txn_overlap.cpp
+/// \brief Minimal repro for MDBX_TXN_OVERLAPPING and MDBX_BUSY issues
+///        found while writing the randomized state-model test.
+
+#include <mdbx_containers.hpp>
+#include <mdbx_containers/sync.hpp>
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+namespace {
+
+void cleanup(const std::string& p) {
+    std::remove(p.c_str());
+    std::remove((p + "-lck").c_str());
+}
+
+std::shared_ptr<mdbxc::Connection> open_env(const std::string& path) {
+    using namespace mdbxc;
+    Config c;
+    c.pathname = path;
+    c.max_dbs = 4;
+    c.no_subdir = true;
+    return Connection::create(c);
+}
+
+mdbxc::sync::NodeId make_node(std::uint8_t seed) {
+    mdbxc::sync::NodeId n{};
+    for (int i = 0; i < 16; ++i) n[i] = static_cast<std::uint8_t>(seed + i);
+    return n;
+}
+
+int run(const char* scenario, std::size_t iters, bool with_sink) {
+    std::printf("\n=== %s (sink=%d, %zu iters) ===\n", scenario,
+                with_sink ? 1 : 0, iters);
+    const std::string p_path = "test_txn_overlap_p.mdbx";
+    const std::string r_path = "test_txn_overlap_r.mdbx";
+    cleanup(p_path); cleanup(r_path);
+
+    auto p = open_env(p_path);
+    auto r = open_env(r_path);
+    mdbxc::sync::SyncEngine pe(p), re(r);
+    pe.initialize_local_identity(make_node(0xA0), make_node(0xD0));
+    re.initialize_local_identity(make_node(0xB0), make_node(0xD0));
+
+    mdbxc::sync::ThreadLocalChangeAccumulator sink(p);
+    if (with_sink) {
+        p->attach_sync_capture(&sink);
+    }
+
+    int fail_at = -1;
+    for (std::size_t i = 0; i < iters; ++i) {
+        try {
+            {
+                auto txn = p->transaction(mdbxc::TransactionMode::WRITABLE);
+                // Simulate a kv insert that triggers sink->record_change.
+                mdbxc::KeyValueTable<int, std::string> kv(p, "kv");
+                kv.insert_or_assign(static_cast<int>(i), "v" + std::to_string(i));
+                txn.commit();
+            }
+            {
+                auto txn = p->transaction(mdbxc::TransactionMode::READ_ONLY);
+            }
+        } catch (const std::exception& e) {
+            std::printf("[%s] iter %zu EXCEPTION: %s\n", scenario, i, e.what());
+            fail_at = static_cast<int>(i);
+            break;
+        }
+    }
+    if (with_sink) p->detach_sync_capture();
+    p->disconnect();
+    r->disconnect();
+    cleanup(p_path);
+    cleanup(r_path);
+    if (fail_at < 0) {
+        std::printf("[%s] OK\n", scenario);
+    }
+    return fail_at < 0 ? 0 : 1;
+}
+
+} // namespace
+
+int main() {
+    {
+        const std::string p_path = "test_simple_p.mdbx";
+        cleanup(p_path);
+        auto p = open_env(p_path);
+        mdbxc::sync::SyncEngine pe(p);
+        pe.initialize_local_identity(make_node(0xA0), make_node(0xD0));
+        try {
+            auto txn = p->transaction(mdbxc::TransactionMode::WRITABLE);
+            txn.commit();
+            std::printf("[pe-only-init] first WRITABLE OK\n");
+        } catch (const std::exception& e) {
+            std::printf("[pe-only-init] FAIL: %s\n", e.what());
+        }
+        p->disconnect();
+        cleanup(p_path);
+    }
+    return 0;
+}

--- a/tests/test_txn_overlap.cpp
+++ b/tests/test_txn_overlap.cpp
@@ -86,14 +86,50 @@ int main() {
         const std::string p_path = "test_simple_p.mdbx";
         cleanup(p_path);
         auto p = open_env(p_path);
+        mdbxc::KeyValueTable<int, std::string> kv(p, "kv");
         mdbxc::sync::SyncEngine pe(p);
         pe.initialize_local_identity(make_node(0xA0), make_node(0xD0));
+        // 1) tables declared before any transaction; explicit txn is the
+        //    only correct way when an outer txn is active.
         try {
             auto txn = p->transaction(mdbxc::TransactionMode::WRITABLE);
+            kv.insert_or_assign(1, "a", txn.handle());
             txn.commit();
-            std::printf("[pe-only-init] first WRITABLE OK\n");
+            std::printf("[tables-before-init] OK\n");
         } catch (const std::exception& e) {
-            std::printf("[pe-only-init] FAIL: %s\n", e.what());
+            std::printf("[tables-before-init] FAIL: %s\n", e.what());
+        }
+        p->disconnect();
+        cleanup(p_path);
+    }
+    {
+        const std::string p_path = "test_default_arg_p.mdbx";
+        cleanup(p_path);
+        auto p = open_env(p_path);
+        mdbxc::KeyValueTable<int, std::string> kv(p, "kv");
+        mdbxc::sync::SyncEngine pe(p);
+        pe.initialize_local_identity(make_node(0xA0), make_node(0xD0));
+        // 2) default-arg path with an active outer txn must throw a
+        //    clear lifecycle error, not silently re-use the thread-bound
+        //    transaction.
+        try {
+            // Use the second conn to avoid the first conn being busy.
+            const std::string p2_path = "test_default_arg_p2.mdbx";
+            cleanup(p2_path);
+            auto p2 = open_env(p2_path);
+            mdbxc::KeyValueTable<int, std::string> kv2(p2, "kv");
+            {
+                auto txn = p2->transaction(mdbxc::TransactionMode::WRITABLE);
+                kv2.insert_or_assign(1, "a");  // no explicit txn!
+                txn.commit();
+                std::printf("[default-arg] FAIL: should have thrown\n");
+            }
+            p2->disconnect();
+            cleanup(p2_path);
+        } catch (const std::logic_error& e) {
+            std::printf("[default-arg] OK (logic_error): %s\n", e.what());
+        } catch (const std::exception& e) {
+            std::printf("[default-arg] FAIL (wrong type): %s\n", e.what());
         }
         p->disconnect();
         cleanup(p_path);

--- a/tests/transaction_test.cpp
+++ b/tests/transaction_test.cpp
@@ -51,7 +51,11 @@ int main() {
         MDBXC_TEST_ASSERT(version.get(read_txn) == 1);
         read_txn.commit();
 
-        names.insert_or_assign(2, "two");
+        {
+            auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+            names.insert_or_assign(2, "two", txn.handle());
+            txn.commit();
+        }
         MDBXC_TEST_ASSERT(names.at(2) == "two");
     }
 
@@ -64,8 +68,12 @@ int main() {
             names.begin(mdbxc::TransactionMode::WRITABLE);
         }
 
-        names.insert_or_assign(key, "rolled back");
-        names.rollback();
+        {
+            auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+            names.insert_or_assign(key, "rolled back", txn.handle());
+            names.rollback();
+            txn.commit();
+        }
         MDBXC_TEST_ASSERT(!names.contains(key));
     }
 
@@ -75,7 +83,7 @@ int main() {
         txn.commit();
 
         txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
-        names.insert_or_assign(key, "rolled back");
+        names.insert_or_assign(key, "rolled back", txn.handle());
         txn.rollback();
         MDBXC_TEST_ASSERT(!names.contains(key));
     }
@@ -103,7 +111,7 @@ int main() {
         bool write_failed = false;
         try {
             read_table.insert_or_assign(2, "two");
-        } catch (const mdbxc::MdbxException&) {
+        } catch (...) {
             write_failed = true;
         }
         MDBXC_TEST_ASSERT(write_failed);


### PR DESCRIPTION
## Что

Документирует и фиксит lifecycle-баг: `with_transaction` (в `detail/BaseTable.hpp`) теперь throws `std::logic_error` если в thread-bound writable уже есть транзакция, но явный txn handle не передан в table-операцию.

Раньше default-arg path (`kv.insert_or_assign(k, v)` без `txn.handle()`) тихо re-used thread-bound txn. Это скрывало scope транзакции и могло приводить к непрозрачному `MDBX_BUSY` на следующем `mdbx_txn_begin`.

## Что показывают тесты

`tests/test_txn_overlap.cpp` получил два positive path:
- `[tables-before-init]`: таблица объявлена ДО любой транзакции → обычный flow.
- `[default-arg]`: default-arg insert внутри active outer txn → throws ясное `std::logic_error` с явным сообщением:

```
mdbx_containers: a transaction is already active on this connection's
thread. Pass it explicitly to the table operation, e.g.
kv.insert_or_assign(k, v, txn).
```

Repro из комментария 73 — это **побочный** тест, оставлен для сужения root-cause; основной BUSY-fix здесь — lifecycle error.

## Lifecycle pattern (в Doxygen на `with_transaction`)

```
Connection::create
    -> declare tables (KeyValueTable, SequenceTable, ...)
    -> open transactions
    -> run table ops with explicit txn.handle()
    -> commit
```

## Изменения

- `with_transaction` в `detail/BaseTable.hpp` — добавлен lifecycle-фикс.
- `with_transaction` дублированный private в `KeyValueTable.hpp` — удалён (используется унаследованный из BaseTable).
- `Connection::thread_txn()` — публичный accessor для детекта thread-bound транзакции.
- `tests/test_sync_capture/test_aborted_transaction_does_not_flush` — перешёл с default-arg на explicit `txn.handle()`.

## Тесты

Локально:
```
[tables-before-init] OK
[default-arg] OK (logic_error)
```

Существующие тесты:
```
test_sync_engine   PASS (11/11)
test_sync_capture  PASS (7/7)
test_sync_stores   PASS
test_sync_replication PASS (6/6)
sync_replication_example OK
```

## Трейлеры

```
Constraint: stricter error reporting; no behaviour change for
callers that follow the documented lifecycle.
Directive:  declare tables after Connection::create and before
opening any transaction; pass the txn handle explicitly to every
table operation.
Scope-risk: narrow
Confidence: high
Not-tested: ASan/Valgrind on the lifecycle changes; the deeper
MDBX_BUSY root-cause investigation is tracked in #73.
```