### PR TITLE
fix(sync): preserve DBI flags and guard nested transactions

### DIFF
--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -95,6 +95,12 @@ namespace mdbxc {
         if (!m_env) {
             throw std::logic_error("Connection is not connected.");
         }
+        if (current_thread_has_txn()) {
+            throw std::logic_error(
+                "A transaction is already active on this connection's thread. "
+                "Reuse it through table operations or pass the active transaction explicitly."
+            );
+        }
         return Transaction(static_cast<TransactionTracker*>(this), m_env, mode);
     }
 
@@ -110,6 +116,12 @@ namespace mdbxc {
         auto it = m_transactions.find(tid);
         if (it != m_transactions.end()) {
             throw std::logic_error("Transaction already started for this thread.");
+        }
+        if (current_thread_has_txn()) {
+            throw std::logic_error(
+                "A transaction is already active on this connection's thread. "
+                "Commit or roll it back before starting a manual transaction."
+            );
         }
         auto txn = std::make_shared<Transaction>(static_cast<TransactionTracker*>(this), m_env, mode);
         m_transactions[tid] = txn;

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -53,6 +53,12 @@ namespace mdbxc {
                 mdbx_dbi_open(txn.handle(), m_name.c_str(), open_flags, &m_dbi),
                 "Failed to open table"
             );
+            unsigned dbi_flags = 0;
+            check_mdbx(
+                mdbx_dbi_flags(txn.handle(), m_dbi, &dbi_flags),
+                "Failed to read table flags"
+            );
+            m_dbi_flags = static_cast<std::uint32_t>(dbi_flags);
             txn.commit();
         }
         
@@ -143,6 +149,7 @@ namespace mdbxc {
 
         std::shared_ptr<Connection>  m_connection;   ///< Shared connection to MDBX environment.
         MDBX_dbi                     m_dbi{};         ///< DBI handle for the opened table.
+        std::uint32_t                m_dbi_flags{};   ///< Persistent MDBX DBI flags for sync capture.
         std::string                  m_name;          ///< DBI name (used for sync capture).
 
         /// \brief Returns the transaction bound to the current thread, if any.
@@ -179,13 +186,7 @@ namespace mdbxc {
             if (m_connection->is_read_only()) return;
             sync::ISyncCaptureSink* sink = m_connection->sync_capture();
             if (sink == nullptr) return;
-            unsigned flags = 0;
-            check_mdbx(
-                mdbx_dbi_flags(txn, m_dbi, &flags),
-                "Failed to read table flags for sync capture"
-            );
-            sink->record_change(txn, m_name, op_type,
-                                static_cast<std::uint32_t>(flags),
+            sink->record_change(txn, m_name, op_type, m_dbi_flags,
                                 storage_key, value);
         }
 #       endif

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -179,7 +179,14 @@ namespace mdbxc {
             if (m_connection->is_read_only()) return;
             sync::ISyncCaptureSink* sink = m_connection->sync_capture();
             if (sink == nullptr) return;
-            sink->record_change(txn, m_name, op_type, storage_key, value);
+            unsigned flags = 0;
+            check_mdbx(
+                mdbx_dbi_flags(txn, m_dbi, &flags),
+                "Failed to read table flags for sync capture"
+            );
+            sink->record_change(txn, m_name, op_type,
+                                static_cast<std::uint32_t>(flags),
+                                storage_key, value);
         }
 #       endif
     };

--- a/include/mdbx_containers/sync/ChangeAccumulator.hpp
+++ b/include/mdbx_containers/sync/ChangeAccumulator.hpp
@@ -67,10 +67,12 @@ namespace sync {
         void record_change(MDBX_txn* txn,
                            const std::string& dbi_name,
                            ChangeOpType op_type,
+                           std::uint32_t dbi_flags,
                            const std::vector<std::uint8_t>& storage_key,
                            const std::vector<std::uint8_t>& value) override {
             PendingOp op;
             op.op_type = op_type;
+            op.dbi_flags = dbi_flags;
             op.dbi_name = dbi_name;
             op.storage_key = storage_key;
             op.value = value;
@@ -104,6 +106,7 @@ namespace sync {
     private:
         struct PendingOp {
             ChangeOpType op_type = ChangeOpType::Put;
+            std::uint32_t dbi_flags = 0;
             std::string dbi_name;
             std::vector<std::uint8_t> storage_key;
             std::vector<std::uint8_t> value;
@@ -142,6 +145,7 @@ namespace sync {
             for (const PendingOp& op : ops) {
                 ChangeOp co;
                 co.op_type = op.op_type;
+                co.dbi_flags = op.dbi_flags;
                 co.dbi_name = op.dbi_name;
                 co.storage_key = op.storage_key;
                 co.value = op.value;

--- a/include/mdbx_containers/sync/ChangeOp.hpp
+++ b/include/mdbx_containers/sync/ChangeOp.hpp
@@ -23,17 +23,19 @@ namespace sync {
 
     /// \brief Single raw DBI operation captured by the change recorder.
     /// \details \c storage_key is the MDBX key serialized by the table.
-    /// \c identity_key is the application-level identity (empty when equal to
-    /// storage_key). \c revision_key is an optional application-level version.
+    /// \c dbi_flags carries the persistent MDBX DBI flags needed to open the
+    /// destination DBI compatibly during apply. \c identity_key is the
+    /// application-level identity (empty when equal to storage_key).
+    /// \c revision_key is an optional application-level version.
     struct ChangeOp {
-        ChangeOpType           op_type   = ChangeOpType::Put; ///< Per-batch feature flags (BATCH_NONE, BATCH_HAS_MORE, ...).
-        std::uint32_t          op_flags  = OP_NONE;           ///< Identifier of the node that produced this batch.
-        std::uint32_t          dbi_flags = 0;                 ///< Monotonic per-node sequence number assigned by MetaStore::increment_local_seq.
-        std::string            dbi_name;                      ///< List of operations in this batch; order is preserved on apply.
-        std::vector<std::uint8_t> storage_key;                ///< Operation kind: Put/Delete/ClearTable.
-        std::vector<std::uint8_t> value;                      ///< Per-op feature flags (OP_HAS_IDENTITY_KEY, OP_HAS_REVISION_KEY, OP_TOMBSTONE).
-        std::vector<std::uint8_t> identity_key;               ///< Raw MDBX_DBI flags passed to mdbx_dbi_open for the DBI named in `dbi_name.
-        std::vector<std::uint8_t> revision_key;               ///< Name of the user table (also the DBI name).
+        ChangeOpType           op_type   = ChangeOpType::Put; ///< Operation kind: Put/Delete/ClearTable.
+        std::uint32_t          op_flags  = OP_NONE;           ///< Per-op feature flags.
+        std::uint32_t          dbi_flags = 0;                 ///< Raw MDBX DBI flags for \c dbi_name.
+        std::string            dbi_name;                      ///< User table name (MDBX DBI name).
+        std::vector<std::uint8_t> storage_key;                ///< Serialized MDBX key bytes.
+        std::vector<std::uint8_t> value;                      ///< Serialized value bytes for Put.
+        std::vector<std::uint8_t> identity_key;               ///< Optional logical identity key.
+        std::vector<std::uint8_t> revision_key;               ///< Optional application revision/version key.
     };
 
 } // namespace sync

--- a/include/mdbx_containers/sync/ISyncCaptureSink.hpp
+++ b/include/mdbx_containers/sync/ISyncCaptureSink.hpp
@@ -43,12 +43,15 @@ namespace sync {
         /// \param dbi_name Name of the user table (the DBI name as passed
         ///        to the table constructor).
         /// \param op_type Kind of write (put/delete/clear).
+        /// \param dbi_flags MDBX DBI flags reported by \c mdbx_dbi_flags()
+        ///        for the user table, used by apply to open compatible DBIs.
         /// \param storage_key Serialized MDBX key bytes of the touched record.
         /// \param value Serialized MDBX value bytes for \c Put; empty for
         ///        \c Delete / \c ClearTable.
         virtual void record_change(MDBX_txn* txn,
                                    const std::string& dbi_name,
                                    ChangeOpType op_type,
+                                   std::uint32_t dbi_flags,
                                    const std::vector<std::uint8_t>& storage_key,
                                    const std::vector<std::uint8_t>& value) = 0;
 

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -116,7 +116,8 @@ namespace sync {
         /// \brief Applies a single \c ChangeBatch to local DBIs inside \p txn.
         /// \details See class-level docs for the seq / apply rules. The
         /// caller commits the transaction. User DBIs are opened lazily by
-        /// name with \c MDBX_CREATE; existing DBIs are reused within \p txn.
+        /// name with the captured \c ChangeOp::dbi_flags plus
+        /// \c MDBX_CREATE so destination tables keep compatible MDBX flags.
         ApplyResult apply_batch(MDBX_txn* txn, const ChangeBatch& batch) {
             MetaStore meta(m_conn->env_handle());
             AppliedStore applied(m_conn->env_handle());
@@ -429,14 +430,31 @@ namespace sync {
 
         static MDBX_dbi resolve_user_dbi(MDBX_txn* txn,
                                          const std::string& name,
+                                         std::uint32_t dbi_flags,
                                          std::unordered_map<std::string, MDBX_dbi>& cache) {
             auto it = cache.find(name);
             if (it != cache.end() && it->second != 0) {
                 return it->second;
             }
             MDBX_dbi dbi = 0;
-            check_mdbx(mdbx_dbi_open(txn, name.c_str(), MDBX_CREATE, &dbi),
-                       "SyncEngine: failed to open user DBI '" + name + "'");
+            const std::uint32_t supported_flags =
+                static_cast<std::uint32_t>(MDBX_REVERSEKEY) |
+                static_cast<std::uint32_t>(MDBX_DUPSORT) |
+                static_cast<std::uint32_t>(MDBX_INTEGERKEY) |
+                static_cast<std::uint32_t>(MDBX_DUPFIXED) |
+                static_cast<std::uint32_t>(MDBX_INTEGERDUP) |
+                static_cast<std::uint32_t>(MDBX_REVERSEDUP);
+            const MDBX_db_flags_t open_flags = static_cast<MDBX_db_flags_t>(
+                (dbi_flags & supported_flags) | static_cast<std::uint32_t>(MDBX_CREATE));
+            int rc = mdbx_dbi_open(txn, name.c_str(), open_flags, &dbi);
+            if (rc == MDBX_INCOMPATIBLE &&
+                (dbi_flags & static_cast<std::uint32_t>(MDBX_INTEGERKEY)) == 0) {
+                const MDBX_db_flags_t integer_flags = static_cast<MDBX_db_flags_t>(
+                    static_cast<std::uint32_t>(open_flags) |
+                    static_cast<std::uint32_t>(MDBX_INTEGERKEY));
+                rc = mdbx_dbi_open(txn, name.c_str(), integer_flags, &dbi);
+            }
+            check_mdbx(rc, "SyncEngine: failed to open user DBI '" + name + "'");
             cache[name] = dbi;
             return dbi;
         }
@@ -444,7 +462,7 @@ namespace sync {
         static void apply_one_op(MDBX_txn* txn,
                                  const ChangeOp& op,
                                  std::unordered_map<std::string, MDBX_dbi>& cache) {
-            MDBX_dbi dbi = resolve_user_dbi(txn, op.dbi_name, cache);
+            MDBX_dbi dbi = resolve_user_dbi(txn, op.dbi_name, op.dbi_flags, cache);
             switch (op.op_type) {
                 case ChangeOpType::Put: {
                     MDBX_val k = { op.storage_key.empty() ? nullptr

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -449,6 +449,9 @@ namespace sync {
             int rc = mdbx_dbi_open(txn, name.c_str(), open_flags, &dbi);
             if (rc == MDBX_INCOMPATIBLE &&
                 (dbi_flags & static_cast<std::uint32_t>(MDBX_INTEGERKEY)) == 0) {
+                // Compatibility path for batches produced before dbi_flags
+                // capture was implemented. Existing integer-key DBIs may
+                // reject open_flags=MDBX_CREATE with MDBX_INCOMPATIBLE.
                 const MDBX_db_flags_t integer_flags = static_cast<MDBX_db_flags_t>(
                     static_cast<std::uint32_t>(open_flags) |
                     static_cast<std::uint32_t>(MDBX_INTEGERKEY));

--- a/tests/test_sync_capture.cpp
+++ b/tests/test_sync_capture.cpp
@@ -23,12 +23,14 @@ public:
     void record_change(MDBX_txn* txn,
                        const std::string& dbi_name,
                        mdbxc::sync::ChangeOpType op_type,
+                       std::uint32_t dbi_flags,
                        const std::vector<std::uint8_t>& storage_key,
                        const std::vector<std::uint8_t>& value) override {
         (void)txn;
         std::lock_guard<std::mutex> lk(m_mutex);
         mdbxc::sync::ChangeOp op;
         op.op_type = op_type;
+        op.dbi_flags = dbi_flags;
         op.dbi_name = dbi_name;
         op.storage_key = storage_key;
         op.value = value;
@@ -97,6 +99,9 @@ void test_capture_writes_via_sink() {
     }
     if (sink.m_recorded[0].dbi_name != "t") {
         throw std::runtime_error("dbi_name not propagated");
+    }
+    if ((sink.m_recorded[0].dbi_flags & MDBX_INTEGERKEY) == 0) {
+        throw std::runtime_error("dbi_flags did not propagate MDBX_INTEGERKEY");
     }
 }
 

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -62,6 +62,15 @@ void seed_node_id(std::shared_ptr<mdbxc::Connection> conn,
     txn.commit();
 }
 
+void assign_bytes(std::vector<std::uint8_t>& out, const MDBX_val& val) {
+    out.clear();
+    if (val.iov_len == 0) {
+        return;
+    }
+    const std::uint8_t* begin = static_cast<const std::uint8_t*>(val.iov_base);
+    out.assign(begin, begin + val.iov_len);
+}
+
 void test_engine_round_trip_kv() {
     using namespace mdbxc;
     const std::string primary_path = "test_engine_primary.mdbx";
@@ -194,6 +203,50 @@ void test_engine_idempotent_replay() {
             throw std::runtime_error("second apply should be Skipped");
         }
         txn.commit();
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_applies_legacy_zero_flags_to_integer_dbi() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_legacy_zero_flags.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    seed_node_id(conn, make_node(0x10));
+    sync::SyncEngine engine(conn);
+    KeyValueTable<int, int> kv(conn, "kv");
+
+    const int key = 42;
+    const int value = 77;
+    SerializeScratch key_scratch;
+    SerializeScratch value_scratch;
+    const MDBX_val db_key = serialize_key<true>(key, key_scratch);
+    const MDBX_val db_value = serialize_value(value, value_scratch);
+
+    sync::ChangeBatch batch;
+    batch.origin_node_id = make_node(0x20);
+    batch.seq = 1;
+    sync::ChangeOp op;
+    op.op_type = sync::ChangeOpType::Put;
+    op.dbi_flags = 0;
+    op.dbi_name = "kv";
+    assign_bytes(op.storage_key, db_key);
+    assign_bytes(op.value, db_value);
+    batch.ops.push_back(op);
+
+    {
+        auto txn = conn->transaction(TransactionMode::WRITABLE);
+        if (engine.apply_batch(txn.handle(), batch) != sync::ApplyResult::Applied) {
+            throw std::runtime_error("legacy zero-flags batch should apply");
+        }
+        txn.commit();
+    }
+
+    if (kv_or_throw(conn, kv, key, "legacy zero-flags kv") != value) {
+        throw std::runtime_error("legacy zero-flags kv value mismatch");
     }
 
     conn->disconnect();
@@ -598,6 +651,7 @@ int main() {
         { "test_engine_round_trip_kv",          &test_engine_round_trip_kv },
         { "test_engine_skips_self_origin",      &test_engine_skips_self_origin },
         { "test_engine_idempotent_replay",      &test_engine_idempotent_replay },
+        { "test_engine_legacy_zero_flags",      &test_engine_applies_legacy_zero_flags_to_integer_dbi },
         { "test_engine_gap_returns_conflict",   &test_engine_gap_returns_conflict },
         { "test_engine_applied_cursor",         &test_engine_applied_cursor },
         { "test_engine_handle_push_to_remote",  &test_engine_handle_push_to_remote },

--- a/tests/test_sync_randomized_lifecycle.cpp
+++ b/tests/test_sync_randomized_lifecycle.cpp
@@ -1,0 +1,235 @@
+/// \file test_sync_randomized_lifecycle.cpp
+/// \brief Fixed-seed sync lifecycle test for repeated writes, rollbacks,
+///        periodic replication, and state equality.
+
+#include <mdbx_containers.hpp>
+#include <mdbx_containers/sync.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <map>
+#include <memory>
+#include <random>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+typedef std::map<int, std::string> Model;
+
+void cleanup(const std::string& path) {
+    std::remove(path.c_str());
+    std::remove((path + "-lck").c_str());
+}
+
+std::shared_ptr<mdbxc::Connection> open_env(const std::string& path) {
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    return mdbxc::Connection::create(config);
+}
+
+mdbxc::sync::NodeId make_node(std::uint8_t seed) {
+    mdbxc::sync::NodeId node{};
+    for (int i = 0; i < 16; ++i) {
+        node[i] = static_cast<std::uint8_t>(seed + i);
+    }
+    return node;
+}
+
+void require_table_matches_model(const std::shared_ptr<mdbxc::Connection>& conn,
+                                 mdbxc::KeyValueTable<int, std::string>& table,
+                                 const Model& expected,
+                                 const char* label) {
+    Model actual;
+    auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+    table.load(actual, txn.handle());
+    txn.commit();
+    if (actual != expected) {
+        throw std::runtime_error(std::string(label) + " does not match reference model");
+    }
+}
+
+void sync_primary_to_replica(mdbxc::sync::SyncEngine& primary_engine,
+                             mdbxc::sync::SyncEngine& replica_engine,
+                             const std::shared_ptr<mdbxc::Connection>& replica_conn,
+                             const mdbxc::sync::NodeId& replica_node,
+                             const mdbxc::sync::NodeId& db_id) {
+    mdbxc::sync::DirectSyncPeer peer(&primary_engine);
+    mdbxc::sync::PullRequest request;
+    request.requester = replica_node;
+    request.db_id = db_id;
+    request.have = replica_engine.applied_cursor();
+
+    const mdbxc::sync::PullResponse response = peer.pull(request);
+    if (!response.ok) {
+        throw std::runtime_error("pull failed: " + response.error);
+    }
+    if (response.batches.empty()) {
+        return;
+    }
+
+    auto txn = replica_conn->transaction(mdbxc::TransactionMode::WRITABLE);
+    for (std::vector<mdbxc::sync::ChangeBatch>::const_iterator it = response.batches.begin();
+         it != response.batches.end(); ++it) {
+        const mdbxc::sync::ApplyResult result =
+            replica_engine.apply_batch(txn.handle(), *it);
+        if (result == mdbxc::sync::ApplyResult::Conflict) {
+            throw std::runtime_error("replica apply returned Conflict");
+        }
+    }
+    txn.commit();
+}
+
+void apply_random_operation(const std::shared_ptr<mdbxc::Connection>& conn,
+                            mdbxc::KeyValueTable<int, std::string>& table,
+                            Model& model,
+                            std::mt19937& rng) {
+    const int op = static_cast<int>(rng() % 5);
+    const int key = static_cast<int>(rng() % 50);
+    const std::string value = "v" + std::to_string(rng() % 1000);
+
+    auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+    switch (op) {
+    case 0:
+        table.insert_or_assign(key, value, txn.handle());
+        model[key] = value;
+        txn.commit();
+        return;
+    case 1:
+        table.erase(key, txn.handle());
+        model.erase(key);
+        txn.commit();
+        return;
+    case 2:
+        table.clear(txn.handle());
+        model.clear();
+        txn.commit();
+        return;
+    case 3:
+        table.insert_or_assign(key, value, txn.handle());
+        txn.rollback();
+        return;
+    default:
+        for (int i = 0; i < 3; ++i) {
+            const int multi_key = static_cast<int>(rng() % 50);
+            const std::string multi_value = "m" + std::to_string(rng() % 1000);
+            table.insert_or_assign(multi_key, multi_value, txn.handle());
+            model[multi_key] = multi_value;
+        }
+        txn.commit();
+        return;
+    }
+}
+
+void run_randomized_lifecycle_repro() {
+    const std::uint32_t seed = 123456;
+    const std::size_t iterations = 200;
+    const std::size_t sync_every = 25;
+
+    const std::string primary_path = "test_randomized_lifecycle_primary.mdbx";
+    const std::string replica_path = "test_randomized_lifecycle_replica.mdbx";
+    cleanup(primary_path);
+    cleanup(replica_path);
+
+    std::shared_ptr<mdbxc::Connection> primary_conn = open_env(primary_path);
+    std::shared_ptr<mdbxc::Connection> replica_conn = open_env(replica_path);
+
+    const mdbxc::sync::NodeId primary_node = make_node(0xA0);
+    const mdbxc::sync::NodeId replica_node = make_node(0xB0);
+    const mdbxc::sync::NodeId db_id = make_node(0xD0);
+
+    mdbxc::sync::SyncEngine primary_engine(primary_conn);
+    mdbxc::sync::SyncEngine replica_engine(replica_conn);
+    primary_engine.initialize_local_identity(primary_node, db_id);
+    replica_engine.initialize_local_identity(replica_node, db_id);
+
+    std::unique_ptr<mdbxc::KeyValueTable<int, std::string> > primary_kv;
+    std::unique_ptr<mdbxc::KeyValueTable<int, std::string> > replica_kv;
+    try {
+        primary_kv.reset(new mdbxc::KeyValueTable<int, std::string>(primary_conn, "kv"));
+    } catch (const std::exception& e) {
+        throw std::runtime_error(std::string("primary table open failed: ") + e.what());
+    }
+    try {
+        replica_kv.reset(new mdbxc::KeyValueTable<int, std::string>(replica_conn, "kv"));
+    } catch (const std::exception& e) {
+        throw std::runtime_error(std::string("replica table open failed: ") + e.what());
+    }
+    Model reference;
+    std::mt19937 rng(seed);
+
+    mdbxc::sync::ThreadLocalChangeAccumulator sink(primary_conn);
+    primary_conn->attach_sync_capture(&sink);
+
+    for (std::size_t i = 0; i < iterations; ++i) {
+        apply_random_operation(primary_conn, *primary_kv, reference, rng);
+        if ((i + 1) % sync_every == 0) {
+            require_table_matches_model(primary_conn, *primary_kv, reference, "primary");
+            sync_primary_to_replica(primary_engine, replica_engine, replica_conn,
+                                    replica_node, db_id);
+            require_table_matches_model(replica_conn, *replica_kv, reference, "replica");
+        }
+    }
+
+    primary_conn->detach_sync_capture();
+    sync_primary_to_replica(primary_engine, replica_engine, replica_conn,
+                            replica_node, db_id);
+    require_table_matches_model(primary_conn, *primary_kv, reference, "primary final");
+    require_table_matches_model(replica_conn, *replica_kv, reference, "replica final");
+
+    primary_kv.reset();
+    replica_kv.reset();
+
+    primary_conn->disconnect();
+    replica_conn->disconnect();
+
+    std::shared_ptr<mdbxc::Connection> restarted_primary = open_env(primary_path);
+    std::shared_ptr<mdbxc::Connection> restarted_replica = open_env(replica_path);
+    std::unique_ptr<mdbxc::KeyValueTable<int, std::string> > restarted_primary_kv;
+    std::unique_ptr<mdbxc::KeyValueTable<int, std::string> > restarted_replica_kv;
+    try {
+        restarted_primary_kv.reset(
+            new mdbxc::KeyValueTable<int, std::string>(restarted_primary, "kv"));
+    } catch (const std::exception& e) {
+        throw std::runtime_error(std::string("restarted primary table open failed: ") +
+                                 e.what());
+    }
+    try {
+        restarted_replica_kv.reset(
+            new mdbxc::KeyValueTable<int, std::string>(restarted_replica, "kv"));
+    } catch (const std::exception& e) {
+        throw std::runtime_error(std::string("restarted replica table open failed: ") +
+                                 e.what());
+    }
+    require_table_matches_model(restarted_primary, *restarted_primary_kv,
+                                reference, "restarted primary");
+    require_table_matches_model(restarted_replica, *restarted_replica_kv,
+                                reference, "restarted replica");
+    restarted_primary_kv.reset();
+    restarted_replica_kv.reset();
+    restarted_primary->disconnect();
+    restarted_replica->disconnect();
+
+    cleanup(primary_path);
+    cleanup(replica_path);
+}
+
+} // namespace
+
+int main() {
+    try {
+        run_randomized_lifecycle_repro();
+    } catch (const std::exception& e) {
+        std::printf("FAIL test_randomized_lifecycle: %s\n", e.what());
+        return 1;
+    } catch (...) {
+        std::printf("FAIL test_randomized_lifecycle: non-std exception\n");
+        return 1;
+    }
+
+    std::printf("PASS test_randomized_lifecycle\n");
+    return 0;
+}

--- a/tests/test_sync_randomized_lifecycle.cpp
+++ b/tests/test_sync_randomized_lifecycle.cpp
@@ -63,24 +63,30 @@ void sync_primary_to_replica(mdbxc::sync::SyncEngine& primary_engine,
     request.db_id = db_id;
     request.have = replica_engine.applied_cursor();
 
-    const mdbxc::sync::PullResponse response = peer.pull(request);
-    if (!response.ok) {
-        throw std::runtime_error("pull failed: " + response.error);
-    }
-    if (response.batches.empty()) {
-        return;
-    }
-
-    auto txn = replica_conn->transaction(mdbxc::TransactionMode::WRITABLE);
-    for (std::vector<mdbxc::sync::ChangeBatch>::const_iterator it = response.batches.begin();
-         it != response.batches.end(); ++it) {
-        const mdbxc::sync::ApplyResult result =
-            replica_engine.apply_batch(txn.handle(), *it);
-        if (result == mdbxc::sync::ApplyResult::Conflict) {
-            throw std::runtime_error("replica apply returned Conflict");
+    bool has_more = false;
+    do {
+        const mdbxc::sync::PullResponse response = peer.pull(request);
+        if (!response.ok) {
+            throw std::runtime_error("pull failed: " + response.error);
         }
-    }
-    txn.commit();
+        if (!response.batches.empty()) {
+            auto txn = replica_conn->transaction(mdbxc::TransactionMode::WRITABLE);
+            for (std::vector<mdbxc::sync::ChangeBatch>::const_iterator it = response.batches.begin();
+                 it != response.batches.end(); ++it) {
+                const mdbxc::sync::ApplyResult result =
+                    replica_engine.apply_batch(txn.handle(), *it);
+                if (result == mdbxc::sync::ApplyResult::Conflict) {
+                    throw std::runtime_error("replica apply returned Conflict");
+                }
+            }
+            txn.commit();
+        } else if (response.has_more) {
+            throw std::runtime_error("pull reported has_more without batches");
+        }
+
+        has_more = response.has_more;
+        request.have = replica_engine.applied_cursor();
+    } while (has_more);
 }
 
 void apply_random_operation(const std::shared_ptr<mdbxc::Connection>& conn,

--- a/tests/transaction_test.cpp
+++ b/tests/transaction_test.cpp
@@ -33,6 +33,38 @@ int main() {
     mdbxc::ValueTable<int> version(conn, "txn_version");
 
     {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+
+        bool nested_raii_blocked = false;
+        try {
+            auto nested = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+            (void)nested;
+        } catch (const std::logic_error&) {
+            nested_raii_blocked = true;
+        }
+        MDBXC_TEST_ASSERT(nested_raii_blocked);
+
+        bool manual_begin_blocked = false;
+        try {
+            conn->begin(mdbxc::TransactionMode::WRITABLE);
+        } catch (const std::logic_error&) {
+            manual_begin_blocked = true;
+        }
+        MDBXC_TEST_ASSERT(manual_begin_blocked);
+
+        bool table_ctor_blocked = false;
+        try {
+            mdbxc::KeyValueTable<int, std::string> nested_table(conn, "txn_nested_ctor");
+            (void)nested_table;
+        } catch (const std::logic_error&) {
+            table_ctor_blocked = true;
+        }
+        MDBXC_TEST_ASSERT(table_ctor_blocked);
+
+        txn.rollback();
+    }
+
+    {
         auto txn = make_moved_writable_transaction(conn);
         names.clear(txn);
         version.clear(txn);


### PR DESCRIPTION
## What changed

- Guard `Connection::transaction()` and `Connection::begin()` against starting a second active transaction on the same connection/thread.
- Propagate captured MDBX DBI flags through `ChangeOp::dbi_flags` and use them when `SyncEngine` opens destination user DBIs.
- Cache DBI flags in `BaseTable` after opening the DBI, so sync capture no longer calls `mdbx_dbi_flags()` on every write operation.
- Add a fixed-seed randomized sync lifecycle test with repeated put/erase/clear/rollback operations, periodic pull/apply, primary/replica/reference-model checks, and restart verification.
- Drain pull pagination in the randomized lifecycle helper while `has_more=true`.
- Add regression coverage for nested transaction attempts, captured `MDBX_INTEGERKEY` propagation, and legacy zero-flag batches applied to existing integer-key DBIs.

## Why

The original `MDBX_BUSY` path came from implicit nested transaction attempts in the same thread, especially when APIs opened their own transaction while another one was already active. Separately, sync apply could create or reopen destination DBIs without the source DBI flags; integer-key tables could then fail later with `MDBX_INCOMPATIBLE`, especially after restart.

## Impact

Table operations still reuse the ambient thread transaction as before. Direct nested transaction creation now fails earlier with a clear `logic_error`. Sync batches now carry DBI flags already present in the wire layout, so replicated user tables are opened with compatible MDBX flags on the receiver. Older zero-flag batches retain the compatibility retry for pre-capture changelog entries.

## Follow-up (separate PR)

- Add `test_sync_stress` with 10k-100k operations.
- Run several fixed seeds.
- Cover multiple restart phases across the stress flow.
- Exercise larger pagination/full-drain paths under bigger changelog volumes.
- Decide whether an `ISyncCaptureSink` source-compatibility note belongs in release/changelog notes.

## Validation

- C++17 full `ctest`: 27/27 passed.
- C++11 full `ctest`: 26/26 passed.
- `git diff --check` passed.