### PR TITLE
feat(sync): add peer cancellation hook

### DIFF
--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -214,9 +214,11 @@ Worker invariants:
 - no local MDBX transaction is held during idle or backoff sleeps;
 - pulled pages are applied through `SyncEngine::handle_push()`, so each page
   uses one short local write transaction;
-- stop requests call `ISyncPeer::request_cancel()` as a best-effort transport
-  hook only while a peer pull call is in flight, and a page returned after stop
-  was requested is not applied;
+- stop requests call `ISyncPeer::request_cancel()` at most once for each
+  observed in-flight peer pull call, and a page returned after stop was
+  requested is not applied;
+- a stop request recorded before peer-call activation prevents the next pull
+  call from starting;
 - `stop()`, `join()`, and destruction may wait for an in-flight peer call to
   return when the concrete transport does not support cancellation;
 - lifecycle mutations (`start`, `stop`, `join`, `run_once`) are caller-serialized,

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -215,7 +215,8 @@ Worker invariants:
 - pulled pages are applied through `SyncEngine::handle_push()`, so each page
   uses one short local write transaction;
 - stop requests call `ISyncPeer::request_cancel()` as a best-effort transport
-  hook, and a page returned after stop was requested is not applied;
+  hook only while a peer pull call is in flight, and a page returned after stop
+  was requested is not applied;
 - `stop()`, `join()`, and destruction may wait for an in-flight peer call to
   return when the concrete transport does not support cancellation;
 - lifecycle mutations (`start`, `stop`, `join`, `run_once`) are caller-serialized,

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -214,10 +214,10 @@ Worker invariants:
 - no local MDBX transaction is held during idle or backoff sleeps;
 - pulled pages are applied through `SyncEngine::handle_push()`, so each page
   uses one short local write transaction;
-- stop requests do not interrupt a blocking peer call, but a page returned
-  after stop was requested is not applied;
+- stop requests call `ISyncPeer::request_cancel()` as a best-effort transport
+  hook, and a page returned after stop was requested is not applied;
 - `stop()`, `join()`, and destruction may wait for an in-flight peer call to
-  return; timeout/cancellation belongs to the concrete transport adapter;
+  return when the concrete transport does not support cancellation;
 - lifecycle mutations (`start`, `stop`, `join`, `run_once`) are caller-serialized,
   while `request_stop`, `state`, `last_error`, and `wait_until_state` are
   thread-safe;
@@ -227,7 +227,9 @@ Worker invariants:
   them and never cross the worker boundary.
 
 The worker is a lifecycle/concurrency helper, not a transport. HTTP/WebSocket
-peers remain separate adapters over `ISyncPeer`.
+peers remain separate adapters over `ISyncPeer`. Transport adapters that can
+interrupt blocking I/O should implement `request_cancel()` by using their own
+timeout, cancellation token, socket shutdown, or equivalent mechanism.
 
 ## Why `prune_up_to` uses cursor walk + `MDBX_NEXT`
 

--- a/include/mdbx_containers/sync/ISyncPeer.hpp
+++ b/include/mdbx_containers/sync/ISyncPeer.hpp
@@ -13,6 +13,8 @@ namespace sync {
     /// \brief Abstract peer that exchanges pull and push requests.
     /// \details Concrete implementations (in-process, HTTP, WebSocket) live
     /// outside the core sync layer and depend on optional transport headers.
+    /// Implementations that override \c request_cancel() must allow it to be
+    /// called concurrently with \c pull() / \c push().
     class ISyncPeer {
     public:
         virtual ~ISyncPeer() {}
@@ -22,6 +24,12 @@ namespace sync {
 
         /// \brief Sends a push request and returns the response.
         virtual PushResponse push(const PushRequest& request) = 0;
+
+        /// \brief Requests cancellation of in-flight transport operations.
+        /// \details Best-effort hook for blocking transports. The default
+        /// implementation is a no-op, so non-interruptible peers remain valid.
+        /// Overrides should return quickly and should not throw.
+        virtual void request_cancel() {}
     };
 
 } // namespace sync

--- a/include/mdbx_containers/sync/ISyncPeer.hpp
+++ b/include/mdbx_containers/sync/ISyncPeer.hpp
@@ -14,7 +14,8 @@ namespace sync {
     /// \details Concrete implementations (in-process, HTTP, WebSocket) live
     /// outside the core sync layer and depend on optional transport headers.
     /// Implementations that override \c request_cancel() must allow it to be
-    /// called concurrently with \c pull() / \c push().
+    /// called concurrently with \c pull() / \c push() and tolerate calls that
+    /// race with operation startup or completion.
     class ISyncPeer {
     public:
         virtual ~ISyncPeer() {}

--- a/include/mdbx_containers/sync/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/SyncWorker.hpp
@@ -81,8 +81,8 @@ namespace sync {
     /// waiting in \c ISyncPeer::pull(), idle sleep, or backoff sleep. Pulled
     /// batches are applied through \c SyncEngine::handle_push(), which opens
     /// and commits a short local write transaction for each pulled page.
-    /// Stop requests call \c ISyncPeer::request_cancel() only while a peer
-    /// call is in flight, and cancellation is best-effort: \c stop(),
+    /// Stop requests call \c ISyncPeer::request_cancel() at most once for each
+    /// observed in-flight peer call. Cancellation is best-effort: \c stop(),
     /// \c join(), and the destructor may still wait until the peer returns.
     class SyncWorker {
     public:
@@ -98,7 +98,8 @@ namespace sync {
               m_options(options),
               m_state(SyncWorkerState::Stopped),
               m_stop_requested(false),
-              m_peer_call_active(false) {
+              m_peer_call_active(false),
+              m_peer_cancel_requested(false) {
             validate_options(m_options);
         }
 
@@ -127,6 +128,7 @@ namespace sync {
                 }
                 m_stop_requested = false;
                 m_peer_call_active = false;
+                m_peer_cancel_requested = false;
                 m_last_error.clear();
                 m_state = SyncWorkerState::Starting;
             }
@@ -138,6 +140,7 @@ namespace sync {
                     std::lock_guard<std::mutex> lock(m_mutex);
                     m_stop_requested = true;
                     m_peer_call_active = false;
+                    m_peer_cancel_requested = false;
                     m_state = SyncWorkerState::Stopped;
                 }
                 m_state_changed.notify_all();
@@ -147,15 +150,18 @@ namespace sync {
 
         /// \brief Requests background worker shutdown.
         /// \details Calls \c ISyncPeer::request_cancel() outside the worker
-        /// mutex only when a peer call is in flight. Cancellation is
-        /// best-effort; the worker exits before applying a page returned after
-        /// stop was requested.
+        /// mutex at most once for each observed in-flight peer call.
+        /// Cancellation is best-effort; the worker exits before applying a
+        /// page returned after stop was requested.
         void request_stop() {
             bool cancel_peer = false;
             {
                 std::lock_guard<std::mutex> lock(m_mutex);
                 m_stop_requested = true;
-                cancel_peer = m_peer_call_active;
+                if (m_peer_call_active && !m_peer_cancel_requested) {
+                    m_peer_cancel_requested = true;
+                    cancel_peer = true;
+                }
                 if (m_state != SyncWorkerState::Stopped &&
                     m_state != SyncWorkerState::Failed) {
                     m_state = SyncWorkerState::Stopping;
@@ -200,6 +206,7 @@ namespace sync {
                 }
                 m_stop_requested = false;
                 m_peer_call_active = false;
+                m_peer_cancel_requested = false;
                 m_last_error.clear();
             }
             const SyncWorkerRoundResult result = run_once_impl();
@@ -243,12 +250,19 @@ namespace sync {
     private:
         class PeerCallGuard {
         public:
-            explicit PeerCallGuard(SyncWorker& worker) : m_worker(worker) {
-                m_worker.begin_peer_call();
+            explicit PeerCallGuard(SyncWorker& worker)
+                : m_worker(worker),
+                  m_active(worker.begin_peer_call()) {
             }
 
             ~PeerCallGuard() {
-                m_worker.end_peer_call();
+                if (m_active) {
+                    m_worker.end_peer_call();
+                }
+            }
+
+            bool active() const {
+                return m_active;
             }
 
             PeerCallGuard(const PeerCallGuard&) = delete;
@@ -256,6 +270,7 @@ namespace sync {
 
         private:
             SyncWorker& m_worker;
+            bool        m_active;
         };
 
         static void validate_options(const SyncWorkerOptions& options) {
@@ -306,6 +321,10 @@ namespace sync {
                     PullResponse response;
                     {
                         PeerCallGuard peer_call(*this);
+                        if (!peer_call.active()) {
+                            result.has_more = has_more;
+                            return result;
+                        }
                         response = m_peer.pull(request);
                     }
                     if (!response.ok) {
@@ -362,18 +381,27 @@ namespace sync {
             return result;
         }
 
-        void begin_peer_call() const {
+        bool begin_peer_call() const {
+            bool started = false;
             {
                 std::lock_guard<std::mutex> lock(m_mutex);
-                m_state = SyncWorkerState::Pulling;
-                m_peer_call_active = true;
+                if (!m_stop_requested) {
+                    m_state = SyncWorkerState::Pulling;
+                    m_peer_call_active = true;
+                    m_peer_cancel_requested = false;
+                    started = true;
+                }
             }
-            m_state_changed.notify_all();
+            if (started) {
+                m_state_changed.notify_all();
+            }
+            return started;
         }
 
         void end_peer_call() const {
             std::lock_guard<std::mutex> lock(m_mutex);
             m_peer_call_active = false;
+            m_peer_cancel_requested = false;
         }
 
         void request_peer_cancel() const {
@@ -466,6 +494,7 @@ namespace sync {
         mutable SyncWorkerState     m_state;
         mutable bool                m_stop_requested;
         mutable bool                m_peer_call_active;
+        mutable bool                m_peer_cancel_requested;
         mutable std::string         m_last_error;
     };
 

--- a/include/mdbx_containers/sync/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/SyncWorker.hpp
@@ -81,9 +81,9 @@ namespace sync {
     /// waiting in \c ISyncPeer::pull(), idle sleep, or backoff sleep. Pulled
     /// batches are applied through \c SyncEngine::handle_push(), which opens
     /// and commits a short local write transaction for each pulled page.
-    /// Stop requests call \c ISyncPeer::request_cancel(), but cancellation is
-    /// best-effort: \c stop(), \c join(), and the destructor may still wait
-    /// until the peer returns.
+    /// Stop requests call \c ISyncPeer::request_cancel() only while a peer
+    /// call is in flight, and cancellation is best-effort: \c stop(),
+    /// \c join(), and the destructor may still wait until the peer returns.
     class SyncWorker {
     public:
         /// \brief Constructs a worker over a local engine and remote peer.
@@ -97,7 +97,8 @@ namespace sync {
               m_peer(peer),
               m_options(options),
               m_state(SyncWorkerState::Stopped),
-              m_stop_requested(false) {
+              m_stop_requested(false),
+              m_peer_call_active(false) {
             validate_options(m_options);
         }
 
@@ -125,6 +126,7 @@ namespace sync {
                     throw std::logic_error("SyncWorker is not stopped");
                 }
                 m_stop_requested = false;
+                m_peer_call_active = false;
                 m_last_error.clear();
                 m_state = SyncWorkerState::Starting;
             }
@@ -135,6 +137,7 @@ namespace sync {
                 {
                     std::lock_guard<std::mutex> lock(m_mutex);
                     m_stop_requested = true;
+                    m_peer_call_active = false;
                     m_state = SyncWorkerState::Stopped;
                 }
                 m_state_changed.notify_all();
@@ -144,17 +147,18 @@ namespace sync {
 
         /// \brief Requests background worker shutdown.
         /// \details Calls \c ISyncPeer::request_cancel() outside the worker
-        /// mutex. Cancellation is best-effort; the worker exits before applying
-        /// a page returned after stop was requested.
+        /// mutex only when a peer call is in flight. Cancellation is
+        /// best-effort; the worker exits before applying a page returned after
+        /// stop was requested.
         void request_stop() {
             bool cancel_peer = false;
             {
                 std::lock_guard<std::mutex> lock(m_mutex);
                 m_stop_requested = true;
+                cancel_peer = m_peer_call_active;
                 if (m_state != SyncWorkerState::Stopped &&
                     m_state != SyncWorkerState::Failed) {
                     m_state = SyncWorkerState::Stopping;
-                    cancel_peer = true;
                 }
             }
             if (cancel_peer) {
@@ -195,6 +199,7 @@ namespace sync {
                     throw std::logic_error("SyncWorker is not stopped");
                 }
                 m_stop_requested = false;
+                m_peer_call_active = false;
                 m_last_error.clear();
             }
             const SyncWorkerRoundResult result = run_once_impl();
@@ -236,6 +241,23 @@ namespace sync {
         }
 
     private:
+        class PeerCallGuard {
+        public:
+            explicit PeerCallGuard(SyncWorker& worker) : m_worker(worker) {
+                m_worker.begin_peer_call();
+            }
+
+            ~PeerCallGuard() {
+                m_worker.end_peer_call();
+            }
+
+            PeerCallGuard(const PeerCallGuard&) = delete;
+            PeerCallGuard& operator=(const PeerCallGuard&) = delete;
+
+        private:
+            SyncWorker& m_worker;
+        };
+
         static void validate_options(const SyncWorkerOptions& options) {
             if (options.max_batches == 0) {
                 throw std::invalid_argument(
@@ -281,8 +303,11 @@ namespace sync {
                     }
 
                     const SyncCursor before = request.have;
-                    set_state(SyncWorkerState::Pulling);
-                    const PullResponse response = m_peer.pull(request);
+                    PullResponse response;
+                    {
+                        PeerCallGuard peer_call(*this);
+                        response = m_peer.pull(request);
+                    }
                     if (!response.ok) {
                         result.ok = false;
                         result.error = response.error.empty()
@@ -335,6 +360,20 @@ namespace sync {
                 result.error = "unknown sync worker error";
             }
             return result;
+        }
+
+        void begin_peer_call() const {
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                m_state = SyncWorkerState::Pulling;
+                m_peer_call_active = true;
+            }
+            m_state_changed.notify_all();
+        }
+
+        void end_peer_call() const {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_peer_call_active = false;
         }
 
         void request_peer_cancel() const {
@@ -426,6 +465,7 @@ namespace sync {
         mutable std::condition_variable m_state_changed;
         mutable SyncWorkerState     m_state;
         mutable bool                m_stop_requested;
+        mutable bool                m_peer_call_active;
         mutable std::string         m_last_error;
     };
 

--- a/include/mdbx_containers/sync/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/SyncWorker.hpp
@@ -81,8 +81,9 @@ namespace sync {
     /// waiting in \c ISyncPeer::pull(), idle sleep, or backoff sleep. Pulled
     /// batches are applied through \c SyncEngine::handle_push(), which opens
     /// and commits a short local write transaction for each pulled page.
-    /// Stop requests do not interrupt a blocking peer call; \c stop(),
-    /// \c join(), and the destructor may wait until the peer returns.
+    /// Stop requests call \c ISyncPeer::request_cancel(), but cancellation is
+    /// best-effort: \c stop(), \c join(), and the destructor may still wait
+    /// until the peer returns.
     class SyncWorker {
     public:
         /// \brief Constructs a worker over a local engine and remote peer.
@@ -142,16 +143,22 @@ namespace sync {
         }
 
         /// \brief Requests background worker shutdown.
-        /// \details Does not interrupt an in-flight peer call. The worker exits
-        /// before applying a page returned after stop was requested.
+        /// \details Calls \c ISyncPeer::request_cancel() outside the worker
+        /// mutex. Cancellation is best-effort; the worker exits before applying
+        /// a page returned after stop was requested.
         void request_stop() {
+            bool cancel_peer = false;
             {
                 std::lock_guard<std::mutex> lock(m_mutex);
                 m_stop_requested = true;
                 if (m_state != SyncWorkerState::Stopped &&
                     m_state != SyncWorkerState::Failed) {
                     m_state = SyncWorkerState::Stopping;
+                    cancel_peer = true;
                 }
+            }
+            if (cancel_peer) {
+                request_peer_cancel();
             }
             m_state_changed.notify_all();
         }
@@ -328,6 +335,17 @@ namespace sync {
                 result.error = "unknown sync worker error";
             }
             return result;
+        }
+
+        void request_peer_cancel() const {
+            try {
+                m_peer.request_cancel();
+            } catch (const std::exception& e) {
+                set_last_error(std::string("peer cancellation failed: ") +
+                               e.what());
+            } catch (...) {
+                set_last_error("peer cancellation failed");
+            }
         }
 
         void thread_main() {

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -100,7 +100,8 @@ private:
 class BlockingPeer : public mdbxc::sync::ISyncPeer {
 public:
     explicit BlockingPeer(const mdbxc::sync::PullResponse& response)
-        : m_response(response), m_entered(false), m_release(false) {}
+        : m_response(response), m_entered(false), m_release(false),
+          m_cancel_count(0) {}
 
     mdbxc::sync::PullResponse pull(
             const mdbxc::sync::PullRequest& request) override {
@@ -118,11 +119,21 @@ public:
         return mdbxc::sync::PushResponse();
     }
 
+    void request_cancel() override {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        ++m_cancel_count;
+    }
+
     bool wait_until_entered(std::chrono::milliseconds timeout) const {
         std::unique_lock<std::mutex> lock(m_mutex);
         return m_changed.wait_for(
             lock, timeout,
             [this] { return m_entered; });
+    }
+
+    int cancel_count() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_cancel_count;
     }
 
     void release() {
@@ -139,6 +150,7 @@ private:
     mutable std::condition_variable m_changed;
     bool m_entered;
     bool m_release;
+    int  m_cancel_count;
 };
 
 class CancelableBlockingPeer : public mdbxc::sync::ISyncPeer {
@@ -483,6 +495,9 @@ void test_worker_stop_while_pull_blocked_does_not_apply_returned_page() {
         throw std::runtime_error("worker did not enter blocking pull");
     }
     worker.request_stop();
+    if (peer.cancel_count() != 1) {
+        throw std::runtime_error("blocked worker did not request cancellation");
+    }
     peer.release();
     worker.join();
 
@@ -491,6 +506,56 @@ void test_worker_stop_while_pull_blocked_does_not_apply_returned_page() {
     }
     if (engine.applied_cursor().last_seq_for(remote_origin) != 0u) {
         throw std::runtime_error("worker applied a page returned after stop");
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_worker_repeated_stop_cancels_blocking_peer_once() {
+    using namespace mdbxc;
+    const std::string path = "test_worker_cancel_once.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    const sync::NodeId replica_node = make_node(0xB1);
+    const sync::NodeId remote_origin = make_node(0xA1);
+    const sync::NodeId db_id = make_node(0xD1);
+
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
+
+    sync::ChangeBatch batch;
+    batch.origin_node_id = remote_origin;
+    batch.seq = 1;
+
+    sync::PullResponse response;
+    response.batches.push_back(batch);
+
+    BlockingPeer peer(response);
+    sync::SyncWorkerOptions options;
+    options.idle_interval = std::chrono::milliseconds(10000);
+    sync::SyncWorker worker(engine, peer, options);
+
+    worker.start();
+    if (!peer.wait_until_entered(std::chrono::milliseconds(2000))) {
+        throw std::runtime_error("worker did not enter blocking pull");
+    }
+    worker.request_stop();
+    worker.request_stop();
+
+    if (peer.cancel_count() != 1) {
+        throw std::runtime_error("repeated stop cancelled active peer more than once");
+    }
+
+    peer.release();
+    worker.join();
+
+    if (worker.state() != sync::SyncWorkerState::Stopped) {
+        throw std::runtime_error("cancel-once worker did not stop");
+    }
+    if (engine.applied_cursor().last_seq_for(remote_origin) != 0u) {
+        throw std::runtime_error("worker applied a page after repeated stop");
     }
 
     conn->disconnect();
@@ -583,6 +648,8 @@ int main() {
           &test_worker_rejects_invalid_options },
         { "test_worker_stop_while_pull_blocked",
           &test_worker_stop_while_pull_blocked_does_not_apply_returned_page },
+        { "test_worker_repeated_stop_cancels_blocking_peer_once",
+          &test_worker_repeated_stop_cancels_blocking_peer_once },
         { "test_worker_stop_cancels_blocking_peer",
           &test_worker_stop_cancels_blocking_peer },
         { "test_worker_rejects_self_join", &test_worker_rejects_self_join },

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -130,6 +130,58 @@ private:
     bool m_release;
 };
 
+class CancelableBlockingPeer : public mdbxc::sync::ISyncPeer {
+public:
+    explicit CancelableBlockingPeer(const mdbxc::sync::PullResponse& response)
+        : m_response(response), m_entered(false), m_cancelled(false),
+          m_cancel_count(0) {}
+
+    mdbxc::sync::PullResponse pull(
+            const mdbxc::sync::PullRequest& request) override {
+        (void)request;
+        std::unique_lock<std::mutex> lock(m_mutex);
+        m_entered = true;
+        m_changed.notify_all();
+        m_changed.wait(lock, [this] { return m_cancelled; });
+        return m_response;
+    }
+
+    mdbxc::sync::PushResponse push(
+            const mdbxc::sync::PushRequest& request) override {
+        (void)request;
+        return mdbxc::sync::PushResponse();
+    }
+
+    void request_cancel() override {
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_cancelled = true;
+            ++m_cancel_count;
+        }
+        m_changed.notify_all();
+    }
+
+    bool wait_until_entered(std::chrono::milliseconds timeout) const {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        return m_changed.wait_for(
+            lock, timeout,
+            [this] { return m_entered; });
+    }
+
+    int cancel_count() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_cancel_count;
+    }
+
+private:
+    mdbxc::sync::PullResponse m_response;
+    mutable std::mutex m_mutex;
+    mutable std::condition_variable m_changed;
+    bool m_entered;
+    bool m_cancelled;
+    int  m_cancel_count;
+};
+
 class FailingPeer : public mdbxc::sync::ISyncPeer {
 public:
     mdbxc::sync::PullResponse pull(
@@ -412,6 +464,52 @@ void test_worker_stop_while_pull_blocked_does_not_apply_returned_page() {
     cleanup(path);
 }
 
+void test_worker_stop_cancels_blocking_peer() {
+    using namespace mdbxc;
+    const std::string path = "test_worker_cancel_peer.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    const sync::NodeId replica_node = make_node(0xB0);
+    const sync::NodeId remote_origin = make_node(0xA0);
+    const sync::NodeId db_id = make_node(0xD0);
+
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
+
+    sync::ChangeBatch batch;
+    batch.origin_node_id = remote_origin;
+    batch.seq = 1;
+
+    sync::PullResponse response;
+    response.batches.push_back(batch);
+
+    CancelableBlockingPeer peer(response);
+    sync::SyncWorkerOptions options;
+    options.idle_interval = std::chrono::milliseconds(10000);
+    sync::SyncWorker worker(engine, peer, options);
+
+    worker.start();
+    if (!peer.wait_until_entered(std::chrono::milliseconds(2000))) {
+        throw std::runtime_error("worker did not enter cancellable pull");
+    }
+    worker.request_stop();
+    worker.join();
+
+    if (peer.cancel_count() == 0) {
+        throw std::runtime_error("worker did not request peer cancellation");
+    }
+    if (worker.state() != sync::SyncWorkerState::Stopped) {
+        throw std::runtime_error("cancelled worker did not stop");
+    }
+    if (engine.applied_cursor().last_seq_for(remote_origin) != 0u) {
+        throw std::runtime_error("worker applied a page returned after cancel");
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 void test_worker_rejects_self_join() {
     using namespace mdbxc;
     const std::string path = "test_worker_self_join.mdbx";
@@ -452,6 +550,8 @@ int main() {
           &test_worker_rejects_invalid_options },
         { "test_worker_stop_while_pull_blocked",
           &test_worker_stop_while_pull_blocked_does_not_apply_returned_page },
+        { "test_worker_stop_cancels_blocking_peer",
+          &test_worker_stop_cancels_blocking_peer },
         { "test_worker_rejects_self_join", &test_worker_rejects_self_join },
     };
 

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -54,7 +54,7 @@ typename KVT::value_type::second_type kv_or_throw(
 
 class EmptyPeer : public mdbxc::sync::ISyncPeer {
 public:
-    EmptyPeer() : m_pull_count(0) {}
+    EmptyPeer() : m_pull_count(0), m_cancel_count(0) {}
 
     mdbxc::sync::PullResponse pull(
             const mdbxc::sync::PullRequest& request) override {
@@ -73,6 +73,11 @@ public:
         return mdbxc::sync::PushResponse();
     }
 
+    void request_cancel() override {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        ++m_cancel_count;
+    }
+
     bool wait_for_pulls(int count, std::chrono::milliseconds timeout) const {
         std::unique_lock<std::mutex> lock(m_mutex);
         return m_changed.wait_for(
@@ -80,10 +85,16 @@ public:
             [this, count] { return m_pull_count >= count; });
     }
 
+    int cancel_count() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_cancel_count;
+    }
+
 private:
     mutable std::mutex m_mutex;
     mutable std::condition_variable m_changed;
     int m_pull_count;
+    int m_cancel_count;
 };
 
 class BlockingPeer : public mdbxc::sync::ISyncPeer {
@@ -184,6 +195,8 @@ private:
 
 class FailingPeer : public mdbxc::sync::ISyncPeer {
 public:
+    FailingPeer() : m_cancel_count(0) {}
+
     mdbxc::sync::PullResponse pull(
             const mdbxc::sync::PullRequest& request) override {
         (void)request;
@@ -198,6 +211,20 @@ public:
         (void)request;
         return mdbxc::sync::PushResponse();
     }
+
+    void request_cancel() override {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        ++m_cancel_count;
+    }
+
+    int cancel_count() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_cancel_count;
+    }
+
+private:
+    mutable std::mutex m_mutex;
+    int m_cancel_count;
 };
 
 class SelfStoppingPeer : public mdbxc::sync::ISyncPeer {
@@ -342,6 +369,9 @@ void test_worker_start_stop_idle() {
     if (worker.state() != sync::SyncWorkerState::Stopped) {
         throw std::runtime_error("worker did not stop");
     }
+    if (peer.cancel_count() != 0) {
+        throw std::runtime_error("idle stop should not cancel peer transport");
+    }
 
     conn->disconnect();
     cleanup(path);
@@ -373,6 +403,9 @@ void test_worker_backoff_on_pull_error() {
     worker.stop();
     if (worker.state() != sync::SyncWorkerState::Stopped) {
         throw std::runtime_error("backoff worker did not stop");
+    }
+    if (peer.cancel_count() != 0) {
+        throw std::runtime_error("backoff stop should not cancel peer transport");
     }
 
     conn->disconnect();


### PR DESCRIPTION
﻿## Summary

- add `ISyncPeer::request_cancel()` as a default no-op best-effort cancellation hook
- have `SyncWorker::request_stop()` call the peer hook outside the worker mutex
- keep non-interruptible peers valid while letting transport adapters wake blocking I/O
- document cancellation and worker lifetime semantics in `sync/DESIGN.md`
- add a cancellable blocking peer test that proves stop wakes pull and skips the late page

## Notes

Cancellation is best-effort. Transports that can interrupt blocking I/O should implement `request_cancel()` using their own timeout, cancellation token, socket shutdown, or equivalent mechanism. The default implementation is a no-op, so existing in-process and non-interruptible peers continue to work.

## Validation

- `git diff --check`
- C++17 `test_sync_worker`: passed
- C++11 `test_sync_worker`: passed
- C++17 sync group: `test_sync_worker`, `test_sync_engine`, `test_sync_replication`, `test_sync_randomized`, `test_sync_randomized_lifecycle`, `test_sync_stress` passed
- C++11 sync group: `test_sync_worker`, `test_sync_engine`, `test_sync_replication`, `test_sync_randomized`, `test_sync_randomized_lifecycle`, `test_sync_stress` passed