### PR TITLE
feat(sync): add origin index maintenance

### DIFF
--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -109,6 +109,12 @@ backfills the index by scanning existing changelog keys. Read-only pull keeps
 a compatibility fallback: if `_mdbxc_origins` is absent or empty, origin
 discovery scans `_mdbxc_changelog`.
 
+`ChangeLogStore::origin_index_matches_changelog()` compares the index against
+the changelog-derived origin tails. `ChangeLogStore::rebuild_origin_index()`
+is the explicit maintenance path for a manually damaged or otherwise partial
+`_mdbxc_origins` DBI; ordinary pull does not rebuild metadata in a read-only
+transaction.
+
 ### `_mdbxc_applied` (AppliedStore)
 
 | | |

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -115,6 +115,10 @@ is the explicit maintenance path for a manually damaged or otherwise partial
 `_mdbxc_origins` DBI; ordinary pull does not rebuild metadata in a read-only
 transaction.
 
+These maintenance operations scan the changelog. Use them for startup
+diagnostics, manual repair, or rare integrity checks; do not place them in the
+normal background-sync loop or per-pull hot path.
+
 ### `_mdbxc_applied` (AppliedStore)
 
 | | |

--- a/include/mdbx_containers/sync/stores/ChangeLogStore.hpp
+++ b/include/mdbx_containers/sync/stores/ChangeLogStore.hpp
@@ -181,6 +181,9 @@ namespace sync {
         /// \param txn Active transaction.
         /// \return \c true when every changelog origin has one matching index
         /// entry with the same max seq, and the index has no extra origins.
+        /// \complexity O(changelog entries + indexed origins).
+        /// \note Intended for startup diagnostics, manual repair, or rare
+        /// integrity checks. Do not call from the normal pull/sync hot path.
         bool origin_index_matches_changelog(MDBX_txn* txn) const {
             ensure_open();
             const std::vector<OriginTail> expected =
@@ -212,6 +215,8 @@ namespace sync {
         /// \param txn Active transaction.
         /// \return Number of origins written to the rebuilt index.
         /// \pre Transaction must be writable.
+        /// \complexity O(changelog entries + indexed origins).
+        /// \note Explicit maintenance operation; ordinary pull does not call it.
         std::size_t rebuild_origin_index(MDBX_txn* txn) {
             ensure_open();
             const std::vector<OriginTail> tails =

--- a/include/mdbx_containers/sync/stores/ChangeLogStore.hpp
+++ b/include/mdbx_containers/sync/stores/ChangeLogStore.hpp
@@ -177,7 +177,58 @@ namespace sync {
             return removed;
         }
 
+        /// \brief Checks whether \c _mdbxc_origins exactly mirrors changelog tails.
+        /// \param txn Active transaction.
+        /// \return \c true when every changelog origin has one matching index
+        /// entry with the same max seq, and the index has no extra origins.
+        bool origin_index_matches_changelog(MDBX_txn* txn) const {
+            ensure_open();
+            const std::vector<OriginTail> expected =
+                collect_changelog_origin_tails(txn);
+
+            OriginIndexStore origins(m_env);
+            if (!origins.open_existing(txn)) {
+                return expected.empty();
+            }
+
+            const std::vector<NodeId> actual_origins = origins.origins(txn);
+            if (actual_origins.size() != expected.size()) {
+                return false;
+            }
+            for (std::size_t i = 0; i < expected.size(); ++i) {
+                if (actual_origins[i] != expected[i].origin) {
+                    return false;
+                }
+                std::uint64_t actual_seq = 0;
+                if (!origins.last_seq(txn, actual_origins[i], actual_seq) ||
+                    actual_seq != expected[i].seq) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// \brief Rebuilds \c _mdbxc_origins from changelog keys.
+        /// \param txn Active transaction.
+        /// \return Number of origins written to the rebuilt index.
+        /// \pre Transaction must be writable.
+        std::size_t rebuild_origin_index(MDBX_txn* txn) {
+            ensure_open();
+            const std::vector<OriginTail> tails =
+                collect_changelog_origin_tails(txn);
+            m_origins.open(txn);
+            m_origins.clear(txn);
+            write_origin_tails(txn, tails);
+            m_origin_index_ready = true;
+            return tails.size();
+        }
+
     private:
+        struct OriginTail {
+            NodeId origin;
+            std::uint64_t seq;
+        };
+
         static void encode_key(const NodeId& origin, std::uint64_t seq,
                                std::vector<std::uint8_t>& out) {
             out.resize(24);
@@ -211,6 +262,46 @@ namespace sync {
             return seq;
         }
 
+        std::vector<OriginTail> collect_changelog_origin_tails(MDBX_txn* txn) const {
+            std::vector<OriginTail> out;
+            MDBX_cursor* raw = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &raw),
+                       "ChangeLogStore origin scan cursor open failed");
+            try {
+                MDBX_val k, v;
+                int rc = mdbx_cursor_get(raw, &k, &v, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    const NodeId origin = decode_key_origin(k);
+                    const std::uint64_t seq = decode_key_seq(k);
+                    if (out.empty() ||
+                        compare_node_id(out.back().origin, origin) != 0) {
+                        OriginTail tail;
+                        tail.origin = origin;
+                        tail.seq = seq;
+                        out.push_back(tail);
+                    } else {
+                        out.back().seq = seq;
+                    }
+                    rc = mdbx_cursor_get(raw, &k, &v, MDBX_NEXT);
+                }
+                if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "ChangeLogStore origin scan cursor walk failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(raw);
+                throw;
+            }
+            mdbx_cursor_close(raw);
+            return out;
+        }
+
+        void write_origin_tails(MDBX_txn* txn,
+                                const std::vector<OriginTail>& tails) {
+            for (std::size_t i = 0; i < tails.size(); ++i) {
+                m_origins.note_origin(txn, tails[i].origin, tails[i].seq);
+            }
+        }
+
         void ensure_origin_index_ready(MDBX_txn* txn) {
             if (m_origin_index_ready) {
                 return;
@@ -225,42 +316,9 @@ namespace sync {
         }
 
         void backfill_origin_index(MDBX_txn* txn) {
-            MDBX_cursor* raw = nullptr;
-            check_mdbx(mdbx_cursor_open(txn, m_dbi, &raw),
-                       "ChangeLogStore origin backfill cursor open failed");
-            try {
-                MDBX_val k, v;
-                NodeId current_origin{};
-                std::uint64_t current_seq = 0;
-                bool have_current = false;
-                int rc = mdbx_cursor_get(raw, &k, &v, MDBX_FIRST);
-                while (rc == MDBX_SUCCESS) {
-                    const NodeId origin = decode_key_origin(k);
-                    const std::uint64_t seq = decode_key_seq(k);
-                    if (!have_current) {
-                        current_origin = origin;
-                        current_seq = seq;
-                        have_current = true;
-                    } else if (compare_node_id(current_origin, origin) == 0) {
-                        current_seq = seq;
-                    } else {
-                        m_origins.note_origin(txn, current_origin, current_seq);
-                        current_origin = origin;
-                        current_seq = seq;
-                    }
-                    rc = mdbx_cursor_get(raw, &k, &v, MDBX_NEXT);
-                }
-                if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc, "ChangeLogStore origin backfill cursor walk failed");
-                }
-                if (have_current) {
-                    m_origins.note_origin(txn, current_origin, current_seq);
-                }
-            } catch (...) {
-                mdbx_cursor_close(raw);
-                throw;
-            }
-            mdbx_cursor_close(raw);
+            const std::vector<OriginTail> tails =
+                collect_changelog_origin_tails(txn);
+            write_origin_tails(txn, tails);
         }
 
         MDBX_env*     m_env;

--- a/include/mdbx_containers/sync/stores/OriginIndexStore.hpp
+++ b/include/mdbx_containers/sync/stores/OriginIndexStore.hpp
@@ -82,6 +82,36 @@ namespace sync {
             return false;
         }
 
+        /// \brief Removes all indexed origins.
+        /// \param txn Active transaction.
+        /// \return Number of removed origin entries.
+        /// \pre Transaction must be writable.
+        std::size_t clear(MDBX_txn* txn) {
+            ensure_open();
+            MDBX_cursor* raw = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &raw),
+                       "OriginIndexStore clear cursor open failed");
+            std::size_t removed = 0;
+            try {
+                MDBX_val k, v;
+                int rc = mdbx_cursor_get(raw, &k, &v, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    check_mdbx(mdbx_cursor_del(raw, MDBX_CURRENT),
+                               "OriginIndexStore clear cursor_del failed");
+                    ++removed;
+                    rc = mdbx_cursor_get(raw, &k, &v, MDBX_NEXT);
+                }
+                if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "OriginIndexStore clear cursor walk failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(raw);
+                throw;
+            }
+            mdbx_cursor_close(raw);
+            return removed;
+        }
+
         /// \brief Records \p origin with at least \p seq as its known tail.
         void note_origin(MDBX_txn* txn, const NodeId& origin, std::uint64_t seq) {
             ensure_open();
@@ -127,6 +157,9 @@ namespace sync {
                 while (rc == MDBX_SUCCESS) {
                     if (k.iov_len != 16) {
                         throw std::runtime_error("OriginIndexStore key has invalid size");
+                    }
+                    if (v.iov_len != 8) {
+                        throw std::runtime_error("OriginIndexStore value has invalid size");
                     }
                     NodeId origin{};
                     std::memcpy(origin.data(), k.iov_base, 16);

--- a/tests/test_sync_stores.cpp
+++ b/tests/test_sync_stores.cpp
@@ -143,6 +143,17 @@ void test_origin_index_store() {
         }
     }
 
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        OriginIndexStore writable(conn->env_handle());
+        writable.open(txn.handle());
+        const std::size_t removed = writable.clear(txn.handle());
+        if (removed != 2u || !writable.empty(txn.handle())) {
+            throw std::runtime_error("origin index clear mismatch");
+        }
+        txn.commit();
+    }
+
     conn->disconnect();
     cleanup(p);
 }
@@ -276,6 +287,83 @@ void test_changelog_backfills_legacy_origins_on_append() {
         }
         if (!origins.last_seq(txn.handle(), origin_b, seq) || seq != 1u) {
             throw std::runtime_error("new origin was not indexed");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_changelog_rebuilds_partial_origin_index() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_changelog_origin_rebuild.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    const NodeId origin_a = make_node(0x10);
+    const NodeId origin_b = make_node(0x40);
+    const NodeId stale_origin = make_node(0x70);
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        MDBX_dbi raw = 0;
+        mdbxc::check_mdbx(mdbx_dbi_open(txn.handle(), "_mdbxc_changelog",
+                                        MDBX_CREATE, &raw),
+                          "open raw changelog failed");
+        put_raw_changelog(txn.handle(), raw, origin_a, 1, { 0xA1 });
+        put_raw_changelog(txn.handle(), raw, origin_a, 2, { 0xA2 });
+        put_raw_changelog(txn.handle(), raw, origin_b, 1, { 0xB1 });
+
+        OriginIndexStore origins(conn->env_handle());
+        origins.open(txn.handle());
+        origins.note_origin(txn.handle(), origin_a, 2);
+        origins.note_origin(txn.handle(), stale_origin, 9);
+        txn.commit();
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        ChangeLogStore log(conn->env_handle());
+        log.open(txn.handle());
+        if (log.origin_index_matches_changelog(txn.handle())) {
+            throw std::runtime_error("partial origin index should not validate");
+        }
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        ChangeLogStore log(conn->env_handle());
+        log.open(txn.handle());
+        const std::size_t origins_written = log.rebuild_origin_index(txn.handle());
+        if (origins_written != 2u) {
+            throw std::runtime_error("origin rebuild wrote wrong count");
+        }
+        if (!log.origin_index_matches_changelog(txn.handle())) {
+            throw std::runtime_error("rebuilt origin index should validate");
+        }
+        txn.commit();
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        OriginIndexStore origins(conn->env_handle());
+        if (!origins.open_existing(txn.handle())) {
+            throw std::runtime_error("rebuilt origin index should exist");
+        }
+        std::uint64_t seq = 0;
+        if (!origins.last_seq(txn.handle(), origin_a, seq) || seq != 2u) {
+            throw std::runtime_error("rebuilt origin_a tail mismatch");
+        }
+        if (!origins.last_seq(txn.handle(), origin_b, seq) || seq != 1u) {
+            throw std::runtime_error("rebuilt origin_b tail mismatch");
+        }
+        if (origins.last_seq(txn.handle(), stale_origin, seq)) {
+            throw std::runtime_error("rebuilt index kept stale origin");
         }
     }
 
@@ -574,11 +662,17 @@ void test_stores_require_open() {
                             [&] { (void)change.erase(txn.handle(), make_node(0xC0), 1); });
         expect_open_required("ChangeLogStore::prune_up_to", change,
                             [&] { (void)change.prune_up_to(txn.handle(), make_node(0xC0), 1); });
+        expect_open_required("ChangeLogStore::origin_index_matches_changelog", change,
+                            [&change, &txn] { (void)change.origin_index_matches_changelog(txn.handle()); });
+        expect_open_required("ChangeLogStore::rebuild_origin_index", change,
+                            [&change, &txn] { (void)change.rebuild_origin_index(txn.handle()); });
 
         OriginIndexStore origins(conn->env_handle());
         std::uint64_t seq = 0;
         expect_open_required("OriginIndexStore::empty", origins,
                             [&origins, &txn] { (void)origins.empty(txn.handle()); });
+        expect_open_required("OriginIndexStore::clear", origins,
+                            [&origins, &txn] { (void)origins.clear(txn.handle()); });
         expect_open_required("OriginIndexStore::note_origin", origins,
                             [&origins, &txn] { origins.note_origin(txn.handle(), make_node(0xD0), 1); });
         expect_open_required("OriginIndexStore::last_seq", origins,
@@ -610,6 +704,7 @@ int main() {
     test_changelog_store();
     test_changelog_updates_origin_index();
     test_changelog_backfills_legacy_origins_on_append();
+    test_changelog_rebuilds_partial_origin_index();
     test_applied_store();
     test_identity_index_store();
     test_changelog_prune_up_to_boundary();


### PR DESCRIPTION
﻿## Summary
- add explicit origin-index maintenance APIs: `origin_index_matches_changelog()` and `rebuild_origin_index()`
- add `OriginIndexStore::clear()` and validate origin-index value size while enumerating origins
- cover partial/corrupt-by-construction index behavior: missing origin plus stale origin is detected, then rebuild repairs the index exactly
- document that ordinary read-only pull does not rebuild `_mdbxc_origins`

## Notes
This is intentionally not a migration state machine. It adds a small manual maintenance path for a partially damaged `_mdbxc_origins` DBI while keeping the pull hot path unchanged.

## Validation
- `cmake -S . -B tmp/build-origin-maint-cpp17 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=17`
- `cmake --build tmp/build-origin-maint-cpp17 --parallel 1`
- `ctest --test-dir tmp/build-origin-maint-cpp17 --output-on-failure` (28/28 passed)
- `cmake -S . -B tmp/build-origin-maint-cpp11 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=11`
- `cmake --build tmp/build-origin-maint-cpp11 --parallel 1`
- `ctest --test-dir tmp/build-origin-maint-cpp11 --output-on-failure` (27/27 passed)
- `git diff --check`
