### PR TITLE
perf(sync): index changelog origins

### DIFF
--- a/benchmarks/sync_tick_hub_benchmark.cpp
+++ b/benchmarks/sync_tick_hub_benchmark.cpp
@@ -181,6 +181,18 @@ void seed_changelog(const std::shared_ptr<mdbxc::Connection>& conn,
     txn.commit();
 }
 
+std::uint64_t count_origin_index_entries(
+        const std::shared_ptr<mdbxc::Connection>& conn) {
+    auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+    mdbxc::sync::OriginIndexStore origins(conn->env_handle());
+    if (!origins.open_existing(txn.handle())) {
+        return 0;
+    }
+    const std::vector<mdbxc::sync::NodeId> indexed =
+        origins.origins(txn.handle());
+    return static_cast<std::uint64_t>(indexed.size());
+}
+
 std::uint64_t pull_incremental(mdbxc::sync::SyncEngine& engine,
                                const BenchmarkConfig& config,
                                std::uint64_t& pages) {
@@ -238,6 +250,12 @@ int run(int argc, char** argv) {
     seed_changelog(conn, config);
     const std::chrono::steady_clock::time_point seed_finish =
         std::chrono::steady_clock::now();
+    const std::uint64_t origin_index_entries = count_origin_index_entries(conn);
+    if (origin_index_entries != config.origins) {
+        throw std::runtime_error("wrong number of origin index entries: expected " +
+                                 std::to_string(config.origins) + ", got " +
+                                 std::to_string(origin_index_entries));
+    }
 
     std::uint64_t pages = 0;
     const std::chrono::steady_clock::time_point pull_start =
@@ -271,6 +289,7 @@ int run(int argc, char** argv) {
               << "  ticks_per_chunk=" << config.ticks_per_chunk << "\n"
               << "  max_batches=" << config.max_batches << "\n"
               << "  seeded_batches=" << seeded << "\n"
+              << "  origin_index_entries=" << origin_index_entries << "\n"
               << "  pulled_batches=" << pulled << "\n"
               << "  pull_pages=" << pages << "\n"
               << "  seed_ms=" << seed_ms << "\n"

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -29,6 +29,7 @@
 #include "sync/SyncEngine.hpp"
 #include "sync/DirectSyncPeer.hpp"
 #include "sync/stores/MetaStore.hpp"
+#include "sync/stores/OriginIndexStore.hpp"
 #include "sync/stores/ChangeLogStore.hpp"
 #include "sync/stores/AppliedStore.hpp"
 #include "sync/stores/IdentityIndexStore.hpp"

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -9,7 +9,7 @@
 ## Scope
 
 Multi-master replication of logical MDBX tables between node-local envs.
-Wire is transport-agnostic, codec is versioned, storage is four named DBIs.
+Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
 
 ## Already implemented (merged into main)
 
@@ -17,8 +17,9 @@ Wire is transport-agnostic, codec is versioned, storage is four named DBIs.
   `Common`, `ChangeBatch`, `ChangeOp`, `CodecFlags`, `CodecBounds`,
   `Protocol`, `SyncCursor`, `ConflictPolicy`, `ISyncPeer`,
   `IdentityProvider`, `ChangeBatchCodec`.
-- Four system stores under `include/mdbx_containers/sync/stores/`:
-  `MetaStore`, `ChangeLogStore`, `AppliedStore`, `IdentityIndexStore`.
+- Five system stores under `include/mdbx_containers/sync/stores/`:
+  `MetaStore`, `ChangeLogStore`, `OriginIndexStore`, `AppliedStore`,
+  `IdentityIndexStore`.
 - `ChangeBatchCodec` strict versioned wire format (magic, codec version,
   batch version, batch flags, then payload); rejects unknown mandatory
   flags and version mismatches at both encode and decode.
@@ -94,6 +95,20 @@ any new payload integer: little-endian.
 deletes each hit, then closes. The boundary comparison is on the bytewise
 key, which is why `seq` is big-endian in the key.
 
+### `_mdbxc_origins` (OriginIndexStore)
+
+| | |
+|---|---|
+| Key | `origin_node_id` (16 raw bytes) |
+| Value | u64 LE - max known changelog `seq` for that origin |
+
+This index is a discovery accelerator for hub-style pull. `ChangeLogStore::append`
+updates it atomically with the changelog row. When an upgraded database has
+legacy changelog rows but no `_mdbxc_origins`, the first writable append
+backfills the index by scanning existing changelog keys. Read-only pull keeps
+a compatibility fallback: if `_mdbxc_origins` is absent or empty, origin
+discovery scans `_mdbxc_changelog`.
+
 ### `_mdbxc_applied` (AppliedStore)
 
 | | |
@@ -145,7 +160,8 @@ multi-master:
 ```
 origin A writes
     -> Transaction::commit pre-commit hook
-        -> ChangeAccumulator.flush (writes ChangeLogStore + IdentityIndexStore)
+        -> ChangeAccumulator.flush (writes ChangeLogStore + OriginIndexStore
+           + IdentityIndexStore)
             -> mdbx_txn_commit() — changes land atomically
 
 receiver B

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -47,6 +47,7 @@
 #include "../detail/utils.hpp"
 #include "stores/AppliedStore.hpp"
 #include "stores/MetaStore.hpp"
+#include "stores/OriginIndexStore.hpp"
 
 namespace mdbxc {
 namespace sync {
@@ -245,14 +246,14 @@ namespace sync {
             return "unknown";
         }
 
-        /// \brief Handles a pull request: scans the local \c ChangeLogStore
+        /// \brief Handles a pull request: reads the local changelog
         /// for batches newer than the requester's cursor.
         /// \details When \c request.have is empty, returns a full snapshot
         /// (all known origins, batches from seq=1). Non-empty cursors still
-        /// scan all origins so newly discovered origins and multi-origin
-        /// pagination are not stranded. Validates \c request.db_id against
-        /// the local \c db_uuid; mismatched peers receive an empty response
-        /// with \c ok=false.
+        /// consider all known origins so newly discovered origins and
+        /// multi-origin pagination are not stranded. Validates
+        /// \c request.db_id against the local \c db_uuid; mismatched peers
+        /// receive an empty response with \c ok=false.
         /// \c has_more is set to \c true when the loop stopped because of
         /// \c request.max_batches or \c request.max_bytes rather than
         /// running out of changelog entries.
@@ -285,19 +286,20 @@ namespace sync {
             return pull_full_snapshot(txn, changelog_dbi, request);
         }
 
-        /// \brief Range-scans the changelog and returns batches newer than
-        /// \c request.have.
+        /// \brief Returns batches newer than \c request.have.
         /// \details Empty \c request.have returns a full snapshot. Non-empty
         /// cursors filter each origin independently and still include origins
-        /// missing from the cursor. Uses changelog keys to seek to
-        /// \c have_seq+1 for each origin so old values are not decoded.
+        /// missing from the cursor. Origin discovery uses \c _mdbxc_origins
+        /// when available, with a changelog scan fallback for pre-index
+        /// databases. Uses changelog keys to seek to \c have_seq+1 for each
+        /// origin so old values are not decoded.
         /// Sets \c has_more=true when the walk stopped because of
         /// \c request.max_batches or \c request.max_bytes.
         PullResponse pull_full_snapshot(MDBX_txn* txn, MDBX_dbi dbi,
                                         const PullRequest& request) {
             PullResponse out;
             out.remote_have = read_applied_cursor(txn, out.remote_have);
-            const std::vector<NodeId> origins = collect_changelog_origins(txn, dbi);
+            const std::vector<NodeId> origins = collect_known_origins(txn, dbi);
             std::size_t total_bytes = 0;
             bool truncated = false;
             for (std::size_t i = 0; i < origins.size(); ++i) {
@@ -669,6 +671,23 @@ namespace sync {
                 check_mdbx(rc, "pull_full: origin cursor walk failed");
             }
             return origins;
+        }
+
+        std::vector<NodeId> collect_indexed_origins(MDBX_txn* txn) const {
+            OriginIndexStore origins(m_conn->env_handle());
+            if (!origins.open_existing(txn)) {
+                return std::vector<NodeId>();
+            }
+            return origins.origins(txn);
+        }
+
+        std::vector<NodeId> collect_known_origins(MDBX_txn* txn,
+                                                  MDBX_dbi changelog_dbi) const {
+            const std::vector<NodeId> indexed = collect_indexed_origins(txn);
+            if (!indexed.empty()) {
+                return indexed;
+            }
+            return collect_changelog_origins(txn, changelog_dbi);
         }
 
         static bool pull_origin_batches(MDBX_txn* txn,

--- a/include/mdbx_containers/sync/stores/ChangeLogStore.hpp
+++ b/include/mdbx_containers/sync/stores/ChangeLogStore.hpp
@@ -13,6 +13,8 @@
 
 #include <mdbx.h>
 
+#include "OriginIndexStore.hpp"
+
 namespace mdbxc {
 namespace sync {
 
@@ -26,7 +28,12 @@ namespace sync {
         /// \brief Constructs a wrapper bound to \p env.
         ChangeLogStore(MDBX_env* env,
                        const std::string& dbi_name = "_mdbxc_changelog")
-            : m_env(env), m_dbi_name(dbi_name), m_dbi(0), m_open(false) {}
+            : m_env(env),
+              m_dbi_name(dbi_name),
+              m_dbi(0),
+              m_open(false),
+              m_origin_index_ready(false),
+              m_origins(env) {}
 
         /// \brief Opens the DBI inside the supplied transaction.
         /// \details Tries \c MDBX_CREATE first; falls back to a plain open
@@ -48,7 +55,11 @@ namespace sync {
         /// \brief Resets the open flag so the next \c open() reopens the DBI
         /// inside the supplied transaction. Use between transactions to avoid
         /// using a stale handle from a prior committed/closed transaction.
-        void reset_open() { m_open = false; }
+        void reset_open() {
+            m_open = false;
+            m_origin_index_ready = false;
+            m_origins.reset_open();
+        }
 
         /// \brief Throws when the DBI has not been opened yet.
         void ensure_open() const {
@@ -63,6 +74,7 @@ namespace sync {
         void append(MDBX_txn* txn, const NodeId& origin,
                     std::uint64_t seq, const std::vector<std::uint8_t>& bytes) {
             ensure_open();
+            ensure_origin_index_ready(txn);
             std::vector<std::uint8_t> key_buf;
             encode_key(origin, seq, key_buf);
             MDBX_val k = { key_buf.empty() ? nullptr : &key_buf[0], key_buf.size() };
@@ -72,6 +84,7 @@ namespace sync {
                 mdbx_put(txn, m_dbi, &k, &v, MDBX_NOOVERWRITE),
                 "ChangeLogStore append failed"
             );
+            m_origins.note_origin(txn, origin, seq);
         }
 
         /// \brief Returns true when a record exists for (\p origin, \p seq).
@@ -177,10 +190,85 @@ namespace sync {
             }
         }
 
+        static NodeId decode_key_origin(const MDBX_val& key) {
+            if (key.iov_len != 24) {
+                throw std::runtime_error("ChangeLogStore key has invalid size");
+            }
+            NodeId origin{};
+            std::memcpy(origin.data(), key.iov_base, 16);
+            return origin;
+        }
+
+        static std::uint64_t decode_key_seq(const MDBX_val& key) {
+            if (key.iov_len != 24) {
+                throw std::runtime_error("ChangeLogStore key has invalid size");
+            }
+            const std::uint8_t* bytes = static_cast<const std::uint8_t*>(key.iov_base);
+            std::uint64_t seq = 0;
+            for (int i = 0; i < 8; ++i) {
+                seq = (seq << 8) | static_cast<std::uint64_t>(bytes[16 + i]);
+            }
+            return seq;
+        }
+
+        void ensure_origin_index_ready(MDBX_txn* txn) {
+            if (m_origin_index_ready) {
+                return;
+            }
+            m_origins.open(txn);
+            if (!m_origins.empty(txn)) {
+                m_origin_index_ready = true;
+                return;
+            }
+            backfill_origin_index(txn);
+            m_origin_index_ready = true;
+        }
+
+        void backfill_origin_index(MDBX_txn* txn) {
+            MDBX_cursor* raw = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &raw),
+                       "ChangeLogStore origin backfill cursor open failed");
+            try {
+                MDBX_val k, v;
+                NodeId current_origin{};
+                std::uint64_t current_seq = 0;
+                bool have_current = false;
+                int rc = mdbx_cursor_get(raw, &k, &v, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    const NodeId origin = decode_key_origin(k);
+                    const std::uint64_t seq = decode_key_seq(k);
+                    if (!have_current) {
+                        current_origin = origin;
+                        current_seq = seq;
+                        have_current = true;
+                    } else if (compare_node_id(current_origin, origin) == 0) {
+                        current_seq = seq;
+                    } else {
+                        m_origins.note_origin(txn, current_origin, current_seq);
+                        current_origin = origin;
+                        current_seq = seq;
+                    }
+                    rc = mdbx_cursor_get(raw, &k, &v, MDBX_NEXT);
+                }
+                if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "ChangeLogStore origin backfill cursor walk failed");
+                }
+                if (have_current) {
+                    m_origins.note_origin(txn, current_origin, current_seq);
+                }
+            } catch (...) {
+                mdbx_cursor_close(raw);
+                throw;
+            }
+            mdbx_cursor_close(raw);
+        }
+
         MDBX_env*     m_env;
         std::string   m_dbi_name;
         MDBX_dbi      m_dbi;
         bool          m_open;
+        bool          m_origin_index_ready;
+        OriginIndexStore m_origins;
     };
 
 } // namespace sync

--- a/include/mdbx_containers/sync/stores/OriginIndexStore.hpp
+++ b/include/mdbx_containers/sync/stores/OriginIndexStore.hpp
@@ -1,0 +1,173 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_STORES_ORIGIN_INDEX_STORE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_STORES_ORIGIN_INDEX_STORE_HPP_INCLUDED
+
+/// \file OriginIndexStore.hpp
+/// \brief Compact index of origins present in the local changelog.
+
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mdbx.h>
+
+#include "../common.hpp"
+#include "../../detail/utils.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Thin wrapper around \c _mdbxc_origins.
+    /// \details Key = \c origin_node_id (16 raw bytes), value = max known
+    /// changelog seq for that origin as \c u64 little-endian. The value is
+    /// diagnostic/maintenance metadata; pull pagination uses the changelog
+    /// keys for exact batch iteration.
+    class OriginIndexStore {
+    public:
+        /// \brief Constructs a wrapper bound to \p env.
+        OriginIndexStore(MDBX_env* env,
+                         const std::string& dbi_name = "_mdbxc_origins")
+            : m_env(env), m_dbi_name(dbi_name), m_dbi(0), m_open(false) {}
+
+        /// \brief Opens or creates the DBI inside the supplied transaction.
+        void open(MDBX_txn* txn) {
+            if (m_open) return;
+            int rc = mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE, &m_dbi);
+            if (rc == MDBX_EACCESS) {
+                rc = mdbx_dbi_open(txn, m_dbi_name.c_str(),
+                                   static_cast<MDBX_db_flags_t>(0), &m_dbi);
+            }
+            check_mdbx(rc, "Failed to open OriginIndexStore DBI");
+            m_open = true;
+        }
+
+        /// \brief Opens the DBI only if it already exists.
+        /// \return \c true when opened, \c false when the DBI is absent.
+        bool open_existing(MDBX_txn* txn) {
+            if (m_open) return true;
+            const int rc = mdbx_dbi_open(txn, m_dbi_name.c_str(),
+                                         static_cast<MDBX_db_flags_t>(0), &m_dbi);
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "Failed to open existing OriginIndexStore DBI");
+            m_open = true;
+            return true;
+        }
+
+        bool is_open() const { return m_open; }
+        MDBX_dbi handle() const { return m_dbi; }
+
+        /// \brief Resets the open flag so the next \c open() reopens the DBI.
+        void reset_open() { m_open = false; }
+
+        /// \brief Throws when the DBI has not been opened yet.
+        void ensure_open() const {
+            if (!m_open) {
+                throw std::logic_error("OriginIndexStore is not open");
+            }
+        }
+
+        /// \brief Returns true when the index contains no origins.
+        bool empty(MDBX_txn* txn) const {
+            ensure_open();
+            MDBX_cursor* raw = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &raw),
+                       "OriginIndexStore empty cursor open failed");
+            MDBX_val k, v;
+            const int rc = mdbx_cursor_get(raw, &k, &v, MDBX_FIRST);
+            mdbx_cursor_close(raw);
+            if (rc == MDBX_NOTFOUND) return true;
+            check_mdbx(rc, "OriginIndexStore empty cursor get failed");
+            return false;
+        }
+
+        /// \brief Records \p origin with at least \p seq as its known tail.
+        void note_origin(MDBX_txn* txn, const NodeId& origin, std::uint64_t seq) {
+            ensure_open();
+            std::uint64_t current = 0;
+            if (last_seq(txn, origin, current) && current >= seq) {
+                return;
+            }
+            std::uint8_t value[8];
+            encode_u64_le(seq, value);
+            MDBX_val k = { const_cast<std::uint8_t*>(origin.data()), origin.size() };
+            MDBX_val v = { value, sizeof(value) };
+            check_mdbx(mdbx_put(txn, m_dbi, &k, &v, MDBX_UPSERT),
+                       "OriginIndexStore note_origin failed");
+        }
+
+        /// \brief Reads the max known changelog seq for \p origin.
+        /// \return true when the origin exists.
+        bool last_seq(MDBX_txn* txn, const NodeId& origin,
+                      std::uint64_t& out) const {
+            ensure_open();
+            MDBX_val k = { const_cast<std::uint8_t*>(origin.data()), origin.size() };
+            MDBX_val v;
+            const int rc = mdbx_get(txn, m_dbi, &k, &v);
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "OriginIndexStore last_seq failed");
+            if (v.iov_len != 8) {
+                throw std::runtime_error("OriginIndexStore value has invalid size");
+            }
+            out = decode_u64_le(v);
+            return true;
+        }
+
+        /// \brief Returns all indexed origins in DB key order.
+        std::vector<NodeId> origins(MDBX_txn* txn) const {
+            ensure_open();
+            std::vector<NodeId> out;
+            MDBX_cursor* raw = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &raw),
+                       "OriginIndexStore origins cursor open failed");
+            try {
+                MDBX_val k, v;
+                int rc = mdbx_cursor_get(raw, &k, &v, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    if (k.iov_len != 16) {
+                        throw std::runtime_error("OriginIndexStore key has invalid size");
+                    }
+                    NodeId origin{};
+                    std::memcpy(origin.data(), k.iov_base, 16);
+                    out.push_back(origin);
+                    rc = mdbx_cursor_get(raw, &k, &v, MDBX_NEXT);
+                }
+                if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "OriginIndexStore origins cursor walk failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(raw);
+                throw;
+            }
+            mdbx_cursor_close(raw);
+            return out;
+        }
+
+    private:
+        static void encode_u64_le(std::uint64_t value, std::uint8_t out[8]) {
+            for (int i = 0; i < 8; ++i) {
+                out[i] = static_cast<std::uint8_t>((value >> (i * 8)) & 0xff);
+            }
+        }
+
+        static std::uint64_t decode_u64_le(const MDBX_val& value) {
+            const std::uint8_t* bytes =
+                static_cast<const std::uint8_t*>(value.iov_base);
+            std::uint64_t out = 0;
+            for (int i = 0; i < 8; ++i) {
+                out |= static_cast<std::uint64_t>(bytes[i]) << (i * 8);
+            }
+            return out;
+        }
+
+        MDBX_env*     m_env;
+        std::string   m_dbi_name;
+        MDBX_dbi      m_dbi;
+        bool          m_open;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_STORES_ORIGIN_INDEX_STORE_HPP_INCLUDED

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -88,6 +88,30 @@ mdbxc::sync::ChangeBatch make_raw_batch(const mdbxc::sync::NodeId& origin,
     return batch;
 }
 
+std::vector<std::uint8_t> make_changelog_key(const mdbxc::sync::NodeId& origin,
+                                             std::uint64_t seq) {
+    std::vector<std::uint8_t> out(24);
+    std::memcpy(out.data(), origin.data(), 16);
+    for (int i = 0; i < 8; ++i) {
+        out[16 + i] =
+            static_cast<std::uint8_t>((seq >> ((7 - i) * 8)) & 0xff);
+    }
+    return out;
+}
+
+void put_raw_changelog(MDBX_txn* txn,
+                       MDBX_dbi dbi,
+                       const mdbxc::sync::NodeId& origin,
+                       std::uint64_t seq,
+                       const std::vector<std::uint8_t>& bytes) {
+    std::vector<std::uint8_t> key = make_changelog_key(origin, seq);
+    MDBX_val k = { key.empty() ? nullptr : &key[0], key.size() };
+    MDBX_val v = { bytes.empty() ? nullptr : const_cast<std::uint8_t*>(&bytes[0]),
+                   bytes.size() };
+    mdbxc::check_mdbx(mdbx_put(txn, dbi, &k, &v, MDBX_NOOVERWRITE),
+                      "raw changelog put failed");
+}
+
 void append_raw_batch(mdbxc::sync::ChangeLogStore& log,
                       MDBX_txn* txn,
                       const mdbxc::sync::NodeId& origin,
@@ -943,6 +967,60 @@ void test_engine_handle_pull_multi_origin_pagination() {
     cleanup(primary_path); cleanup(replica_path);
 }
 
+void test_engine_handle_pull_legacy_changelog_without_origin_index() {
+    using namespace mdbxc;
+    const std::string primary_path = "test_engine_pull_legacy_origins.mdbx";
+    cleanup(primary_path);
+
+    auto primary_conn = open_env(primary_path);
+
+    const sync::NodeId primary_node = make_node(0xA0);
+    const sync::NodeId replica_node = make_node(0xB0);
+    const sync::NodeId db_uuid = make_node(0xD0);
+    const sync::NodeId origin = make_node(0x20);
+
+    sync::SyncEngine primary_engine(primary_conn);
+    primary_engine.initialize_local_identity(primary_node, db_uuid);
+
+    {
+        auto txn = primary_conn->transaction(TransactionMode::WRITABLE);
+        MDBX_dbi raw = 0;
+        check_mdbx(mdbx_dbi_open(txn.handle(), "_mdbxc_changelog",
+                                 MDBX_CREATE, &raw),
+                   "open raw changelog failed");
+        const sync::ChangeBatch batch = make_raw_batch(origin, 1, "kv", 0xA1);
+        const std::vector<std::uint8_t> bytes = sync::ChangeBatchCodec::encode(batch);
+        put_raw_changelog(txn.handle(), raw, origin, 1, bytes);
+        txn.commit();
+    }
+
+    {
+        auto txn = primary_conn->transaction(TransactionMode::READ_ONLY);
+        sync::OriginIndexStore origins(primary_conn->env_handle());
+        if (origins.open_existing(txn.handle())) {
+            throw std::runtime_error("legacy setup should not create origin index");
+        }
+    }
+
+    sync::DirectSyncPeer peer(&primary_engine);
+    sync::PullRequest req;
+    req.requester = replica_node;
+    req.db_id = db_uuid;
+    const sync::PullResponse response = peer.pull(req);
+    if (!response.ok) {
+        throw std::runtime_error("legacy origin-index fallback pull failed: " +
+                                 response.error);
+    }
+    if (response.batches.size() != 1u ||
+        response.batches[0].origin_node_id != origin ||
+        response.batches[0].seq != 1u) {
+        throw std::runtime_error("legacy origin-index fallback returned wrong batch");
+    }
+
+    primary_conn->disconnect();
+    cleanup(primary_path);
+}
+
 void test_engine_handle_pull_skips_old_batches_without_decoding() {
     using namespace mdbxc;
     const std::string primary_path = "test_engine_pull_skip_old_decode.mdbx";
@@ -1039,6 +1117,7 @@ int main() {
         { "test_engine_handle_push_wrong_db_id",&test_engine_handle_push_wrong_db_id },
         { "test_engine_handle_pull_pagination", &test_engine_handle_pull_pagination_has_more },
         { "test_engine_handle_pull_multi_origin",&test_engine_handle_pull_multi_origin_pagination },
+        { "test_engine_handle_pull_legacy_origin_index",&test_engine_handle_pull_legacy_changelog_without_origin_index },
         { "test_engine_handle_pull_skip_old_decode",&test_engine_handle_pull_skips_old_batches_without_decoding },
         { "test_engine_handle_pull_lifecycle", &test_engine_handle_pull_lifecycle },
     };

--- a/tests/test_sync_stores.cpp
+++ b/tests/test_sync_stores.cpp
@@ -2,6 +2,7 @@
 #include <mdbx_containers/sync.hpp>
 #include <cstdio>
 #include <cstdint>
+#include <cstring>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -18,6 +19,30 @@ mdbxc::sync::NodeId make_node(std::uint8_t seed) {
         n[i] = static_cast<std::uint8_t>(seed + i);
     }
     return n;
+}
+
+std::vector<std::uint8_t> make_changelog_key(const mdbxc::sync::NodeId& origin,
+                                             std::uint64_t seq) {
+    std::vector<std::uint8_t> out(24);
+    std::memcpy(out.data(), origin.data(), 16);
+    for (int i = 0; i < 8; ++i) {
+        out[16 + i] =
+            static_cast<std::uint8_t>((seq >> ((7 - i) * 8)) & 0xff);
+    }
+    return out;
+}
+
+void put_raw_changelog(MDBX_txn* txn,
+                       MDBX_dbi dbi,
+                       const mdbxc::sync::NodeId& origin,
+                       std::uint64_t seq,
+                       const std::vector<std::uint8_t>& bytes) {
+    std::vector<std::uint8_t> key = make_changelog_key(origin, seq);
+    MDBX_val k = { key.empty() ? nullptr : &key[0], key.size() };
+    MDBX_val v = { bytes.empty() ? nullptr : const_cast<std::uint8_t*>(&bytes[0]),
+                   bytes.size() };
+    mdbxc::check_mdbx(mdbx_put(txn, dbi, &k, &v, MDBX_NOOVERWRITE),
+                      "raw changelog put failed");
 }
 
 void test_meta_store() {
@@ -70,6 +95,58 @@ void test_meta_store() {
     cleanup(p);
 }
 
+void test_origin_index_store() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_origins.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    OriginIndexStore store(conn->env_handle());
+    const NodeId origin_a = make_node(0x10);
+    const NodeId origin_b = make_node(0x20);
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        store.open(txn.handle());
+        if (!store.empty(txn.handle())) {
+            throw std::runtime_error("new origin index should be empty");
+        }
+        store.note_origin(txn.handle(), origin_a, 7);
+        store.note_origin(txn.handle(), origin_b, 3);
+        store.note_origin(txn.handle(), origin_a, 2);
+        txn.commit();
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        OriginIndexStore ro(conn->env_handle());
+        if (!ro.open_existing(txn.handle())) {
+            throw std::runtime_error("origin index should exist");
+        }
+        std::uint64_t seq = 0;
+        if (!ro.last_seq(txn.handle(), origin_a, seq) || seq != 7u) {
+            throw std::runtime_error("origin_a last seq mismatch");
+        }
+        if (!ro.last_seq(txn.handle(), origin_b, seq) || seq != 3u) {
+            throw std::runtime_error("origin_b last seq mismatch");
+        }
+        const std::vector<NodeId> origins = ro.origins(txn.handle());
+        if (origins.size() != 2u ||
+            origins[0] != origin_a ||
+            origins[1] != origin_b) {
+            throw std::runtime_error("origin index order mismatch");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 void test_changelog_store() {
     using namespace mdbxc::sync;
     const std::string p = "test_sync_stores_changelog.mdbx";
@@ -113,6 +190,92 @@ void test_changelog_store() {
         if (decoded.seq != 7) throw std::runtime_error("decoded seq mismatch");
         if (decoded.origin_node_id != origin) {
             throw std::runtime_error("decoded origin mismatch");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_changelog_updates_origin_index() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_changelog_origins.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    ChangeLogStore log(conn->env_handle());
+    const NodeId origin = make_node(0x30);
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        log.open(txn.handle());
+        log.append(txn.handle(), origin, 1, { 0x01 });
+        log.append(txn.handle(), origin, 3, { 0x03 });
+        txn.commit();
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        OriginIndexStore origins(conn->env_handle());
+        if (!origins.open_existing(txn.handle())) {
+            throw std::runtime_error("origin index should exist after append");
+        }
+        std::uint64_t seq = 0;
+        if (!origins.last_seq(txn.handle(), origin, seq) || seq != 3u) {
+            throw std::runtime_error("changelog did not update origin tail");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_changelog_backfills_legacy_origins_on_append() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_changelog_origin_backfill.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    const NodeId origin_a = make_node(0x10);
+    const NodeId origin_b = make_node(0x40);
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        MDBX_dbi raw = 0;
+        mdbxc::check_mdbx(mdbx_dbi_open(txn.handle(), "_mdbxc_changelog",
+                                        MDBX_CREATE, &raw),
+                          "open raw changelog failed");
+        put_raw_changelog(txn.handle(), raw, origin_a, 1, { 0xA1 });
+        put_raw_changelog(txn.handle(), raw, origin_a, 2, { 0xA2 });
+
+        ChangeLogStore log(conn->env_handle());
+        log.open(txn.handle());
+        log.append(txn.handle(), origin_b, 1, { 0xB1 });
+        txn.commit();
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        OriginIndexStore origins(conn->env_handle());
+        if (!origins.open_existing(txn.handle())) {
+            throw std::runtime_error("origin index should exist after backfill");
+        }
+        std::uint64_t seq = 0;
+        if (!origins.last_seq(txn.handle(), origin_a, seq) || seq != 2u) {
+            throw std::runtime_error("legacy origin was not backfilled");
+        }
+        if (!origins.last_seq(txn.handle(), origin_b, seq) || seq != 1u) {
+            throw std::runtime_error("new origin was not indexed");
         }
     }
 
@@ -412,6 +575,17 @@ void test_stores_require_open() {
         expect_open_required("ChangeLogStore::prune_up_to", change,
                             [&] { (void)change.prune_up_to(txn.handle(), make_node(0xC0), 1); });
 
+        OriginIndexStore origins(conn->env_handle());
+        std::uint64_t seq = 0;
+        expect_open_required("OriginIndexStore::empty", origins,
+                            [&origins, &txn] { (void)origins.empty(txn.handle()); });
+        expect_open_required("OriginIndexStore::note_origin", origins,
+                            [&origins, &txn] { origins.note_origin(txn.handle(), make_node(0xD0), 1); });
+        expect_open_required("OriginIndexStore::last_seq", origins,
+                            [&origins, &txn, &seq] { (void)origins.last_seq(txn.handle(), make_node(0xD0), seq); });
+        expect_open_required("OriginIndexStore::origins", origins,
+                            [&origins, &txn] { (void)origins.origins(txn.handle()); });
+
         IdentityIndexStore identity(conn->env_handle());
         IdentityIndexValue iv;
         expect_open_required("IdentityIndexStore::put", identity,
@@ -432,7 +606,10 @@ void test_stores_require_open() {
 
 int main() {
     test_meta_store();
+    test_origin_index_store();
     test_changelog_store();
+    test_changelog_updates_origin_index();
+    test_changelog_backfills_legacy_origins_on_append();
     test_applied_store();
     test_identity_index_store();
     test_changelog_prune_up_to_boundary();


### PR DESCRIPTION
﻿## Summary
- add `_mdbxc_origins` / `OriginIndexStore` as an origin discovery index for changelog pulls
- update `ChangeLogStore::append()` to maintain the origin index and backfill legacy changelog rows on first writable append
- use indexed origin discovery in `SyncEngine::handle_pull()` with read-only fallback for pre-index databases
- extend sync store/engine tests and the tick hub benchmark to verify indexed origins

## Validation
- `cmake -S . -B tmp/build-origin-index-cpp17 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_BUILD_BENCHMARKS=ON -DCMAKE_CXX_STANDARD=17`
- `cmake --build tmp/build-origin-index-cpp17 --parallel 1`
- `ctest --test-dir tmp/build-origin-index-cpp17 --output-on-failure` (28/28 passed)
- `tmp\build-origin-index-cpp17\bin\benchmarks\sync_tick_hub_benchmark.exe` (`origin_index_entries=16`, `pulled_batches=128`, `pull_pages=2`, `pull_ms=0.96`)
- `tmp\build-origin-index-cpp17\bin\benchmarks\sync_tick_hub_benchmark.exe 128 256 2 64 128` (`origin_index_entries=128`, `pulled_batches=256`, `pull_pages=2`, `pull_ms=2.635`)
- `cmake -S . -B tmp/build-origin-index-cpp11 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_BUILD_BENCHMARKS=ON -DCMAKE_CXX_STANDARD=11`
- `cmake --build tmp/build-origin-index-cpp11 --parallel 1`
- `ctest --test-dir tmp/build-origin-index-cpp11 --output-on-failure` (27/27 passed)
- `tmp\build-origin-index-cpp11\bin\benchmarks\sync_tick_hub_benchmark.exe` (`origin_index_entries=16`, `pulled_batches=128`, `pull_pages=2`, `pull_ms=0.962`)
- `git diff --check`
