### PR TITLE
test(headers): add standalone public header smoke checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,14 +160,25 @@ if(MDBXC_BUILD_TESTS)
     set(MDBXC_SYNC_DISABLED_TESTS
         header_sync_disabled_test
     )
-    foreach(test_file IN LISTS TESTS)
-        get_filename_component(test_name ${test_file} NAME_WE)
+    set(MDBXC_STANDALONE_PUBLIC_HEADERS
+        mdbx_containers/common.hpp
+        mdbx_containers/AnyValueTable.hpp
+        mdbx_containers/Hash.hpp
+        mdbx_containers/HashedKeyValueStore.hpp
+        mdbx_containers/KeyMultiValueTable.hpp
+        mdbx_containers/KeyTable.hpp
+        mdbx_containers/KeyValueTable.hpp
+        mdbx_containers/SequenceTable.hpp
+        mdbx_containers/ValueTable.hpp
+    )
+
+    function(mdbxc_add_test_target test_name test_file)
         add_executable(${test_name} ${test_file})
         set_target_properties(${test_name} PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tests
         )
         target_compile_features(${test_name} PRIVATE cxx_std_11)
-        
+
         mdbxc_enable_asan(${test_name})
 
         target_link_libraries(${test_name} PRIVATE ${_PKG_TARGET})
@@ -201,7 +212,21 @@ if(MDBXC_BUILD_TESTS)
                 )
             endif()
         endif()
+    endfunction()
 
+    foreach(test_file IN LISTS TESTS)
+        get_filename_component(test_name ${test_file} NAME_WE)
+        mdbxc_add_test_target(${test_name} ${test_file})
+    endforeach()
+
+    set(_mdbxc_generated_test_dir "${CMAKE_CURRENT_BINARY_DIR}/generated_tests")
+    file(MAKE_DIRECTORY "${_mdbxc_generated_test_dir}")
+    foreach(header IN LISTS MDBXC_STANDALONE_PUBLIC_HEADERS)
+        string(MAKE_C_IDENTIFIER "${header}" header_target_suffix)
+        set(test_name "header_standalone_${header_target_suffix}")
+        set(test_file "${_mdbxc_generated_test_dir}/${test_name}.cpp")
+        file(WRITE "${test_file}" "#include <${header}>\n\nint main() {\n    return 0;\n}\n")
+        mdbxc_add_test_target(${test_name} ${test_file})
     endforeach()
 endif()
 

--- a/guides/codebase-orientation.md
+++ b/guides/codebase-orientation.md
@@ -14,8 +14,8 @@ of truth.
 
 | Path | Purpose | Edit when |
 | --- | --- | --- |
-| `include/mdbx_containers.hpp` | Top-level public include for all table headers. | Changing the umbrella API. |
-| `include/mdbx_containers/*.hpp` | Public headers: table APIs plus small supported helpers such as `Hash.hpp`. | Changing table user APIs or reusable user-facing helpers. |
+| `include/mdbx_containers.hpp` | Top-level public include for tables, sync, and vector APIs. | Changing the umbrella API. |
+| `include/mdbx_containers/*.hpp` | Public headers: aggregators, table APIs, and supported helpers such as `Hash.hpp`. | Changing table user APIs or reusable user-facing helpers. |
 | `include/mdbx_containers/common/` | Core infrastructure: `Config`, `Connection`, `Transaction`, `MdbxException`. | Changing env/config/transaction/error behavior. |
 | `include/mdbx_containers/detail/` | Internal building blocks: `BaseTable`, `TransactionTracker`, serialization, path utilities, vendored/private helpers. Not public API. | Changing shared mechanisms. |
 | `tests/` | Standalone CTest executables. | Adding behavior, regressions, serialization, path, or transaction checks. |

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -211,11 +211,13 @@ Operational rules:
 
 ## Header Include Discipline
 
-- The only top-level include points are `mdbx_containers.hpp` (umbrella for
-  all table wrappers) and the per-domain aggregators: `common.hpp`,
-  `vector.hpp`, `sync.hpp`. End users must not include subdomain headers
-  directly (`common/...`, `detail/...`, `sync/...`); they include through
-  the aggregator that already pulls the right pieces in the right order.
+- Supported public include points are `mdbx_containers.hpp` (umbrella for the
+  full public surface), the per-domain aggregators `common.hpp`, `tables.hpp`,
+  `vector.hpp`, `sync.hpp`, and the root table/helper headers such as
+  `KeyValueTable.hpp`, `ValueTable.hpp`, and `Hash.hpp`. End users must not
+  include subdomain or internal headers directly (`common/...`, `detail/...`,
+  `sync/...`, `vector/...`); they include through the aggregator that already
+  pulls the right pieces in the right order.
 - Inside `include/mdbx_containers/`, leaf headers under one subdomain may
   rely on the umbrella having included the cross-domain prerequisites. Do
   not self-contain every dependency; that spreads ordering decisions across


### PR DESCRIPTION
## Summary
- generate standalone compile-smoke CTest targets for supported public root headers
- cover `common.hpp`, table headers, and `Hash.hpp` as first includes in separate generated translation units
- reuse one CMake helper for normal and generated test targets
- align include-discipline docs with the public header surface after the umbrella cleanup

## Notes
This intentionally does not make `common/...`, `detail/...`, `sync/...`, or `vector/...` subdomain headers standalone user entry points. Those remain behind their aggregators.

## Validation
- `cmake -S . -B tmp\pr97-mingw-cpp17 -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=17`
- `cmake -S . -B tmp\pr97-mingw-cpp11 -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=11`
- `cmake --build tmp\pr97-mingw-cpp17 -- -j`
- `cmake --build tmp\pr97-mingw-cpp11 -- -j`
- `ctest --test-dir tmp\pr97-mingw-cpp17 --output-on-failure`
- `ctest --test-dir tmp\pr97-mingw-cpp11 --output-on-failure`
- `git diff --check`
