### PR TITLE
test(sync): expand hub benchmark scenarios

### DIFF
--- a/benchmarks/sync_tick_hub_benchmark.cpp
+++ b/benchmarks/sync_tick_hub_benchmark.cpp
@@ -49,7 +49,7 @@ struct PhaseMetrics {
     std::uint64_t applied_batches = 0;
     std::uint64_t pull_pages = 0;
     double        seed_ms = 0.0;
-    double        reopen_ms = 0.0;
+    double        restart_ms = 0.0;
     double        pull_ms = 0.0;
     double        apply_ms = 0.0;
     std::uint64_t primary_bytes = 0;
@@ -402,7 +402,7 @@ PhaseMetrics run_sync_phase(const std::string& phase,
                             std::uint64_t chunks_per_origin,
                             std::uint64_t seeded_batches,
                             double seed_ms,
-                            double reopen_ms,
+                            double restart_ms,
                             const std::shared_ptr<mdbxc::Connection>& primary_conn,
                             const std::shared_ptr<mdbxc::Connection>& replica_conn,
                             mdbxc::sync::SyncEngine& primary_engine,
@@ -432,7 +432,7 @@ PhaseMetrics run_sync_phase(const std::string& phase,
     metrics.applied_batches = sync.applied_batches;
     metrics.pull_pages = sync.pull_pages;
     metrics.seed_ms = seed_ms;
-    metrics.reopen_ms = reopen_ms;
+    metrics.restart_ms = restart_ms;
     metrics.pull_ms = sync.pull_ms;
     metrics.apply_ms = sync.apply_ms;
     metrics.primary_bytes = used_database_bytes(primary_conn);
@@ -451,14 +451,14 @@ void print_csv_header() {
         << "scenario,phase,origins,historical_chunks_per_origin,"
         << "new_chunks_per_origin,chunks_per_origin,ticks_per_chunk,"
         << "max_batches,max_bytes,seeded_batches,pulled_batches,"
-        << "applied_batches,pull_pages,seed_ms,reopen_ms,pull_ms,"
+        << "applied_batches,pull_pages,seed_ms,restart_ms,pull_ms,"
         << "apply_ms,total_ms,batches_per_sec,primary_bytes,replica_bytes\n";
 }
 
 void print_csv_row(const Scenario& scenario,
                    const PhaseMetrics& metrics) {
     const double total_ms =
-        metrics.seed_ms + metrics.reopen_ms + metrics.pull_ms + metrics.apply_ms;
+        metrics.seed_ms + metrics.restart_ms + metrics.pull_ms + metrics.apply_ms;
     const double batches_per_sec =
         (metrics.pull_ms + metrics.apply_ms) <= 0.0
             ? 0.0
@@ -478,7 +478,7 @@ void print_csv_row(const Scenario& scenario,
               << metrics.applied_batches << ','
               << metrics.pull_pages << ','
               << metrics.seed_ms << ','
-              << metrics.reopen_ms << ','
+              << metrics.restart_ms << ','
               << metrics.pull_ms << ','
               << metrics.apply_ms << ','
               << total_ms << ','
@@ -499,99 +499,109 @@ void run_scenario(const Scenario& scenario, const std::string& id) {
 
     std::shared_ptr<mdbxc::Connection> primary_conn = open_env(paths.primary);
     std::shared_ptr<mdbxc::Connection> replica_conn = open_env(paths.replica);
-    mdbxc::sync::SyncEngine primary_engine(primary_conn);
-    mdbxc::sync::SyncEngine replica_engine(replica_conn);
-    initialize_engine(primary_engine, primary_node, db_id);
-    initialize_engine(replica_engine, replica_node, db_id);
 
-    const std::chrono::steady_clock::time_point historical_seed_start =
-        std::chrono::steady_clock::now();
-    const std::uint64_t historical_seeded =
-        append_changelog_range(primary_conn, scenario, 1,
-                               scenario.historical_chunks_per_origin);
-    const std::chrono::steady_clock::time_point historical_seed_finish =
-        std::chrono::steady_clock::now();
-    verify_origin_index(primary_conn, scenario,
-                        scenario.historical_chunks_per_origin == 0 ? 0 : scenario.origins);
+    {
+        mdbxc::sync::SyncEngine primary_engine(primary_conn);
+        mdbxc::sync::SyncEngine replica_engine(replica_conn);
+        initialize_engine(primary_engine, primary_node, db_id);
+        initialize_engine(replica_engine, replica_node, db_id);
 
-    PhaseMetrics full = run_sync_phase(
-        "full_cold_replica",
-        scenario.historical_chunks_per_origin,
-        historical_seeded,
-        elapsed_ms(historical_seed_start, historical_seed_finish),
-        0.0,
-        primary_conn,
-        replica_conn,
-        primary_engine,
-        replica_engine,
-        scenario,
-        replica_node,
-        db_id);
-    print_csv_row(scenario, full);
+        const std::chrono::steady_clock::time_point historical_seed_start =
+            std::chrono::steady_clock::now();
+        const std::uint64_t historical_seeded =
+            append_changelog_range(primary_conn, scenario, 1,
+                                   scenario.historical_chunks_per_origin);
+        const std::chrono::steady_clock::time_point historical_seed_finish =
+            std::chrono::steady_clock::now();
+        verify_origin_index(primary_conn, scenario,
+                            scenario.historical_chunks_per_origin == 0
+                                ? 0
+                                : scenario.origins);
 
-    const std::uint64_t hot_first_seq = scenario.historical_chunks_per_origin + 1;
-    const std::chrono::steady_clock::time_point hot_seed_start =
-        std::chrono::steady_clock::now();
-    const std::uint64_t hot_seeded =
-        append_changelog_range(primary_conn, scenario, hot_first_seq,
-                               scenario.new_chunks_per_origin);
-    const std::chrono::steady_clock::time_point hot_seed_finish =
-        std::chrono::steady_clock::now();
-    verify_origin_index(primary_conn, scenario, scenario.origins);
+        PhaseMetrics full = run_sync_phase(
+            "full_cold_replica",
+            scenario.historical_chunks_per_origin,
+            historical_seeded,
+            elapsed_ms(historical_seed_start, historical_seed_finish),
+            0.0,
+            primary_conn,
+            replica_conn,
+            primary_engine,
+            replica_engine,
+            scenario,
+            replica_node,
+            db_id);
+        print_csv_row(scenario, full);
 
-    PhaseMetrics hot = run_sync_phase(
-        "incremental_hot",
-        scenario.new_chunks_per_origin,
-        hot_seeded,
-        elapsed_ms(hot_seed_start, hot_seed_finish),
-        0.0,
-        primary_conn,
-        replica_conn,
-        primary_engine,
-        replica_engine,
-        scenario,
-        replica_node,
-        db_id);
-    print_csv_row(scenario, hot);
+        const std::uint64_t hot_first_seq = scenario.historical_chunks_per_origin + 1;
+        const std::chrono::steady_clock::time_point hot_seed_start =
+            std::chrono::steady_clock::now();
+        const std::uint64_t hot_seeded =
+            append_changelog_range(primary_conn, scenario, hot_first_seq,
+                                   scenario.new_chunks_per_origin);
+        const std::chrono::steady_clock::time_point hot_seed_finish =
+            std::chrono::steady_clock::now();
+        verify_origin_index(primary_conn, scenario, scenario.origins);
 
-    const std::chrono::steady_clock::time_point close_start =
+        PhaseMetrics hot = run_sync_phase(
+            "incremental_hot",
+            scenario.new_chunks_per_origin,
+            hot_seeded,
+            elapsed_ms(hot_seed_start, hot_seed_finish),
+            0.0,
+            primary_conn,
+            replica_conn,
+            primary_engine,
+            replica_engine,
+            scenario,
+            replica_node,
+            db_id);
+        print_csv_row(scenario, hot);
+    }
+
+    const std::chrono::steady_clock::time_point restart_start =
         std::chrono::steady_clock::now();
     primary_conn->disconnect();
     replica_conn->disconnect();
+    primary_conn.reset();
+    replica_conn.reset();
     primary_conn = open_env(paths.primary);
     replica_conn = open_env(paths.replica);
-    mdbxc::sync::SyncEngine restarted_primary(primary_conn);
-    mdbxc::sync::SyncEngine restarted_replica(replica_conn);
-    initialize_engine(restarted_primary, primary_node, db_id);
-    initialize_engine(restarted_replica, replica_node, db_id);
-    const std::chrono::steady_clock::time_point close_finish =
-        std::chrono::steady_clock::now();
 
-    const std::uint64_t restart_first_seq =
-        scenario.historical_chunks_per_origin + scenario.new_chunks_per_origin + 1;
-    const std::chrono::steady_clock::time_point restart_seed_start =
-        std::chrono::steady_clock::now();
-    const std::uint64_t restart_seeded =
-        append_changelog_range(primary_conn, scenario, restart_first_seq,
-                               scenario.new_chunks_per_origin);
-    const std::chrono::steady_clock::time_point restart_seed_finish =
-        std::chrono::steady_clock::now();
-    verify_origin_index(primary_conn, scenario, scenario.origins);
+    {
+        mdbxc::sync::SyncEngine restarted_primary(primary_conn);
+        mdbxc::sync::SyncEngine restarted_replica(replica_conn);
+        initialize_engine(restarted_primary, primary_node, db_id);
+        initialize_engine(restarted_replica, replica_node, db_id);
+        const std::chrono::steady_clock::time_point restart_finish =
+            std::chrono::steady_clock::now();
 
-    PhaseMetrics restarted = run_sync_phase(
-        "incremental_after_restart",
-        scenario.new_chunks_per_origin,
-        restart_seeded,
-        elapsed_ms(restart_seed_start, restart_seed_finish),
-        elapsed_ms(close_start, close_finish),
-        primary_conn,
-        replica_conn,
-        restarted_primary,
-        restarted_replica,
-        scenario,
-        replica_node,
-        db_id);
-    print_csv_row(scenario, restarted);
+        const std::uint64_t restart_first_seq =
+            scenario.historical_chunks_per_origin + scenario.new_chunks_per_origin + 1;
+        const std::chrono::steady_clock::time_point restart_seed_start =
+            std::chrono::steady_clock::now();
+        const std::uint64_t restart_seeded =
+            append_changelog_range(primary_conn, scenario, restart_first_seq,
+                                   scenario.new_chunks_per_origin);
+        const std::chrono::steady_clock::time_point restart_seed_finish =
+            std::chrono::steady_clock::now();
+        verify_origin_index(primary_conn, scenario, scenario.origins);
+
+        PhaseMetrics restarted = run_sync_phase(
+            "incremental_after_restart",
+            scenario.new_chunks_per_origin,
+            restart_seeded,
+            elapsed_ms(restart_seed_start, restart_seed_finish),
+            elapsed_ms(restart_start, restart_finish),
+            primary_conn,
+            replica_conn,
+            restarted_primary,
+            restarted_replica,
+            scenario,
+            replica_node,
+            db_id);
+        print_csv_row(scenario, restarted);
+    }
 
     primary_conn->disconnect();
     replica_conn->disconnect();

--- a/benchmarks/sync_tick_hub_benchmark.cpp
+++ b/benchmarks/sync_tick_hub_benchmark.cpp
@@ -1,13 +1,14 @@
 /// \file sync_tick_hub_benchmark.cpp
-/// \brief Manual benchmark for hub-style sync pull over tick chunks.
+/// \brief Manual benchmark for hub-style sync pull/apply over tick chunks.
 
 #include <mdbx_containers.hpp>
 #include <mdbx_containers/sync.hpp>
 
 #include <chrono>
 #include <cstdint>
-#include <cstdlib>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -15,21 +16,57 @@
 
 namespace {
 
-struct BenchmarkConfig {
-    std::uint64_t origins = 16;
-    std::uint64_t historical_chunks_per_origin = 512;
-    std::uint64_t new_chunks_per_origin = 8;
-    std::uint64_t ticks_per_chunk = 128;
-    std::uint64_t max_batches = 64;
+const std::uint64_t default_max_bytes = 4ULL * 1024ULL * 1024ULL;
+
+struct Scenario {
+    std::string   name;
+    std::uint64_t origins;
+    std::uint64_t historical_chunks_per_origin;
+    std::uint64_t new_chunks_per_origin;
+    std::uint64_t ticks_per_chunk;
+    std::uint64_t max_batches;
+    std::uint64_t max_bytes;
+};
+
+struct Paths {
+    std::string primary;
+    std::string replica;
+};
+
+struct PullApplyMetrics {
+    std::uint64_t pulled_batches = 0;
+    std::uint64_t applied_batches = 0;
+    std::uint64_t pull_pages = 0;
+    double pull_ms = 0.0;
+    double apply_ms = 0.0;
+};
+
+struct PhaseMetrics {
+    std::string   phase;
+    std::uint64_t chunks_per_origin = 0;
+    std::uint64_t seeded_batches = 0;
+    std::uint64_t pulled_batches = 0;
+    std::uint64_t applied_batches = 0;
+    std::uint64_t pull_pages = 0;
+    double        seed_ms = 0.0;
+    double        reopen_ms = 0.0;
+    double        pull_ms = 0.0;
+    double        apply_ms = 0.0;
+    std::uint64_t primary_bytes = 0;
+    std::uint64_t replica_bytes = 0;
 };
 
 void cleanup(const std::string& path);
 
 struct CleanupGuard {
-    explicit CleanupGuard(const std::string& path_value) : path(path_value) {}
-    ~CleanupGuard() { cleanup(path); }
+    explicit CleanupGuard(const Paths& paths_value) : paths(paths_value) {}
 
-    std::string path;
+    ~CleanupGuard() {
+        cleanup(paths.primary);
+        cleanup(paths.replica);
+    }
+
+    Paths paths;
 };
 
 void cleanup(const std::string& path) {
@@ -37,13 +74,21 @@ void cleanup(const std::string& path) {
     std::remove((path + "-lck").c_str());
 }
 
-std::string benchmark_path() {
+std::string run_id() {
     const std::chrono::steady_clock::time_point now =
         std::chrono::steady_clock::now();
     const std::chrono::nanoseconds ticks =
         std::chrono::duration_cast<std::chrono::nanoseconds>(
             now.time_since_epoch());
-    return "benchmark_sync_tick_hub_" + std::to_string(ticks.count()) + ".mdbx";
+    return std::to_string(ticks.count());
+}
+
+Paths make_paths(const std::string& id, const std::string& scenario_name) {
+    Paths paths;
+    const std::string prefix = "benchmark_sync_tick_hub_" + id + "_" + scenario_name;
+    paths.primary = prefix + "_primary.mdbx";
+    paths.replica = prefix + "_replica.mdbx";
+    return paths;
 }
 
 std::uint64_t parse_arg(int argc,
@@ -62,25 +107,91 @@ std::uint64_t parse_arg(int argc,
     return static_cast<std::uint64_t>(value);
 }
 
-BenchmarkConfig parse_config(int argc, char** argv) {
-    BenchmarkConfig config;
-    config.origins = parse_arg(argc, argv, 1, config.origins, "origins");
-    config.historical_chunks_per_origin =
-        parse_arg(argc, argv, 2, config.historical_chunks_per_origin,
-                  "historical_chunks_per_origin");
-    config.new_chunks_per_origin =
-        parse_arg(argc, argv, 3, config.new_chunks_per_origin,
-                  "new_chunks_per_origin");
-    config.ticks_per_chunk =
-        parse_arg(argc, argv, 4, config.ticks_per_chunk, "ticks_per_chunk");
-    config.max_batches = parse_arg(argc, argv, 5, config.max_batches, "max_batches");
-    if (config.origins == 0 || config.max_batches == 0) {
-        throw std::runtime_error("origins and max_batches must be positive");
+void validate_scenario(const Scenario& scenario) {
+    if (scenario.origins == 0 ||
+        scenario.max_batches == 0 ||
+        scenario.max_bytes == 0) {
+        throw std::runtime_error("origins, max_batches, and max_bytes must be positive");
     }
-    if (config.ticks_per_chunk > 1000000ULL) {
+    if (scenario.historical_chunks_per_origin == 0 &&
+        scenario.new_chunks_per_origin == 0) {
+        throw std::runtime_error(
+            "historical_chunks_per_origin and new_chunks_per_origin cannot both be zero");
+    }
+    if (scenario.ticks_per_chunk > 1000000ULL) {
         throw std::runtime_error("ticks_per_chunk is too large for this benchmark");
     }
-    return config;
+}
+
+std::vector<Scenario> default_scenarios() {
+    std::vector<Scenario> scenarios;
+
+    Scenario single;
+    single.name = "one_origin_small_chunks";
+    single.origins = 1;
+    single.historical_chunks_per_origin = 512;
+    single.new_chunks_per_origin = 64;
+    single.ticks_per_chunk = 16;
+    single.max_batches = 64;
+    single.max_bytes = default_max_bytes;
+    scenarios.push_back(single);
+
+    Scenario hub;
+    hub.name = "ten_origins_tick_chunks";
+    hub.origins = 10;
+    hub.historical_chunks_per_origin = 512;
+    hub.new_chunks_per_origin = 32;
+    hub.ticks_per_chunk = 128;
+    hub.max_batches = 64;
+    hub.max_bytes = default_max_bytes;
+    scenarios.push_back(hub);
+
+    Scenario paged;
+    paged.name = "hundred_origins_paged";
+    paged.origins = 100;
+    paged.historical_chunks_per_origin = 128;
+    paged.new_chunks_per_origin = 8;
+    paged.ticks_per_chunk = 128;
+    paged.max_batches = 32;
+    paged.max_bytes = default_max_bytes;
+    scenarios.push_back(paged);
+
+    return scenarios;
+}
+
+std::vector<Scenario> parse_scenarios(int argc, char** argv) {
+    if (argc == 1) {
+        return default_scenarios();
+    }
+    if (std::string(argv[1]) == "--help" ||
+        std::string(argv[1]) == "-h") {
+        std::cout
+            << "usage: sync_tick_hub_benchmark "
+            << "[origins historical_chunks_per_origin new_chunks_per_origin "
+            << "ticks_per_chunk max_batches max_bytes]\n"
+            << "\n"
+            << "Without arguments, runs a small built-in scenario matrix.\n"
+            << "The new_chunks_per_origin value is used for both hot and "
+            << "after-restart incremental phases.\n";
+        std::exit(0);
+    }
+
+    Scenario scenario;
+    scenario.name = "custom";
+    scenario.origins = parse_arg(argc, argv, 1, 16, "origins");
+    scenario.historical_chunks_per_origin =
+        parse_arg(argc, argv, 2, 512, "historical_chunks_per_origin");
+    scenario.new_chunks_per_origin =
+        parse_arg(argc, argv, 3, 8, "new_chunks_per_origin");
+    scenario.ticks_per_chunk =
+        parse_arg(argc, argv, 4, 128, "ticks_per_chunk");
+    scenario.max_batches = parse_arg(argc, argv, 5, 64, "max_batches");
+    scenario.max_bytes = parse_arg(argc, argv, 6, default_max_bytes, "max_bytes");
+    validate_scenario(scenario);
+
+    std::vector<Scenario> scenarios;
+    scenarios.push_back(scenario);
+    return scenarios;
 }
 
 std::shared_ptr<mdbxc::Connection> open_env(const std::string& path) {
@@ -89,8 +200,19 @@ std::shared_ptr<mdbxc::Connection> open_env(const std::string& path) {
     config.max_dbs = 16;
     config.no_subdir = true;
     config.size_now = 512LL * 1024LL * 1024LL;
-    config.size_upper = 8LL * 1024LL * 1024LL * 1024LL;
+    config.size_upper = 16LL * 1024LL * 1024LL * 1024LL;
     return mdbxc::Connection::create(config);
+}
+
+std::uint64_t used_database_bytes(
+        const std::shared_ptr<mdbxc::Connection>& conn) {
+    MDBX_envinfo info;
+    std::memset(&info, 0, sizeof(info));
+    mdbxc::check_mdbx(
+        mdbx_env_info_ex(conn->env_handle(), nullptr, &info, sizeof(info)),
+        "sync_tick_hub_benchmark: failed to read MDBX env info");
+    return (info.mi_last_pgno + 1) *
+           static_cast<std::uint64_t>(info.mi_dxb_pagesize);
 }
 
 mdbxc::sync::NodeId make_node(std::uint8_t seed) {
@@ -159,19 +281,25 @@ double elapsed_ms(std::chrono::steady_clock::time_point start,
     return static_cast<double>(elapsed.count()) / 1000.0;
 }
 
-void seed_changelog(const std::shared_ptr<mdbxc::Connection>& conn,
-                    const BenchmarkConfig& config) {
+std::uint64_t append_changelog_range(
+        const std::shared_ptr<mdbxc::Connection>& conn,
+        const Scenario& scenario,
+        std::uint64_t first_seq,
+        std::uint64_t chunks_per_origin) {
+    if (chunks_per_origin == 0) {
+        return 0;
+    }
+
     auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
     mdbxc::sync::ChangeLogStore log(conn->env_handle());
     log.open(txn.handle());
 
-    const std::uint64_t total_chunks =
-        config.historical_chunks_per_origin + config.new_chunks_per_origin;
-    for (std::uint64_t origin_index = 0; origin_index < config.origins; ++origin_index) {
+    for (std::uint64_t origin_index = 0; origin_index < scenario.origins; ++origin_index) {
         const mdbxc::sync::NodeId origin = make_origin(origin_index);
-        for (std::uint64_t seq = 1; seq <= total_chunks; ++seq) {
+        const std::uint64_t end_seq = first_seq + chunks_per_origin;
+        for (std::uint64_t seq = first_seq; seq < end_seq; ++seq) {
             const mdbxc::sync::ChangeBatch batch =
-                make_tick_batch(origin_index, origin, seq, config.ticks_per_chunk);
+                make_tick_batch(origin_index, origin, seq, scenario.ticks_per_chunk);
             const std::vector<std::uint8_t> bytes =
                 mdbxc::sync::ChangeBatchCodec::encode(batch);
             log.append(txn.handle(), origin, seq, bytes);
@@ -179,6 +307,7 @@ void seed_changelog(const std::shared_ptr<mdbxc::Connection>& conn,
     }
 
     txn.commit();
+    return scenario.origins * chunks_per_origin;
 }
 
 std::uint64_t count_origin_index_entries(
@@ -193,108 +322,288 @@ std::uint64_t count_origin_index_entries(
     return static_cast<std::uint64_t>(indexed.size());
 }
 
-std::uint64_t pull_incremental(mdbxc::sync::SyncEngine& engine,
-                               const BenchmarkConfig& config,
-                               std::uint64_t& pages) {
-    mdbxc::sync::DirectSyncPeer peer(&engine);
-    mdbxc::sync::PullRequest request;
-    request.requester = make_node(0xB0);
-    request.db_id = make_node(0xD0);
-    request.max_batches = config.max_batches;
-    for (std::uint64_t origin_index = 0; origin_index < config.origins; ++origin_index) {
-        request.have.last_seq_by_origin[make_origin(origin_index)] =
-            config.historical_chunks_per_origin;
+void verify_origin_index(const std::shared_ptr<mdbxc::Connection>& conn,
+                         const Scenario& scenario,
+                         std::uint64_t expected_origins) {
+    const std::uint64_t actual = count_origin_index_entries(conn);
+    if (actual != expected_origins) {
+        throw std::runtime_error("wrong number of origin index entries: expected " +
+                                 std::to_string(expected_origins) + ", got " +
+                                 std::to_string(actual) + " for scenario " +
+                                 scenario.name);
     }
+}
 
-    std::uint64_t pulled = 0;
-    pages = 0;
+PullApplyMetrics pull_and_apply(mdbxc::sync::SyncEngine& primary_engine,
+                                mdbxc::sync::SyncEngine& replica_engine,
+                                const Scenario& scenario,
+                                const mdbxc::sync::NodeId& replica_node,
+                                const mdbxc::sync::NodeId& db_id) {
+    mdbxc::sync::DirectSyncPeer peer(&primary_engine);
+    mdbxc::sync::PullRequest request;
+    request.requester = replica_node;
+    request.db_id = db_id;
+    request.have = replica_engine.applied_cursor();
+    request.max_batches = scenario.max_batches;
+    request.max_bytes = scenario.max_bytes;
+
+    PullApplyMetrics metrics;
     bool has_more = false;
     do {
         const mdbxc::sync::SyncCursor before = request.have;
+        const std::chrono::steady_clock::time_point pull_start =
+            std::chrono::steady_clock::now();
         const mdbxc::sync::PullResponse response = peer.pull(request);
+        const std::chrono::steady_clock::time_point pull_finish =
+            std::chrono::steady_clock::now();
+        metrics.pull_ms += elapsed_ms(pull_start, pull_finish);
+
         if (!response.ok) {
             throw std::runtime_error("pull failed: " + response.error);
         }
-        ++pages;
-        pulled += static_cast<std::uint64_t>(response.batches.size());
-        for (std::vector<mdbxc::sync::ChangeBatch>::const_iterator it =
-                 response.batches.begin();
-             it != response.batches.end(); ++it) {
-            std::uint64_t& seq = request.have.last_seq_by_origin[it->origin_node_id];
-            if (it->seq > seq) {
-                seq = it->seq;
+        ++metrics.pull_pages;
+        metrics.pulled_batches += static_cast<std::uint64_t>(response.batches.size());
+
+        if (!response.batches.empty()) {
+            mdbxc::sync::PushRequest push;
+            push.sender = primary_engine.local_node_id();
+            push.db_id = db_id;
+            push.batches = response.batches;
+
+            const std::chrono::steady_clock::time_point apply_start =
+                std::chrono::steady_clock::now();
+            const mdbxc::sync::PushResponse pushed =
+                replica_engine.handle_push(push);
+            const std::chrono::steady_clock::time_point apply_finish =
+                std::chrono::steady_clock::now();
+            metrics.apply_ms += elapsed_ms(apply_start, apply_finish);
+
+            if (!pushed.ok) {
+                throw std::runtime_error("apply failed: " + pushed.error);
             }
+            metrics.applied_batches +=
+                static_cast<std::uint64_t>(response.batches.size());
+        } else if (response.has_more) {
+            throw std::runtime_error("pull reported has_more without batches");
         }
-        if (response.has_more &&
-            request.have.last_seq_by_origin == before.last_seq_by_origin) {
-            throw std::runtime_error("pagination made no cursor progress");
-        }
+
         has_more = response.has_more;
+        request.have = replica_engine.applied_cursor();
+        if (has_more &&
+            request.have.last_seq_by_origin == before.last_seq_by_origin) {
+            throw std::runtime_error("pull pagination made no cursor progress");
+        }
     } while (has_more);
 
-    return pulled;
+    return metrics;
+}
+
+PhaseMetrics run_sync_phase(const std::string& phase,
+                            std::uint64_t chunks_per_origin,
+                            std::uint64_t seeded_batches,
+                            double seed_ms,
+                            double reopen_ms,
+                            const std::shared_ptr<mdbxc::Connection>& primary_conn,
+                            const std::shared_ptr<mdbxc::Connection>& replica_conn,
+                            mdbxc::sync::SyncEngine& primary_engine,
+                            mdbxc::sync::SyncEngine& replica_engine,
+                            const Scenario& scenario,
+                            const mdbxc::sync::NodeId& replica_node,
+                            const mdbxc::sync::NodeId& db_id) {
+    const PullApplyMetrics sync =
+        pull_and_apply(primary_engine, replica_engine, scenario, replica_node, db_id);
+    const std::uint64_t expected = scenario.origins * chunks_per_origin;
+    if (sync.pulled_batches != expected) {
+        throw std::runtime_error(phase + " pulled wrong batch count: expected " +
+                                 std::to_string(expected) + ", got " +
+                                 std::to_string(sync.pulled_batches));
+    }
+    if (sync.applied_batches != expected) {
+        throw std::runtime_error(phase + " applied wrong batch count: expected " +
+                                 std::to_string(expected) + ", got " +
+                                 std::to_string(sync.applied_batches));
+    }
+
+    PhaseMetrics metrics;
+    metrics.phase = phase;
+    metrics.chunks_per_origin = chunks_per_origin;
+    metrics.seeded_batches = seeded_batches;
+    metrics.pulled_batches = sync.pulled_batches;
+    metrics.applied_batches = sync.applied_batches;
+    metrics.pull_pages = sync.pull_pages;
+    metrics.seed_ms = seed_ms;
+    metrics.reopen_ms = reopen_ms;
+    metrics.pull_ms = sync.pull_ms;
+    metrics.apply_ms = sync.apply_ms;
+    metrics.primary_bytes = used_database_bytes(primary_conn);
+    metrics.replica_bytes = used_database_bytes(replica_conn);
+    return metrics;
+}
+
+void initialize_engine(mdbxc::sync::SyncEngine& engine,
+                       const mdbxc::sync::NodeId& node,
+                       const mdbxc::sync::NodeId& db_id) {
+    engine.initialize_local_identity(node, db_id);
+}
+
+void print_csv_header() {
+    std::cout
+        << "scenario,phase,origins,historical_chunks_per_origin,"
+        << "new_chunks_per_origin,chunks_per_origin,ticks_per_chunk,"
+        << "max_batches,max_bytes,seeded_batches,pulled_batches,"
+        << "applied_batches,pull_pages,seed_ms,reopen_ms,pull_ms,"
+        << "apply_ms,total_ms,batches_per_sec,primary_bytes,replica_bytes\n";
+}
+
+void print_csv_row(const Scenario& scenario,
+                   const PhaseMetrics& metrics) {
+    const double total_ms =
+        metrics.seed_ms + metrics.reopen_ms + metrics.pull_ms + metrics.apply_ms;
+    const double batches_per_sec =
+        (metrics.pull_ms + metrics.apply_ms) <= 0.0
+            ? 0.0
+            : (static_cast<double>(metrics.applied_batches) * 1000.0) /
+              (metrics.pull_ms + metrics.apply_ms);
+    std::cout << scenario.name << ','
+              << metrics.phase << ','
+              << scenario.origins << ','
+              << scenario.historical_chunks_per_origin << ','
+              << scenario.new_chunks_per_origin << ','
+              << metrics.chunks_per_origin << ','
+              << scenario.ticks_per_chunk << ','
+              << scenario.max_batches << ','
+              << scenario.max_bytes << ','
+              << metrics.seeded_batches << ','
+              << metrics.pulled_batches << ','
+              << metrics.applied_batches << ','
+              << metrics.pull_pages << ','
+              << metrics.seed_ms << ','
+              << metrics.reopen_ms << ','
+              << metrics.pull_ms << ','
+              << metrics.apply_ms << ','
+              << total_ms << ','
+              << batches_per_sec << ','
+              << metrics.primary_bytes << ','
+              << metrics.replica_bytes << '\n';
+}
+
+void run_scenario(const Scenario& scenario, const std::string& id) {
+    validate_scenario(scenario);
+    const mdbxc::sync::NodeId primary_node = make_node(0xA0);
+    const mdbxc::sync::NodeId replica_node = make_node(0xB0);
+    const mdbxc::sync::NodeId db_id = make_node(0xD0);
+    const Paths paths = make_paths(id, scenario.name);
+    CleanupGuard cleanup_guard(paths);
+    cleanup(paths.primary);
+    cleanup(paths.replica);
+
+    std::shared_ptr<mdbxc::Connection> primary_conn = open_env(paths.primary);
+    std::shared_ptr<mdbxc::Connection> replica_conn = open_env(paths.replica);
+    mdbxc::sync::SyncEngine primary_engine(primary_conn);
+    mdbxc::sync::SyncEngine replica_engine(replica_conn);
+    initialize_engine(primary_engine, primary_node, db_id);
+    initialize_engine(replica_engine, replica_node, db_id);
+
+    const std::chrono::steady_clock::time_point historical_seed_start =
+        std::chrono::steady_clock::now();
+    const std::uint64_t historical_seeded =
+        append_changelog_range(primary_conn, scenario, 1,
+                               scenario.historical_chunks_per_origin);
+    const std::chrono::steady_clock::time_point historical_seed_finish =
+        std::chrono::steady_clock::now();
+    verify_origin_index(primary_conn, scenario,
+                        scenario.historical_chunks_per_origin == 0 ? 0 : scenario.origins);
+
+    PhaseMetrics full = run_sync_phase(
+        "full_cold_replica",
+        scenario.historical_chunks_per_origin,
+        historical_seeded,
+        elapsed_ms(historical_seed_start, historical_seed_finish),
+        0.0,
+        primary_conn,
+        replica_conn,
+        primary_engine,
+        replica_engine,
+        scenario,
+        replica_node,
+        db_id);
+    print_csv_row(scenario, full);
+
+    const std::uint64_t hot_first_seq = scenario.historical_chunks_per_origin + 1;
+    const std::chrono::steady_clock::time_point hot_seed_start =
+        std::chrono::steady_clock::now();
+    const std::uint64_t hot_seeded =
+        append_changelog_range(primary_conn, scenario, hot_first_seq,
+                               scenario.new_chunks_per_origin);
+    const std::chrono::steady_clock::time_point hot_seed_finish =
+        std::chrono::steady_clock::now();
+    verify_origin_index(primary_conn, scenario, scenario.origins);
+
+    PhaseMetrics hot = run_sync_phase(
+        "incremental_hot",
+        scenario.new_chunks_per_origin,
+        hot_seeded,
+        elapsed_ms(hot_seed_start, hot_seed_finish),
+        0.0,
+        primary_conn,
+        replica_conn,
+        primary_engine,
+        replica_engine,
+        scenario,
+        replica_node,
+        db_id);
+    print_csv_row(scenario, hot);
+
+    const std::chrono::steady_clock::time_point close_start =
+        std::chrono::steady_clock::now();
+    primary_conn->disconnect();
+    replica_conn->disconnect();
+    primary_conn = open_env(paths.primary);
+    replica_conn = open_env(paths.replica);
+    mdbxc::sync::SyncEngine restarted_primary(primary_conn);
+    mdbxc::sync::SyncEngine restarted_replica(replica_conn);
+    initialize_engine(restarted_primary, primary_node, db_id);
+    initialize_engine(restarted_replica, replica_node, db_id);
+    const std::chrono::steady_clock::time_point close_finish =
+        std::chrono::steady_clock::now();
+
+    const std::uint64_t restart_first_seq =
+        scenario.historical_chunks_per_origin + scenario.new_chunks_per_origin + 1;
+    const std::chrono::steady_clock::time_point restart_seed_start =
+        std::chrono::steady_clock::now();
+    const std::uint64_t restart_seeded =
+        append_changelog_range(primary_conn, scenario, restart_first_seq,
+                               scenario.new_chunks_per_origin);
+    const std::chrono::steady_clock::time_point restart_seed_finish =
+        std::chrono::steady_clock::now();
+    verify_origin_index(primary_conn, scenario, scenario.origins);
+
+    PhaseMetrics restarted = run_sync_phase(
+        "incremental_after_restart",
+        scenario.new_chunks_per_origin,
+        restart_seeded,
+        elapsed_ms(restart_seed_start, restart_seed_finish),
+        elapsed_ms(close_start, close_finish),
+        primary_conn,
+        replica_conn,
+        restarted_primary,
+        restarted_replica,
+        scenario,
+        replica_node,
+        db_id);
+    print_csv_row(scenario, restarted);
+
+    primary_conn->disconnect();
+    replica_conn->disconnect();
 }
 
 int run(int argc, char** argv) {
-    const BenchmarkConfig config = parse_config(argc, argv);
-    const std::string path = benchmark_path();
-    CleanupGuard cleanup_guard(path);
-    cleanup(path);
-
-    std::shared_ptr<mdbxc::Connection> conn = open_env(path);
-    mdbxc::sync::SyncEngine engine(conn);
-    engine.initialize_local_identity(make_node(0xA0), make_node(0xD0));
-
-    const std::chrono::steady_clock::time_point seed_start =
-        std::chrono::steady_clock::now();
-    seed_changelog(conn, config);
-    const std::chrono::steady_clock::time_point seed_finish =
-        std::chrono::steady_clock::now();
-    const std::uint64_t origin_index_entries = count_origin_index_entries(conn);
-    if (origin_index_entries != config.origins) {
-        throw std::runtime_error("wrong number of origin index entries: expected " +
-                                 std::to_string(config.origins) + ", got " +
-                                 std::to_string(origin_index_entries));
+    const std::vector<Scenario> scenarios = parse_scenarios(argc, argv);
+    const std::string id = run_id();
+    print_csv_header();
+    for (std::size_t i = 0; i < scenarios.size(); ++i) {
+        run_scenario(scenarios[i], id);
     }
-
-    std::uint64_t pages = 0;
-    const std::chrono::steady_clock::time_point pull_start =
-        std::chrono::steady_clock::now();
-    const std::uint64_t pulled = pull_incremental(engine, config, pages);
-    const std::chrono::steady_clock::time_point pull_finish =
-        std::chrono::steady_clock::now();
-
-    const std::uint64_t expected = config.origins * config.new_chunks_per_origin;
-    if (pulled != expected) {
-        throw std::runtime_error("wrong number of pulled batches: expected " +
-                                 std::to_string(expected) + ", got " +
-                                 std::to_string(pulled));
-    }
-
-    conn->disconnect();
-
-    const std::uint64_t seeded =
-        config.origins *
-        (config.historical_chunks_per_origin + config.new_chunks_per_origin);
-    const double seed_ms = elapsed_ms(seed_start, seed_finish);
-    const double pull_ms = elapsed_ms(pull_start, pull_finish);
-    const double us_per_batch =
-        pulled == 0 ? 0.0 : (pull_ms * 1000.0) / static_cast<double>(pulled);
-
-    std::cout << "sync_tick_hub_benchmark\n"
-              << "  origins=" << config.origins << "\n"
-              << "  historical_chunks_per_origin="
-              << config.historical_chunks_per_origin << "\n"
-              << "  new_chunks_per_origin=" << config.new_chunks_per_origin << "\n"
-              << "  ticks_per_chunk=" << config.ticks_per_chunk << "\n"
-              << "  max_batches=" << config.max_batches << "\n"
-              << "  seeded_batches=" << seeded << "\n"
-              << "  origin_index_entries=" << origin_index_entries << "\n"
-              << "  pulled_batches=" << pulled << "\n"
-              << "  pull_pages=" << pages << "\n"
-              << "  seed_ms=" << seed_ms << "\n"
-              << "  pull_ms=" << pull_ms << "\n"
-              << "  pull_us_per_batch=" << us_per_batch << "\n";
     return 0;
 }
 

--- a/guides/build-and-test.md
+++ b/guides/build-and-test.md
@@ -80,7 +80,10 @@ tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark
 ```
 
 `sync_tick_hub_benchmark` prints CSV rows for full cold-replica sync,
-incremental hot sync, and incremental sync after reopening both databases.
+incremental hot sync, and incremental sync after restarting both connections
+and sync engines. It uses `DirectSyncPeer` in one process, so the timings measure
+the sync core, pagination, and local apply path rather than network transport
+latency.
 Pass positional arguments to run one custom scenario:
 
 ```bash

--- a/guides/build-and-test.md
+++ b/guides/build-and-test.md
@@ -16,6 +16,7 @@ All project options use the `MDBXC_` prefix.
 | `MDBXC_DEPS_MODE` | `AUTO` | MDBX dependency mode: `AUTO`, `SYSTEM`, or `BUNDLED`. |
 | `MDBXC_BUILD_EXAMPLES` | `ON` | Build examples from `examples/`. |
 | `MDBXC_BUILD_TESTS` | `ON` | Build tests from `tests/` and register them with CTest. |
+| `MDBXC_BUILD_BENCHMARKS` | `OFF` | Build manual benchmark executables from `benchmarks/`. |
 | `MDBXC_USE_ASAN` | `ON` | Enable AddressSanitizer for tests/examples when supported. |
 
 When `mdbx-containers` is added as a subproject, existing parent-provided
@@ -60,6 +61,33 @@ ctest --test-dir tmp/build-cpp11 --output-on-failure
 On Windows, the repository includes helper scripts such as
 `build-mingw-17-tests.bat`, `build-mingw-11-tests.bat`, and
 `build-mingw-17-examples.bat`.
+
+## Benchmarks
+
+Benchmarks are manual tools, not CTest targets. Enable them only for local
+measurement runs:
+
+```bash
+cmake -S . -B tmp/build-bench \
+    -DMDBXC_DEPS_MODE=BUNDLED \
+    -DMDBXC_BUILD_TESTS=OFF \
+    -DMDBXC_BUILD_EXAMPLES=OFF \
+    -DMDBXC_BUILD_BENCHMARKS=ON \
+    -DCMAKE_CXX_STANDARD=17
+
+cmake --build tmp/build-bench --target sync_tick_hub_benchmark
+tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark
+```
+
+`sync_tick_hub_benchmark` prints CSV rows for full cold-replica sync,
+incremental hot sync, and incremental sync after reopening both databases.
+Pass positional arguments to run one custom scenario:
+
+```bash
+sync_tick_hub_benchmark \
+    origins historical_chunks_per_origin new_chunks_per_origin \
+    ticks_per_chunk max_batches max_bytes
+```
 
 ## CI Expectations
 


### PR DESCRIPTION
## Summary

- expand `sync_tick_hub_benchmark` into a CSV-producing hub sync benchmark
- measure full cold-replica sync, hot incremental sync, and incremental sync after reopening both databases
- include pull/apply timing, pagination counts, applied batch throughput, and MDBX used-byte estimates
- document how to build and run manual benchmark targets

## Validation

- `git diff --check`
- `cmake -S . -B tmp/build-bench-cxx17 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=OFF -DMDBXC_BUILD_EXAMPLES=OFF -DMDBXC_BUILD_BENCHMARKS=ON -DCMAKE_CXX_STANDARD=17`
- `cmake --build tmp/build-bench-cxx17 --target sync_tick_hub_benchmark -j 4`
- `tmp\build-bench-cxx17\bin\benchmarks\sync_tick_hub_benchmark.exe 3 8 3 4 2 4096`
- `tmp\build-bench-cxx17\bin\benchmarks\sync_tick_hub_benchmark.exe`
- `cmake -S . -B tmp/build-bench-cxx11 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=OFF -DMDBXC_BUILD_EXAMPLES=OFF -DMDBXC_BUILD_BENCHMARKS=ON -DCMAKE_CXX_STANDARD=11`
- `cmake --build tmp/build-bench-cxx11 --target sync_tick_hub_benchmark -j 4`
- `tmp\build-bench-cxx11\bin\benchmarks\sync_tick_hub_benchmark.exe 3 8 3 4 2 4096`