### PR TITLE
feat(sync): add background sync worker

### DIFF
--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -27,6 +27,7 @@
 #include "sync/protocol.hpp"
 #include "sync/SyncCursor.hpp"
 #include "sync/SyncEngine.hpp"
+#include "sync/SyncWorker.hpp"
 #include "sync/DirectSyncPeer.hpp"
 #include "sync/stores/MetaStore.hpp"
 #include "sync/stores/OriginIndexStore.hpp"

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -216,6 +216,11 @@ Worker invariants:
   uses one short local write transaction;
 - stop requests do not interrupt a blocking peer call, but a page returned
   after stop was requested is not applied;
+- `stop()`, `join()`, and destruction may wait for an in-flight peer call to
+  return; timeout/cancellation belongs to the concrete transport adapter;
+- lifecycle mutations (`start`, `stop`, `join`, `run_once`) are caller-serialized,
+  while `request_stop`, `state`, `last_error`, and `wait_until_state` are
+  thread-safe;
 - `Transaction`, raw `MDBX_txn*`, and cursors stay on the thread that opened
   them and never cross the worker boundary.
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -221,6 +221,8 @@ Worker invariants:
 - lifecycle mutations (`start`, `stop`, `join`, `run_once`) are caller-serialized,
   while `request_stop`, `state`, `last_error`, and `wait_until_state` are
   thread-safe;
+- the `SyncWorker` object must outlive its background thread and must not be
+  destroyed from callbacks running on that worker thread;
 - `Transaction`, raw `MDBX_txn*`, and cursors stay on the thread that opened
   them and never cross the worker boundary.
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -16,7 +16,7 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
 - Public types in `include/mdbx_containers/sync/`:
   `Common`, `ChangeBatch`, `ChangeOp`, `CodecFlags`, `CodecBounds`,
   `Protocol`, `SyncCursor`, `ConflictPolicy`, `ISyncPeer`,
-  `IdentityProvider`, `ChangeBatchCodec`.
+  `IdentityProvider`, `ChangeBatchCodec`, `SyncWorker`.
 - Five system stores under `include/mdbx_containers/sync/stores/`:
   `MetaStore`, `ChangeLogStore`, `OriginIndexStore`, `AppliedStore`,
   `IdentityIndexStore`.
@@ -194,6 +194,33 @@ A: detects request_full_snapshot
 B: applies each batch as above
     -> onward sync is incremental pull-from-have
 ```
+
+## Background worker lifecycle
+
+`SyncWorker` is the minimal background driver for `SyncEngine + ISyncPeer`.
+It owns its thread but does not own the engine, peer, or connection. The
+runtime state shape is:
+
+```
+Stopped -> Starting -> Idle -> Pulling -> Applying -> Idle
+                              -> Backoff -> Idle
+                              -> Stopping -> Stopped
+                              -> Failed
+```
+
+Worker invariants:
+
+- no local MDBX transaction is held while waiting in `ISyncPeer::pull()`;
+- no local MDBX transaction is held during idle or backoff sleeps;
+- pulled pages are applied through `SyncEngine::handle_push()`, so each page
+  uses one short local write transaction;
+- stop requests do not interrupt a blocking peer call, but a page returned
+  after stop was requested is not applied;
+- `Transaction`, raw `MDBX_txn*`, and cursors stay on the thread that opened
+  them and never cross the worker boundary.
+
+The worker is a lifecycle/concurrency helper, not a transport. HTTP/WebSocket
+peers remain separate adapters over `ISyncPeer`.
 
 ## Why `prune_up_to` uses cursor walk + `MDBX_NEXT`
 

--- a/include/mdbx_containers/sync/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/SyncWorker.hpp
@@ -1,0 +1,367 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_SYNC_WORKER_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_SYNC_WORKER_HPP_INCLUDED
+
+/// \file SyncWorker.hpp
+/// \brief Background pull/apply loop for \c SyncEngine.
+
+#include <algorithm>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#include "ISyncPeer.hpp"
+#include "SyncEngine.hpp"
+#include "protocol.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Runtime state of a \c SyncWorker.
+    enum class SyncWorkerState {
+        Stopped,  ///< No worker thread is running.
+        Starting, ///< Worker thread has been created but has not entered the loop.
+        Idle,     ///< Worker is sleeping between sync rounds.
+        Pulling,  ///< Worker is waiting for \c ISyncPeer::pull().
+        Applying, ///< Worker is applying a pulled page locally.
+        Backoff,  ///< Last round failed; worker is waiting before retry.
+        Stopping, ///< Stop has been requested; current operation is draining.
+        Failed,   ///< Worker thread exited after an unexpected exception.
+    };
+
+    /// \brief Timing and pagination settings for \c SyncWorker.
+    struct SyncWorkerOptions {
+        /// \brief Max batches requested from the peer per pull page.
+        std::uint64_t max_batches = 1000;
+
+        /// \brief Max encoded batch bytes requested from the peer per pull page.
+        std::uint64_t max_bytes = 4ULL * 1024ULL * 1024ULL;
+
+        /// \brief Delay between successful background sync rounds.
+        std::chrono::milliseconds idle_interval =
+            std::chrono::milliseconds(1000);
+
+        /// \brief Initial delay after a failed background sync round.
+        std::chrono::milliseconds initial_backoff =
+            std::chrono::milliseconds(100);
+
+        /// \brief Maximum delay after repeated failed background sync rounds.
+        std::chrono::milliseconds max_backoff =
+            std::chrono::milliseconds(5000);
+
+        /// \brief Whether one round drains all \c has_more pages immediately.
+        bool drain_pages = true;
+    };
+
+    /// \brief Result of one \c SyncWorker sync round.
+    struct SyncWorkerRoundResult {
+        bool        ok = true; ///< Whether the round completed without error.
+        std::size_t pages_pulled = 0; ///< Number of successful pull pages.
+        std::size_t batches_applied = 0; ///< Number of batches applied locally.
+        bool        has_more = false; ///< Whether the peer reported more pages.
+        std::string error; ///< Failure detail when \c ok is false.
+    };
+
+    /// \brief Drives incremental pull/apply sync in a caller-owned lifecycle.
+    /// \details The worker owns only its std::thread. It does not own the
+    /// supplied \c SyncEngine or \c ISyncPeer; both must outlive the worker.
+    ///
+    /// The implementation never keeps a local MDBX transaction open while
+    /// waiting in \c ISyncPeer::pull(), idle sleep, or backoff sleep. Pulled
+    /// batches are applied through \c SyncEngine::handle_push(), which opens
+    /// and commits a short local write transaction for each pulled page.
+    class SyncWorker {
+    public:
+        /// \brief Constructs a worker over a local engine and remote peer.
+        /// \param engine Local engine that applies pulled batches.
+        /// \param peer Remote peer that serves pull requests.
+        /// \param options Worker timing and pagination options.
+        SyncWorker(SyncEngine& engine,
+                   ISyncPeer& peer,
+                   const SyncWorkerOptions& options = SyncWorkerOptions())
+            : m_engine(engine),
+              m_peer(peer),
+              m_options(options),
+              m_state(SyncWorkerState::Stopped),
+              m_stop_requested(false) {}
+
+        ~SyncWorker() {
+            request_stop();
+            join();
+        }
+
+        SyncWorker(const SyncWorker&) = delete;
+        SyncWorker& operator=(const SyncWorker&) = delete;
+
+        /// \brief Starts the background worker thread.
+        /// \throws std::logic_error if a worker thread is already running.
+        void start() {
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                if (m_thread.joinable()) {
+                    throw std::logic_error("SyncWorker is already running");
+                }
+                if (m_state != SyncWorkerState::Stopped &&
+                    m_state != SyncWorkerState::Failed) {
+                    throw std::logic_error("SyncWorker is not stopped");
+                }
+                m_stop_requested = false;
+                m_last_error.clear();
+                m_state = SyncWorkerState::Starting;
+            }
+            m_state_changed.notify_all();
+            try {
+                m_thread = std::thread(&SyncWorker::thread_main, this);
+            } catch (...) {
+                {
+                    std::lock_guard<std::mutex> lock(m_mutex);
+                    m_stop_requested = true;
+                    m_state = SyncWorkerState::Stopped;
+                }
+                m_state_changed.notify_all();
+                throw;
+            }
+        }
+
+        /// \brief Requests background worker shutdown.
+        /// \details Does not interrupt an in-flight peer call. The worker exits
+        /// before applying a page returned after stop was requested.
+        void request_stop() {
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                m_stop_requested = true;
+                if (m_state != SyncWorkerState::Stopped &&
+                    m_state != SyncWorkerState::Failed) {
+                    m_state = SyncWorkerState::Stopping;
+                }
+            }
+            m_state_changed.notify_all();
+        }
+
+        /// \brief Joins the background worker thread if it is running.
+        void join() {
+            if (m_thread.joinable()) {
+                m_thread.join();
+            }
+        }
+
+        /// \brief Requests stop and joins the background worker thread.
+        void stop() {
+            request_stop();
+            join();
+        }
+
+        /// \brief Runs one pull/apply round on the calling thread.
+        /// \return Round result with page and batch counts.
+        SyncWorkerRoundResult run_once() {
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                if (m_thread.joinable()) {
+                    throw std::logic_error("SyncWorker is already running");
+                }
+                if (m_state != SyncWorkerState::Stopped &&
+                    m_state != SyncWorkerState::Failed) {
+                    throw std::logic_error("SyncWorker is not stopped");
+                }
+                m_stop_requested = false;
+                m_last_error.clear();
+            }
+            const SyncWorkerRoundResult result = run_once_impl();
+            if (stop_requested()) {
+                set_state(SyncWorkerState::Stopped);
+                return result;
+            }
+            if (result.ok) {
+                set_state(SyncWorkerState::Stopped);
+            } else {
+                set_last_error(result.error);
+                set_state(SyncWorkerState::Failed);
+            }
+            return result;
+        }
+
+        /// \brief Returns the current worker state.
+        SyncWorkerState state() const {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            return m_state;
+        }
+
+        /// \brief Returns the most recent failure message.
+        std::string last_error() const {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            return m_last_error;
+        }
+
+        /// \brief Waits until \p desired is observed or \p timeout expires.
+        /// \param desired State to wait for.
+        /// \param timeout Maximum wait duration.
+        /// \return \c true when \p desired was observed.
+        bool wait_until_state(SyncWorkerState desired,
+                              std::chrono::milliseconds timeout) const {
+            std::unique_lock<std::mutex> lock(m_mutex);
+            return m_state_changed.wait_for(
+                lock, timeout,
+                [this, desired] { return m_state == desired; });
+        }
+
+    private:
+        SyncWorkerRoundResult run_once_impl() {
+            SyncWorkerRoundResult result;
+            try {
+                PullRequest request;
+                request.requester = m_engine.local_node_id();
+                request.db_id = m_engine.db_uuid();
+                request.have = m_engine.applied_cursor();
+                request.max_batches = m_options.max_batches;
+                request.max_bytes = m_options.max_bytes;
+
+                bool has_more = false;
+                do {
+                    if (stop_requested()) {
+                        result.has_more = has_more;
+                        return result;
+                    }
+
+                    const SyncCursor before = request.have;
+                    set_state(SyncWorkerState::Pulling);
+                    const PullResponse response = m_peer.pull(request);
+                    if (!response.ok) {
+                        result.ok = false;
+                        result.error = response.error.empty()
+                            ? "pull failed"
+                            : response.error;
+                        return result;
+                    }
+                    ++result.pages_pulled;
+
+                    has_more = response.has_more;
+                    if (stop_requested()) {
+                        result.has_more = has_more;
+                        return result;
+                    }
+
+                    if (!response.batches.empty()) {
+                        set_state(SyncWorkerState::Applying);
+                        PushRequest apply;
+                        apply.db_id = request.db_id;
+                        apply.batches = response.batches;
+                        const PushResponse applied = m_engine.handle_push(apply);
+                        if (!applied.ok) {
+                            result.ok = false;
+                            result.error = applied.error.empty()
+                                ? "apply failed"
+                                : applied.error;
+                            return result;
+                        }
+                        result.batches_applied += response.batches.size();
+                    } else if (response.has_more) {
+                        result.ok = false;
+                        result.error = "pull reported has_more without batches";
+                        return result;
+                    }
+
+                    request.have = m_engine.applied_cursor();
+                    if (has_more &&
+                        request.have.last_seq_by_origin == before.last_seq_by_origin) {
+                        result.ok = false;
+                        result.error = "pull pagination made no cursor progress";
+                        return result;
+                    }
+                    result.has_more = has_more;
+                } while (has_more && m_options.drain_pages);
+            } catch (const std::exception& e) {
+                result.ok = false;
+                result.error = e.what();
+            } catch (...) {
+                result.ok = false;
+                result.error = "unknown sync worker error";
+            }
+            return result;
+        }
+
+        void thread_main() {
+            std::chrono::milliseconds backoff = m_options.initial_backoff;
+            try {
+                set_state(SyncWorkerState::Idle);
+                while (!stop_requested()) {
+                    const SyncWorkerRoundResult result = run_once_impl();
+                    if (stop_requested()) {
+                        break;
+                    }
+                    if (result.ok) {
+                        backoff = m_options.initial_backoff;
+                        set_state(SyncWorkerState::Idle);
+                        if (wait_for_stop(m_options.idle_interval)) {
+                            break;
+                        }
+                    } else {
+                        set_last_error(result.error);
+                        set_state(SyncWorkerState::Backoff);
+                        if (wait_for_stop(backoff)) {
+                            break;
+                        }
+                        backoff = next_backoff(backoff);
+                    }
+                }
+                set_state(SyncWorkerState::Stopped);
+            } catch (const std::exception& e) {
+                set_last_error(e.what());
+                set_state(SyncWorkerState::Failed);
+            } catch (...) {
+                set_last_error("unknown sync worker thread error");
+                set_state(SyncWorkerState::Failed);
+            }
+        }
+
+        bool wait_for_stop(std::chrono::milliseconds duration) const {
+            std::unique_lock<std::mutex> lock(m_mutex);
+            return m_state_changed.wait_for(
+                lock, duration,
+                [this] { return m_stop_requested; });
+        }
+
+        std::chrono::milliseconds next_backoff(
+                std::chrono::milliseconds current) const {
+            const std::chrono::milliseconds doubled(current.count() * 2);
+            return std::min(doubled, m_options.max_backoff);
+        }
+
+        bool stop_requested() const {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            return m_stop_requested;
+        }
+
+        void set_state(SyncWorkerState state) const {
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                m_state = state;
+            }
+            m_state_changed.notify_all();
+        }
+
+        void set_last_error(const std::string& error) const {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_last_error = error;
+        }
+
+        SyncEngine&                 m_engine;
+        ISyncPeer&                  m_peer;
+        SyncWorkerOptions           m_options;
+        std::thread                 m_thread;
+        mutable std::mutex          m_mutex;
+        mutable std::condition_variable m_state_changed;
+        mutable SyncWorkerState     m_state;
+        mutable bool                m_stop_requested;
+        mutable std::string         m_last_error;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_SYNC_WORKER_HPP_INCLUDED

--- a/include/mdbx_containers/sync/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/SyncWorker.hpp
@@ -70,6 +70,8 @@ namespace sync {
     /// \brief Drives incremental pull/apply sync in a caller-owned lifecycle.
     /// \details The worker owns only its std::thread. It does not own the
     /// supplied \c SyncEngine or \c ISyncPeer; both must outlive the worker.
+    /// The \c SyncWorker object itself must outlive its worker thread and must
+    /// not be destroyed from callbacks running on that worker thread.
     /// Lifecycle mutations (\c start(), \c stop(), \c join(), \c run_once())
     /// must be serialized by the caller. Observers and stop signalling
     /// (\c state(), \c last_error(), \c wait_until_state(),
@@ -100,6 +102,7 @@ namespace sync {
 
         /// \brief Requests stop and waits for the background worker to finish.
         /// \details May block until an in-flight \c ISyncPeer::pull() returns.
+        /// The worker object must not be destroyed from its own worker thread.
         ~SyncWorker() {
             request_stop();
             join();

--- a/include/mdbx_containers/sync/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/SyncWorker.hpp
@@ -5,7 +5,6 @@
 /// \file SyncWorker.hpp
 /// \brief Background pull/apply loop for \c SyncEngine.
 
-#include <algorithm>
 #include <chrono>
 #include <condition_variable>
 #include <cstddef>
@@ -71,11 +70,17 @@ namespace sync {
     /// \brief Drives incremental pull/apply sync in a caller-owned lifecycle.
     /// \details The worker owns only its std::thread. It does not own the
     /// supplied \c SyncEngine or \c ISyncPeer; both must outlive the worker.
+    /// Lifecycle mutations (\c start(), \c stop(), \c join(), \c run_once())
+    /// must be serialized by the caller. Observers and stop signalling
+    /// (\c state(), \c last_error(), \c wait_until_state(),
+    /// \c request_stop()) are thread-safe.
     ///
     /// The implementation never keeps a local MDBX transaction open while
     /// waiting in \c ISyncPeer::pull(), idle sleep, or backoff sleep. Pulled
     /// batches are applied through \c SyncEngine::handle_push(), which opens
     /// and commits a short local write transaction for each pulled page.
+    /// Stop requests do not interrupt a blocking peer call; \c stop(),
+    /// \c join(), and the destructor may wait until the peer returns.
     class SyncWorker {
     public:
         /// \brief Constructs a worker over a local engine and remote peer.
@@ -89,8 +94,12 @@ namespace sync {
               m_peer(peer),
               m_options(options),
               m_state(SyncWorkerState::Stopped),
-              m_stop_requested(false) {}
+              m_stop_requested(false) {
+            validate_options(m_options);
+        }
 
+        /// \brief Requests stop and waits for the background worker to finish.
+        /// \details May block until an in-flight \c ISyncPeer::pull() returns.
         ~SyncWorker() {
             request_stop();
             join();
@@ -145,13 +154,19 @@ namespace sync {
         }
 
         /// \brief Joins the background worker thread if it is running.
+        /// \throws std::logic_error if called from the worker thread.
         void join() {
             if (m_thread.joinable()) {
+                if (m_thread.get_id() == std::this_thread::get_id()) {
+                    throw std::logic_error("SyncWorker cannot join itself");
+                }
                 m_thread.join();
             }
         }
 
         /// \brief Requests stop and joins the background worker thread.
+        /// \details May block until an in-flight \c ISyncPeer::pull() returns.
+        /// \throws std::logic_error if called from the worker thread.
         void stop() {
             request_stop();
             join();
@@ -211,6 +226,33 @@ namespace sync {
         }
 
     private:
+        static void validate_options(const SyncWorkerOptions& options) {
+            if (options.max_batches == 0) {
+                throw std::invalid_argument(
+                    "SyncWorkerOptions::max_batches must be greater than zero");
+            }
+            if (options.max_bytes == 0) {
+                throw std::invalid_argument(
+                    "SyncWorkerOptions::max_bytes must be greater than zero");
+            }
+            if (options.idle_interval < std::chrono::milliseconds::zero()) {
+                throw std::invalid_argument(
+                    "SyncWorkerOptions::idle_interval must not be negative");
+            }
+            if (options.initial_backoff < std::chrono::milliseconds::zero()) {
+                throw std::invalid_argument(
+                    "SyncWorkerOptions::initial_backoff must not be negative");
+            }
+            if (options.max_backoff < std::chrono::milliseconds::zero()) {
+                throw std::invalid_argument(
+                    "SyncWorkerOptions::max_backoff must not be negative");
+            }
+            if (options.max_backoff < options.initial_backoff) {
+                throw std::invalid_argument(
+                    "SyncWorkerOptions::max_backoff must be at least initial_backoff");
+            }
+        }
+
         SyncWorkerRoundResult run_once_impl() {
             SyncWorkerRoundResult result;
             try {
@@ -328,8 +370,13 @@ namespace sync {
 
         std::chrono::milliseconds next_backoff(
                 std::chrono::milliseconds current) const {
-            const std::chrono::milliseconds doubled(current.count() * 2);
-            return std::min(doubled, m_options.max_backoff);
+            if (current >= m_options.max_backoff) {
+                return m_options.max_backoff;
+            }
+            if (current.count() >= m_options.max_backoff.count() / 2) {
+                return m_options.max_backoff;
+            }
+            return current + current;
         }
 
         bool stop_requested() const {

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -1,0 +1,344 @@
+/// \file test_sync_worker.cpp
+/// \brief Background SyncWorker lifecycle tests.
+
+#include <mdbx_containers.hpp>
+#include <mdbx_containers/sync.hpp>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+void cleanup(const std::string& path) {
+    std::remove(path.c_str());
+    std::remove((path + "-lck").c_str());
+}
+
+mdbxc::sync::NodeId make_node(std::uint8_t seed) {
+    mdbxc::sync::NodeId node{};
+    for (int i = 0; i < 16; ++i) {
+        node[i] = static_cast<std::uint8_t>(seed + i);
+    }
+    return node;
+}
+
+std::shared_ptr<mdbxc::Connection> open_env(const std::string& path) {
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    return mdbxc::Connection::create(config);
+}
+
+template<class KVT>
+typename KVT::value_type::second_type kv_or_throw(
+        const std::shared_ptr<mdbxc::Connection>& conn,
+        KVT& kv,
+        const typename KVT::value_type::first_type& key,
+        const char* what) {
+    typename KVT::value_type::second_type out{};
+    auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+    if (!kv.try_get(key, out, txn.handle())) {
+        throw std::runtime_error(std::string("missing: ") + what);
+    }
+    return out;
+}
+
+class EmptyPeer : public mdbxc::sync::ISyncPeer {
+public:
+    EmptyPeer() : m_pull_count(0) {}
+
+    mdbxc::sync::PullResponse pull(
+            const mdbxc::sync::PullRequest& request) override {
+        (void)request;
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            ++m_pull_count;
+        }
+        m_changed.notify_all();
+        return mdbxc::sync::PullResponse();
+    }
+
+    mdbxc::sync::PushResponse push(
+            const mdbxc::sync::PushRequest& request) override {
+        (void)request;
+        return mdbxc::sync::PushResponse();
+    }
+
+    bool wait_for_pulls(int count, std::chrono::milliseconds timeout) const {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        return m_changed.wait_for(
+            lock, timeout,
+            [this, count] { return m_pull_count >= count; });
+    }
+
+private:
+    mutable std::mutex m_mutex;
+    mutable std::condition_variable m_changed;
+    int m_pull_count;
+};
+
+class BlockingPeer : public mdbxc::sync::ISyncPeer {
+public:
+    explicit BlockingPeer(const mdbxc::sync::PullResponse& response)
+        : m_response(response), m_entered(false), m_release(false) {}
+
+    mdbxc::sync::PullResponse pull(
+            const mdbxc::sync::PullRequest& request) override {
+        (void)request;
+        std::unique_lock<std::mutex> lock(m_mutex);
+        m_entered = true;
+        m_changed.notify_all();
+        m_changed.wait(lock, [this] { return m_release; });
+        return m_response;
+    }
+
+    mdbxc::sync::PushResponse push(
+            const mdbxc::sync::PushRequest& request) override {
+        (void)request;
+        return mdbxc::sync::PushResponse();
+    }
+
+    bool wait_until_entered(std::chrono::milliseconds timeout) const {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        return m_changed.wait_for(
+            lock, timeout,
+            [this] { return m_entered; });
+    }
+
+    void release() {
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_release = true;
+        }
+        m_changed.notify_all();
+    }
+
+private:
+    mdbxc::sync::PullResponse m_response;
+    mutable std::mutex m_mutex;
+    mutable std::condition_variable m_changed;
+    bool m_entered;
+    bool m_release;
+};
+
+class FailingPeer : public mdbxc::sync::ISyncPeer {
+public:
+    mdbxc::sync::PullResponse pull(
+            const mdbxc::sync::PullRequest& request) override {
+        (void)request;
+        mdbxc::sync::PullResponse response;
+        response.ok = false;
+        response.error = "synthetic pull failure";
+        return response;
+    }
+
+    mdbxc::sync::PushResponse push(
+            const mdbxc::sync::PushRequest& request) override {
+        (void)request;
+        return mdbxc::sync::PushResponse();
+    }
+};
+
+void test_worker_run_once_drains_paginated_pull() {
+    using namespace mdbxc;
+    const std::string primary_path = "test_worker_primary.mdbx";
+    const std::string replica_path = "test_worker_replica.mdbx";
+    cleanup(primary_path);
+    cleanup(replica_path);
+
+    std::shared_ptr<Connection> primary_conn = open_env(primary_path);
+    std::shared_ptr<Connection> replica_conn = open_env(replica_path);
+
+    const sync::NodeId primary_node = make_node(0xA0);
+    const sync::NodeId replica_node = make_node(0xB0);
+    const sync::NodeId db_id = make_node(0xD0);
+
+    sync::SyncEngine primary_engine(primary_conn);
+    sync::SyncEngine replica_engine(replica_conn);
+    primary_engine.initialize_local_identity(primary_node, db_id);
+    replica_engine.initialize_local_identity(replica_node, db_id);
+
+    sync::ThreadLocalChangeAccumulator sink(primary_conn);
+    primary_conn->attach_sync_capture(&sink);
+    {
+        KeyValueTable<int, int> kv(primary_conn, "kv");
+        for (int i = 1; i <= 5; ++i) {
+            kv.insert_or_assign(i, i * 10);
+        }
+    }
+    primary_conn->detach_sync_capture();
+
+    sync::DirectSyncPeer peer(&primary_engine);
+    sync::SyncWorkerOptions options;
+    options.max_batches = 2;
+    options.idle_interval = std::chrono::milliseconds(1);
+
+    sync::SyncWorker worker(replica_engine, peer, options);
+    const sync::SyncWorkerRoundResult result = worker.run_once();
+    if (!result.ok) {
+        throw std::runtime_error("worker run_once failed: " + result.error);
+    }
+    if (result.pages_pulled != 3u || result.batches_applied != 5u) {
+        throw std::runtime_error("worker did not drain paginated pull");
+    }
+    if (worker.state() != sync::SyncWorkerState::Stopped) {
+        throw std::runtime_error("worker run_once should finish Stopped");
+    }
+
+    KeyValueTable<int, int> replica_kv(replica_conn, "kv");
+    for (int i = 1; i <= 5; ++i) {
+        if (kv_or_throw(replica_conn, replica_kv, i, "replica kv") != i * 10) {
+            throw std::runtime_error("replica value mismatch after worker sync");
+        }
+    }
+
+    primary_conn->disconnect();
+    replica_conn->disconnect();
+    cleanup(primary_path);
+    cleanup(replica_path);
+}
+
+void test_worker_start_stop_idle() {
+    using namespace mdbxc;
+    const std::string path = "test_worker_idle.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0xB0), make_node(0xD0));
+
+    EmptyPeer peer;
+    sync::SyncWorkerOptions options;
+    options.idle_interval = std::chrono::milliseconds(10000);
+    sync::SyncWorker worker(engine, peer, options);
+
+    worker.start();
+    if (!peer.wait_for_pulls(1, std::chrono::milliseconds(2000))) {
+        throw std::runtime_error("worker did not perform initial pull");
+    }
+    if (!worker.wait_until_state(sync::SyncWorkerState::Idle,
+                                 std::chrono::milliseconds(2000))) {
+        throw std::runtime_error("worker did not enter Idle");
+    }
+    worker.stop();
+    if (worker.state() != sync::SyncWorkerState::Stopped) {
+        throw std::runtime_error("worker did not stop");
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_worker_backoff_on_pull_error() {
+    using namespace mdbxc;
+    const std::string path = "test_worker_backoff.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0xB0), make_node(0xD0));
+
+    FailingPeer peer;
+    sync::SyncWorkerOptions options;
+    options.initial_backoff = std::chrono::milliseconds(10000);
+    options.max_backoff = std::chrono::milliseconds(10000);
+    sync::SyncWorker worker(engine, peer, options);
+
+    worker.start();
+    if (!worker.wait_until_state(sync::SyncWorkerState::Backoff,
+                                 std::chrono::milliseconds(2000))) {
+        throw std::runtime_error("worker did not enter Backoff after pull error");
+    }
+    if (worker.last_error().find("synthetic pull failure") == std::string::npos) {
+        throw std::runtime_error("worker did not record pull error");
+    }
+    worker.stop();
+    if (worker.state() != sync::SyncWorkerState::Stopped) {
+        throw std::runtime_error("backoff worker did not stop");
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_worker_stop_while_pull_blocked_does_not_apply_returned_page() {
+    using namespace mdbxc;
+    const std::string path = "test_worker_blocked_stop.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    const sync::NodeId replica_node = make_node(0xB0);
+    const sync::NodeId remote_origin = make_node(0xA0);
+    const sync::NodeId db_id = make_node(0xD0);
+
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
+
+    sync::ChangeBatch batch;
+    batch.origin_node_id = remote_origin;
+    batch.seq = 1;
+
+    sync::PullResponse response;
+    response.batches.push_back(batch);
+
+    BlockingPeer peer(response);
+    sync::SyncWorkerOptions options;
+    options.idle_interval = std::chrono::milliseconds(10000);
+    sync::SyncWorker worker(engine, peer, options);
+
+    worker.start();
+    if (!peer.wait_until_entered(std::chrono::milliseconds(2000))) {
+        throw std::runtime_error("worker did not enter blocking pull");
+    }
+    worker.request_stop();
+    peer.release();
+    worker.join();
+
+    if (worker.state() != sync::SyncWorkerState::Stopped) {
+        throw std::runtime_error("blocked worker did not stop");
+    }
+    if (engine.applied_cursor().last_seq_for(remote_origin) != 0u) {
+        throw std::runtime_error("worker applied a page returned after stop");
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+} // namespace
+
+int main() {
+    struct Case { const char* name; void (*fn)(); };
+    const Case cases[] = {
+        { "test_worker_run_once_drains_paginated_pull",
+          &test_worker_run_once_drains_paginated_pull },
+        { "test_worker_start_stop_idle", &test_worker_start_stop_idle },
+        { "test_worker_backoff_on_pull_error", &test_worker_backoff_on_pull_error },
+        { "test_worker_stop_while_pull_blocked",
+          &test_worker_stop_while_pull_blocked_does_not_apply_returned_page },
+    };
+
+    int rc = 0;
+    for (std::size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
+        try {
+            cases[i].fn();
+            std::printf("PASS %s\n", cases[i].name);
+        } catch (const std::exception& e) {
+            std::printf("FAIL %s: %s\n", cases[i].name, e.what());
+            rc = static_cast<int>(i + 1);
+        } catch (...) {
+            std::printf("FAIL %s: non-std exception\n", cases[i].name);
+            rc = static_cast<int>(i + 1);
+        }
+    }
+    return rc;
+}

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -148,6 +148,63 @@ public:
     }
 };
 
+class SelfStoppingPeer : public mdbxc::sync::ISyncPeer {
+public:
+    SelfStoppingPeer() : m_worker(nullptr), m_saw_logic_error(false) {}
+
+    void set_worker(mdbxc::sync::SyncWorker* worker) {
+        m_worker = worker;
+    }
+
+    mdbxc::sync::PullResponse pull(
+            const mdbxc::sync::PullRequest& request) override {
+        (void)request;
+        if (m_worker == nullptr) {
+            throw std::runtime_error("self-stopping peer has no worker");
+        }
+        try {
+            m_worker->stop();
+        } catch (const std::logic_error& e) {
+            if (std::string(e.what()).find("cannot join itself") ==
+                std::string::npos) {
+                throw;
+            }
+            m_saw_logic_error = true;
+        }
+        return mdbxc::sync::PullResponse();
+    }
+
+    mdbxc::sync::PushResponse push(
+            const mdbxc::sync::PushRequest& request) override {
+        (void)request;
+        return mdbxc::sync::PushResponse();
+    }
+
+    bool saw_logic_error() const {
+        return m_saw_logic_error;
+    }
+
+private:
+    mdbxc::sync::SyncWorker* m_worker;
+    bool m_saw_logic_error;
+};
+
+void expect_invalid_options(mdbxc::sync::SyncEngine& engine,
+                            mdbxc::sync::ISyncPeer& peer,
+                            const mdbxc::sync::SyncWorkerOptions& options,
+                            const char* name) {
+    bool threw = false;
+    try {
+        mdbxc::sync::SyncWorker worker(engine, peer, options);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    if (!threw) {
+        throw std::runtime_error(
+            std::string("SyncWorker accepted invalid options: ") + name);
+    }
+}
+
 void test_worker_run_once_drains_paginated_pull() {
     using namespace mdbxc;
     const std::string primary_path = "test_worker_primary.mdbx";
@@ -270,6 +327,47 @@ void test_worker_backoff_on_pull_error() {
     cleanup(path);
 }
 
+void test_worker_rejects_invalid_options() {
+    using namespace mdbxc;
+    const std::string path = "test_worker_invalid_options.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0xB0), make_node(0xD0));
+
+    EmptyPeer peer;
+    sync::SyncWorkerOptions options;
+
+    sync::SyncWorkerOptions invalid = options;
+    invalid.max_batches = 0;
+    expect_invalid_options(engine, peer, invalid, "max_batches");
+
+    invalid = options;
+    invalid.max_bytes = 0;
+    expect_invalid_options(engine, peer, invalid, "max_bytes");
+
+    invalid = options;
+    invalid.idle_interval = std::chrono::milliseconds(-1);
+    expect_invalid_options(engine, peer, invalid, "idle_interval");
+
+    invalid = options;
+    invalid.initial_backoff = std::chrono::milliseconds(-1);
+    expect_invalid_options(engine, peer, invalid, "initial_backoff");
+
+    invalid = options;
+    invalid.max_backoff = std::chrono::milliseconds(-1);
+    expect_invalid_options(engine, peer, invalid, "max_backoff");
+
+    invalid = options;
+    invalid.initial_backoff = std::chrono::milliseconds(10);
+    invalid.max_backoff = std::chrono::milliseconds(9);
+    expect_invalid_options(engine, peer, invalid, "max_backoff ordering");
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 void test_worker_stop_while_pull_blocked_does_not_apply_returned_page() {
     using namespace mdbxc;
     const std::string path = "test_worker_blocked_stop.mdbx";
@@ -314,6 +412,33 @@ void test_worker_stop_while_pull_blocked_does_not_apply_returned_page() {
     cleanup(path);
 }
 
+void test_worker_rejects_self_join() {
+    using namespace mdbxc;
+    const std::string path = "test_worker_self_join.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0xB0), make_node(0xD0));
+
+    SelfStoppingPeer peer;
+    sync::SyncWorker worker(engine, peer);
+    peer.set_worker(&worker);
+
+    worker.start();
+    worker.join();
+
+    if (!peer.saw_logic_error()) {
+        throw std::runtime_error("worker did not reject self-join");
+    }
+    if (worker.state() != sync::SyncWorkerState::Stopped) {
+        throw std::runtime_error("self-join worker did not stop");
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 } // namespace
 
 int main() {
@@ -323,8 +448,11 @@ int main() {
           &test_worker_run_once_drains_paginated_pull },
         { "test_worker_start_stop_idle", &test_worker_start_stop_idle },
         { "test_worker_backoff_on_pull_error", &test_worker_backoff_on_pull_error },
+        { "test_worker_rejects_invalid_options",
+          &test_worker_rejects_invalid_options },
         { "test_worker_stop_while_pull_blocked",
           &test_worker_stop_while_pull_blocked_does_not_apply_returned_page },
+        { "test_worker_rejects_self_join", &test_worker_rejects_self_join },
     };
 
     int rc = 0;


### PR DESCRIPTION
﻿## Summary

- add a public `SyncWorker` lifecycle helper over `SyncEngine + ISyncPeer`
- support foreground `run_once()` and background `start()` / `request_stop()` / `join()` / `stop()` flows
- keep local MDBX transactions out of peer waits, idle sleeps, and backoff sleeps
- document worker state invariants in `sync/DESIGN.md`
- add lifecycle tests for paginated drain, idle stop, pull-error backoff, and stopping during a blocking pull

## Notes

`SyncWorker` owns only its thread. The caller still owns the engine, peer, and connection. Stop requests do not interrupt a blocking peer call, but a page returned after stop was requested is not applied.

## Validation

- `git diff --check`
- C++17 full build + full `ctest`: 29/29 passed before the final foreground stop-state polish
- C++11 full build + full `ctest`: 28/28 passed before the final foreground stop-state polish
- C++17 `test_sync_worker`: passed after the final polish
- C++11 `test_sync_worker`: passed after the final polish