### PR TITLE
test(headers): add umbrella include smoke checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,9 @@ if(MDBXC_BUILD_TESTS)
     set(MDBXC_STRESS_TESTS
         test_sync_stress
     )
+    set(MDBXC_SYNC_DISABLED_TESTS
+        header_sync_disabled_test
+    )
     foreach(test_file IN LISTS TESTS)
         get_filename_component(test_name ${test_file} NAME_WE)
         add_executable(${test_name} ${test_file})
@@ -171,7 +174,12 @@ if(MDBXC_BUILD_TESTS)
         message(STATUS "Test ${test_name} -> ${_PKG_TARGET}")
 
         # Enable the optional sync subsystem when its headers are exercised.
-        target_compile_definitions(${test_name} PRIVATE MDBXC_SYNC_ENABLED=1)
+        list(FIND MDBXC_SYNC_DISABLED_TESTS
+             "${test_name}"
+             _mdbxc_sync_disabled_test_index)
+        if(_mdbxc_sync_disabled_test_index EQUAL -1)
+            target_compile_definitions(${test_name} PRIVATE MDBXC_SYNC_ENABLED=1)
+        endif()
 
         list(FIND MDBXC_STRESS_TESTS "${test_name}" _mdbxc_stress_test_index)
         set(_mdbxc_is_stress_test FALSE)

--- a/tests/header_all_umbrella_test.cpp
+++ b/tests/header_all_umbrella_test.cpp
@@ -1,0 +1,42 @@
+#include <mdbx_containers.hpp>
+
+#include "test_assert.hpp"
+
+#include <cstdint>
+#include <string>
+
+#ifndef MDBXC_SYNC_ENABLED
+#error "MDBXC_SYNC_ENABLED must be defined by the test target"
+#endif
+
+#if !MDBXC_SYNC_ENABLED
+#error "header_all_umbrella_test must be compiled with sync enabled"
+#endif
+
+int main() {
+    mdbxc::Config config;
+    config.max_dbs = 8;
+    MDBXC_TEST_ASSERT(config.max_dbs == 8);
+
+    mdbxc::KeyValueTable<std::uint64_t, std::string>* key_value_table = nullptr;
+    MDBXC_TEST_ASSERT(key_value_table == nullptr);
+
+    mdbxc::sync::NodeId node = mdbxc::sync::make_zero_node();
+    MDBXC_TEST_ASSERT(node.size() == 16u);
+
+    mdbxc::sync::ChangeBatch batch;
+    batch.origin_node_id = node;
+    batch.seq = 1;
+    MDBXC_TEST_ASSERT(batch.seq == 1u);
+
+    mdbxc::Embedding embedding;
+    embedding.dim = 2;
+    embedding.values.push_back(1.0f);
+    embedding.values.push_back(0.0f);
+    MDBXC_TEST_ASSERT(embedding.values.size() == 2u);
+
+    mdbxc::VectorStore* store = nullptr;
+    MDBXC_TEST_ASSERT(store == nullptr);
+
+    return 0;
+}

--- a/tests/header_sync_disabled_test.cpp
+++ b/tests/header_sync_disabled_test.cpp
@@ -1,0 +1,26 @@
+#include <mdbx_containers/sync.hpp>
+
+#ifndef MDBXC_SYNC_ENABLED
+#error "sync.hpp must define MDBXC_SYNC_ENABLED when it is omitted by callers"
+#endif
+
+#if MDBXC_SYNC_ENABLED
+#error "header_sync_disabled_test must be compiled without enabling sync"
+#endif
+
+#include <mdbx_containers.hpp>
+
+#include "test_assert.hpp"
+
+int main() {
+    MDBXC_TEST_ASSERT(MDBXC_SYNC_ENABLED == 0);
+
+    mdbxc::Config config;
+    config.max_dbs = 4;
+    MDBXC_TEST_ASSERT(config.max_dbs == 4);
+
+    const mdbxc::VectorMetric metric = mdbxc::VectorMetric::COSINE;
+    MDBXC_TEST_ASSERT(metric == mdbxc::VectorMetric::COSINE);
+
+    return 0;
+}

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -1,0 +1,47 @@
+#include <mdbx_containers/sync.hpp>
+
+#include "test_assert.hpp"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#ifndef MDBXC_SYNC_ENABLED
+#error "MDBXC_SYNC_ENABLED must be defined by the test target"
+#endif
+
+#if !MDBXC_SYNC_ENABLED
+#error "header_sync_umbrella_test must be compiled with sync enabled"
+#endif
+
+int main() {
+    mdbxc::sync::NodeId node = mdbxc::sync::make_zero_node();
+    MDBXC_TEST_ASSERT(node.size() == 16u);
+
+    mdbxc::sync::ChangeOp op;
+    op.op_type = mdbxc::sync::ChangeOpType::Put;
+    op.dbi_name = "sync_umbrella_table";
+    op.storage_key.push_back(1u);
+    op.value.push_back(2u);
+
+    mdbxc::sync::ChangeBatch batch;
+    batch.origin_node_id = node;
+    batch.seq = 1;
+    batch.ops.push_back(op);
+
+    const std::vector<std::uint8_t> encoded =
+        mdbxc::sync::ChangeBatchCodec::encode(batch);
+    const mdbxc::sync::ChangeBatch decoded =
+        mdbxc::sync::ChangeBatchCodec::decode_exact(encoded);
+    MDBXC_TEST_ASSERT(decoded.seq == 1u);
+    MDBXC_TEST_ASSERT(decoded.ops.size() == 1u);
+    MDBXC_TEST_ASSERT(decoded.ops[0].dbi_name == "sync_umbrella_table");
+
+    mdbxc::sync::CancellationSource source;
+    const mdbxc::sync::CancellationToken token = source.token();
+    MDBXC_TEST_ASSERT(token.can_be_cancelled());
+    source.request_cancel();
+    MDBXC_TEST_ASSERT(token.is_cancellation_requested());
+
+    return 0;
+}

--- a/tests/header_tables_umbrella_test.cpp
+++ b/tests/header_tables_umbrella_test.cpp
@@ -1,0 +1,40 @@
+#include <mdbx_containers/tables.hpp>
+
+#include "test_assert.hpp"
+
+#include <cstdint>
+#include <string>
+
+int main() {
+    mdbxc::AnyValueTable<std::uint64_t>* any_value_table = nullptr;
+    MDBXC_TEST_ASSERT(any_value_table == nullptr);
+
+    mdbxc::KeyTable<std::uint64_t>* key_table = nullptr;
+    MDBXC_TEST_ASSERT(key_table == nullptr);
+
+    mdbxc::KeyValueTable<std::uint64_t, std::string>* key_value_table = nullptr;
+    MDBXC_TEST_ASSERT(key_value_table == nullptr);
+
+    mdbxc::KeyMultiValueTable<std::uint64_t, std::string>* multi_value_table = nullptr;
+    MDBXC_TEST_ASSERT(multi_value_table == nullptr);
+
+    mdbxc::SequenceTable<std::uint64_t>* sequence_table = nullptr;
+    MDBXC_TEST_ASSERT(sequence_table == nullptr);
+
+    mdbxc::ValueTable<std::string>* value_table = nullptr;
+    MDBXC_TEST_ASSERT(value_table == nullptr);
+
+    mdbxc::HashedKeyValueStore<std::string, std::string>* hashed_store = nullptr;
+    MDBXC_TEST_ASSERT(hashed_store == nullptr);
+
+    const std::string key = "tables";
+    const mdbxc::ByteView view = mdbxc::make_byte_view(key);
+    MDBXC_TEST_ASSERT(view.data != nullptr);
+    MDBXC_TEST_ASSERT(view.size == key.size());
+
+    const mdbxc::XXH3Hasher hasher;
+    const std::uint64_t digest = hasher(view);
+    MDBXC_TEST_ASSERT(digest == hasher(view));
+
+    return 0;
+}

--- a/tests/header_vector_umbrella_test.cpp
+++ b/tests/header_vector_umbrella_test.cpp
@@ -1,0 +1,37 @@
+#include <mdbx_containers/vector.hpp>
+
+#include "test_assert.hpp"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+int main() {
+    const mdbxc::VectorMetric metric = mdbxc::VectorMetric::COSINE;
+    MDBXC_TEST_ASSERT(metric == mdbxc::VectorMetric::COSINE);
+
+    mdbxc::Embedding embedding;
+    embedding.dim = 2;
+    embedding.values.push_back(1.0f);
+    embedding.values.push_back(0.0f);
+    const std::vector<std::uint8_t> embedding_bytes = embedding.to_bytes();
+    const mdbxc::Embedding restored =
+        mdbxc::Embedding::from_bytes(embedding_bytes.data(), embedding_bytes.size());
+    MDBXC_TEST_ASSERT(restored.dim == 2u);
+
+    mdbxc::VectorRecord record;
+    record.id = 7;
+    record.collection = "headers";
+    record.embedding = restored;
+    MDBXC_TEST_ASSERT(record.embedding.values.size() == 2u);
+
+    mdbxc::SearchResult result;
+    result.id = record.id;
+    result.collection = record.collection;
+    MDBXC_TEST_ASSERT(result.id == 7u);
+
+    mdbxc::VectorStore* store = nullptr;
+    MDBXC_TEST_ASSERT(store == nullptr);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a sync-enabled umbrella include smoke test for `<mdbx_containers.hpp>`, `<mdbx_containers/sync.hpp>`, and `<mdbx_containers/vector.hpp>`
- add a sync-disabled smoke test that verifies `sync.hpp` defines the default disabled state cleanly
- keep the test CMake default as sync-enabled, with an explicit exception list for sync-disabled header tests

## Validation
- `cmake -S . -B tmp\pr95-mingw-cpp17 -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=17`
- `cmake -S . -B tmp\pr95-mingw-cpp11 -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=11`
- `cmake --build tmp\pr95-mingw-cpp17 --target header_umbrella_test header_sync_disabled_test -- -j`
- `cmake --build tmp\pr95-mingw-cpp11 --target header_umbrella_test header_sync_disabled_test -- -j`
- `ctest --test-dir tmp\pr95-mingw-cpp17 -R "header_umbrella_test|header_sync_disabled_test" --output-on-failure`
- `ctest --test-dir tmp\pr95-mingw-cpp11 -R "header_umbrella_test|header_sync_disabled_test" --output-on-failure`
- `cmake --build tmp\pr95-mingw-cpp17 -- -j`
- `cmake --build tmp\pr95-mingw-cpp11 -- -j`
- `ctest --test-dir tmp\pr95-mingw-cpp17 --output-on-failure`
- `ctest --test-dir tmp\pr95-mingw-cpp11 --output-on-failure`
