### PR TITLE
ci(sync): add scheduled stress workflow

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -1,0 +1,78 @@
+name: Stress
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "37 2 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync-stress:
+    name: Sync stress (Linux C++17)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build
+
+      - name: Ensure libmdbx tags
+        run: |
+          set -euo pipefail
+          git submodule update --init --recursive
+          git -C external/libmdbx rev-parse --is-inside-work-tree >/dev/null
+          git -C external/libmdbx config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+          git -C external/libmdbx fetch --prune --tags --force
+          if git -C external/libmdbx rev-parse --is-shallow-repository | grep -qi true; then
+            git -C external/libmdbx fetch --unshallow || git -C external/libmdbx fetch --deepen=1000
+          fi
+          git -C external/libmdbx describe --tags --abbrev=0 >/dev/null
+
+      - name: Configure stress tests
+        run: |
+          set -euo pipefail
+          mkdir -p build
+          cmake -S . -B build -G "Ninja" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_STANDARD=17 \
+            -DMDBXC_DEPS_MODE=BUNDLED \
+            -DMDBXC_BUILD_TESTS=ON \
+            -DMDBXC_BUILD_EXAMPLES=OFF \
+            -DMDBXC_BUILD_BENCHMARKS=OFF \
+            -DMDBXC_ENABLE_STRESS_TESTS=ON \
+            -Wno-dev \
+          2>&1 | tee build/configure.log
+
+      - name: Build stress tests
+        run: |
+          set -euo pipefail
+          cmake --build build --target test_sync_stress --config Release --parallel \
+          2>&1 | tee build/build.log
+
+      - name: Run stress tests
+        run: |
+          set -euo pipefail
+          ctest --test-dir build -L stress --output-on-failure -C Release \
+          2>&1 | tee build/ctest.log
+
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sync-stress-linux-cxx17-logs
+          path: build/*.log
+          if-no-files-found: ignore

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -63,6 +63,13 @@ jobs:
           cmake --build build --target test_sync_stress --config Release --parallel \
           2>&1 | tee build/build.log
 
+      - name: Verify stress registration
+        run: |
+          set -euo pipefail
+          ctest --test-dir build -N -L stress \
+          2>&1 | tee build/ctest-list.log
+          grep -q "test_sync_stress" build/ctest-list.log
+
       - name: Run stress tests
         run: |
           set -euo pipefail

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,9 @@ if(MDBXC_BUILD_TESTS)
     include(CTest)
     enable_testing()
     file(GLOB TESTS CONFIGURE_DEPENDS tests/*.cpp)
+    set(MDBXC_STRESS_TESTS
+        test_sync_stress
+    )
     foreach(test_file IN LISTS TESTS)
         get_filename_component(test_name ${test_file} NAME_WE)
         add_executable(${test_name} ${test_file})
@@ -170,8 +173,9 @@ if(MDBXC_BUILD_TESTS)
         # Enable the optional sync subsystem when its headers are exercised.
         target_compile_definitions(${test_name} PRIVATE MDBXC_SYNC_ENABLED=1)
 
+        list(FIND MDBXC_STRESS_TESTS "${test_name}" _mdbxc_stress_test_index)
         set(_mdbxc_is_stress_test FALSE)
-        if(test_name MATCHES "stress")
+        if(NOT _mdbxc_stress_test_index EQUAL -1)
             set(_mdbxc_is_stress_test TRUE)
         endif()
 

--- a/guides/build-and-test.md
+++ b/guides/build-and-test.md
@@ -80,6 +80,10 @@ cmake --build tmp/build-stress --target test_sync_stress
 ctest --test-dir tmp/build-stress -L stress --output-on-failure
 ```
 
+The GitHub Actions `Stress` workflow runs the same stress label on Linux C++17.
+It is intentionally separate from the main `CI` workflow and is triggered by
+manual dispatch or the nightly schedule, not by ordinary pull requests.
+
 ## Benchmarks
 
 Benchmarks are manual tools, not CTest targets. Enable them only for local
@@ -119,6 +123,8 @@ sync_tick_hub_benchmark \
 - CI uses CMake with Ninja and runs `ctest --output-on-failure`.
 - A separate Linux C++17 smoke job builds and runs `sync_tick_hub_benchmark`
   with `MDBXC_BUILD_BENCHMARKS=ON`.
+- The separate `Stress` workflow runs `ctest -L stress` on Linux C++17 when
+  manually dispatched or triggered by its schedule.
 
 ## Generated Outputs
 


### PR DESCRIPTION
## Summary
- add a separate `Stress` GitHub Actions workflow for manual and nightly Linux C++17 stress runs
- keep ordinary PR/push CI unchanged while running `MDBXC_ENABLE_STRESS_TESTS=ON` in the dedicated workflow
- replace substring-based stress detection in CMake with an explicit `MDBXC_STRESS_TESTS` target list
- document the new stress workflow in `guides/build-and-test.md`

## Verification
- `cmake -S . -B tmp/build-stress-ci-default -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=OFF -DMDBXC_BUILD_BENCHMARKS=OFF -DCMAKE_CXX_STANDARD=17 -DCMAKE_BUILD_TYPE=Release`
- `ctest --test-dir tmp/build-stress-ci-default -N | Select-String -Pattern "test_sync_stress|Total Tests"`
- `cmake -S . -B tmp/build-stress-ci-enabled -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=OFF -DMDBXC_BUILD_BENCHMARKS=OFF -DMDBXC_ENABLE_STRESS_TESTS=ON -DCMAKE_CXX_STANDARD=17 -DCMAKE_BUILD_TYPE=Release`
- `cmake --build tmp/build-stress-ci-enabled --target test_sync_stress -- -j`
- `ctest --test-dir tmp/build-stress-ci-enabled -L stress --output-on-failure`
- `git diff --check`
