### PR TITLE
feat(sync): add apply diagnostics and hub benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin CACHE PATH "")
 # ---------------------------------------
 option(MDBXC_BUILD_EXAMPLES     "Build examples"                                  ON)
 option(MDBXC_BUILD_TESTS        "Build tests with CTest"                           ON)
+option(MDBXC_BUILD_BENCHMARKS   "Build benchmark executables"                      OFF)
 option(MDBXC_USE_ASAN "Enable AddressSanitizer for tests/examples (not for libmdbx)" ON)
 
 # Three-mode dependency policy for MDBX: AUTO | SYSTEM | BUNDLED
@@ -25,6 +26,7 @@ set_property(CACHE MDBXC_DEPS_MODE PROPERTY STRINGS AUTO SYSTEM BUNDLED)
 message(STATUS "MDBXC_DEPS_MODE         = ${MDBXC_DEPS_MODE}")
 message(STATUS "MDBXC_BUILD_EXAMPLES    = ${MDBXC_BUILD_EXAMPLES}")
 message(STATUS "MDBXC_BUILD_TESTS       = ${MDBXC_BUILD_TESTS}")
+message(STATUS "MDBXC_BUILD_BENCHMARKS  = ${MDBXC_BUILD_BENCHMARKS}")
 message(STATUS "MDBXC_USE_ASAN          = ${MDBXC_USE_ASAN}")
 
 set(MDBXC_HAS_ASAN OFF CACHE BOOL "Compiler+linker support -fsanitize=address")
@@ -175,6 +177,24 @@ if(MDBXC_BUILD_TESTS)
             )
         endif()
         
+    endforeach()
+endif()
+
+# ---------------------------------------
+# Benchmarks (manual targets; not registered as tests)
+# ---------------------------------------
+if(MDBXC_BUILD_BENCHMARKS)
+    file(GLOB BENCHMARKS CONFIGURE_DEPENDS benchmarks/*.cpp)
+    foreach(benchmark_file IN LISTS BENCHMARKS)
+        get_filename_component(benchmark_name ${benchmark_file} NAME_WE)
+        add_executable(${benchmark_name} ${benchmark_file})
+        set_target_properties(${benchmark_name} PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/benchmarks
+        )
+        target_compile_features(${benchmark_name} PRIVATE cxx_std_11)
+        target_link_libraries(${benchmark_name} PRIVATE ${_PKG_TARGET})
+        target_compile_definitions(${benchmark_name} PRIVATE MDBXC_SYNC_ENABLED=1)
+        message(STATUS "Benchmark ${benchmark_name} -> ${_PKG_TARGET}")
     endforeach()
 endif()
 

--- a/benchmarks/sync_tick_hub_benchmark.cpp
+++ b/benchmarks/sync_tick_hub_benchmark.cpp
@@ -1,0 +1,293 @@
+/// \file sync_tick_hub_benchmark.cpp
+/// \brief Manual benchmark for hub-style sync pull over tick chunks.
+
+#include <mdbx_containers.hpp>
+#include <mdbx_containers/sync.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <cstdio>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct BenchmarkConfig {
+    std::uint64_t origins = 16;
+    std::uint64_t historical_chunks_per_origin = 512;
+    std::uint64_t new_chunks_per_origin = 8;
+    std::uint64_t ticks_per_chunk = 128;
+    std::uint64_t max_batches = 64;
+};
+
+void cleanup(const std::string& path);
+
+struct CleanupGuard {
+    explicit CleanupGuard(const std::string& path_value) : path(path_value) {}
+    ~CleanupGuard() { cleanup(path); }
+
+    std::string path;
+};
+
+void cleanup(const std::string& path) {
+    std::remove(path.c_str());
+    std::remove((path + "-lck").c_str());
+}
+
+std::string benchmark_path() {
+    const std::chrono::steady_clock::time_point now =
+        std::chrono::steady_clock::now();
+    const std::chrono::nanoseconds ticks =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            now.time_since_epoch());
+    return "benchmark_sync_tick_hub_" + std::to_string(ticks.count()) + ".mdbx";
+}
+
+std::uint64_t parse_arg(int argc,
+                        char** argv,
+                        int index,
+                        std::uint64_t fallback,
+                        const char* name) {
+    if (index >= argc) {
+        return fallback;
+    }
+    char* end = nullptr;
+    const unsigned long long value = std::strtoull(argv[index], &end, 10);
+    if (end == argv[index] || *end != '\0') {
+        throw std::runtime_error(std::string("invalid ") + name + ": " + argv[index]);
+    }
+    return static_cast<std::uint64_t>(value);
+}
+
+BenchmarkConfig parse_config(int argc, char** argv) {
+    BenchmarkConfig config;
+    config.origins = parse_arg(argc, argv, 1, config.origins, "origins");
+    config.historical_chunks_per_origin =
+        parse_arg(argc, argv, 2, config.historical_chunks_per_origin,
+                  "historical_chunks_per_origin");
+    config.new_chunks_per_origin =
+        parse_arg(argc, argv, 3, config.new_chunks_per_origin,
+                  "new_chunks_per_origin");
+    config.ticks_per_chunk =
+        parse_arg(argc, argv, 4, config.ticks_per_chunk, "ticks_per_chunk");
+    config.max_batches = parse_arg(argc, argv, 5, config.max_batches, "max_batches");
+    if (config.origins == 0 || config.max_batches == 0) {
+        throw std::runtime_error("origins and max_batches must be positive");
+    }
+    if (config.ticks_per_chunk > 1000000ULL) {
+        throw std::runtime_error("ticks_per_chunk is too large for this benchmark");
+    }
+    return config;
+}
+
+std::shared_ptr<mdbxc::Connection> open_env(const std::string& path) {
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    config.size_now = 512LL * 1024LL * 1024LL;
+    config.size_upper = 8LL * 1024LL * 1024LL * 1024LL;
+    return mdbxc::Connection::create(config);
+}
+
+mdbxc::sync::NodeId make_node(std::uint8_t seed) {
+    mdbxc::sync::NodeId node{};
+    for (int i = 0; i < 16; ++i) {
+        node[i] = static_cast<std::uint8_t>(seed + i);
+    }
+    return node;
+}
+
+mdbxc::sync::NodeId make_origin(std::uint64_t index) {
+    mdbxc::sync::NodeId node{};
+    node[0] = 0x40;
+    for (int i = 0; i < 8; ++i) {
+        node[8 + i] = static_cast<std::uint8_t>((index >> ((7 - i) * 8)) & 0xff);
+    }
+    return node;
+}
+
+std::vector<std::uint8_t> make_chunk_key(std::uint64_t origin_index,
+                                         std::uint64_t seq) {
+    std::vector<std::uint8_t> key(16);
+    for (int i = 0; i < 8; ++i) {
+        key[i] = static_cast<std::uint8_t>((origin_index >> ((7 - i) * 8)) & 0xff);
+        key[8 + i] = static_cast<std::uint8_t>((seq >> ((7 - i) * 8)) & 0xff);
+    }
+    return key;
+}
+
+std::vector<std::uint8_t> make_tick_chunk(std::uint64_t origin_index,
+                                          std::uint64_t seq,
+                                          std::uint64_t ticks_per_chunk) {
+    const std::size_t tick_size = 32;
+    const std::size_t size =
+        static_cast<std::size_t>(ticks_per_chunk) * tick_size;
+    std::vector<std::uint8_t> value(size);
+    for (std::size_t i = 0; i < value.size(); ++i) {
+        value[i] = static_cast<std::uint8_t>(
+            (origin_index * 131ULL + seq * 17ULL + i) & 0xff);
+    }
+    return value;
+}
+
+mdbxc::sync::ChangeBatch make_tick_batch(std::uint64_t origin_index,
+                                         const mdbxc::sync::NodeId& origin,
+                                         std::uint64_t seq,
+                                         std::uint64_t ticks_per_chunk) {
+    mdbxc::sync::ChangeBatch batch;
+    batch.origin_node_id = origin;
+    batch.seq = seq;
+    batch.time_unix_ns = seq;
+
+    mdbxc::sync::ChangeOp op;
+    op.op_type = mdbxc::sync::ChangeOpType::Put;
+    op.dbi_name = "tick_chunks";
+    op.storage_key = make_chunk_key(origin_index, seq);
+    op.value = make_tick_chunk(origin_index, seq, ticks_per_chunk);
+    batch.ops.push_back(op);
+    return batch;
+}
+
+double elapsed_ms(std::chrono::steady_clock::time_point start,
+                  std::chrono::steady_clock::time_point finish) {
+    const std::chrono::microseconds elapsed =
+        std::chrono::duration_cast<std::chrono::microseconds>(finish - start);
+    return static_cast<double>(elapsed.count()) / 1000.0;
+}
+
+void seed_changelog(const std::shared_ptr<mdbxc::Connection>& conn,
+                    const BenchmarkConfig& config) {
+    auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+    mdbxc::sync::ChangeLogStore log(conn->env_handle());
+    log.open(txn.handle());
+
+    const std::uint64_t total_chunks =
+        config.historical_chunks_per_origin + config.new_chunks_per_origin;
+    for (std::uint64_t origin_index = 0; origin_index < config.origins; ++origin_index) {
+        const mdbxc::sync::NodeId origin = make_origin(origin_index);
+        for (std::uint64_t seq = 1; seq <= total_chunks; ++seq) {
+            const mdbxc::sync::ChangeBatch batch =
+                make_tick_batch(origin_index, origin, seq, config.ticks_per_chunk);
+            const std::vector<std::uint8_t> bytes =
+                mdbxc::sync::ChangeBatchCodec::encode(batch);
+            log.append(txn.handle(), origin, seq, bytes);
+        }
+    }
+
+    txn.commit();
+}
+
+std::uint64_t pull_incremental(mdbxc::sync::SyncEngine& engine,
+                               const BenchmarkConfig& config,
+                               std::uint64_t& pages) {
+    mdbxc::sync::DirectSyncPeer peer(&engine);
+    mdbxc::sync::PullRequest request;
+    request.requester = make_node(0xB0);
+    request.db_id = make_node(0xD0);
+    request.max_batches = config.max_batches;
+    for (std::uint64_t origin_index = 0; origin_index < config.origins; ++origin_index) {
+        request.have.last_seq_by_origin[make_origin(origin_index)] =
+            config.historical_chunks_per_origin;
+    }
+
+    std::uint64_t pulled = 0;
+    pages = 0;
+    bool has_more = false;
+    do {
+        const mdbxc::sync::SyncCursor before = request.have;
+        const mdbxc::sync::PullResponse response = peer.pull(request);
+        if (!response.ok) {
+            throw std::runtime_error("pull failed: " + response.error);
+        }
+        ++pages;
+        pulled += static_cast<std::uint64_t>(response.batches.size());
+        for (std::vector<mdbxc::sync::ChangeBatch>::const_iterator it =
+                 response.batches.begin();
+             it != response.batches.end(); ++it) {
+            std::uint64_t& seq = request.have.last_seq_by_origin[it->origin_node_id];
+            if (it->seq > seq) {
+                seq = it->seq;
+            }
+        }
+        if (response.has_more &&
+            request.have.last_seq_by_origin == before.last_seq_by_origin) {
+            throw std::runtime_error("pagination made no cursor progress");
+        }
+        has_more = response.has_more;
+    } while (has_more);
+
+    return pulled;
+}
+
+int run(int argc, char** argv) {
+    const BenchmarkConfig config = parse_config(argc, argv);
+    const std::string path = benchmark_path();
+    CleanupGuard cleanup_guard(path);
+    cleanup(path);
+
+    std::shared_ptr<mdbxc::Connection> conn = open_env(path);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0xA0), make_node(0xD0));
+
+    const std::chrono::steady_clock::time_point seed_start =
+        std::chrono::steady_clock::now();
+    seed_changelog(conn, config);
+    const std::chrono::steady_clock::time_point seed_finish =
+        std::chrono::steady_clock::now();
+
+    std::uint64_t pages = 0;
+    const std::chrono::steady_clock::time_point pull_start =
+        std::chrono::steady_clock::now();
+    const std::uint64_t pulled = pull_incremental(engine, config, pages);
+    const std::chrono::steady_clock::time_point pull_finish =
+        std::chrono::steady_clock::now();
+
+    const std::uint64_t expected = config.origins * config.new_chunks_per_origin;
+    if (pulled != expected) {
+        throw std::runtime_error("wrong number of pulled batches: expected " +
+                                 std::to_string(expected) + ", got " +
+                                 std::to_string(pulled));
+    }
+
+    conn->disconnect();
+
+    const std::uint64_t seeded =
+        config.origins *
+        (config.historical_chunks_per_origin + config.new_chunks_per_origin);
+    const double seed_ms = elapsed_ms(seed_start, seed_finish);
+    const double pull_ms = elapsed_ms(pull_start, pull_finish);
+    const double us_per_batch =
+        pulled == 0 ? 0.0 : (pull_ms * 1000.0) / static_cast<double>(pulled);
+
+    std::cout << "sync_tick_hub_benchmark\n"
+              << "  origins=" << config.origins << "\n"
+              << "  historical_chunks_per_origin="
+              << config.historical_chunks_per_origin << "\n"
+              << "  new_chunks_per_origin=" << config.new_chunks_per_origin << "\n"
+              << "  ticks_per_chunk=" << config.ticks_per_chunk << "\n"
+              << "  max_batches=" << config.max_batches << "\n"
+              << "  seeded_batches=" << seeded << "\n"
+              << "  pulled_batches=" << pulled << "\n"
+              << "  pull_pages=" << pages << "\n"
+              << "  seed_ms=" << seed_ms << "\n"
+              << "  pull_ms=" << pull_ms << "\n"
+              << "  pull_us_per_batch=" << us_per_batch << "\n";
+    return 0;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        return run(argc, argv);
+    } catch (const std::exception& e) {
+        std::cerr << "FAIL sync_tick_hub_benchmark: " << e.what() << "\n";
+    } catch (...) {
+        std::cerr << "FAIL sync_tick_hub_benchmark: non-std exception\n";
+    }
+    return 1;
+}

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -56,7 +56,31 @@ namespace sync {
         Applied,  ///< Batch was applied to local DBIs.
         Skipped,  ///< Batch was redundant (seq <= last contiguous applied)
                   ///< or originated from the local node.
-        Conflict, ///< Gap detected (seq > last + 1); not applied.
+        Conflict, ///< Conflict detected; batch was not applied.
+    };
+
+    /// \brief More specific reason when \c ApplyResult::Conflict is returned.
+    enum class ApplyConflictReason {
+        None,                     ///< No conflict; result is not Conflict.
+        SequenceGap,              ///< Batch seq is not last_applied_seq + 1.
+        InconsistentBatchDbiFlags,///< One batch carries contradictory flags for one DBI.
+        ExistingDbiFlagsMismatch, ///< Existing destination DBI rejects captured flags.
+    };
+
+    /// \brief Detailed result for callers that need conflict diagnostics.
+    /// \details \c apply_batch() preserves the original compact API. New code
+    /// can use \c apply_batch_ex() when it needs to distinguish retryable
+    /// sequence gaps from schema/DBI incompatibilities.
+    struct ApplyOutcome {
+        ApplyResult          result = ApplyResult::Applied;
+        ApplyConflictReason  conflict_reason = ApplyConflictReason::None;
+        NodeId               origin_node_id{};
+        std::uint64_t        last_applied_seq = 0;
+        std::uint64_t        batch_seq = 0;
+        std::string          dbi_name;
+        std::uint32_t        expected_dbi_flags = 0;
+        std::uint32_t        incoming_dbi_flags = 0;
+        int                  mdbx_error_code = MDBX_SUCCESS;
     };
 
     /// \brief Pull/push/apply coordinator bound to a single \c Connection.
@@ -122,6 +146,16 @@ namespace sync {
         /// name with the captured \c ChangeOp::dbi_flags plus
         /// \c MDBX_CREATE so destination tables keep compatible MDBX flags.
         ApplyResult apply_batch(MDBX_txn* txn, const ChangeBatch& batch) {
+            return apply_batch_ex(txn, batch).result;
+        }
+
+        /// \brief Applies a batch and returns detailed conflict diagnostics.
+        /// \details This is the diagnostic form of \c apply_batch(). It keeps
+        /// the same write semantics while exposing whether a conflict was a
+        /// sequence gap, an inconsistent batch schema, or a destination DBI
+        /// flag mismatch.
+        ApplyOutcome apply_batch_ex(MDBX_txn* txn, const ChangeBatch& batch) {
+            ApplyOutcome outcome = make_apply_outcome(ApplyResult::Applied, batch, 0);
             MetaStore meta(m_conn->env_handle());
             AppliedStore applied(m_conn->env_handle());
             meta.open(txn);
@@ -129,23 +163,50 @@ namespace sync {
 
             const NodeId local_node = meta.get_node_id(txn);
             if (compare_node_id(batch.origin_node_id, local_node) == 0) {
-                return ApplyResult::Skipped;
+                outcome.result = ApplyResult::Skipped;
+                return outcome;
             }
 
             const std::uint64_t last = applied.last_applied_seq(txn, batch.origin_node_id);
-            if (batch.seq <= last) return ApplyResult::Skipped;
-            if (batch.seq != last + 1) return ApplyResult::Conflict;
-            if (!batch_has_consistent_dbi_flags(batch)) return ApplyResult::Conflict;
+            outcome.last_applied_seq = last;
+            if (batch.seq <= last) {
+                outcome.result = ApplyResult::Skipped;
+                return outcome;
+            }
+            if (batch.seq != last + 1) {
+                outcome.result = ApplyResult::Conflict;
+                outcome.conflict_reason = ApplyConflictReason::SequenceGap;
+                return outcome;
+            }
+            if (!batch_has_consistent_dbi_flags(batch, &outcome)) return outcome;
 
             std::unordered_map<std::string, MDBX_dbi> dbi_cache;
-            if (!preflight_batch_user_dbis(txn, batch, dbi_cache)) {
-                return ApplyResult::Conflict;
+            if (!preflight_batch_user_dbis(txn, batch, dbi_cache, &outcome)) {
+                return outcome;
             }
             for (const ChangeOp& op : batch.ops) {
                 apply_one_op(txn, op, dbi_cache);
             }
             applied.set_last_applied_seq(txn, batch.origin_node_id, batch.seq);
-            return ApplyResult::Applied;
+            outcome.result = ApplyResult::Applied;
+            outcome.conflict_reason = ApplyConflictReason::None;
+            outcome.last_applied_seq = batch.seq;
+            return outcome;
+        }
+
+        /// \brief Returns a stable short name for an apply conflict reason.
+        static const char* apply_conflict_reason_name(ApplyConflictReason reason) {
+            switch (reason) {
+                case ApplyConflictReason::None:
+                    return "none";
+                case ApplyConflictReason::SequenceGap:
+                    return "sequence_gap";
+                case ApplyConflictReason::InconsistentBatchDbiFlags:
+                    return "inconsistent_batch_dbi_flags";
+                case ApplyConflictReason::ExistingDbiFlagsMismatch:
+                    return "existing_dbi_flags_mismatch";
+            }
+            return "unknown";
         }
 
         /// \brief Handles a pull request: scans the local \c ChangeLogStore
@@ -229,10 +290,10 @@ namespace sync {
             }
             auto txn = m_conn->transaction(TransactionMode::WRITABLE);
             for (const ChangeBatch& batch : request.batches) {
-                const ApplyResult r = apply_batch(txn.handle(), batch);
-                if (r == ApplyResult::Conflict) {
+                const ApplyOutcome outcome = apply_batch_ex(txn.handle(), batch);
+                if (outcome.result == ApplyResult::Conflict) {
                     out.ok = false;
-                    out.error = "gap/conflict while applying pushed batch";
+                    out.error = apply_conflict_message(outcome);
                     return out;  // txn dtor rolls back; receiver_have stays stale
                 }
             }
@@ -327,6 +388,43 @@ namespace sync {
             return compare_node_id(request_db_id, db_uuid()) == 0;
         }
 
+        static ApplyOutcome make_apply_outcome(ApplyResult result,
+                                               const ChangeBatch& batch,
+                                               std::uint64_t last_applied_seq) {
+            ApplyOutcome outcome;
+            outcome.result = result;
+            outcome.conflict_reason = ApplyConflictReason::None;
+            outcome.origin_node_id = batch.origin_node_id;
+            outcome.last_applied_seq = last_applied_seq;
+            outcome.batch_seq = batch.seq;
+            return outcome;
+        }
+
+        static std::string apply_conflict_message(const ApplyOutcome& outcome) {
+            std::string message = std::string(apply_conflict_reason_name(outcome.conflict_reason)) +
+                                  " while applying pushed batch";
+            if (outcome.conflict_reason == ApplyConflictReason::SequenceGap) {
+                message += " (last_applied_seq=" +
+                           std::to_string(outcome.last_applied_seq) +
+                           ", batch_seq=" + std::to_string(outcome.batch_seq) + ")";
+            } else if (outcome.conflict_reason ==
+                       ApplyConflictReason::InconsistentBatchDbiFlags) {
+                message += " (dbi='" + outcome.dbi_name +
+                           "', expected_flags=" +
+                           std::to_string(outcome.expected_dbi_flags) +
+                           ", incoming_flags=" +
+                           std::to_string(outcome.incoming_dbi_flags) + ")";
+            } else if (outcome.conflict_reason ==
+                       ApplyConflictReason::ExistingDbiFlagsMismatch) {
+                message += " (dbi='" + outcome.dbi_name +
+                           "', incoming_flags=" +
+                           std::to_string(outcome.incoming_dbi_flags) +
+                           ", mdbx_error_code=" +
+                           std::to_string(outcome.mdbx_error_code) + ")";
+            }
+            return message;
+        }
+
         static std::uint32_t persistent_dbi_flags_mask() {
             return static_cast<std::uint32_t>(MDBX_REVERSEKEY) |
                    static_cast<std::uint32_t>(MDBX_DUPSORT) |
@@ -340,13 +438,22 @@ namespace sync {
             return dbi_flags & persistent_dbi_flags_mask();
         }
 
-        static bool batch_has_consistent_dbi_flags(const ChangeBatch& batch) {
+        static bool batch_has_consistent_dbi_flags(const ChangeBatch& batch,
+                                                   ApplyOutcome* outcome) {
             std::unordered_map<std::string, std::uint32_t> flags_by_name;
             for (const ChangeOp& op : batch.ops) {
                 const std::uint32_t flags = persistent_dbi_flags(op.dbi_flags);
                 const std::pair<std::unordered_map<std::string, std::uint32_t>::iterator, bool> inserted =
                     flags_by_name.insert(std::make_pair(op.dbi_name, flags));
                 if (!inserted.second && inserted.first->second != flags) {
+                    if (outcome != nullptr) {
+                        outcome->result = ApplyResult::Conflict;
+                        outcome->conflict_reason =
+                            ApplyConflictReason::InconsistentBatchDbiFlags;
+                        outcome->dbi_name = op.dbi_name;
+                        outcome->expected_dbi_flags = inserted.first->second;
+                        outcome->incoming_dbi_flags = flags;
+                    }
                     return false;
                 }
             }
@@ -356,7 +463,9 @@ namespace sync {
         static bool open_existing_user_dbi(MDBX_txn* txn,
                                            const std::string& name,
                                            std::uint32_t dbi_flags,
-                                           MDBX_dbi& dbi) {
+                                           MDBX_dbi& dbi,
+                                           int& error_code) {
+            error_code = MDBX_SUCCESS;
             const std::uint32_t open_dbi_flags = persistent_dbi_flags(dbi_flags);
             MDBX_db_flags_t open_flags = static_cast<MDBX_db_flags_t>(open_dbi_flags);
             int rc = mdbx_dbi_open(txn, name.c_str(), open_flags, &dbi);
@@ -372,6 +481,7 @@ namespace sync {
             }
             if (rc == MDBX_INCOMPATIBLE || rc == MDBX_EINVAL) {
                 dbi = 0;
+                error_code = rc;
                 return false;
             }
             check_mdbx(rc, "SyncEngine: failed to preflight user DBI '" + name + "'");
@@ -380,7 +490,8 @@ namespace sync {
 
         static bool preflight_batch_user_dbis(MDBX_txn* txn,
                                               const ChangeBatch& batch,
-                                              std::unordered_map<std::string, MDBX_dbi>& cache) {
+                                              std::unordered_map<std::string, MDBX_dbi>& cache,
+                                              ApplyOutcome* outcome) {
             std::unordered_map<std::string, std::uint32_t> flags_by_name;
             for (const ChangeOp& op : batch.ops) {
                 flags_by_name.insert(std::make_pair(op.dbi_name, persistent_dbi_flags(op.dbi_flags)));
@@ -390,7 +501,16 @@ namespace sync {
                      flags_by_name.begin();
                  it != flags_by_name.end(); ++it) {
                 MDBX_dbi dbi = 0;
-                if (!open_existing_user_dbi(txn, it->first, it->second, dbi)) {
+                int error_code = MDBX_SUCCESS;
+                if (!open_existing_user_dbi(txn, it->first, it->second, dbi, error_code)) {
+                    if (outcome != nullptr) {
+                        outcome->result = ApplyResult::Conflict;
+                        outcome->conflict_reason =
+                            ApplyConflictReason::ExistingDbiFlagsMismatch;
+                        outcome->dbi_name = it->first;
+                        outcome->incoming_dbi_flags = it->second;
+                        outcome->mdbx_error_code = error_code;
+                    }
                     return false;
                 }
                 if (dbi != 0) {

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -251,8 +251,8 @@ void test_engine_applies_legacy_zero_flags_to_integer_dbi() {
     cleanup(p);
 
     auto conn = open_env(p);
-    seed_node_id(conn, make_node(0x10));
     sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x10), make_node(0xD0));
     KeyValueTable<int, int> kv(conn, "kv");
 
     const int key = 42;
@@ -295,8 +295,8 @@ void test_engine_conflicting_dbi_flags_returns_conflict() {
     cleanup(p);
 
     auto conn = open_env(p);
-    seed_node_id(conn, make_node(0x10));
     sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x10), make_node(0xD0));
 
     sync::ChangeBatch batch;
     batch.origin_node_id = make_node(0x20);
@@ -318,9 +318,15 @@ void test_engine_conflicting_dbi_flags_returns_conflict() {
 
     {
         auto txn = conn->transaction(TransactionMode::WRITABLE);
-        const sync::ApplyResult result = engine.apply_batch(txn.handle(), batch);
-        if (result != sync::ApplyResult::Conflict) {
+        const sync::ApplyOutcome outcome = engine.apply_batch_ex(txn.handle(), batch);
+        if (outcome.result != sync::ApplyResult::Conflict) {
             throw std::runtime_error("conflicting dbi_flags batch should return Conflict");
+        }
+        if (outcome.conflict_reason != sync::ApplyConflictReason::InconsistentBatchDbiFlags) {
+            throw std::runtime_error("conflicting dbi_flags batch returned wrong reason");
+        }
+        if (outcome.dbi_name != "kv") {
+            throw std::runtime_error("conflicting dbi_flags batch returned wrong DBI name");
         }
         txn.commit();
     }
@@ -387,9 +393,18 @@ void test_engine_existing_dbi_flag_mismatch_returns_conflict() {
 
     {
         auto txn = conn->transaction(TransactionMode::WRITABLE);
-        const sync::ApplyResult result = engine.apply_batch(txn.handle(), bad);
-        if (result != sync::ApplyResult::Conflict) {
+        const sync::ApplyOutcome outcome = engine.apply_batch_ex(txn.handle(), bad);
+        if (outcome.result != sync::ApplyResult::Conflict) {
             throw std::runtime_error("existing DBI flag mismatch should return Conflict");
+        }
+        if (outcome.conflict_reason != sync::ApplyConflictReason::ExistingDbiFlagsMismatch) {
+            throw std::runtime_error("existing DBI flag mismatch returned wrong reason");
+        }
+        if (outcome.dbi_name != "kv") {
+            throw std::runtime_error("existing DBI flag mismatch returned wrong DBI name");
+        }
+        if (outcome.incoming_dbi_flags != static_cast<std::uint32_t>(MDBX_REVERSEKEY)) {
+            throw std::runtime_error("existing DBI flag mismatch returned wrong flags");
         }
         txn.commit();
     }
@@ -431,8 +446,14 @@ void test_engine_gap_returns_conflict() {
     if (engine.apply_batch(txn.handle(), make_batch(1)) != sync::ApplyResult::Applied) {
         throw std::runtime_error("seq=1 should apply");
     }
-    if (engine.apply_batch(txn.handle(), make_batch(3)) != sync::ApplyResult::Conflict) {
+    const sync::ApplyOutcome gap = engine.apply_batch_ex(txn.handle(), make_batch(3));
+    if (gap.result != sync::ApplyResult::Conflict) {
         throw std::runtime_error("seq=3 should be Conflict (gap after seq=1)");
+    }
+    if (gap.conflict_reason != sync::ApplyConflictReason::SequenceGap ||
+        gap.last_applied_seq != 1u ||
+        gap.batch_seq != 3u) {
+        throw std::runtime_error("seq=3 returned wrong conflict details");
     }
     if (engine.apply_batch(txn.handle(), make_batch(2)) != sync::ApplyResult::Applied) {
         throw std::runtime_error("seq=2 should apply after seq=1");
@@ -553,8 +574,8 @@ void test_engine_push_gap_rolls_back() {
     cleanup(p);
 
     auto conn = open_env(p);
-    seed_node_id(conn, make_node(0x10));
     sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x10), make_node(0xD0));
 
     auto make_batch = [](std::uint64_t seq) {
         sync::ChangeBatch b;
@@ -583,12 +604,15 @@ void test_engine_push_gap_rolls_back() {
         sync::DirectSyncPeer peer(&engine);
         sync::PushRequest req;
         req.sender = make_node(0x20);
-        req.db_id  = make_node(0x10);  // peer db_id == local db_uuid
+        req.db_id  = make_node(0xD0);
         req.batches.push_back(make_batch(3));
 
         const sync::PushResponse resp = peer.push(req);
         if (resp.ok) {
             throw std::runtime_error("push with gap should return ok=false");
+        }
+        if (resp.error.find("sequence_gap") == std::string::npos) {
+            throw std::runtime_error("push with gap should return sequence_gap error");
         }
     }
 


### PR DESCRIPTION
﻿## Summary
- add `ApplyOutcome` and `ApplyConflictReason` so callers can distinguish sequence gaps from DBI/schema conflicts without breaking `apply_batch()`
- use detailed apply outcomes in `handle_push()` error strings
- add a manual `sync_tick_hub_benchmark` target behind `MDBXC_BUILD_BENCHMARKS=ON` for hub-style tick-chunk pull measurements

## Notes
- `apply_batch()` remains source-compatible and returns the original `ApplyResult`
- benchmark targets are not registered as CTest tests; they are explicit/manual performance tools
- fixed the existing push-gap test setup so it now exercises a real sequence gap instead of a db_id mismatch

## Local validation
- C++17 configure/build with `MDBXC_BUILD_BENCHMARKS=ON`
- C++17 full `ctest --output-on-failure`: 28/28
- C++11 configure/build with `MDBXC_BUILD_BENCHMARKS=ON`
- C++11 full `ctest --output-on-failure`: 27/27
- `sync_tick_hub_benchmark` default run in C++17 and C++11: 16 origins, 8320 seeded batches, 128 pulled batches, 2 pull pages
