### PR TITLE
fix(sync): skip origins already at indexed tail

### DIFF
--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -119,11 +119,13 @@ key, which is why `seq` is big-endian in the key.
 | Value | u64 LE - max known changelog `seq` for that origin |
 
 This index is a discovery accelerator for hub-style pull. `ChangeLogStore::append`
-updates it atomically with the changelog row. When an upgraded database has
-legacy changelog rows but no `_mdbxc_origins`, the first writable append
-backfills the index by scanning existing changelog keys. Read-only pull keeps
-a compatibility fallback: if `_mdbxc_origins` is absent or empty, origin
-discovery scans `_mdbxc_changelog`.
+updates it atomically with the changelog row. Pull uses the indexed tail to skip
+origins where the requester already has `last_seq`, then still seeks exact
+`have_seq + 1` changelog keys for origins with possible new batches. When an
+upgraded database has legacy changelog rows but no `_mdbxc_origins`, the first
+writable append backfills the index by scanning existing changelog keys.
+Read-only pull keeps a compatibility fallback: if `_mdbxc_origins` is absent or
+empty, origin discovery scans `_mdbxc_changelog`.
 
 `ChangeLogStore::origin_index_matches_changelog()` compares the index against
 the changelog-derived origin tails. `ChangeLogStore::rebuild_origin_index()`

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -121,6 +121,12 @@ namespace sync {
 
     /// \brief Pull/push/apply coordinator bound to a single \c Connection.
     class SyncEngine {
+        struct PullOrigin {
+            NodeId origin;
+            std::uint64_t last_seq;
+            bool has_last_seq;
+        };
+
     public:
         /// \brief Constructs an engine bound to \p conn.
         /// \param conn Shared connection that owns the env and stores.
@@ -291,19 +297,24 @@ namespace sync {
         /// cursors filter each origin independently and still include origins
         /// missing from the cursor. Origin discovery uses \c _mdbxc_origins
         /// when available, with a changelog scan fallback for pre-index
-        /// databases. Uses changelog keys to seek to \c have_seq+1 for each
-        /// origin so old values are not decoded.
+        /// databases. Indexed origin tails skip origins that have no new
+        /// batches; changelog keys are still used for exact \c have_seq+1
+        /// seeks so old values are not decoded.
         /// Sets \c has_more=true when the walk stopped because of
         /// \c request.max_batches or \c request.max_bytes.
         PullResponse pull_full_snapshot(MDBX_txn* txn, MDBX_dbi dbi,
                                         const PullRequest& request) {
             PullResponse out;
             out.remote_have = read_applied_cursor(txn, out.remote_have);
-            const std::vector<NodeId> origins = collect_known_origins(txn, dbi);
+            const std::vector<PullOrigin> origins = collect_known_origins(txn, dbi);
             std::size_t total_bytes = 0;
             bool truncated = false;
             for (std::size_t i = 0; i < origins.size(); ++i) {
-                if (pull_origin_batches(txn, dbi, origins[i], request, out, total_bytes)) {
+                if (origin_is_at_tail(origins[i], request)) {
+                    continue;
+                }
+                if (pull_origin_batches(txn, dbi, origins[i].origin,
+                                        request, out, total_bytes)) {
                     truncated = true;
                     break;
                 }
@@ -635,9 +646,32 @@ namespace sync {
             return compare_node_id(changelog_key_origin(key), origin) == 0;
         }
 
-        static std::vector<NodeId> collect_changelog_origins(MDBX_txn* txn,
-                                                             MDBX_dbi dbi) {
-            std::vector<NodeId> origins;
+        static PullOrigin make_pull_origin(const NodeId& origin) {
+            PullOrigin out;
+            out.origin = origin;
+            out.last_seq = 0;
+            out.has_last_seq = false;
+            return out;
+        }
+
+        static PullOrigin make_pull_origin(const NodeId& origin,
+                                           std::uint64_t last_seq) {
+            PullOrigin out;
+            out.origin = origin;
+            out.last_seq = last_seq;
+            out.has_last_seq = true;
+            return out;
+        }
+
+        static bool origin_is_at_tail(const PullOrigin& origin,
+                                      const PullRequest& request) {
+            return origin.has_last_seq &&
+                   request.have.last_seq_for(origin.origin) >= origin.last_seq;
+        }
+
+        static std::vector<PullOrigin> collect_changelog_origins(MDBX_txn* txn,
+                                                                 MDBX_dbi dbi) {
+            std::vector<PullOrigin> origins;
             MDBX_cursor* raw = nullptr;
             check_mdbx(mdbx_cursor_open(txn, dbi, &raw),
                        "pull_full: origin cursor open failed");
@@ -648,7 +682,7 @@ namespace sync {
             int rc = mdbx_cursor_get(raw, &k, &v, MDBX_FIRST);
             while (rc == MDBX_SUCCESS) {
                 const NodeId origin = changelog_key_origin(k);
-                origins.push_back(origin);
+                origins.push_back(make_pull_origin(origin));
 
                 std::vector<std::uint8_t> next_key_buf =
                     make_changelog_key(origin, std::numeric_limits<std::uint64_t>::max());
@@ -673,17 +707,26 @@ namespace sync {
             return origins;
         }
 
-        std::vector<NodeId> collect_indexed_origins(MDBX_txn* txn) const {
+        std::vector<PullOrigin> collect_indexed_origins(MDBX_txn* txn) const {
             OriginIndexStore origins(m_conn->env_handle());
             if (!origins.open_existing(txn)) {
-                return std::vector<NodeId>();
+                return std::vector<PullOrigin>();
             }
-            return origins.origins(txn);
+            const std::vector<OriginIndexStore::OriginTail> tails =
+                origins.origin_tails(txn);
+            std::vector<PullOrigin> out;
+            out.reserve(tails.size());
+            for (std::vector<OriginIndexStore::OriginTail>::const_iterator it =
+                     tails.begin();
+                 it != tails.end(); ++it) {
+                out.push_back(make_pull_origin(it->origin, it->last_seq));
+            }
+            return out;
         }
 
-        std::vector<NodeId> collect_known_origins(MDBX_txn* txn,
-                                                  MDBX_dbi changelog_dbi) const {
-            const std::vector<NodeId> indexed = collect_indexed_origins(txn);
+        std::vector<PullOrigin> collect_known_origins(MDBX_txn* txn,
+                                                      MDBX_dbi changelog_dbi) const {
+            const std::vector<PullOrigin> indexed = collect_indexed_origins(txn);
             if (!indexed.empty()) {
                 return indexed;
             }

--- a/include/mdbx_containers/sync/stores/OriginIndexStore.hpp
+++ b/include/mdbx_containers/sync/stores/OriginIndexStore.hpp
@@ -21,11 +21,17 @@ namespace sync {
 
     /// \brief Thin wrapper around \c _mdbxc_origins.
     /// \details Key = \c origin_node_id (16 raw bytes), value = max known
-    /// changelog seq for that origin as \c u64 little-endian. The value is
-    /// diagnostic/maintenance metadata; pull pagination uses the changelog
-    /// keys for exact batch iteration.
+    /// changelog seq for that origin as \c u64 little-endian. Pull pagination
+    /// uses the value as a cheap tail check before seeking changelog keys for
+    /// exact batch iteration.
     class OriginIndexStore {
     public:
+        /// \brief Indexed origin and its max known changelog sequence.
+        struct OriginTail {
+            NodeId origin;
+            std::uint64_t last_seq;
+        };
+
         /// \brief Constructs a wrapper bound to \p env.
         OriginIndexStore(MDBX_env* env,
                          const std::string& dbi_name = "_mdbxc_origins")
@@ -144,13 +150,13 @@ namespace sync {
             return true;
         }
 
-        /// \brief Returns all indexed origins in DB key order.
-        std::vector<NodeId> origins(MDBX_txn* txn) const {
+        /// \brief Returns all indexed origins with their tails in DB key order.
+        std::vector<OriginTail> origin_tails(MDBX_txn* txn) const {
             ensure_open();
-            std::vector<NodeId> out;
+            std::vector<OriginTail> out;
             MDBX_cursor* raw = nullptr;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, &raw),
-                       "OriginIndexStore origins cursor open failed");
+                       "OriginIndexStore origin_tails cursor open failed");
             try {
                 MDBX_val k, v;
                 int rc = mdbx_cursor_get(raw, &k, &v, MDBX_FIRST);
@@ -161,19 +167,33 @@ namespace sync {
                     if (v.iov_len != 8) {
                         throw std::runtime_error("OriginIndexStore value has invalid size");
                     }
-                    NodeId origin{};
-                    std::memcpy(origin.data(), k.iov_base, 16);
-                    out.push_back(origin);
+                    OriginTail tail;
+                    tail.origin = NodeId();
+                    std::memcpy(tail.origin.data(), k.iov_base, 16);
+                    tail.last_seq = decode_u64_le(v);
+                    out.push_back(tail);
                     rc = mdbx_cursor_get(raw, &k, &v, MDBX_NEXT);
                 }
                 if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc, "OriginIndexStore origins cursor walk failed");
+                    check_mdbx(rc, "OriginIndexStore origin_tails cursor walk failed");
                 }
             } catch (...) {
                 mdbx_cursor_close(raw);
                 throw;
             }
             mdbx_cursor_close(raw);
+            return out;
+        }
+
+        /// \brief Returns all indexed origins in DB key order.
+        std::vector<NodeId> origins(MDBX_txn* txn) const {
+            const std::vector<OriginTail> tails = origin_tails(txn);
+            std::vector<NodeId> out;
+            out.reserve(tails.size());
+            for (std::vector<OriginTail>::const_iterator it = tails.begin();
+                 it != tails.end(); ++it) {
+                out.push_back(it->origin);
+            }
             return out;
         }
 

--- a/tests/test_sync_stores.cpp
+++ b/tests/test_sync_stores.cpp
@@ -141,6 +141,15 @@ void test_origin_index_store() {
             origins[1] != origin_b) {
             throw std::runtime_error("origin index order mismatch");
         }
+        const std::vector<OriginIndexStore::OriginTail> tails =
+            ro.origin_tails(txn.handle());
+        if (tails.size() != 2u ||
+            tails[0].origin != origin_a ||
+            tails[0].last_seq != 7u ||
+            tails[1].origin != origin_b ||
+            tails[1].last_seq != 3u) {
+            throw std::runtime_error("origin index tail mismatch");
+        }
     }
 
     {


### PR DESCRIPTION
﻿## Summary

- expose `OriginIndexStore::origin_tails()` so pull can read indexed per-origin tails without a changelog scan
- skip indexed origins whose requester cursor is already at or beyond the indexed tail before doing the exact changelog seek
- keep the legacy changelog-origin fallback unchanged for databases without `_mdbxc_origins`
- document the hot-path use of `_mdbxc_origins` and cover tail enumeration in store tests

## Why

Hub-style incremental pull can have many origins while each requester only needs a small new tail. The previous indexed path still opened/searched the changelog for every known origin on every page, including origins that the requester already had fully applied. The index already stores each origin tail, so `handle_pull()` can avoid those unnecessary exact seeks.

## Local validation

- `git diff --check`
- `cmake -S . -B tmp\build-pr93-cpp17 -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=17`
- `cmake --build tmp\build-pr93-cpp17 --target test_sync_engine test_sync_stores test_sync_replication test_sync_randomized_lifecycle`
- `ctest --test-dir tmp\build-pr93-cpp17 -R "test_sync_engine|test_sync_stores|test_sync_replication|test_sync_randomized_lifecycle" --output-on-failure`
- `cmake -S . -B tmp\build-pr93-cpp11 -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=11`
- `cmake --build tmp\build-pr93-cpp11 --target test_sync_engine test_sync_stores test_sync_replication test_sync_randomized_lifecycle`
- `ctest --test-dir tmp\build-pr93-cpp11 -R "test_sync_engine|test_sync_stores|test_sync_replication|test_sync_randomized_lifecycle" --output-on-failure`

## Local benchmark notes

Release MinGW, `sync_tick_hub_benchmark`, illustrative incremental `pull_ms` only:

- `200 32 1 32 1 4194304`: incremental hot `21.108 ms -> 8.302 ms`, after restart `22.562 ms -> 9.773 ms`
- `200 64 4 64 16 4194304`: incremental hot `21.030 ms -> 4.832 ms`, after restart `14.151 ms -> 6.540 ms`
