### PR TITLE
feat(sync): add cooperative cancellation tokens

### DIFF
--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -17,7 +17,7 @@
 #include "sync/ChangeBatch.hpp"
 #include "sync/ChangeBatchCodec.hpp"
 #include "sync/ChangeOp.hpp"
-#include "sync/Cancellation.hpp"
+#include "sync/cancellation.hpp"
 #include "sync/CodecBounds.hpp"
 #include "sync/codec_flags.hpp"
 #include "sync/common.hpp"

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -17,6 +17,7 @@
 #include "sync/ChangeBatch.hpp"
 #include "sync/ChangeBatchCodec.hpp"
 #include "sync/ChangeOp.hpp"
+#include "sync/Cancellation.hpp"
 #include "sync/CodecBounds.hpp"
 #include "sync/codec_flags.hpp"
 #include "sync/common.hpp"

--- a/include/mdbx_containers/sync/Cancellation.hpp
+++ b/include/mdbx_containers/sync/Cancellation.hpp
@@ -1,0 +1,84 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_CANCELLATION_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_CANCELLATION_HPP_INCLUDED
+
+/// \file Cancellation.hpp
+/// \brief Cooperative cancellation primitives for sync transports.
+
+#include <atomic>
+#include <memory>
+
+namespace mdbxc {
+namespace sync {
+
+    namespace detail {
+        struct CancellationState {
+            CancellationState() : requested(false) {}
+
+            std::atomic<bool> requested;
+        };
+    } // namespace detail
+
+    /// \brief Read-only view of a cooperative cancellation request.
+    /// \details Tokens are cheap to copy and can be stored by transport code
+    /// for the duration of one operation. A default-constructed token is not
+    /// cancellable and never reports cancellation.
+    class CancellationToken {
+    public:
+        CancellationToken() {}
+
+        /// \brief Returns whether this token is backed by a source.
+        bool can_be_cancelled() const {
+            return static_cast<bool>(m_state);
+        }
+
+        /// \brief Returns whether cancellation has been requested.
+        bool is_cancellation_requested() const {
+            return m_state &&
+                m_state->requested.load(std::memory_order_acquire);
+        }
+
+    private:
+        friend class CancellationSource;
+
+        explicit CancellationToken(
+                const std::shared_ptr<detail::CancellationState>& state)
+            : m_state(state) {}
+
+        std::shared_ptr<detail::CancellationState> m_state;
+    };
+
+    /// \brief Owner side of a cooperative cancellation token.
+    /// \details Calling \c request_cancel() is thread-safe and wakes only
+    /// transports that actively observe the paired \c CancellationToken. It
+    /// does not interrupt arbitrary blocking system calls by itself; transport
+    /// adapters should combine it with socket shutdown, deadlines, or their
+    /// native cancellation primitive when needed.
+    class CancellationSource {
+    public:
+        CancellationSource()
+            : m_state(new detail::CancellationState()) {}
+
+        /// \brief Returns a token associated with this source.
+        CancellationToken token() const {
+            return CancellationToken(m_state);
+        }
+
+        /// \brief Requests cancellation for all tokens from this source.
+        void request_cancel() const {
+            m_state->requested.store(true, std::memory_order_release);
+        }
+
+        /// \brief Returns whether cancellation has been requested.
+        bool is_cancellation_requested() const {
+            return m_state->requested.load(std::memory_order_acquire);
+        }
+
+    private:
+        std::shared_ptr<detail::CancellationState> m_state;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_CANCELLATION_HPP_INCLUDED

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -14,8 +14,8 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
 ## Already implemented (merged into main)
 
 - Public types in `include/mdbx_containers/sync/`:
-  `Common`, `ChangeBatch`, `ChangeOp`, `CodecFlags`, `CodecBounds`,
-  `Protocol`, `SyncCursor`, `ConflictPolicy`, `ISyncPeer`,
+  `Common`, `ChangeBatch`, `ChangeOp`, `Cancellation`, `CodecFlags`,
+  `CodecBounds`, `Protocol`, `SyncCursor`, `ConflictPolicy`, `ISyncPeer`,
   `IdentityProvider`, `ChangeBatchCodec`, `SyncWorker`.
 - Five system stores under `include/mdbx_containers/sync/stores/`:
   `MetaStore`, `ChangeLogStore`, `OriginIndexStore`, `AppliedStore`,
@@ -214,9 +214,9 @@ Worker invariants:
 - no local MDBX transaction is held during idle or backoff sleeps;
 - pulled pages are applied through `SyncEngine::handle_push()`, so each page
   uses one short local write transaction;
-- stop requests call `ISyncPeer::request_cancel()` at most once for each
-  observed in-flight peer pull call, and a page returned after stop was
-  requested is not applied;
+- stop requests cancel the active `PullRequest::cancel_token` and call
+  `ISyncPeer::request_cancel()` at most once for each observed in-flight
+  peer pull call, and a page returned after stop was requested is not applied;
 - a stop request recorded before peer-call activation prevents the next pull
   call from starting;
 - `stop()`, `join()`, and destruction may wait for an in-flight peer call to
@@ -231,8 +231,9 @@ Worker invariants:
 
 The worker is a lifecycle/concurrency helper, not a transport. HTTP/WebSocket
 peers remain separate adapters over `ISyncPeer`. Transport adapters that can
-interrupt blocking I/O should implement `request_cancel()` by using their own
-timeout, cancellation token, socket shutdown, or equivalent mechanism.
+interrupt blocking I/O should poll the request `cancel_token` where possible
+and implement `request_cancel()` by using their own timeout, socket shutdown,
+or equivalent mechanism when polling alone cannot unblock the operation.
 
 ## Why `prune_up_to` uses cursor walk + `MDBX_NEXT`
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -235,6 +235,17 @@ interrupt blocking I/O should poll the request `cancel_token` where possible
 and implement `request_cancel()` by using their own timeout, socket shutdown,
 or equivalent mechanism when polling alone cannot unblock the operation.
 
+Cancellation intentionally stays minimal in the core API: operation-scoped
+tokens plus the existing best-effort peer hook. Do not add callback
+registration, generation-based token reuse, or allocation-free state reuse
+without evidence from a real transport adapter or benchmark. The preferred next
+step for HTTP/WebSocket transports is an adapter-local bridge from
+`cancel_token` / `request_cancel()` to the transport library's native timeout,
+socket shutdown, or cancellation primitive. Revisit the core API only if that
+adapter-local approach proves insufficient, or if benchmark data shows
+per-operation cancellation-state allocation on the `pull()` path is a measured
+hot spot.
+
 ## Why `prune_up_to` uses cursor walk + `MDBX_NEXT`
 
 MDBX has no batch "delete by key range" primitive. The supported pattern

--- a/include/mdbx_containers/sync/ISyncPeer.hpp
+++ b/include/mdbx_containers/sync/ISyncPeer.hpp
@@ -13,9 +13,13 @@ namespace sync {
     /// \brief Abstract peer that exchanges pull and push requests.
     /// \details Concrete implementations (in-process, HTTP, WebSocket) live
     /// outside the core sync layer and depend on optional transport headers.
-    /// Implementations that override \c request_cancel() must allow it to be
-    /// called concurrently with \c pull() / \c push() and tolerate calls that
-    /// race with operation startup or completion.
+    /// Transport operations receive cooperative cancellation tokens through
+    /// \c PullRequest::cancel_token and \c PushRequest::cancel_token. Blocking
+    /// implementations may also override \c request_cancel() to interrupt
+    /// socket waits or other transport-owned blocking primitives. Overrides
+    /// must allow \c request_cancel() to be called concurrently with
+    /// \c pull() / \c push() and tolerate calls that race with operation
+    /// startup or completion.
     class ISyncPeer {
     public:
         virtual ~ISyncPeer() {}
@@ -28,8 +32,9 @@ namespace sync {
 
         /// \brief Requests cancellation of in-flight transport operations.
         /// \details Best-effort hook for blocking transports. The default
-        /// implementation is a no-op, so non-interruptible peers remain valid.
-        /// Overrides should return quickly and should not throw.
+        /// implementation is a no-op, so token-only and non-interruptible
+        /// peers remain valid. Overrides should return quickly and should not
+        /// throw.
         virtual void request_cancel() {}
     };
 

--- a/include/mdbx_containers/sync/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/SyncWorker.hpp
@@ -16,7 +16,7 @@
 #include <thread>
 
 #include "ISyncPeer.hpp"
-#include "Cancellation.hpp"
+#include "cancellation.hpp"
 #include "SyncEngine.hpp"
 #include "protocol.hpp"
 

--- a/include/mdbx_containers/sync/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/SyncWorker.hpp
@@ -16,6 +16,7 @@
 #include <thread>
 
 #include "ISyncPeer.hpp"
+#include "Cancellation.hpp"
 #include "SyncEngine.hpp"
 #include "protocol.hpp"
 
@@ -81,9 +82,10 @@ namespace sync {
     /// waiting in \c ISyncPeer::pull(), idle sleep, or backoff sleep. Pulled
     /// batches are applied through \c SyncEngine::handle_push(), which opens
     /// and commits a short local write transaction for each pulled page.
-    /// Stop requests call \c ISyncPeer::request_cancel() at most once for each
-    /// observed in-flight peer call. Cancellation is best-effort: \c stop(),
-    /// \c join(), and the destructor may still wait until the peer returns.
+    /// Stop requests cancel the active request token and call
+    /// \c ISyncPeer::request_cancel() at most once for each observed in-flight
+    /// peer call. Cancellation is best-effort: \c stop(), \c join(), and the
+    /// destructor may still wait until the peer returns.
     class SyncWorker {
     public:
         /// \brief Constructs a worker over a local engine and remote peer.
@@ -99,7 +101,8 @@ namespace sync {
               m_state(SyncWorkerState::Stopped),
               m_stop_requested(false),
               m_peer_call_active(false),
-              m_peer_cancel_requested(false) {
+              m_peer_cancel_requested(false),
+              m_peer_cancel_source() {
             validate_options(m_options);
         }
 
@@ -149,8 +152,9 @@ namespace sync {
         }
 
         /// \brief Requests background worker shutdown.
-        /// \details Calls \c ISyncPeer::request_cancel() outside the worker
-        /// mutex at most once for each observed in-flight peer call.
+        /// \details Cancels the active \c PullRequest token and calls
+        /// \c ISyncPeer::request_cancel() outside the worker mutex at most
+        /// once for each observed in-flight peer call.
         /// Cancellation is best-effort; the worker exits before applying a
         /// page returned after stop was requested.
         void request_stop() {
@@ -159,6 +163,7 @@ namespace sync {
                 std::lock_guard<std::mutex> lock(m_mutex);
                 m_stop_requested = true;
                 if (m_peer_call_active && !m_peer_cancel_requested) {
+                    m_peer_cancel_source.request_cancel();
                     m_peer_cancel_requested = true;
                     cancel_peer = true;
                 }
@@ -250,9 +255,9 @@ namespace sync {
     private:
         class PeerCallGuard {
         public:
-            explicit PeerCallGuard(SyncWorker& worker)
+            PeerCallGuard(SyncWorker& worker, CancellationToken& token)
                 : m_worker(worker),
-                  m_active(worker.begin_peer_call()) {
+                  m_active(worker.begin_peer_call(token)) {
             }
 
             ~PeerCallGuard() {
@@ -320,11 +325,13 @@ namespace sync {
                     const SyncCursor before = request.have;
                     PullResponse response;
                     {
-                        PeerCallGuard peer_call(*this);
+                        CancellationToken cancel_token;
+                        PeerCallGuard peer_call(*this, cancel_token);
                         if (!peer_call.active()) {
                             result.has_more = has_more;
                             return result;
                         }
+                        request.cancel_token = cancel_token;
                         response = m_peer.pull(request);
                     }
                     if (!response.ok) {
@@ -381,11 +388,13 @@ namespace sync {
             return result;
         }
 
-        bool begin_peer_call() const {
+        bool begin_peer_call(CancellationToken& token) const {
             bool started = false;
             {
                 std::lock_guard<std::mutex> lock(m_mutex);
                 if (!m_stop_requested) {
+                    m_peer_cancel_source = CancellationSource();
+                    token = m_peer_cancel_source.token();
                     m_state = SyncWorkerState::Pulling;
                     m_peer_call_active = true;
                     m_peer_cancel_requested = false;
@@ -495,6 +504,7 @@ namespace sync {
         mutable bool                m_stop_requested;
         mutable bool                m_peer_call_active;
         mutable bool                m_peer_cancel_requested;
+        mutable CancellationSource  m_peer_cancel_source;
         mutable std::string         m_last_error;
     };
 

--- a/include/mdbx_containers/sync/cancellation.hpp
+++ b/include/mdbx_containers/sync/cancellation.hpp
@@ -2,7 +2,7 @@
 #ifndef MDBX_CONTAINERS_HEADER_SYNC_CANCELLATION_HPP_INCLUDED
 #define MDBX_CONTAINERS_HEADER_SYNC_CANCELLATION_HPP_INCLUDED
 
-/// \file Cancellation.hpp
+/// \file cancellation.hpp
 /// \brief Cooperative cancellation primitives for sync transports.
 
 #include <atomic>
@@ -49,11 +49,12 @@ namespace sync {
     };
 
     /// \brief Owner side of a cooperative cancellation token.
-    /// \details Calling \c request_cancel() is thread-safe and wakes only
-    /// transports that actively observe the paired \c CancellationToken. It
-    /// does not interrupt arbitrary blocking system calls by itself; transport
-    /// adapters should combine it with socket shutdown, deadlines, or their
-    /// native cancellation primitive when needed.
+    /// \details Sources are cheap to copy and copied sources share one
+    /// cancellation state. Calling \c request_cancel() on any copy is
+    /// thread-safe and wakes only transports that actively observe the paired
+    /// \c CancellationToken. It does not interrupt arbitrary blocking system
+    /// calls by itself; transport adapters should combine it with socket
+    /// shutdown, deadlines, or their native cancellation primitive when needed.
     class CancellationSource {
     public:
         CancellationSource()

--- a/include/mdbx_containers/sync/cancellation.hpp
+++ b/include/mdbx_containers/sync/cancellation.hpp
@@ -12,6 +12,9 @@ namespace mdbxc {
 namespace sync {
 
     namespace detail {
+        /// \brief Shared cancellation flag observed by sources and tokens.
+        /// \details Kept behind \c shared_ptr because cancellation handles are
+        /// copyable while \c std::atomic<bool> is not copyable by value.
         struct CancellationState {
             CancellationState() : requested(false) {}
 

--- a/include/mdbx_containers/sync/protocol.hpp
+++ b/include/mdbx_containers/sync/protocol.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "ChangeBatch.hpp"
+#include "Cancellation.hpp"
 #include "common.hpp"
 #include "SyncCursor.hpp"
 
@@ -26,6 +27,10 @@ namespace sync {
         /// \brief When true, the responder should produce a full snapshot
         /// instead of an incremental delta.
         bool         request_full_snapshot = false;
+        /// \brief Cooperative cancellation token for this transport call.
+        /// \details Optional; default-constructed tokens never cancel.
+        /// Transports may poll it while waiting on interruptible operations.
+        CancellationToken cancel_token;
     };
 
     /// \brief Response to a \c PullRequest.
@@ -43,6 +48,9 @@ namespace sync {
         NodeId                   sender{};
         DbId                     db_id{};
         std::vector<ChangeBatch> batches;
+        /// \brief Cooperative cancellation token for this transport call.
+        /// \details Optional; default-constructed tokens never cancel.
+        CancellationToken        cancel_token;
     };
 
     /// \brief Response to a \c PushRequest.

--- a/include/mdbx_containers/sync/protocol.hpp
+++ b/include/mdbx_containers/sync/protocol.hpp
@@ -10,7 +10,7 @@
 #include <vector>
 
 #include "ChangeBatch.hpp"
-#include "Cancellation.hpp"
+#include "cancellation.hpp"
 #include "common.hpp"
 #include "SyncCursor.hpp"
 

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -205,6 +205,71 @@ private:
     int  m_cancel_count;
 };
 
+class TokenBlockingPeer : public mdbxc::sync::ISyncPeer {
+public:
+    explicit TokenBlockingPeer(const mdbxc::sync::PullResponse& response)
+        : m_response(response), m_entered(false), m_saw_token(false),
+          m_saw_token_cancel(false), m_cancel_count(0) {}
+
+    mdbxc::sync::PullResponse pull(
+            const mdbxc::sync::PullRequest& request) override {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        m_entered = true;
+        m_saw_token = request.cancel_token.can_be_cancelled();
+        m_changed.notify_all();
+        while (!request.cancel_token.is_cancellation_requested()) {
+            m_changed.wait_for(lock, std::chrono::milliseconds(10));
+        }
+        m_saw_token_cancel = true;
+        return m_response;
+    }
+
+    mdbxc::sync::PushResponse push(
+            const mdbxc::sync::PushRequest& request) override {
+        (void)request;
+        return mdbxc::sync::PushResponse();
+    }
+
+    void request_cancel() override {
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            ++m_cancel_count;
+        }
+        m_changed.notify_all();
+    }
+
+    bool wait_until_entered(std::chrono::milliseconds timeout) const {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        return m_changed.wait_for(
+            lock, timeout,
+            [this] { return m_entered; });
+    }
+
+    bool saw_token() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_saw_token;
+    }
+
+    bool saw_token_cancel() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_saw_token_cancel;
+    }
+
+    int cancel_count() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_cancel_count;
+    }
+
+private:
+    mdbxc::sync::PullResponse m_response;
+    mutable std::mutex m_mutex;
+    mutable std::condition_variable m_changed;
+    bool m_entered;
+    bool m_saw_token;
+    bool m_saw_token_cancel;
+    int  m_cancel_count;
+};
+
 class FailingPeer : public mdbxc::sync::ISyncPeer {
 public:
     FailingPeer() : m_cancel_count(0) {}
@@ -608,6 +673,58 @@ void test_worker_stop_cancels_blocking_peer() {
     cleanup(path);
 }
 
+void test_worker_stop_cancels_request_token() {
+    using namespace mdbxc;
+    const std::string path = "test_worker_cancel_token.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    const sync::NodeId replica_node = make_node(0xB2);
+    const sync::NodeId remote_origin = make_node(0xA2);
+    const sync::NodeId db_id = make_node(0xD2);
+
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
+
+    sync::ChangeBatch batch;
+    batch.origin_node_id = remote_origin;
+    batch.seq = 1;
+
+    sync::PullResponse response;
+    response.batches.push_back(batch);
+
+    TokenBlockingPeer peer(response);
+    sync::SyncWorkerOptions options;
+    options.idle_interval = std::chrono::milliseconds(10000);
+    sync::SyncWorker worker(engine, peer, options);
+
+    worker.start();
+    if (!peer.wait_until_entered(std::chrono::milliseconds(2000))) {
+        throw std::runtime_error("worker did not enter token-blocking pull");
+    }
+    if (!peer.saw_token()) {
+        throw std::runtime_error("worker did not pass a cancellable token");
+    }
+    worker.request_stop();
+    worker.join();
+
+    if (!peer.saw_token_cancel()) {
+        throw std::runtime_error("worker did not cancel request token");
+    }
+    if (peer.cancel_count() != 1) {
+        throw std::runtime_error("worker did not request peer cancellation");
+    }
+    if (worker.state() != sync::SyncWorkerState::Stopped) {
+        throw std::runtime_error("token-cancelled worker did not stop");
+    }
+    if (engine.applied_cursor().last_seq_for(remote_origin) != 0u) {
+        throw std::runtime_error("worker applied a page returned after token cancel");
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 void test_worker_rejects_self_join() {
     using namespace mdbxc;
     const std::string path = "test_worker_self_join.mdbx";
@@ -652,6 +769,8 @@ int main() {
           &test_worker_repeated_stop_cancels_blocking_peer_once },
         { "test_worker_stop_cancels_blocking_peer",
           &test_worker_stop_cancels_blocking_peer },
+        { "test_worker_stop_cancels_request_token",
+          &test_worker_stop_cancels_request_token },
         { "test_worker_rejects_self_join", &test_worker_rejects_self_join },
     };
 

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -209,7 +209,7 @@ class TokenBlockingPeer : public mdbxc::sync::ISyncPeer {
 public:
     explicit TokenBlockingPeer(const mdbxc::sync::PullResponse& response)
         : m_response(response), m_entered(false), m_saw_token(false),
-          m_saw_token_cancel(false), m_cancel_count(0) {}
+          m_saw_token_cancel(false) {}
 
     mdbxc::sync::PullResponse pull(
             const mdbxc::sync::PullRequest& request) override {
@@ -230,14 +230,6 @@ public:
         return mdbxc::sync::PushResponse();
     }
 
-    void request_cancel() override {
-        {
-            std::lock_guard<std::mutex> lock(m_mutex);
-            ++m_cancel_count;
-        }
-        m_changed.notify_all();
-    }
-
     bool wait_until_entered(std::chrono::milliseconds timeout) const {
         std::unique_lock<std::mutex> lock(m_mutex);
         return m_changed.wait_for(
@@ -255,11 +247,6 @@ public:
         return m_saw_token_cancel;
     }
 
-    int cancel_count() const {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        return m_cancel_count;
-    }
-
 private:
     mdbxc::sync::PullResponse m_response;
     mutable std::mutex m_mutex;
@@ -267,7 +254,6 @@ private:
     bool m_entered;
     bool m_saw_token;
     bool m_saw_token_cancel;
-    int  m_cancel_count;
 };
 
 class FailingPeer : public mdbxc::sync::ISyncPeer {
@@ -710,9 +696,6 @@ void test_worker_stop_cancels_request_token() {
 
     if (!peer.saw_token_cancel()) {
         throw std::runtime_error("worker did not cancel request token");
-    }
-    if (peer.cancel_count() != 1) {
-        throw std::runtime_error("worker did not request peer cancellation");
     }
     if (worker.state() != sync::SyncWorkerState::Stopped) {
         throw std::runtime_error("token-cancelled worker did not stop");


### PR DESCRIPTION
## Summary
- add `CancellationToken` / `CancellationSource` primitives for cooperative sync transport cancellation
- attach optional cancellation tokens to `PullRequest` and `PushRequest`
- make `SyncWorker` create a fresh pull token per peer call and cancel it on stop before invoking the existing `ISyncPeer::request_cancel()` hook
- add worker coverage for a peer that exits `pull()` only after observing the request token cancellation
- update sync API/design docs for the token + best-effort peer hook contract

## Verification
- `cmake -S . -B tmp/build-cancel-cpp17 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=OFF -DMDBXC_BUILD_BENCHMARKS=OFF -DCMAKE_CXX_STANDARD=17 -DCMAKE_BUILD_TYPE=Release`
- `cmake --build tmp/build-cancel-cpp17 --target test_sync_worker -- -j`
- `ctest --test-dir tmp/build-cancel-cpp17 -R test_sync_worker --output-on-failure`
- `cmake -S . -B tmp/build-cancel-cpp11 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=OFF -DMDBXC_BUILD_BENCHMARKS=OFF -DCMAKE_CXX_STANDARD=11 -DCMAKE_BUILD_TYPE=Release`
- `cmake --build tmp/build-cancel-cpp11 --target test_sync_worker -- -j`
- `ctest --test-dir tmp/build-cancel-cpp11 -R test_sync_worker --output-on-failure`
- `cmake --build tmp/build-cancel-cpp17 -- -j`
- `git diff --check`
