### PR TITLE
fix(sync): capture missing table write paths

### DIFF
--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -205,6 +205,9 @@ Operational rules:
 - `HashedKeyValueStore`, `KeyMultiValueTable`, and `AnyValueTable` are
   not replicated in v0.1; their wire format is not defined. Do not add
   `record_op()` paths for them without first extending `DESIGN.md`.
+- `VectorStore` persistence is replicated indirectly through its
+  `SequenceTable` and `KeyValueTable` members; it does not own a separate
+  MDBX write path.
 
 ## Header Include Discipline
 

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -198,11 +198,10 @@ Operational rules:
 - The four stores each have an `ensure_open()` guard on every public
   method. Calling a method before `open()` throws `std::logic_error` rather
   than silently writing to DBI 0. Do not weaken this guard.
-- `ConflictPolicy::Reject` is the v0.1 default. `LastWriterWins` is
-  opt-in and must be deterministic. Prefer `revision_key` when present; if
-  no `revision_key` exists, the exact fallback must be defined in
-  `SyncEngine` and documented before use. `time_unix_ns` is metadata, not
-  a reliable conflict authority. `Custom` is deferred to v0.2.
+- `ConflictPolicy::Reject` is the v0.1 default. `LastWriterWins` is declared
+  for future logical-key conflict resolution, but the current raw batch apply
+  path does not use it in a non-test path. `time_unix_ns` is metadata, not a
+  reliable conflict authority. `Custom` is deferred to v0.2.
 - `HashedKeyValueStore`, `KeyMultiValueTable`, and `AnyValueTable` are
   not replicated in v0.1; their wire format is not defined. Do not add
   `record_op()` paths for them without first extending `DESIGN.md`.

--- a/include/mdbx_containers/KeyMultiValueTable.hpp
+++ b/include/mdbx_containers/KeyMultiValueTable.hpp
@@ -1317,10 +1317,10 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
@@ -1348,10 +1348,10 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
@@ -1377,12 +1377,12 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) {
-                return true;
-            }
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) {
+                return true;
+            }
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
@@ -1592,10 +1592,10 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             MDBX_val db_key = db_to_key;
             MDBX_val db_val;
@@ -1634,10 +1634,10 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             MDBX_val db_key = db_to_key;
             MDBX_val db_val;
@@ -1681,10 +1681,10 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return false;
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return false;
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
@@ -1699,10 +1699,10 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return 0;
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return 0;
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
@@ -1728,11 +1728,11 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return 0;
 
             std::size_t removed = 0;
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return 0;
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;

--- a/include/mdbx_containers/KeyTable.hpp
+++ b/include/mdbx_containers/KeyTable.hpp
@@ -849,10 +849,10 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
@@ -880,12 +880,12 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) {
-                return true;
-            }
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) {
+                return true;
+            }
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
@@ -1064,10 +1064,10 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             MDBX_val db_key = db_to_key;
             MDBX_val db_val;
@@ -1103,10 +1103,10 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             MDBX_val db_key = db_to_key;
             MDBX_val db_val;
@@ -1147,10 +1147,10 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return false;
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return false;
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
@@ -1165,10 +1165,10 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return 0;
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return 0;
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
@@ -1194,11 +1194,11 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return 0;
 
             std::size_t removed = 0;
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return 0;
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
@@ -1209,7 +1209,13 @@ namespace mdbxc {
                     stopped_by_upper_bound = true;
                     break;
                 }
+#               if MDBXC_SYNC_ENABLED
+                const std::vector<std::uint8_t> kbytes = capture_bytes(db_key);
+#               endif
                 check_mdbx(mdbx_cursor_del(cursor.get(), MDBX_CURRENT), "Failed to erase key in range");
+#               if MDBXC_SYNC_ENABLED
+                record_op(txn, sync::ChangeOpType::Delete, kbytes, {});
+#               endif
                 ++removed;
                 rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
             }

--- a/include/mdbx_containers/KeyTable.hpp
+++ b/include/mdbx_containers/KeyTable.hpp
@@ -1242,10 +1242,8 @@ namespace mdbxc {
             int rc = mdbx_put(txn, m_dbi, &db_key, &db_val, MDBX_NOOVERWRITE);
             if (rc == MDBX_SUCCESS) {
 #               if MDBXC_SYNC_ENABLED
-                const std::vector<std::uint8_t> kbytes(
-                    static_cast<std::uint8_t*>(db_key.iov_base),
-                    static_cast<std::uint8_t*>(db_key.iov_base) + db_key.iov_len);
-                record_op(txn, sync::ChangeOpType::Put, kbytes, {});
+                record_op(txn, sync::ChangeOpType::Put,
+                          capture_bytes(db_key), {});
 #               endif
                 return true;
             }
@@ -1277,10 +1275,8 @@ namespace mdbxc {
             int rc = mdbx_del(txn, m_dbi, &db_key, nullptr);
             if (rc == MDBX_SUCCESS) {
 #               if MDBXC_SYNC_ENABLED
-                const std::vector<std::uint8_t> kbytes(
-                    static_cast<std::uint8_t*>(db_key.iov_base),
-                    static_cast<std::uint8_t*>(db_key.iov_base) + db_key.iov_len);
-                record_op(txn, sync::ChangeOpType::Delete, kbytes, {});
+                record_op(txn, sync::ChangeOpType::Delete,
+                          capture_bytes(db_key), {});
 #               endif
                 return true;
             }

--- a/include/mdbx_containers/KeyValueTable.hpp
+++ b/include/mdbx_containers/KeyValueTable.hpp
@@ -1468,10 +1468,10 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
@@ -1499,10 +1499,10 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
@@ -1534,12 +1534,12 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) {
-                return true;
-            }
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) {
+                return true;
+            }
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
@@ -1759,10 +1759,10 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             MDBX_val db_key = db_to_key;
             MDBX_val db_val;
@@ -1796,10 +1796,10 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return;
 
             MDBX_val db_key = db_to_key;
             MDBX_val db_val;
@@ -1838,10 +1838,10 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return false;
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return false;
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
@@ -1856,10 +1856,10 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return 0;
 
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return 0;
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
@@ -1885,11 +1885,11 @@ namespace mdbxc {
             SerializeScratch sc_to_key;
             MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
             MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
-            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return 0;
 
             std::size_t removed = 0;
             CursorGuard cursor;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) return 0;
 
             MDBX_val db_key = db_from_key;
             MDBX_val db_val;
@@ -1900,7 +1900,13 @@ namespace mdbxc {
                     stopped_by_upper_bound = true;
                     break;
                 }
+#               if MDBXC_SYNC_ENABLED
+                const std::vector<std::uint8_t> kbytes = capture_bytes(db_key);
+#               endif
                 check_mdbx(mdbx_cursor_del(cursor.get(), MDBX_CURRENT), "Failed to erase pair in range");
+#               if MDBXC_SYNC_ENABLED
+                record_op(txn, sync::ChangeOpType::Delete, kbytes, {});
+#               endif
                 ++removed;
                 rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
             }
@@ -1963,6 +1969,10 @@ namespace mdbxc {
                     mdbx_put(txn_handle, m_dbi, &db_key, &db_val, MDBX_UPSERT),
                     "Failed to write record"
                 );
+#               if MDBXC_SYNC_ENABLED
+                record_op(txn_handle, sync::ChangeOpType::Put,
+                          capture_bytes(db_key), capture_bytes(db_val));
+#               endif
             }
         }
         
@@ -1982,6 +1992,10 @@ namespace mdbxc {
                     mdbx_put(txn_handle, m_dbi, &db_key, &db_val, MDBX_UPSERT),
                     "Failed to write record"
                 );
+#               if MDBXC_SYNC_ENABLED
+                record_op(txn_handle, sync::ChangeOpType::Put,
+                          capture_bytes(db_key), capture_bytes(db_val));
+#               endif
             }
 #           else
             for (typename std::vector<std::pair<KeyT, ValueT> >::const_iterator it = container.begin();
@@ -1994,6 +2008,10 @@ namespace mdbxc {
                     mdbx_put(txn_handle, m_dbi, &db_key, &db_val, MDBX_UPSERT),
                     "Failed to write record"
                 );
+#               if MDBXC_SYNC_ENABLED
+                record_op(txn_handle, sync::ChangeOpType::Put,
+                          capture_bytes(db_key), capture_bytes(db_val));
+#               endif
             }
 #           endif
         }
@@ -2020,6 +2038,10 @@ namespace mdbxc {
                     mdbx_put(txn_handle, m_dbi, &db_key, &db_val, MDBX_UPSERT),
                     "Failed to write record"
                 );
+#               if MDBXC_SYNC_ENABLED
+                record_op(txn_handle, sync::ChangeOpType::Put,
+                          capture_bytes(db_key), capture_bytes(db_val));
+#               endif
             }
 
             // 2. Iterate over existing keys in the DB and remove the extras
@@ -2031,7 +2053,13 @@ namespace mdbxc {
             while ((rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
                 KeyT key = deserialize_key<KeyT>(db_key);
                 if (new_keys.find(key) == new_keys.end()) {
+#                   if MDBXC_SYNC_ENABLED
+                    const std::vector<std::uint8_t> kbytes = capture_bytes(db_key);
+#                   endif
                     check_mdbx(mdbx_cursor_del(cursor.get(), MDBX_CURRENT), "Failed to delete record using cursor");
+#                   if MDBXC_SYNC_ENABLED
+                    record_op(txn_handle, sync::ChangeOpType::Delete, kbytes, {});
+#                   endif
                 }
             }
             if (rc != MDBX_NOTFOUND) {
@@ -2062,6 +2090,10 @@ namespace mdbxc {
                     mdbx_put(txn_handle, m_dbi, &db_key, &db_val, MDBX_UPSERT),
                     "Failed to write record"
                 );
+#               if MDBXC_SYNC_ENABLED
+                record_op(txn_handle, sync::ChangeOpType::Put,
+                          capture_bytes(db_key), capture_bytes(db_val));
+#               endif
             }
 
             // 2. Delete stale keys from DB
@@ -2073,7 +2105,13 @@ namespace mdbxc {
             while ((rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
                 KeyT key = deserialize_key<KeyT>(db_key);
                 if (new_keys.find(key) == new_keys.end()) {
+#                   if MDBXC_SYNC_ENABLED
+                    const std::vector<std::uint8_t> kbytes = capture_bytes(db_key);
+#                   endif
                     check_mdbx(mdbx_cursor_del(cursor.get(), MDBX_CURRENT), "Failed to delete record using cursor");
+#                   if MDBXC_SYNC_ENABLED
+                    record_op(txn_handle, sync::ChangeOpType::Delete, kbytes, {});
+#                   endif
                 }
             }
             if (rc != MDBX_NOTFOUND) {
@@ -2096,13 +2134,8 @@ namespace mdbxc {
 
             if (rc == MDBX_SUCCESS) {
 #               if MDBXC_SYNC_ENABLED
-                const std::vector<std::uint8_t> kbytes(
-                    static_cast<std::uint8_t*>(db_key.iov_base),
-                    static_cast<std::uint8_t*>(db_key.iov_base) + db_key.iov_len);
-                const std::vector<std::uint8_t> vbytes(
-                    static_cast<std::uint8_t*>(db_val.iov_base),
-                    static_cast<std::uint8_t*>(db_val.iov_base) + db_val.iov_len);
-                record_op(txn_handle, sync::ChangeOpType::Put, kbytes, vbytes);
+                record_op(txn_handle, sync::ChangeOpType::Put,
+                          capture_bytes(db_key), capture_bytes(db_val));
 #               endif
                 return true;
             }
@@ -2128,13 +2161,8 @@ namespace mdbxc {
                 "Failed to insert or assign key-value pair"
             );
 #           if MDBXC_SYNC_ENABLED
-            const std::vector<std::uint8_t> kbytes(
-                static_cast<std::uint8_t*>(db_key.iov_base),
-                static_cast<std::uint8_t*>(db_key.iov_base) + db_key.iov_len);
-            const std::vector<std::uint8_t> vbytes(
-                static_cast<std::uint8_t*>(db_val.iov_base),
-                static_cast<std::uint8_t*>(db_val.iov_base) + db_val.iov_len);
-            record_op(txn_handle, sync::ChangeOpType::Put, kbytes, vbytes);
+            record_op(txn_handle, sync::ChangeOpType::Put,
+                      capture_bytes(db_key), capture_bytes(db_val));
 #           endif
         }
 
@@ -2183,10 +2211,8 @@ namespace mdbxc {
             const int rc = mdbx_del(txn_handle, m_dbi, &db_key, nullptr);
             if (rc == MDBX_SUCCESS) {
 #               if MDBXC_SYNC_ENABLED
-                const std::vector<std::uint8_t> kbytes(
-                    static_cast<std::uint8_t*>(db_key.iov_base),
-                    static_cast<std::uint8_t*>(db_key.iov_base) + db_key.iov_len);
-                record_op(txn_handle, sync::ChangeOpType::Delete, kbytes, {});
+                record_op(txn_handle, sync::ChangeOpType::Delete,
+                          capture_bytes(db_key), {});
 #               endif
                 return true;
             }

--- a/include/mdbx_containers/SequenceTable.hpp
+++ b/include/mdbx_containers/SequenceTable.hpp
@@ -575,6 +575,15 @@ namespace mdbxc {
             MDBX_val db_val = serialize_value(value, sc_value);
             check_mdbx(mdbx_put(txn, m_dbi, &db_key, &db_val, MDBX_UPSERT),
                        "Failed to set value");
+#           if MDBXC_SYNC_ENABLED
+            const std::vector<std::uint8_t> kbytes(
+                static_cast<std::uint8_t*>(db_key.iov_base),
+                static_cast<std::uint8_t*>(db_key.iov_base) + db_key.iov_len);
+            const std::vector<std::uint8_t> vbytes(
+                static_cast<std::uint8_t*>(db_val.iov_base),
+                static_cast<std::uint8_t*>(db_val.iov_base) + db_val.iov_len);
+            record_op(txn, sync::ChangeOpType::Put, kbytes, vbytes);
+#           endif
         }
 
         bool db_get(uint64_t id, ValueT& out, MDBX_txn* txn) const {

--- a/include/mdbx_containers/SequenceTable.hpp
+++ b/include/mdbx_containers/SequenceTable.hpp
@@ -556,13 +556,8 @@ namespace mdbxc {
             check_mdbx(rc, "Failed to append value");
             {
 #               if MDBXC_SYNC_ENABLED
-                const std::vector<std::uint8_t> kbytes(
-                    static_cast<std::uint8_t*>(db_key.iov_base),
-                    static_cast<std::uint8_t*>(db_key.iov_base) + db_key.iov_len);
-                const std::vector<std::uint8_t> vbytes(
-                    static_cast<std::uint8_t*>(db_val.iov_base),
-                    static_cast<std::uint8_t*>(db_val.iov_base) + db_val.iov_len);
-                record_op(txn, sync::ChangeOpType::Put, kbytes, vbytes);
+                record_op(txn, sync::ChangeOpType::Put,
+                          capture_bytes(db_key), capture_bytes(db_val));
 #               endif
             }
             return next_id;
@@ -576,13 +571,8 @@ namespace mdbxc {
             check_mdbx(mdbx_put(txn, m_dbi, &db_key, &db_val, MDBX_UPSERT),
                        "Failed to set value");
 #           if MDBXC_SYNC_ENABLED
-            const std::vector<std::uint8_t> kbytes(
-                static_cast<std::uint8_t*>(db_key.iov_base),
-                static_cast<std::uint8_t*>(db_key.iov_base) + db_key.iov_len);
-            const std::vector<std::uint8_t> vbytes(
-                static_cast<std::uint8_t*>(db_val.iov_base),
-                static_cast<std::uint8_t*>(db_val.iov_base) + db_val.iov_len);
-            record_op(txn, sync::ChangeOpType::Put, kbytes, vbytes);
+            record_op(txn, sync::ChangeOpType::Put,
+                      capture_bytes(db_key), capture_bytes(db_val));
 #           endif
         }
 
@@ -614,10 +604,8 @@ namespace mdbxc {
             int rc = mdbx_del(txn, m_dbi, &db_key, nullptr);
             if (rc == MDBX_SUCCESS) {
 #               if MDBXC_SYNC_ENABLED
-                const std::vector<std::uint8_t> kbytes(
-                    static_cast<std::uint8_t*>(db_key.iov_base),
-                    static_cast<std::uint8_t*>(db_key.iov_base) + db_key.iov_len);
-                record_op(txn, sync::ChangeOpType::Delete, kbytes, {});
+                record_op(txn, sync::ChangeOpType::Delete,
+                          capture_bytes(db_key), {});
 #               endif
                 return true;
             }

--- a/include/mdbx_containers/ValueTable.hpp
+++ b/include/mdbx_containers/ValueTable.hpp
@@ -361,6 +361,10 @@ namespace mdbxc {
             MDBX_val db_val = serialize_value(value, sc_value);
             check_mdbx(mdbx_put(txn, m_dbi, &db_key, &db_val, MDBX_UPSERT),
                        "Failed to set value");
+#           if MDBXC_SYNC_ENABLED
+            record_op(txn, sync::ChangeOpType::Put,
+                      capture_bytes(db_key), capture_bytes(db_val));
+#           endif
         }
 
         bool db_insert(const ValueT& value, MDBX_txn* txn) {
@@ -371,10 +375,8 @@ namespace mdbxc {
             int rc = mdbx_put(txn, m_dbi, &db_key, &db_val, MDBX_NOOVERWRITE);
             if (rc == MDBX_SUCCESS) {
 #               if MDBXC_SYNC_ENABLED
-                const std::vector<std::uint8_t> vbytes(
-                    static_cast<std::uint8_t*>(db_val.iov_base),
-                    static_cast<std::uint8_t*>(db_val.iov_base) + db_val.iov_len);
-                record_op(txn, sync::ChangeOpType::Put, {}, vbytes);
+                record_op(txn, sync::ChangeOpType::Put,
+                          capture_bytes(db_key), capture_bytes(db_val));
 #               endif
                 return true;
             }
@@ -411,7 +413,8 @@ namespace mdbxc {
             int rc = mdbx_del(txn, m_dbi, &db_key, nullptr);
             if (rc == MDBX_SUCCESS) {
 #               if MDBXC_SYNC_ENABLED
-                record_op(txn, sync::ChangeOpType::Delete, {}, {});
+                record_op(txn, sync::ChangeOpType::Delete,
+                          capture_bytes(db_key), {});
 #               endif
                 return true;
             }

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -175,6 +175,15 @@ namespace mdbxc {
         }
 
 #       if MDBXC_SYNC_ENABLED
+        /// \brief Copies an MDBX value/key buffer before MDBX can invalidate it.
+        static std::vector<std::uint8_t> capture_bytes(const MDBX_val& val) {
+            if (val.iov_len == 0) {
+                return std::vector<std::uint8_t>();
+            }
+            const std::uint8_t* begin = static_cast<const std::uint8_t*>(val.iov_base);
+            return std::vector<std::uint8_t>(begin, begin + val.iov_len);
+        }
+
         /// \brief Forwards a successful write to the attached sync capture sink.
         /// \details Called from derived table \c db_* helpers right after a
         /// successful \c mdbx_put / \c mdbx_del. No-op when no sink is attached

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -14,27 +14,39 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
 ## Already implemented (merged into main)
 
 - Public types in `include/mdbx_containers/sync/`:
-  `Common`, `ChangeBatch`, `ChangeOp`, `Cancellation`, `CodecFlags`,
-  `CodecBounds`, `Protocol`, `SyncCursor`, `ConflictPolicy`, `ISyncPeer`,
-  `IdentityProvider`, `ChangeBatchCodec`, `SyncWorker`.
+  `Common`, `ChangeAccumulator`, `ChangeBatch`, `ChangeOp`, `Cancellation`,
+  `CodecBounds`, `CodecFlags`, `ConflictPolicy`, `DirectSyncPeer`,
+  `IdentityProvider`, `ISyncCaptureSink`, `ISyncPeer`, `Protocol`,
+  `SyncCursor`, `SyncEngine`, `SyncWorker`.
 - Five system stores under `include/mdbx_containers/sync/stores/`:
   `MetaStore`, `ChangeLogStore`, `OriginIndexStore`, `AppliedStore`,
   `IdentityIndexStore`.
 - `ChangeBatchCodec` strict versioned wire format (magic, codec version,
   batch version, batch flags, then payload); rejects unknown mandatory
   flags and version mismatches at both encode and decode.
+- Change capture hooks: `Connection::attach_sync_capture()`,
+  `BaseTable::record_op()`, and the transaction pre-commit hook route table
+  writes into `ThreadLocalChangeAccumulator`, which appends one local
+  `ChangeBatch` per committing write transaction.
+- `SyncEngine` pull / push / apply protocol logic, `DirectSyncPeer`
+  in-process transport, detailed apply conflict diagnostics, multi-origin
+  pagination, origin-index fallback for legacy changelogs, and
+  `make_push_request()` for example / transport code.
+- Replicated table operation capture for `KeyValueTable`, `KeyTable`,
+  `ValueTable`, and `SequenceTable` normal write paths. `SequenceTable`
+  `append()` remains a local single-writer operation with existing external
+  synchronisation requirements.
+- `ConflictPolicy::Reject` is the default. `ConflictPolicy::LastWriterWins`
+  is declared for future logical-key conflict resolution but is not used by
+  the current raw batch apply path.
+- `SyncWorker` background pull/apply lifecycle, cooperative cancellation
+  tokens, best-effort peer cancellation hook, and focused worker tests.
+- Manual hub-style benchmark (`sync_tick_hub_benchmark`) plus opt-in and
+  scheduled stress coverage for multi-origin sync paths.
 
 ## Planned before v0.1 release (NOT YET implemented)
 
-- Change capture: pre-commit hook in `Transaction::commit` writes a
-  `ChangeBatch` to `ChangeLogStore` inside the same write transaction.
-- `SyncEngine` (pull/push/apply protocol logic, gap handling).
-- `DirectSyncPeer` for in-process tests of `SyncEngine`.
 - Full export/import via `seq=0, BATCH_HAS_MORE` chunks for empty replicas.
-- Replicated table operation coverage: `KeyValueTable`, `KeyTable`,
-  `ValueTable`, `SequenceTable` (single-writer for `append`;
-  `insert_or_assign`/`set`/`erase`/`clear` normal).
-- `ConflictPolicy::Reject` is the default; `LastWriterWins` is opt-in.
 
 ## What v0.1 does NOT cover (deferred to v0.2)
 
@@ -45,15 +57,16 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
 - `IdentityProvider` integration in `BaseTable` — declared in v0.1, no
   write path until HashedKeyValueStore.
 - Automatic remap of physical `storage_key` from logical `identity_key`.
-- HLC for `LastWriterWins` — `time_unix_ns` is metadata only, not a reliable
-  conflict authority. The exact tie-break rule (revision_key priority,
-  fallback when no revision_key is supplied) must be defined in `SyncEngine`
-  and documented before `LastWriterWins` is used in a non-test path.
+- HLC or other production authority for logical-key `LastWriterWins`.
+  `time_unix_ns` is metadata only, not a reliable conflict authority. The
+  current apply path does not maintain enough identity-index conflict state to
+  use `LastWriterWins` in a non-test path.
 - `Custom` conflict resolver — schema-level callback; deferred until the
   first real consumer needs it.
 - HTTP and WebSocket transports (`Simple-Web-Server`,
-  `Simple-WebSocket-Server`) — guarded build flags; first adapter lands
-  after `DirectSyncPeer` integration test.
+  `Simple-WebSocket-Server`) — guarded build flags; first adapter lands after
+  the transport boundary and cancellation bridge are designed against a real
+  adapter.
 - `zstd` compression — reserved flag, encoder throws, decoder rejects.
 
 ## Endianness policy (do not change)
@@ -127,8 +140,9 @@ normal background-sync loop or per-pull hot path.
 | Value | u64 LE — last contiguous applied `seq` |
 
 `SyncEngine` invariant: writes to this store are always contiguous. If
-`incoming.seq > last + 1`, the receiver keeps the incoming batch pending
-until the gap closes. If `incoming.seq <= last`, the batch is a redundant
+`incoming.seq > last + 1`, the current v0.1 apply path reports a
+`SequenceGap` conflict and stores no pending queue; the caller must retry after
+missing batches arrive. If `incoming.seq <= last`, the batch is a redundant
 replay and is skipped.
 
 ### `_mdbxc_identity_index` (IdentityIndexStore) — declared in v0.1, write path deferred
@@ -162,7 +176,7 @@ contract:
 - Decoder rejects trailing bytes when called with `bytes_read == nullptr`
   or via `decode_exact`.
 
-## Sync flow (planned v0.1 behavior, not yet implemented)
+## Sync flow (current v0.1 core behavior)
 
 Default round shape, single-writer friendly and the base case for
 multi-master:
@@ -170,30 +184,34 @@ multi-master:
 ```
 origin A writes
     -> Transaction::commit pre-commit hook
-        -> ChangeAccumulator.flush (writes ChangeLogStore + OriginIndexStore
-           + IdentityIndexStore)
+        -> ChangeAccumulator.flush (writes ChangeLogStore; OriginIndexStore
+           is updated by ChangeLogStore::append)
             -> mdbx_txn_commit() — changes land atomically
 
 receiver B
     -> pull / push via ISyncPeer
         -> SyncEngine.handle_push / handle_pull
             -> begin write txn
-                if already_applied(origin, seq): commit no-op
+                if already_applied(origin, seq): skip
+                if sequence gap: conflict / rollback
                 for op in batch.ops: apply raw dbi_op
                 mark_applied(origin, seq)
             -> commit
 ```
 
-Multi-master initial sync of an empty replica:
+Cold replica sync currently uses changelog replay:
 
 ```
 B: empty cursor
     -> pull request, have = empty
-A: detects request_full_snapshot
-    -> streams ChangeBatches with seq=0 and BATCH_HAS_MORE until done
-B: applies each batch as above
+A: handle_pull treats it as a full changelog snapshot across known origins
+    -> streams persisted ChangeBatches from seq=1 with pagination limits
+B: applies each page as above
     -> onward sync is incremental pull-from-have
 ```
+
+The reserved `seq=0, BATCH_HAS_MORE` full export/import format remains planned
+for v0.1 and is not the current cold-replica implementation.
 
 ## Background worker lifecycle
 
@@ -289,10 +307,6 @@ When HLC or similar lands in v0.2, it goes in as opaque bytes inside
 
 - `meta_schema_version()` currently returns 1; bump rule + migration
   procedure not defined.
-- `SyncEngine` API surface (`SyncEngine(Connection&)` vs factory,
-  pull/push ordering, per-batch txn commit semantics).
-- SyncEngine ownership model relative to `Connection` — currently
-  `Connection::attach_sync_engine(SyncEngine*)` is the design direction,
-  non-owning, lifetime explicitly documented.
+- Public sync API stability after the first external transport adapter.
 - `PeerRegistry` for multi-peer fan-out — single peer per sync invocation
   in v0.1.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -33,9 +33,12 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
   pagination, origin-index fallback for legacy changelogs, and
   `make_push_request()` for example / transport code.
 - Replicated table operation capture for `KeyValueTable`, `KeyTable`,
-  `ValueTable`, and `SequenceTable` normal write paths. `SequenceTable`
-  `append()` remains a local single-writer operation with existing external
-  synchronisation requirements.
+  `ValueTable`, and `SequenceTable` normal write paths, including bulk
+  upserts, reconcile deletes, singleton value writes, and range erases.
+  `SequenceTable` `append()` remains a local single-writer operation with
+  existing external synchronisation requirements. `VectorStore` is covered
+  indirectly because its persistent write path uses `SequenceTable` and
+  `KeyValueTable`.
 - `ConflictPolicy::Reject` is the default. `ConflictPolicy::LastWriterWins`
   is declared for future logical-key conflict resolution but is not used by
   the current raw batch apply path.

--- a/include/mdbx_containers/sync/sync_module.hpp
+++ b/include/mdbx_containers/sync/sync_module.hpp
@@ -8,7 +8,7 @@
 #ifndef MDBXC_SYNC_ENABLED
 /// \brief Define to 1 to compile in the sync subsystem (changelog, peers,
 /// replication). When undefined, sync headers expand to no-op stubs and
-/// \c Connection::attach_sync_engine is not available.
+/// sync capture / replication APIs are not available.
 #define MDBXC_SYNC_ENABLED 0
 #endif
 

--- a/tests/test_sync_capture.cpp
+++ b/tests/test_sync_capture.cpp
@@ -105,6 +105,46 @@ void test_capture_writes_via_sink() {
     }
 }
 
+void test_sequence_set_writes_via_sink() {
+    using namespace mdbxc;
+    const std::string p = "test_capture_sequence_set.mdbx";
+    cleanup(p);
+
+    Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = Connection::create(cfg);
+
+    StubSink sink;
+    conn->attach_sync_capture(&sink);
+
+    SequenceTable<std::string> events(conn, "events");
+    events.insert_or_assign(7, "seven");
+
+    conn->detach_sync_capture();
+    conn->disconnect();
+    cleanup(p);
+
+    if (sink.m_recorded.size() != 1u) {
+        throw std::runtime_error("expected one sequence set op, got " +
+                                 std::to_string(sink.m_recorded.size()));
+    }
+    const sync::ChangeOp& op = sink.m_recorded[0];
+    if (op.op_type != sync::ChangeOpType::Put) {
+        throw std::runtime_error("sequence set must capture Put");
+    }
+    if (op.dbi_name != "events") {
+        throw std::runtime_error("sequence set dbi_name not propagated");
+    }
+    if (op.storage_key.empty() || op.value.empty()) {
+        throw std::runtime_error("sequence set key/value not captured");
+    }
+    if ((op.dbi_flags & MDBX_INTEGERKEY) == 0) {
+        throw std::runtime_error("sequence set dbi_flags missing MDBX_INTEGERKEY");
+    }
+}
+
 void test_capture_flush_on_commit() {
     using namespace mdbxc;
     const std::string p = "test_capture_flush.mdbx";
@@ -434,53 +474,64 @@ int main() {
         return 2;
     }
     try {
+        test_sequence_set_writes_via_sink();
+        std::printf("PASS test_sequence_set_writes_via_sink\n");
+    } catch (const std::exception& e) {
+        std::printf("FAIL test_sequence_set_writes_via_sink: %s\n", e.what());
+        return 3;
+    } catch (...) {
+        std::printf("FAIL test_sequence_set_writes_via_sink: non-std exception\n");
+        return 3;
+    }
+    try {
         test_capture_flush_on_commit();
         std::printf("PASS test_capture_flush_on_commit\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_capture_flush_on_commit: %s\n", e.what());
-        return 3;
+        return 4;
     } catch (...) {
         std::printf("FAIL test_capture_flush_on_commit: non-std exception\n");
-        return 3;
+        return 4;
     }
     try {
         test_changelog_capture_roundtrip();
         std::printf("PASS test_changelog_capture_roundtrip\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_changelog_capture_roundtrip: %s\n", e.what());
-        return 4;
+        return 5;
     } catch (...) {
         std::printf("FAIL test_changelog_capture_roundtrip: non-std exception\n");
-        return 4;
+        return 5;
     }
     try {
         test_zero_node_id_rejected();
         std::printf("PASS test_zero_node_id_rejected\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_zero_node_id_rejected: %s\n", e.what());
-        return 5;
+        return 6;
     } catch (...) {
         std::printf("FAIL test_zero_node_id_rejected: non-std exception\n");
-        return 5;
+        return 6;
     }
     try {
         test_aborted_transaction_does_not_flush();
         std::printf("PASS test_aborted_transaction_does_not_flush\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_aborted_transaction_does_not_flush: %s\n", e.what());
-        return 6;
+        return 7;
     } catch (...) {
         std::printf("FAIL test_aborted_transaction_does_not_flush: non-std exception\n");
-        return 6;
-    }    try {
+        return 7;
+    }
+    try {
         test_explicit_rollback_does_not_flush();
         std::printf("PASS test_explicit_rollback_does_not_flush\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_explicit_rollback_does_not_flush: %s\n", e.what());
-        return 7;
+        return 8;
     } catch (...) {
         std::printf("FAIL test_explicit_rollback_does_not_flush: non-std exception\n");
-        return 7;
+        return 8;
     }
 
     return 0;

--- a/tests/test_sync_capture.cpp
+++ b/tests/test_sync_capture.cpp
@@ -135,27 +135,36 @@ void test_sequence_set_writes_via_sink() {
 
     SequenceTable<std::string> events(conn, "events");
     events.insert_or_assign(7, "seven");
+    events.insert_or_assign(8, "");
 
     conn->detach_sync_capture();
     conn->disconnect();
     cleanup(p);
 
-    if (sink.m_recorded.size() != 1u) {
-        throw std::runtime_error("expected one sequence set op, got " +
+    if (sink.m_recorded.size() != 2u) {
+        throw std::runtime_error("expected two sequence set ops, got " +
                                  std::to_string(sink.m_recorded.size()));
     }
-    const sync::ChangeOp& op = sink.m_recorded[0];
-    if (op.op_type != sync::ChangeOpType::Put) {
-        throw std::runtime_error("sequence set must capture Put");
+    for (std::size_t i = 0; i < sink.m_recorded.size(); ++i) {
+        const sync::ChangeOp& op = sink.m_recorded[i];
+        if (op.op_type != sync::ChangeOpType::Put) {
+            throw std::runtime_error("sequence set must capture Put");
+        }
+        if (op.dbi_name != "events") {
+            throw std::runtime_error("sequence set dbi_name not propagated");
+        }
+        if (op.storage_key.empty()) {
+            throw std::runtime_error("sequence set key not captured");
+        }
+        if ((op.dbi_flags & MDBX_INTEGERKEY) == 0) {
+            throw std::runtime_error("sequence set dbi_flags missing MDBX_INTEGERKEY");
+        }
     }
-    if (op.dbi_name != "events") {
-        throw std::runtime_error("sequence set dbi_name not propagated");
+    if (sink.m_recorded[0].value.empty()) {
+        throw std::runtime_error("non-empty sequence set value not captured");
     }
-    if (op.storage_key.empty() || op.value.empty()) {
-        throw std::runtime_error("sequence set key/value not captured");
-    }
-    if ((op.dbi_flags & MDBX_INTEGERKEY) == 0) {
-        throw std::runtime_error("sequence set dbi_flags missing MDBX_INTEGERKEY");
+    if (!sink.m_recorded[1].value.empty()) {
+        throw std::runtime_error("empty sequence set value must remain empty");
     }
 }
 

--- a/tests/test_sync_capture.cpp
+++ b/tests/test_sync_capture.cpp
@@ -6,6 +6,7 @@
 #include <mutex>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -42,7 +43,20 @@ public:
         std::lock_guard<std::mutex> lk(m_mutex);
         m_flushed.emplace_back();
     }
+
+    void clear_recorded() {
+        std::lock_guard<std::mutex> lk(m_mutex);
+        m_recorded.clear();
+        m_flushed.clear();
+    }
 };
+
+mdbxc::Embedding make_embedding(const std::vector<float>& values) {
+    mdbxc::Embedding e;
+    e.dim = static_cast<std::uint32_t>(values.size());
+    e.values = values;
+    return e;
+}
 
 void test_no_sink_no_capture() {
     using namespace mdbxc;
@@ -142,6 +156,241 @@ void test_sequence_set_writes_via_sink() {
     }
     if ((op.dbi_flags & MDBX_INTEGERKEY) == 0) {
         throw std::runtime_error("sequence set dbi_flags missing MDBX_INTEGERKEY");
+    }
+}
+
+void test_value_table_writes_storage_key_via_sink() {
+    using namespace mdbxc;
+    const std::string p = "test_capture_value_table.mdbx";
+    cleanup(p);
+
+    Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = Connection::create(cfg);
+
+    StubSink sink;
+    conn->attach_sync_capture(&sink);
+
+    ValueTable<int> state(conn, "state");
+    if (!state.insert(41)) {
+        throw std::runtime_error("value insert unexpectedly returned false");
+    }
+    state.set(42);
+    if (!state.erase()) {
+        throw std::runtime_error("value erase unexpectedly returned false");
+    }
+
+    conn->detach_sync_capture();
+    conn->disconnect();
+    cleanup(p);
+
+    if (sink.m_recorded.size() != 3u) {
+        throw std::runtime_error("expected three value ops, got " +
+                                 std::to_string(sink.m_recorded.size()));
+    }
+    const sync::ChangeOpType expected[] = {
+        sync::ChangeOpType::Put,
+        sync::ChangeOpType::Put,
+        sync::ChangeOpType::Delete
+    };
+    for (std::size_t i = 0; i < sink.m_recorded.size(); ++i) {
+        const sync::ChangeOp& op = sink.m_recorded[i];
+        if (op.dbi_name != "state") {
+            throw std::runtime_error("value table dbi_name not propagated");
+        }
+        if (op.op_type != expected[i]) {
+            throw std::runtime_error("value table op_type sequence incorrect");
+        }
+        if (op.storage_key.empty()) {
+            throw std::runtime_error("value table storage_key must be physical key bytes");
+        }
+        if ((op.dbi_flags & MDBX_INTEGERKEY) == 0) {
+            throw std::runtime_error("value table dbi_flags missing MDBX_INTEGERKEY");
+        }
+        if (op.op_type == sync::ChangeOpType::Put && op.value.empty()) {
+            throw std::runtime_error("value table Put missing value bytes");
+        }
+    }
+}
+
+void test_key_value_bulk_writes_via_sink() {
+    using namespace mdbxc;
+    const std::string p = "test_capture_kv_bulk.mdbx";
+    cleanup(p);
+
+    Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = Connection::create(cfg);
+
+    StubSink sink;
+    conn->attach_sync_capture(&sink);
+
+    KeyValueTable<int, int> kv(conn, "bulk");
+    std::map<int, int> initial;
+    initial[1] = 10;
+    initial[2] = 20;
+    kv.append(initial);
+
+    std::vector<std::pair<int, int> > extra;
+    extra.push_back(std::make_pair(3, 30));
+    kv.append(extra);
+
+    std::map<int, int> replacement;
+    replacement[2] = 200;
+    replacement[3] = 300;
+    replacement[4] = 400;
+    kv.reconcile(replacement);
+
+    std::vector<std::pair<int, int> > final_state;
+    final_state.push_back(std::make_pair(4, 440));
+    kv.reconcile(final_state);
+
+    conn->detach_sync_capture();
+    conn->disconnect();
+    cleanup(p);
+
+    if (sink.m_recorded.size() != 10u) {
+        throw std::runtime_error("expected ten bulk ops, got " +
+                                 std::to_string(sink.m_recorded.size()));
+    }
+    std::size_t put_count = 0;
+    std::size_t delete_count = 0;
+    for (const sync::ChangeOp& op : sink.m_recorded) {
+        if (op.dbi_name != "bulk") {
+            throw std::runtime_error("bulk dbi_name not propagated");
+        }
+        if (op.storage_key.empty()) {
+            throw std::runtime_error("bulk op missing storage_key");
+        }
+        if (op.op_type == sync::ChangeOpType::Put) {
+            ++put_count;
+            if (op.value.empty()) {
+                throw std::runtime_error("bulk Put missing value bytes");
+            }
+        } else if (op.op_type == sync::ChangeOpType::Delete) {
+            ++delete_count;
+        } else {
+            throw std::runtime_error("bulk op_type unexpected");
+        }
+    }
+    if (put_count != 7u || delete_count != 3u) {
+        throw std::runtime_error("bulk Put/Delete counts incorrect");
+    }
+}
+
+void test_range_erase_writes_via_sink() {
+    using namespace mdbxc;
+    const std::string p = "test_capture_range_erase.mdbx";
+    cleanup(p);
+
+    Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = Connection::create(cfg);
+
+    StubSink sink;
+    conn->attach_sync_capture(&sink);
+
+    KeyTable<int> keys(conn, "keys");
+    keys.insert(1);
+    keys.insert(2);
+    keys.insert(3);
+    keys.insert(4);
+    sink.clear_recorded();
+    if (keys.erase_range(2, 3) != 2u) {
+        throw std::runtime_error("key range erase count incorrect");
+    }
+    if (sink.m_recorded.size() != 2u) {
+        throw std::runtime_error("expected two key range Delete ops");
+    }
+    for (const sync::ChangeOp& op : sink.m_recorded) {
+        if (op.dbi_name != "keys" ||
+            op.op_type != sync::ChangeOpType::Delete ||
+            op.storage_key.empty()) {
+            throw std::runtime_error("key range Delete capture incorrect");
+        }
+    }
+
+    KeyValueTable<int, int> kv(conn, "range_kv");
+    kv.insert_or_assign(1, 10);
+    kv.insert_or_assign(2, 20);
+    kv.insert_or_assign(3, 30);
+    kv.insert_or_assign(4, 40);
+    sink.clear_recorded();
+    if (kv.erase_range(2, 3) != 2u) {
+        throw std::runtime_error("kv range erase count incorrect");
+    }
+    if (sink.m_recorded.size() != 2u) {
+        throw std::runtime_error("expected two kv range Delete ops");
+    }
+    for (const sync::ChangeOp& op : sink.m_recorded) {
+        if (op.dbi_name != "range_kv" ||
+            op.op_type != sync::ChangeOpType::Delete ||
+            op.storage_key.empty()) {
+            throw std::runtime_error("kv range Delete capture incorrect");
+        }
+    }
+
+    conn->detach_sync_capture();
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_vector_store_writes_via_sink() {
+    using namespace mdbxc;
+    const std::string p = "test_capture_vector_store.mdbx";
+    cleanup(p);
+
+    Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    auto conn = Connection::create(cfg);
+
+    StubSink sink;
+    conn->attach_sync_capture(&sink);
+
+    {
+        VectorStore store(conn, "sync_vector");
+        const uint64_t id = store.add(make_embedding({ 1.0f, 0.0f }),
+                                      "document", "{}");
+        if (id != 0u) {
+            throw std::runtime_error("first vector id should be zero");
+        }
+    }
+
+    conn->detach_sync_capture();
+    conn->disconnect();
+    cleanup(p);
+
+    if (sink.m_recorded.size() != 4u) {
+        throw std::runtime_error("expected four vector store ops, got " +
+                                 std::to_string(sink.m_recorded.size()));
+    }
+    const char* expected_dbi[] = {
+        "vectors_sync_vector_ids",
+        "vectors_sync_vector_embeddings",
+        "vectors_sync_vector_texts",
+        "vectors_sync_vector_metadata"
+    };
+    for (std::size_t i = 0; i < sink.m_recorded.size(); ++i) {
+        const sync::ChangeOp& op = sink.m_recorded[i];
+        if (op.dbi_name != expected_dbi[i]) {
+            throw std::runtime_error("vector store dbi order/name incorrect");
+        }
+        if (op.op_type != sync::ChangeOpType::Put ||
+            op.storage_key.empty() ||
+            op.value.empty()) {
+            throw std::runtime_error("vector store Put capture incorrect");
+        }
+        if ((op.dbi_flags & MDBX_INTEGERKEY) == 0) {
+            throw std::runtime_error("vector store dbi_flags missing MDBX_INTEGERKEY");
+        }
     }
 }
 
@@ -484,54 +733,94 @@ int main() {
         return 3;
     }
     try {
+        test_value_table_writes_storage_key_via_sink();
+        std::printf("PASS test_value_table_writes_storage_key_via_sink\n");
+    } catch (const std::exception& e) {
+        std::printf("FAIL test_value_table_writes_storage_key_via_sink: %s\n", e.what());
+        return 4;
+    } catch (...) {
+        std::printf("FAIL test_value_table_writes_storage_key_via_sink: non-std exception\n");
+        return 4;
+    }
+    try {
+        test_key_value_bulk_writes_via_sink();
+        std::printf("PASS test_key_value_bulk_writes_via_sink\n");
+    } catch (const std::exception& e) {
+        std::printf("FAIL test_key_value_bulk_writes_via_sink: %s\n", e.what());
+        return 5;
+    } catch (...) {
+        std::printf("FAIL test_key_value_bulk_writes_via_sink: non-std exception\n");
+        return 5;
+    }
+    try {
+        test_range_erase_writes_via_sink();
+        std::printf("PASS test_range_erase_writes_via_sink\n");
+    } catch (const std::exception& e) {
+        std::printf("FAIL test_range_erase_writes_via_sink: %s\n", e.what());
+        return 6;
+    } catch (...) {
+        std::printf("FAIL test_range_erase_writes_via_sink: non-std exception\n");
+        return 6;
+    }
+    try {
+        test_vector_store_writes_via_sink();
+        std::printf("PASS test_vector_store_writes_via_sink\n");
+    } catch (const std::exception& e) {
+        std::printf("FAIL test_vector_store_writes_via_sink: %s\n", e.what());
+        return 7;
+    } catch (...) {
+        std::printf("FAIL test_vector_store_writes_via_sink: non-std exception\n");
+        return 7;
+    }
+    try {
         test_capture_flush_on_commit();
         std::printf("PASS test_capture_flush_on_commit\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_capture_flush_on_commit: %s\n", e.what());
-        return 4;
+        return 8;
     } catch (...) {
         std::printf("FAIL test_capture_flush_on_commit: non-std exception\n");
-        return 4;
+        return 8;
     }
     try {
         test_changelog_capture_roundtrip();
         std::printf("PASS test_changelog_capture_roundtrip\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_changelog_capture_roundtrip: %s\n", e.what());
-        return 5;
+        return 9;
     } catch (...) {
         std::printf("FAIL test_changelog_capture_roundtrip: non-std exception\n");
-        return 5;
+        return 9;
     }
     try {
         test_zero_node_id_rejected();
         std::printf("PASS test_zero_node_id_rejected\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_zero_node_id_rejected: %s\n", e.what());
-        return 6;
+        return 10;
     } catch (...) {
         std::printf("FAIL test_zero_node_id_rejected: non-std exception\n");
-        return 6;
+        return 10;
     }
     try {
         test_aborted_transaction_does_not_flush();
         std::printf("PASS test_aborted_transaction_does_not_flush\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_aborted_transaction_does_not_flush: %s\n", e.what());
-        return 7;
+        return 11;
     } catch (...) {
         std::printf("FAIL test_aborted_transaction_does_not_flush: non-std exception\n");
-        return 7;
+        return 11;
     }
     try {
         test_explicit_rollback_does_not_flush();
         std::printf("PASS test_explicit_rollback_does_not_flush\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_explicit_rollback_does_not_flush: %s\n", e.what());
-        return 8;
+        return 12;
     } catch (...) {
         std::printf("FAIL test_explicit_rollback_does_not_flush: non-std exception\n");
-        return 8;
+        return 12;
     }
 
     return 0;

--- a/tests/test_sync_replication.cpp
+++ b/tests/test_sync_replication.cpp
@@ -215,6 +215,94 @@ void test_replication_mixed_ops() {
     cleanup(p); cleanup(r);
 }
 
+void test_replication_value_table_singleton_key() {
+    using namespace mdbxc;
+    const std::string p = "test_rep_value_table.mdbx";
+    const std::string r = "test_rep_value_table_replica.mdbx";
+    cleanup(p); cleanup(r);
+
+    auto primary = open(p);
+    auto replica = open(r);
+    sync::SyncEngine pe(primary), re(replica);
+    pe.initialize_local_identity(make_node(0xA0), make_node(0xD0));
+    re.initialize_local_identity(make_node(0xB0), make_node(0xD0));
+
+    sync::ThreadLocalChangeAccumulator sink(primary);
+    sync::DirectSyncPeer peer(&pe);
+
+    primary->attach_sync_capture(&sink);
+    {
+        ValueTable<int> state(primary, "state");
+        state.set(42);
+    }
+    primary->detach_sync_capture();
+
+    {
+        sync::PullRequest req;
+        req.requester = make_node(0xB0);
+        req.db_id = make_node(0xD0);
+        const sync::PullResponse resp = peer.pull(req);
+        if (resp.batches.size() != 1u) {
+            throw std::runtime_error("value table set expected one batch");
+        }
+        auto txn = replica->transaction(TransactionMode::WRITABLE);
+        for (const sync::ChangeBatch& b : resp.batches) {
+            if (re.apply_batch(txn.handle(), b) != sync::ApplyResult::Applied) {
+                throw std::runtime_error("value table set apply failed");
+            }
+        }
+        txn.commit();
+    }
+
+    {
+        ValueTable<int> state(replica, "state");
+        const std::pair<bool, int> found = state.find_compat();
+        if (!found.first || found.second != 42) {
+            throw std::runtime_error("value table set did not replicate");
+        }
+    }
+
+    primary->attach_sync_capture(&sink);
+    {
+        ValueTable<int> state(primary, "state");
+        if (!state.erase()) {
+            throw std::runtime_error("value table erase unexpectedly returned false");
+        }
+    }
+    primary->detach_sync_capture();
+
+    {
+        sync::PullRequest req;
+        req.requester = make_node(0xB0);
+        req.db_id = make_node(0xD0);
+        const sync::SyncCursor cur = re.applied_cursor();
+        for (const auto& kv : cur.last_seq_by_origin) {
+            req.have.last_seq_by_origin[kv.first] = kv.second;
+        }
+        const sync::PullResponse resp = peer.pull(req);
+        if (resp.batches.size() != 1u) {
+            throw std::runtime_error("value table erase expected one batch");
+        }
+        auto txn = replica->transaction(TransactionMode::WRITABLE);
+        for (const sync::ChangeBatch& b : resp.batches) {
+            if (re.apply_batch(txn.handle(), b) != sync::ApplyResult::Applied) {
+                throw std::runtime_error("value table erase apply failed");
+            }
+        }
+        txn.commit();
+    }
+
+    {
+        ValueTable<int> state(replica, "state");
+        if (state.has_value()) {
+            throw std::runtime_error("value table erase did not replicate");
+        }
+    }
+
+    primary->disconnect(); replica->disconnect();
+    cleanup(p); cleanup(r);
+}
+
 void test_replication_incremental_pull() {
     using namespace mdbxc;
     const std::string p = "test_rep_incr.mdbx";
@@ -436,6 +524,7 @@ int main() {
         { "test_replication_pull_three_tables",  &test_replication_pull_three_tables },
         { "test_replication_push_three_tables",  &test_replication_push_three_tables },
         { "test_replication_mixed_ops",          &test_replication_mixed_ops },
+        { "test_replication_value_table_singleton_key", &test_replication_value_table_singleton_key },
         { "test_replication_incremental_pull",   &test_replication_incremental_pull },
         { "test_replication_idempotent_apply",   &test_replication_idempotent_apply },
         { "test_replication_make_push_request", &test_replication_make_push_request_helper },


### PR DESCRIPTION
## Summary

- capture missing sync write paths across supported raw tables: `ValueTable::set()`, `KeyValueTable::append()` / `reconcile()` / `erase_range()`, and `KeyTable::erase_range()`
- fix `ValueTable` capture to carry the physical singleton MDBX key for Put/Delete instead of an empty storage key
- add regression coverage for singleton, bulk, range, sequence set, vector-store, and value-table replication cases
- harden range helpers by opening MDBX cursors before first `mdbx_cmp()` in `KeyTable`, `KeyValueTable`, and `KeyMultiValueTable`
- document current v0.1 table coverage, including indirect `VectorStore` coverage through `SequenceTable` and `KeyValueTable`

## Root Cause

The first PR91 pass fixed `SequenceTable::db_set()`, but a full write-path audit found more direct MDBX writes that bypassed `record_op()`. `ValueTable` also captured singleton writes with an empty storage key, even though `SyncEngine` applies `ChangeOp::storage_key` as the raw MDBX key.

During local Debug validation, the new range coverage also exposed an existing libmdbx assertion: several range helpers called `mdbx_cmp()` before opening a cursor in the current transaction. Reordering cursor open before the first compare keeps the DBI valid for libmdbx debug checks without changing range semantics.

## Validation

- C++17 MinGW: `ctest --test-dir tmp\\build-pr91-cpp17-mingw -R test_sync_capture|test_sync_replication|key_table_test|kv_container_all_types_test|key_multi_value_table_test --output-on-failure`
- C++11 MinGW: `ctest --test-dir tmp\\build-pr91-cpp11-mingw -R test_sync_capture|test_sync_replication|key_table_test|kv_container_all_types_test|key_multi_value_table_test --output-on-failure`
- `git diff --check`