### PR TITLE
fix(sync): handle multi-origin pagination and harden batch apply

### DIFF
--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -144,12 +144,14 @@ namespace sync {
             return ApplyResult::Applied;
         }
 
-                /// \brief Handles a pull request: scans the local \c ChangeLogStore
+        /// \brief Handles a pull request: scans the local \c ChangeLogStore
         /// for batches newer than the requester's cursor.
         /// \details When \c request.have is empty, returns a full snapshot
-        /// (all known origins, batches from seq=1). Validates
-        /// \c request.db_id against the local \c db_uuid; mismatched peers
-        /// receive an empty response with \c ok=false.
+        /// (all known origins, batches from seq=1). Non-empty cursors still
+        /// scan all origins so newly discovered origins and multi-origin
+        /// pagination are not stranded. Validates \c request.db_id against
+        /// the local \c db_uuid; mismatched peers receive an empty response
+        /// with \c ok=false.
         /// \c has_more is set to \c true when the loop stopped because of
         /// \c request.max_batches or \c request.max_bytes rather than
         /// running out of changelog entries.
@@ -179,42 +181,15 @@ namespace sync {
                 return out;
             }
 
-            if (request.have.last_seq_by_origin.empty()) {
-                return pull_full_snapshot(txn, changelog_dbi, request);
-            }
-
-            std::vector<std::uint8_t> buf;
-            std::size_t total_bytes = 0;
-            bool truncated = false;
-            for (const auto& kv : request.have.last_seq_by_origin) {
-                const NodeId& origin = kv.first;
-                const std::uint64_t have_seq = kv.second;
-                std::uint64_t next_seq = have_seq + 1;
-                while (out.batches.size() < request.max_batches &&
-                       total_bytes < request.max_bytes) {
-                    if (!changelog_get_ro(txn, changelog_dbi, origin,
-                                          next_seq, buf)) {
-                        break;
-                    }
-                    const ChangeBatch b = ChangeBatchCodec::decode_exact(buf);
-                    out.batches.push_back(b);
-                    total_bytes += buf.size();
-                    ++next_seq;
-                }
-                if (out.batches.size() >= request.max_batches ||
-                    total_bytes >= request.max_bytes) {
-                    truncated = true;
-                    break;
-                }
-            }
-            out.has_more = truncated;
-            out.remote_have = read_applied_cursor(txn, out.remote_have);
-            return out;
+            return pull_full_snapshot(txn, changelog_dbi, request);
         }
 
-        /// \brief Walks the changelog with a cursor and returns every batch.
-        /// \details Sets \c has_more=true when the walk stopped because of
-        /// \c request.max_batches or \c request.max_bytes.
+        /// \brief Walks the changelog and returns batches newer than
+        /// \c request.have.
+        /// \details Empty \c request.have returns a full snapshot. Non-empty
+        /// cursors filter each origin independently and still include origins
+        /// missing from the cursor. Sets \c has_more=true when the walk
+        /// stopped because of \c request.max_batches or \c request.max_bytes.
         PullResponse pull_full_snapshot(MDBX_txn* txn, MDBX_dbi dbi,
                                         const PullRequest& request) {
             PullResponse out;
@@ -227,16 +202,21 @@ namespace sync {
                 MDBX_val k, v;
                 int rc = mdbx_cursor_get(raw, &k, &v, MDBX_FIRST);
                 while (rc == MDBX_SUCCESS) {
+                    std::vector<std::uint8_t> buf(v.iov_len);
+                    if (v.iov_len > 0) {
+                        std::memcpy(buf.data(), v.iov_base, v.iov_len);
+                    }
+                    const ChangeBatch batch = ChangeBatchCodec::decode_exact(buf);
+                    if (batch.seq <= request.have.last_seq_for(batch.origin_node_id)) {
+                        rc = mdbx_cursor_get(raw, &k, &v, MDBX_NEXT);
+                        continue;
+                    }
                     if (out.batches.size() >= request.max_batches ||
                         total_bytes >= request.max_bytes) {
                         truncated = true;
                         break;
                     }
-                    std::vector<std::uint8_t> buf(v.iov_len);
-                    if (v.iov_len > 0) {
-                        std::memcpy(buf.data(), v.iov_base, v.iov_len);
-                    }
-                    out.batches.push_back(ChangeBatchCodec::decode_exact(buf));
+                    out.batches.push_back(batch);
                     total_bytes += v.iov_len;
                     rc = mdbx_cursor_get(raw, &k, &v, MDBX_NEXT);
                 }
@@ -435,26 +415,6 @@ namespace sync {
             }
             mdbx_cursor_close(raw);
             return cur;
-        }
-
-        static bool changelog_get_ro(MDBX_txn* txn, MDBX_dbi dbi,
-                                     const NodeId& origin, std::uint64_t seq,
-                                     std::vector<std::uint8_t>& out) {
-            std::vector<std::uint8_t> key_buf(24);
-            std::memcpy(key_buf.data(), origin.data(), 16);
-            for (int i = 0; i < 8; ++i) {
-                key_buf[16 + i] = static_cast<std::uint8_t>((seq >> ((7 - i) * 8)) & 0xff);
-            }
-            MDBX_val k = { key_buf.empty() ? nullptr : &key_buf[0], key_buf.size() };
-            MDBX_val v;
-            const int rc = mdbx_get(txn, dbi, &k, &v);
-            if (rc == MDBX_NOTFOUND) return false;
-            check_mdbx(rc, "changelog read failed");
-            out.resize(v.iov_len);
-            if (v.iov_len > 0) {
-                std::memcpy(out.data(), v.iov_base, v.iov_len);
-            }
-            return true;
         }
 
         static MDBX_dbi resolve_user_dbi(MDBX_txn* txn,

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -15,6 +15,7 @@
 ///  - \c seq <= last_applied_seq: \c Skipped (redundant replay).
 ///  - \c seq == last_applied_seq + 1: \c Applied, ops applied in order.
 ///  - \c seq >  last_applied_seq + 1: \c Conflict (gap; caller must re-pull).
+///  - contradictory persistent DBI flags inside one batch: \c Conflict.
 ///
 /// Self-origin batches are always \c Skipped (the receiver already has them).
 ///
@@ -28,6 +29,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <mdbx.h>
@@ -132,6 +134,7 @@ namespace sync {
             const std::uint64_t last = applied.last_applied_seq(txn, batch.origin_node_id);
             if (batch.seq <= last) return ApplyResult::Skipped;
             if (batch.seq != last + 1) return ApplyResult::Conflict;
+            if (!batch_has_consistent_dbi_flags(batch)) return ApplyResult::Conflict;
 
             std::unordered_map<std::string, MDBX_dbi> dbi_cache;
             for (const ChangeOp& op : batch.ops) {
@@ -354,6 +357,32 @@ namespace sync {
             return compare_node_id(request_db_id, db_uuid()) == 0;
         }
 
+        static std::uint32_t persistent_dbi_flags_mask() {
+            return static_cast<std::uint32_t>(MDBX_REVERSEKEY) |
+                   static_cast<std::uint32_t>(MDBX_DUPSORT) |
+                   static_cast<std::uint32_t>(MDBX_INTEGERKEY) |
+                   static_cast<std::uint32_t>(MDBX_DUPFIXED) |
+                   static_cast<std::uint32_t>(MDBX_INTEGERDUP) |
+                   static_cast<std::uint32_t>(MDBX_REVERSEDUP);
+        }
+
+        static std::uint32_t persistent_dbi_flags(std::uint32_t dbi_flags) {
+            return dbi_flags & persistent_dbi_flags_mask();
+        }
+
+        static bool batch_has_consistent_dbi_flags(const ChangeBatch& batch) {
+            std::unordered_map<std::string, std::uint32_t> flags_by_name;
+            for (const ChangeOp& op : batch.ops) {
+                const std::uint32_t flags = persistent_dbi_flags(op.dbi_flags);
+                const std::pair<std::unordered_map<std::string, std::uint32_t>::iterator, bool> inserted =
+                    flags_by_name.insert(std::make_pair(op.dbi_name, flags));
+                if (!inserted.second && inserted.first->second != flags) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         /// \brief Opens \c _mdbxc_changelog read-only when it exists; 0 otherwise.
         static MDBX_dbi open_changelog_ro(MDBX_txn* txn) {
             return open_store_ro(txn, "_mdbxc_changelog");
@@ -437,18 +466,12 @@ namespace sync {
                 return it->second;
             }
             MDBX_dbi dbi = 0;
-            const std::uint32_t supported_flags =
-                static_cast<std::uint32_t>(MDBX_REVERSEKEY) |
-                static_cast<std::uint32_t>(MDBX_DUPSORT) |
-                static_cast<std::uint32_t>(MDBX_INTEGERKEY) |
-                static_cast<std::uint32_t>(MDBX_DUPFIXED) |
-                static_cast<std::uint32_t>(MDBX_INTEGERDUP) |
-                static_cast<std::uint32_t>(MDBX_REVERSEDUP);
+            const std::uint32_t open_dbi_flags = persistent_dbi_flags(dbi_flags);
             const MDBX_db_flags_t open_flags = static_cast<MDBX_db_flags_t>(
-                (dbi_flags & supported_flags) | static_cast<std::uint32_t>(MDBX_CREATE));
+                open_dbi_flags | static_cast<std::uint32_t>(MDBX_CREATE));
             int rc = mdbx_dbi_open(txn, name.c_str(), open_flags, &dbi);
             if (rc == MDBX_INCOMPATIBLE &&
-                (dbi_flags & static_cast<std::uint32_t>(MDBX_INTEGERKEY)) == 0) {
+                (open_dbi_flags & static_cast<std::uint32_t>(MDBX_INTEGERKEY)) == 0) {
                 // Compatibility path for batches produced before dbi_flags
                 // capture was implemented. Existing integer-key DBIs may
                 // reject open_flags=MDBX_CREATE with MDBX_INCOMPATIBLE.

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -253,6 +253,50 @@ void test_engine_applies_legacy_zero_flags_to_integer_dbi() {
     cleanup(p);
 }
 
+void test_engine_conflicting_dbi_flags_returns_conflict() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_conflicting_dbi_flags.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    seed_node_id(conn, make_node(0x10));
+    sync::SyncEngine engine(conn);
+
+    sync::ChangeBatch batch;
+    batch.origin_node_id = make_node(0x20);
+    batch.seq = 1;
+
+    sync::ChangeOp first;
+    first.op_type = sync::ChangeOpType::Put;
+    first.dbi_name = "kv";
+    first.dbi_flags = static_cast<std::uint32_t>(MDBX_INTEGERKEY);
+    first.storage_key = { 0x01 };
+    first.value = { 0x11 };
+    batch.ops.push_back(first);
+
+    sync::ChangeOp second = first;
+    second.dbi_flags = static_cast<std::uint32_t>(MDBX_REVERSEKEY);
+    second.storage_key = { 0x02 };
+    second.value = { 0x22 };
+    batch.ops.push_back(second);
+
+    {
+        auto txn = conn->transaction(TransactionMode::WRITABLE);
+        const sync::ApplyResult result = engine.apply_batch(txn.handle(), batch);
+        if (result != sync::ApplyResult::Conflict) {
+            throw std::runtime_error("conflicting dbi_flags batch should return Conflict");
+        }
+        txn.commit();
+    }
+
+    if (engine.applied_cursor().last_seq_for(make_node(0x20)) != 0u) {
+        throw std::runtime_error("conflicting dbi_flags batch advanced cursor");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 void test_engine_gap_returns_conflict() {
     using namespace mdbxc;
     const std::string p = "test_engine_gap.mdbx";
@@ -652,6 +696,7 @@ int main() {
         { "test_engine_skips_self_origin",      &test_engine_skips_self_origin },
         { "test_engine_idempotent_replay",      &test_engine_idempotent_replay },
         { "test_engine_legacy_zero_flags",      &test_engine_applies_legacy_zero_flags_to_integer_dbi },
+        { "test_engine_conflicting_dbi_flags",  &test_engine_conflicting_dbi_flags_returns_conflict },
         { "test_engine_gap_returns_conflict",   &test_engine_gap_returns_conflict },
         { "test_engine_applied_cursor",         &test_engine_applied_cursor },
         { "test_engine_handle_push_to_remote",  &test_engine_handle_push_to_remote },

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -71,6 +71,34 @@ void assign_bytes(std::vector<std::uint8_t>& out, const MDBX_val& val) {
     out.assign(begin, begin + val.iov_len);
 }
 
+mdbxc::sync::ChangeBatch make_raw_batch(const mdbxc::sync::NodeId& origin,
+                                        std::uint64_t seq,
+                                        const std::string& dbi_name,
+                                        std::uint8_t key_seed) {
+    mdbxc::sync::ChangeBatch batch;
+    batch.origin_node_id = origin;
+    batch.seq = seq;
+    mdbxc::sync::ChangeOp op;
+    op.op_type = mdbxc::sync::ChangeOpType::Put;
+    op.dbi_name = dbi_name;
+    op.storage_key = { key_seed, static_cast<std::uint8_t>(seq & 0xff) };
+    op.value = { static_cast<std::uint8_t>(0x80u | key_seed),
+                 static_cast<std::uint8_t>(seq & 0xff) };
+    batch.ops.push_back(op);
+    return batch;
+}
+
+void append_raw_batch(mdbxc::sync::ChangeLogStore& log,
+                      MDBX_txn* txn,
+                      const mdbxc::sync::NodeId& origin,
+                      std::uint64_t seq,
+                      const std::string& dbi_name,
+                      std::uint8_t key_seed) {
+    const mdbxc::sync::ChangeBatch batch = make_raw_batch(origin, seq, dbi_name, key_seed);
+    const std::vector<std::uint8_t> bytes = mdbxc::sync::ChangeBatchCodec::encode(batch);
+    log.append(txn, origin, seq, bytes);
+}
+
 void test_engine_round_trip_kv() {
     using namespace mdbxc;
     const std::string primary_path = "test_engine_primary.mdbx";
@@ -658,6 +686,98 @@ void test_engine_handle_pull_pagination_has_more() {
     cleanup(primary_path); cleanup(replica_path);
 }
 
+void test_engine_handle_pull_multi_origin_pagination() {
+    using namespace mdbxc;
+    const std::string primary_path = "test_engine_pull_multi_origin.mdbx";
+    const std::string replica_path = "test_engine_pull_multi_origin_replica.mdbx";
+    cleanup(primary_path); cleanup(replica_path);
+
+    auto primary_conn = open_env(primary_path);
+    auto replica_conn = open_env(replica_path);
+
+    const sync::NodeId primary_node = make_node(0xA0);
+    const sync::NodeId replica_node = make_node(0xB0);
+    const sync::NodeId db_uuid = make_node(0xD0);
+    const sync::NodeId origin_a = make_node(0x20);
+    const sync::NodeId origin_b = make_node(0x40);
+
+    sync::SyncEngine primary_engine(primary_conn);
+    sync::SyncEngine replica_engine(replica_conn);
+    primary_engine.initialize_local_identity(primary_node, db_uuid);
+    replica_engine.initialize_local_identity(replica_node, db_uuid);
+
+    {
+        auto txn = primary_conn->transaction(TransactionMode::WRITABLE);
+        sync::ChangeLogStore log(primary_conn->env_handle());
+        log.open(txn.handle());
+        append_raw_batch(log, txn.handle(), origin_a, 1, "kv", 0xA1);
+        append_raw_batch(log, txn.handle(), origin_a, 2, "kv", 0xA2);
+        append_raw_batch(log, txn.handle(), origin_b, 1, "kv", 0xB1);
+        append_raw_batch(log, txn.handle(), origin_b, 2, "kv", 0xB2);
+        txn.commit();
+    }
+
+    sync::DirectSyncPeer peer(&primary_engine);
+    sync::PullRequest req;
+    req.requester = replica_node;
+    req.db_id = db_uuid;
+    req.max_batches = 2;
+    const sync::PullResponse first = peer.pull(req);
+    if (first.batches.size() != 2u || !first.has_more) {
+        throw std::runtime_error("first multi-origin page should contain 2 batches and has_more");
+    }
+    if (first.batches[0].origin_node_id != origin_a ||
+        first.batches[1].origin_node_id != origin_a) {
+        throw std::runtime_error("first multi-origin page should stop inside origin A");
+    }
+
+    {
+        auto txn = replica_conn->transaction(TransactionMode::WRITABLE);
+        for (const sync::ChangeBatch& batch : first.batches) {
+            if (replica_engine.apply_batch(txn.handle(), batch) != sync::ApplyResult::Applied) {
+                throw std::runtime_error("first multi-origin page apply failed");
+            }
+        }
+        txn.commit();
+    }
+
+    sync::PullRequest req2;
+    req2.requester = replica_node;
+    req2.db_id = db_uuid;
+    req2.have = replica_engine.applied_cursor();
+    req2.max_batches = 2;
+    const sync::PullResponse second = peer.pull(req2);
+    if (second.batches.size() != 2u) {
+        throw std::runtime_error("second multi-origin page should contain origin B batches");
+    }
+    if (second.has_more) {
+        throw std::runtime_error("second multi-origin page should drain changelog");
+    }
+    if (second.batches[0].origin_node_id != origin_b ||
+        second.batches[1].origin_node_id != origin_b) {
+        throw std::runtime_error("second multi-origin page should include origin B");
+    }
+
+    {
+        auto txn = replica_conn->transaction(TransactionMode::WRITABLE);
+        for (const sync::ChangeBatch& batch : second.batches) {
+            if (replica_engine.apply_batch(txn.handle(), batch) != sync::ApplyResult::Applied) {
+                throw std::runtime_error("second multi-origin page apply failed");
+            }
+        }
+        txn.commit();
+    }
+
+    const sync::SyncCursor cursor = replica_engine.applied_cursor();
+    if (cursor.last_seq_for(origin_a) != 2u || cursor.last_seq_for(origin_b) != 2u) {
+        throw std::runtime_error("multi-origin pagination did not apply both origins");
+    }
+
+    primary_conn->disconnect();
+    replica_conn->disconnect();
+    cleanup(primary_path); cleanup(replica_path);
+}
+
 void test_engine_handle_pull_lifecycle() {
     using namespace mdbxc;
     const std::string p = "test_engine_pull_lifecycle.mdbx";
@@ -704,6 +824,7 @@ int main() {
         { "test_engine_handle_pull_wrong_db_id",&test_engine_handle_pull_wrong_db_id },
         { "test_engine_handle_push_wrong_db_id",&test_engine_handle_push_wrong_db_id },
         { "test_engine_handle_pull_pagination", &test_engine_handle_pull_pagination_has_more },
+        { "test_engine_handle_pull_multi_origin",&test_engine_handle_pull_multi_origin_pagination },
         { "test_engine_handle_pull_lifecycle", &test_engine_handle_pull_lifecycle },
     };
 

--- a/tests/test_sync_randomized_lifecycle.cpp
+++ b/tests/test_sync_randomized_lifecycle.cpp
@@ -65,6 +65,7 @@ void sync_primary_to_replica(mdbxc::sync::SyncEngine& primary_engine,
 
     bool has_more = false;
     do {
+        const mdbxc::sync::SyncCursor before = request.have;
         const mdbxc::sync::PullResponse response = peer.pull(request);
         if (!response.ok) {
             throw std::runtime_error("pull failed: " + response.error);
@@ -86,6 +87,10 @@ void sync_primary_to_replica(mdbxc::sync::SyncEngine& primary_engine,
 
         has_more = response.has_more;
         request.have = replica_engine.applied_cursor();
+        if (has_more &&
+            request.have.last_seq_by_origin == before.last_seq_by_origin) {
+            throw std::runtime_error("pull pagination made no cursor progress");
+        }
     } while (has_more);
 }
 

--- a/tests/test_sync_stress.cpp
+++ b/tests/test_sync_stress.cpp
@@ -1,0 +1,300 @@
+/// \file test_sync_stress.cpp
+/// \brief Longer fixed-seed sync stress test with pagination and restarts.
+
+#include <mdbx_containers.hpp>
+#include <mdbx_containers/sync.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <map>
+#include <memory>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+typedef std::map<int, std::string> Model;
+
+void cleanup(const std::string& path) {
+    std::remove(path.c_str());
+    std::remove((path + "-lck").c_str());
+}
+
+std::shared_ptr<mdbxc::Connection> open_env(const std::string& path) {
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    return mdbxc::Connection::create(config);
+}
+
+mdbxc::sync::NodeId make_node(std::uint8_t seed) {
+    mdbxc::sync::NodeId node{};
+    for (int i = 0; i < 16; ++i) {
+        node[i] = static_cast<std::uint8_t>(seed + i);
+    }
+    return node;
+}
+
+void require_table_matches_model(const std::shared_ptr<mdbxc::Connection>& conn,
+                                 mdbxc::KeyValueTable<int, std::string>& table,
+                                 const Model& expected,
+                                 const char* label) {
+    Model actual;
+    auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+    table.load(actual, txn.handle());
+    txn.commit();
+    if (actual != expected) {
+        throw std::runtime_error(std::string(label) + " does not match reference model");
+    }
+}
+
+class StressHarness {
+public:
+    StressHarness(std::uint32_t seed,
+                  const mdbxc::sync::NodeId& primary_node,
+                  const mdbxc::sync::NodeId& replica_node,
+                  const mdbxc::sync::NodeId& db_id)
+        : m_primary_path("test_sync_stress_primary_" + std::to_string(seed) + ".mdbx"),
+          m_replica_path("test_sync_stress_replica_" + std::to_string(seed) + ".mdbx"),
+          m_primary_node(primary_node),
+          m_replica_node(replica_node),
+          m_db_id(db_id),
+          m_capture_attached(false) {}
+
+    ~StressHarness() {
+        try {
+            close();
+        } catch (...) {}
+        cleanup(m_primary_path);
+        cleanup(m_replica_path);
+    }
+
+    void reset_files() {
+        cleanup(m_primary_path);
+        cleanup(m_replica_path);
+    }
+
+    void open() {
+        m_primary_conn = open_env(m_primary_path);
+        m_replica_conn = open_env(m_replica_path);
+
+        m_primary_engine.reset(new mdbxc::sync::SyncEngine(m_primary_conn));
+        m_replica_engine.reset(new mdbxc::sync::SyncEngine(m_replica_conn));
+        m_primary_engine->initialize_local_identity(m_primary_node, m_db_id);
+        m_replica_engine->initialize_local_identity(m_replica_node, m_db_id);
+
+        m_primary_kv.reset(
+            new mdbxc::KeyValueTable<int, std::string>(m_primary_conn, "kv"));
+        m_replica_kv.reset(
+            new mdbxc::KeyValueTable<int, std::string>(m_replica_conn, "kv"));
+
+        m_sink.reset(new mdbxc::sync::ThreadLocalChangeAccumulator(m_primary_conn));
+        m_primary_conn->attach_sync_capture(m_sink.get());
+        m_capture_attached = true;
+    }
+
+    void close() {
+        if (m_capture_attached && m_primary_conn) {
+            m_primary_conn->detach_sync_capture();
+            m_capture_attached = false;
+        }
+        m_sink.reset();
+        m_primary_kv.reset();
+        m_replica_kv.reset();
+        m_primary_engine.reset();
+        m_replica_engine.reset();
+        if (m_primary_conn) {
+            m_primary_conn->disconnect();
+            m_primary_conn.reset();
+        }
+        if (m_replica_conn) {
+            m_replica_conn->disconnect();
+            m_replica_conn.reset();
+        }
+    }
+
+    void restart() {
+        close();
+        open();
+    }
+
+    void require_primary_matches(const Model& expected, const char* label) {
+        require_table_matches_model(m_primary_conn, *m_primary_kv, expected, label);
+    }
+
+    void require_replica_matches(const Model& expected, const char* label) {
+        require_table_matches_model(m_replica_conn, *m_replica_kv, expected, label);
+    }
+
+    void sync_to_replica(std::uint64_t max_batches) {
+        mdbxc::sync::DirectSyncPeer peer(m_primary_engine.get());
+        mdbxc::sync::PullRequest request;
+        request.requester = m_replica_node;
+        request.db_id = m_db_id;
+        request.have = m_replica_engine->applied_cursor();
+        request.max_batches = max_batches;
+
+        bool has_more = false;
+        do {
+            const mdbxc::sync::SyncCursor before = request.have;
+            const mdbxc::sync::PullResponse response = peer.pull(request);
+            if (!response.ok) {
+                throw std::runtime_error("stress pull failed: " + response.error);
+            }
+            if (!response.batches.empty()) {
+                auto txn = m_replica_conn->transaction(mdbxc::TransactionMode::WRITABLE);
+                for (std::vector<mdbxc::sync::ChangeBatch>::const_iterator it =
+                         response.batches.begin();
+                     it != response.batches.end(); ++it) {
+                    const mdbxc::sync::ApplyResult result =
+                        m_replica_engine->apply_batch(txn.handle(), *it);
+                    if (result == mdbxc::sync::ApplyResult::Conflict) {
+                        throw std::runtime_error("stress replica apply returned Conflict");
+                    }
+                }
+                txn.commit();
+            } else if (response.has_more) {
+                throw std::runtime_error("stress pull reported has_more without batches");
+            }
+
+            has_more = response.has_more;
+            request.have = m_replica_engine->applied_cursor();
+            if (has_more &&
+                request.have.last_seq_by_origin == before.last_seq_by_origin) {
+                throw std::runtime_error("stress pull pagination made no cursor progress");
+            }
+        } while (has_more);
+    }
+
+    std::shared_ptr<mdbxc::Connection> primary_conn() const {
+        return m_primary_conn;
+    }
+
+    mdbxc::KeyValueTable<int, std::string>& primary_table() {
+        return *m_primary_kv;
+    }
+
+private:
+    std::string m_primary_path;
+    std::string m_replica_path;
+    mdbxc::sync::NodeId m_primary_node;
+    mdbxc::sync::NodeId m_replica_node;
+    mdbxc::sync::NodeId m_db_id;
+    std::shared_ptr<mdbxc::Connection> m_primary_conn;
+    std::shared_ptr<mdbxc::Connection> m_replica_conn;
+    std::unique_ptr<mdbxc::sync::SyncEngine> m_primary_engine;
+    std::unique_ptr<mdbxc::sync::SyncEngine> m_replica_engine;
+    std::unique_ptr<mdbxc::KeyValueTable<int, std::string> > m_primary_kv;
+    std::unique_ptr<mdbxc::KeyValueTable<int, std::string> > m_replica_kv;
+    std::unique_ptr<mdbxc::sync::ThreadLocalChangeAccumulator> m_sink;
+    bool m_capture_attached;
+};
+
+void apply_random_operation(StressHarness& harness,
+                            Model& model,
+                            std::mt19937& rng) {
+    const int op = static_cast<int>(rng() % 8);
+    const int key = static_cast<int>(rng() % 512);
+    const std::string value = "v" + std::to_string(rng() % 100000);
+
+    auto txn = harness.primary_conn()->transaction(mdbxc::TransactionMode::WRITABLE);
+    switch (op) {
+    case 0:
+    case 1:
+    case 2:
+        harness.primary_table().insert_or_assign(key, value, txn.handle());
+        model[key] = value;
+        txn.commit();
+        return;
+    case 3:
+        harness.primary_table().erase(key, txn.handle());
+        model.erase(key);
+        txn.commit();
+        return;
+    case 4:
+        if ((rng() % 11) == 0) {
+            harness.primary_table().clear(txn.handle());
+            model.clear();
+        } else {
+            harness.primary_table().erase(key, txn.handle());
+            model.erase(key);
+        }
+        txn.commit();
+        return;
+    case 5:
+        harness.primary_table().insert_or_assign(key, value, txn.handle());
+        txn.rollback();
+        return;
+    default:
+        for (int i = 0; i < 4; ++i) {
+            const int multi_key = static_cast<int>(rng() % 512);
+            const std::string multi_value = "m" + std::to_string(rng() % 100000);
+            harness.primary_table().insert_or_assign(multi_key, multi_value, txn.handle());
+            model[multi_key] = multi_value;
+        }
+        txn.commit();
+        return;
+    }
+}
+
+void run_seed(std::uint32_t seed) {
+    const std::size_t operations = 10000;
+    const std::size_t sync_every = 250;
+    const std::size_t restart_every = 2500;
+    const std::uint64_t max_batches_per_pull = 64;
+
+    StressHarness harness(seed, make_node(0xA0), make_node(0xB0), make_node(0xD0));
+    harness.reset_files();
+    harness.open();
+
+    Model reference;
+    std::mt19937 rng(seed);
+    for (std::size_t i = 0; i < operations; ++i) {
+        apply_random_operation(harness, reference, rng);
+
+        if ((i + 1) % restart_every == 0) {
+            harness.restart();
+            harness.require_primary_matches(reference, "stress primary after restart");
+            harness.sync_to_replica(max_batches_per_pull);
+            harness.require_replica_matches(reference, "stress replica after restart sync");
+        } else if ((i + 1) % sync_every == 0) {
+            harness.require_primary_matches(reference, "stress primary");
+            harness.sync_to_replica(max_batches_per_pull);
+            harness.require_replica_matches(reference, "stress replica");
+        }
+    }
+
+    harness.require_primary_matches(reference, "stress primary final");
+    harness.sync_to_replica(max_batches_per_pull);
+    harness.require_replica_matches(reference, "stress replica final");
+    harness.close();
+    harness.reset_files();
+}
+
+void run_stress() {
+    const std::uint32_t seeds[] = { 123456u, 987654u, 424242u };
+    for (std::size_t i = 0; i < sizeof(seeds) / sizeof(seeds[0]); ++i) {
+        run_seed(seeds[i]);
+    }
+}
+
+} // namespace
+
+int main() {
+    try {
+        run_stress();
+    } catch (const std::exception& e) {
+        std::printf("FAIL test_sync_stress: %s\n", e.what());
+        return 1;
+    } catch (...) {
+        std::printf("FAIL test_sync_stress: non-std exception\n");
+        return 1;
+    }
+
+    std::printf("PASS test_sync_stress\n");
+    return 0;
+}


### PR DESCRIPTION
## What changed

- Reject a malformed `ChangeBatch` with contradictory persistent MDBX DBI flags for the same `dbi_name` by returning `ApplyResult::Conflict` before applying user operations.
- Reuse one `persistent_dbi_flags()` mask for batch validation and destination DBI open flags.
- Drain pull pagination across all changelog origins, including origins that are not yet present in the requester's cursor.
- Add a multi-origin pagination regression where the first page stops inside origin A and the second page must still return origin B.
- Add no-progress protection to the paginated sync lifecycle helper when `has_more=true` but the replica cursor does not advance.
- Add `test_sync_stress`: 3 fixed seeds, 10,000 operations per seed, forced pull pagination, periodic state-model checks, and multiple restart phases.

## Why

PR #77 fixed the transaction/DBI flag correctness bug. The remaining review notes were hardening and coverage: avoid infinite pagination loops against defective peers, reject internally inconsistent DBI flag metadata, and add a longer stress target that exercises restart and pagination paths.

The multi-origin pagination note exposed a real edge case: after a full-snapshot page stopped inside origin A, the next requester's cursor might contain only origin A, so the previous incremental path could skip origin B entirely. `handle_pull()` now scans the changelog and filters by the per-origin cursor instead of iterating only over origins already present in `request.have`.

## Future optimization

The corrected incremental pull path currently scans the changelog and decodes entries before filtering out batches already covered by `request.have`. A future PR can optimize this with per-origin MDBX range seeks from `have_seq + 1` and merge the resulting streams, or by maintaining a dedicated origin index.

## Validation

- C++17 targeted `ctest -R ^(test_sync_engine|test_sync_randomized_lifecycle|test_sync_stress)$`: 3/3 passed.
- C++11 targeted `ctest -R ^(test_sync_engine|test_sync_randomized_lifecycle|test_sync_stress)$`: 3/3 passed.
- C++17 full `ctest`: 28/28 passed.
- C++11 full `ctest`: 27/27 passed.
- `git diff --check` passed.