### PR TITLE
docs(sync): document v0.1 support matrix

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -71,9 +71,12 @@
 ### 🔄 Sync-репликация
 - Экспериментальный sync включается явно: определите `MDBXC_SYNC_ENABLED=1`
   перед подключением `mdbx_containers/sync.hpp`.
-- Текущее покрытие захватывает обычные write-path'ы `KeyValueTable`,
-  `KeyTable`, `ValueTable` и `SequenceTable`; `VectorStore` сохраняется через
-  эти таблицы и покрыт end-to-end тестами репликации.
+- v0.1 захватывает обычные write-path'ы `KeyValueTable`, `KeyTable`,
+  `ValueTable` и `SequenceTable`; `VectorStore` реплицируется косвенно через
+  внутренние `SequenceTable` и `KeyValueTable`.
+- `AnyValueTable`, `KeyMultiValueTable` и `HashedKeyValueStore` не
+  реплицируются в v0.1. Их wire-format отложен до явного описания type tags,
+  DUPSORT duplicate framing и hash-index identity semantics.
 - `SyncEngine` предоставляет pull/push/apply primitives, `DirectSyncPeer`
   используется для in-process синхронизации в тестах и примерах, а
   `SyncWorker` запускает фоновой polling. HTTP/WebSocket транспорты и

--- a/README.md
+++ b/README.md
@@ -49,9 +49,12 @@
 ### 🔄 Sync Replication
 - Experimental sync is opt-in: define `MDBXC_SYNC_ENABLED=1` before including
   `mdbx_containers/sync.hpp`.
-- Current coverage captures normal write paths for `KeyValueTable`,
-  `KeyTable`, `ValueTable`, and `SequenceTable`; `VectorStore` persists through
-  those tables and is covered by end-to-end replication tests.
+- v0.1 captures normal write paths for `KeyValueTable`, `KeyTable`,
+  `ValueTable`, and `SequenceTable`; `VectorStore` is replicated indirectly
+  through its internal `SequenceTable` and `KeyValueTable` members.
+- `AnyValueTable`, `KeyMultiValueTable`, and `HashedKeyValueStore` are not
+  replicated in v0.1. Their wire formats are deferred until type tags,
+  DUPSORT duplicate framing, and hash-index identity semantics are specified.
 - `SyncEngine` exposes pull/push/apply primitives, `DirectSyncPeer` provides
   in-process sync for tests and examples, and `SyncWorker` is the background
   polling driver. HTTP/WebSocket transports and specialized table wire formats

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -202,12 +202,14 @@ Operational rules:
   for future logical-key conflict resolution, but the current raw batch apply
   path does not use it in a non-test path. `time_unix_ns` is metadata, not a
   reliable conflict authority. `Custom` is deferred to v0.2.
+- v0.1 sync captures normal write paths for `KeyValueTable`, `KeyTable`,
+  `ValueTable`, and `SequenceTable`. `VectorStore` is sync-covered only because
+  it persists through internal `SequenceTable` and `KeyValueTable` members.
 - `HashedKeyValueStore`, `KeyMultiValueTable`, and `AnyValueTable` are
   not replicated in v0.1; their wire format is not defined. Do not add
   `record_op()` paths for them without first extending `DESIGN.md`.
-- `VectorStore` persistence is replicated indirectly through its
-  `SequenceTable` and `KeyValueTable` members; it does not own a separate
-  MDBX write path.
+- Unsupported specialized tables must keep emitting no `ChangeOp` while sync
+  capture is attached until their wire-format semantics are designed and tested.
 
 ## Header Include Discipline
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -50,6 +50,23 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
 - Manual hub-style benchmark (`sync_tick_hub_benchmark`) plus opt-in and
   scheduled stress coverage for multi-origin sync paths.
 
+## v0.1 table support matrix
+
+| Type | Sync v0.1 status | Notes |
+|------|------------------|-------|
+| `KeyValueTable` | Supported | Captures normal put/delete paths, bulk append, reconcile puts/deletes, range erase, and clear-table ops. |
+| `KeyTable` | Supported | Captures insert/delete, range erase, reconcile/clear paths that operate on physical keys. |
+| `ValueTable` | Supported | Captures singleton put/delete/clear using its fixed physical key. |
+| `SequenceTable` | Supported | Captures set/append/delete/clear against stable `uint64_t` record ids. `append()` remains a local single-writer helper; external synchronization is still required for concurrent appenders. |
+| `VectorStore` | Supported indirectly | Does not own a separate wire format. Its persistent writes go through `SequenceTable` and `KeyValueTable` member tables. |
+| `AnyValueTable` | Not supported in v0.1 | Deferred until heterogeneous value type tags are part of the sync wire format. |
+| `KeyMultiValueTable` | Not supported in v0.1 | Deferred until DUPSORT duplicate-value multiplicity and per-value payload framing are specified. |
+| `HashedKeyValueStore` | Not supported in v0.1 | Deferred until hash-index and identity-key mapping semantics are specified. |
+
+Do not add `record_op()` paths for unsupported table types without first
+updating this design document and adding round-trip replication tests for the
+new wire-format semantics.
+
 ## Planned before v0.1 release (NOT YET implemented)
 
 - Full export/import via `seq=0, BATCH_HAS_MORE` chunks for empty replicas.

--- a/tests/test_sync_capture.cpp
+++ b/tests/test_sync_capture.cpp
@@ -403,6 +403,50 @@ void test_vector_store_writes_via_sink() {
     }
 }
 
+void test_specialized_tables_do_not_capture_in_v01() {
+    using namespace mdbxc;
+    const std::string p = "test_capture_specialized_deferred.mdbx";
+    cleanup(p);
+
+    Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    auto conn = Connection::create(cfg);
+
+    StubSink sink;
+    conn->attach_sync_capture(&sink);
+
+    auto assert_no_capture = [&sink](const char* table_name) {
+        if (!sink.m_recorded.empty()) {
+            throw std::runtime_error(
+                std::string(table_name) +
+                " must not emit sync ChangeOp in v0.1 without wire-format support"
+            );
+        }
+    };
+
+    {
+        AnyValueTable<int> any_values(conn, "any_values");
+        any_values.set(1, std::string("one"));
+        assert_no_capture("AnyValueTable");
+
+        KeyMultiValueTable<int, std::string> multi_values(conn, "multi_values");
+        multi_values.insert(1, "one");
+        assert_no_capture("KeyMultiValueTable");
+        multi_values.insert(1, "uno");
+        assert_no_capture("KeyMultiValueTable");
+
+        HashedKeyValueStore<std::string, std::string> hashed(conn, "hashed_values");
+        hashed.insert_or_assign("one", "uno");
+        assert_no_capture("HashedKeyValueStore");
+    }
+
+    conn->detach_sync_capture();
+    conn->disconnect();
+    cleanup(p);
+}
+
 void test_capture_flush_on_commit() {
     using namespace mdbxc;
     const std::string p = "test_capture_flush.mdbx";
@@ -792,44 +836,54 @@ int main() {
         return 8;
     }
     try {
+        test_specialized_tables_do_not_capture_in_v01();
+        std::printf("PASS test_specialized_tables_do_not_capture_in_v01\n");
+    } catch (const std::exception& e) {
+        std::printf("FAIL test_specialized_tables_do_not_capture_in_v01: %s\n", e.what());
+        return 9;
+    } catch (...) {
+        std::printf("FAIL test_specialized_tables_do_not_capture_in_v01: non-std exception\n");
+        return 9;
+    }
+    try {
         test_changelog_capture_roundtrip();
         std::printf("PASS test_changelog_capture_roundtrip\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_changelog_capture_roundtrip: %s\n", e.what());
-        return 9;
+        return 10;
     } catch (...) {
         std::printf("FAIL test_changelog_capture_roundtrip: non-std exception\n");
-        return 9;
+        return 10;
     }
     try {
         test_zero_node_id_rejected();
         std::printf("PASS test_zero_node_id_rejected\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_zero_node_id_rejected: %s\n", e.what());
-        return 10;
+        return 11;
     } catch (...) {
         std::printf("FAIL test_zero_node_id_rejected: non-std exception\n");
-        return 10;
+        return 11;
     }
     try {
         test_aborted_transaction_does_not_flush();
         std::printf("PASS test_aborted_transaction_does_not_flush\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_aborted_transaction_does_not_flush: %s\n", e.what());
-        return 11;
+        return 12;
     } catch (...) {
         std::printf("FAIL test_aborted_transaction_does_not_flush: non-std exception\n");
-        return 11;
+        return 12;
     }
     try {
         test_explicit_rollback_does_not_flush();
         std::printf("PASS test_explicit_rollback_does_not_flush\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_explicit_rollback_does_not_flush: %s\n", e.what());
-        return 12;
+        return 13;
     } catch (...) {
         std::printf("FAIL test_explicit_rollback_does_not_flush: non-std exception\n");
-        return 12;
+        return 13;
     }
 
     return 0;


### PR DESCRIPTION
## Summary
- document the sync v0.1 table support matrix in `sync/DESIGN.md`
- align README, README-RU, and implementation notes with that matrix
- add a capture regression proving deferred specialized tables emit no `ChangeOp` in v0.1

## Notes
Supported v0.1 capture remains limited to `KeyValueTable`, `KeyTable`, `ValueTable`, `SequenceTable`, and `VectorStore` indirectly through its internal tables. `AnyValueTable`, `KeyMultiValueTable`, and `HashedKeyValueStore` remain intentionally unsupported until their wire-format semantics are designed.

## Validation
- `cmake --build tmp\pr97-mingw-cpp17 --target test_sync_capture -- -j`
- `cmake --build tmp\pr97-mingw-cpp11 --target test_sync_capture -- -j`
- `ctest --test-dir tmp\pr97-mingw-cpp17 -R "^test_sync_capture$" --output-on-failure`
- `ctest --test-dir tmp\pr97-mingw-cpp11 -R "^test_sync_capture$" --output-on-failure`
- `ctest --test-dir tmp\pr97-mingw-cpp17 --output-on-failure`
- `ctest --test-dir tmp\pr97-mingw-cpp11 --output-on-failure`
- `git diff --check`
