### PR TITLE
bench(sync): add realistic pull presets

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -360,7 +360,8 @@ table.insert_or_assign(42, MyData{42, 3.14});
 ## 📚 Документация
 
 - Больше примеров см. в каталоге `examples/`. Примеры топологий sync кратко
-  описаны в `examples/README-sync.md`.
+  описаны в `examples/README-sync-RU.md`.
+- Команды benchmark-а sync и описание CSV находятся в `benchmarks/README-sync-RU.md`.
 - Информация об API и архитектуре находится в Doxygen-страницах `docs/*.dox`.
 - Документацию можно сгенерировать через Doxygen; сгенерированные
   `docs/html/` и `docs/latex/` нельзя редактировать вручную.

--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ table.insert_or_assign(42, MyData{42, 3.14});
 
 - See the `examples/` directory for more examples. Sync topology examples are
   summarized in `examples/README-sync.md`.
+- Sync benchmark commands and CSV notes are in `benchmarks/README-sync.md`.
 - API and architecture information lives in the Doxygen source pages under `docs/*.dox`.
 - Documentation can be generated with Doxygen; generated `docs/html/` and `docs/latex/` output should not be edited manually.
 

--- a/benchmarks/README-sync-RU.md
+++ b/benchmarks/README-sync-RU.md
@@ -1,8 +1,12 @@
-# Benchmark Sync
+# Benchmark синхронизации
 
-`sync_tick_hub_benchmark` измеряет core sync-путь для hub-style tick chunks.
-Он использует `DirectSyncPeer` в одном процессе, поэтому времена показывают
-локальный changelog pull, pagination, decode и local apply, а не latency сети.
+`sync_tick_hub_benchmark` измеряет производительность основных операций
+синхронизации в сценарии, где центральный узел хранит порции тиковых данных от
+множества origin-узлов, а реплика забирает эти изменения. Программа работает в
+одном процессе через `DirectSyncPeer`, поэтому результаты отражают локальное
+чтение changelog, постраничную выдачу, декодирование и применение через
+`handle_push()`. Задержки сети и сериализация реального транспорта здесь не
+измеряются.
 
 ## Сборка
 
@@ -17,23 +21,34 @@ cmake -S . -B tmp/build-bench \
 cmake --build tmp/build-bench --target sync_tick_hub_benchmark
 ```
 
-## Presets
+Команды ниже используют пути в стиле Linux/MSYS2. На Windows имя исполняемого
+файла заканчивается на `.exe`, например:
+
+```powershell
+.\tmp\build-bench\bin\benchmarks\sync_tick_hub_benchmark.exe --preset quick
+```
+
+## Готовые сценарии
+
+Без аргументов запускается сценарий `quick`.
 
 ```bash
 tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark --preset quick
 tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark --preset realistic
 ```
 
-Без аргументов benchmark запускает preset `quick`. `realistic` предназначен
-для ручных измерений перед изменениями pull pagination или changelog indexing.
+| Сценарий | Назначение |
+| --- | --- |
+| `quick` | Короткий набор для проверки сборки и грубого сравнения изменений. |
+| `realistic` | Более крупный ручной набор с большим числом origin-узлов и историей. Название означает нагрузку, более близкую к hub-сценарию, а не универсальную модель рабочей нагрузки. |
 
-Список presets:
+Вывести список доступных сценариев:
 
 ```bash
 tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark --list-presets
 ```
 
-Один custom scenario:
+## Пользовательский сценарий
 
 ```bash
 tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark \
@@ -41,20 +56,71 @@ tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark \
     ticks_per_chunk max_batches max_bytes
 ```
 
+Позиционные аргументы задаются слева направо. Если пропустить параметры в
+конце, benchmark использует значения по умолчанию из таблицы.
+
+| Аргумент | По умолчанию | Значение |
+| --- | ---: | --- |
+| `origins` | 16 | Количество независимых origin-узлов, чьи batches находятся в changelog. |
+| `historical_chunks_per_origin` | 512 | Число уже существующих batches каждого origin перед первым pull. |
+| `new_chunks_per_origin` | 8 | Число новых batches каждого origin в каждой инкрементальной фазе. Значение используется дважды: в `incremental_hot` и после перезапуска. |
+| `ticks_per_chunk` | 128 | Число тиковых записей внутри одного batch. |
+| `max_batches` | 64 | Максимальное число batches в одной странице `PullResponse`. |
+| `max_bytes` | 4194304 | Приблизительный предел размера одной страницы в байтах. |
+
 ## CSV
 
-Каждый scenario печатает три фазы:
+Каждый сценарий печатает три фазы:
 
-- `full_cold_replica` проигрывает historical changelog в пустую replica.
-- `incremental_hot` добавляет новые chunks и делает pull без restart engines.
-- `incremental_after_restart` закрывает, заново открывает и реконструирует оба
-  engine, затем добавляет и тянет ещё один incremental range.
+- `full_cold_replica` - первичная синхронизация пустой реплики со всей
+  накопленной историей.
+- `incremental_hot` - добавление новых batches и повторная синхронизация без
+  закрытия соединений и пересоздания `SyncEngine`.
+- `incremental_after_restart` - закрытие и повторное открытие обеих БД,
+  пересоздание `SyncEngine`, добавление ещё одного диапазона batches и
+  инкрементальная синхронизация от сохранённого курсора получателя.
 
-`origin_index_entries` обычно должен совпадать с `origins` после historical
-seeding. Это подтверждает, что `_mdbxc_origins` заполнен и pull path может
-пропускать origins, которые уже находятся на cursor получателя, до точного seek
-по changelog key.
+| Колонка | Значение |
+| --- | --- |
+| `scenario` | Имя сценария. |
+| `phase` | Одна из трёх фаз, перечисленных выше. |
+| `origins` | Количество origin-узлов в сценарии. |
+| `historical_chunks_per_origin` | Исторические batches каждого origin перед первичной синхронизацией. |
+| `new_chunks_per_origin` | Новые batches каждого origin для каждой инкрементальной фазы. |
+| `chunks_per_origin` | Batches каждого origin, существующие в измеряемой фазе. |
+| `ticks_per_chunk` | Тиковые записи внутри одного batch. |
+| `max_batches` | Ограничение страницы по числу batches. |
+| `max_bytes` | Приблизительное ограничение страницы по числу байтов. |
+| `seeded_batches` | Batches, записанные локально перед измеряемым pull. |
+| `pulled_batches` | Batches, полученные через страницы `PullResponse`. |
+| `applied_batches` | Batches, применённые через `SyncEngine::handle_push()`. |
+| `pull_pages` | Число pull-запросов, нужных для завершения фазы. |
+| `origin_index_entries` | Число origin-узлов, зарегистрированных в `_mdbxc_origins` на primary. |
+| `seed_ms` | Время локальной записи данных для фазы. |
+| `restart_ms` | Время закрытия, повторного открытия и пересоздания объектов в фазе перезапуска. В остальных фазах равно нулю. |
+| `pull_ms` | Время, затраченное на вызовы `DirectSyncPeer::pull()`. |
+| `apply_ms` | Время, затраченное на вызовы `SyncEngine::handle_push()`. |
+| `total_ms` | `seed_ms + restart_ms + pull_ms + apply_ms`. |
+| `batches_per_sec` | `applied_batches / (pull_ms + apply_ms)`. Время подготовки данных и перезапуска не учитывается. |
+| `primary_bytes` | Размер занятых страниц MDBX у primary после фазы. |
+| `replica_bytes` | Размер занятых страниц MDBX у replica после фазы. |
 
-Для сравнения sync-core изменений используйте `pull_ms`, `apply_ms`,
-`pull_pages` и `batches_per_sec`. `seed_ms` и `restart_ms` выводятся отдельно,
-чтобы не смешивать подготовку данных с pull/apply поведением.
+`origin_index_entries` после заполнения исторических данных обычно совпадает с
+`origins`. Этот индекс позволяет `SyncEngine::handle_pull()` не открывать и не
+позиционировать changelog cursor для origin-узлов, по которым получатель уже
+дошёл до последнего известного `seq`. Для отстающих origin-узлов
+движок выполняет точный поиск начиная с `have_seq + 1`.
+
+## Как сравнивать результаты
+
+1. Соберите обе версии в одинаковом режиме, желательно `Release`.
+2. Запустите один и тот же готовый или пользовательский сценарий не меньше пяти
+   раз.
+3. Первый запуск можно считать прогревом файлового кэша, если результаты
+   заметно плавают.
+4. Сравнивайте медиану `pull_ms`, `apply_ms`, `pull_pages` и
+   `batches_per_sec`.
+5. Не сравнивайте запуски с разными компиляторами, настройками MDBX,
+   сценариями или аргументами.
+6. Используйте этот benchmark только для оценки изменений ядра синхронизации.
+   Он не показывает стоимость HTTP, WebSocket, IPC или шифрования.

--- a/benchmarks/README-sync-RU.md
+++ b/benchmarks/README-sync-RU.md
@@ -1,0 +1,60 @@
+# Benchmark Sync
+
+`sync_tick_hub_benchmark` измеряет core sync-путь для hub-style tick chunks.
+Он использует `DirectSyncPeer` в одном процессе, поэтому времена показывают
+локальный changelog pull, pagination, decode и local apply, а не latency сети.
+
+## Сборка
+
+```bash
+cmake -S . -B tmp/build-bench \
+    -DMDBXC_DEPS_MODE=BUNDLED \
+    -DMDBXC_BUILD_TESTS=OFF \
+    -DMDBXC_BUILD_EXAMPLES=OFF \
+    -DMDBXC_BUILD_BENCHMARKS=ON \
+    -DCMAKE_CXX_STANDARD=17
+
+cmake --build tmp/build-bench --target sync_tick_hub_benchmark
+```
+
+## Presets
+
+```bash
+tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark --preset quick
+tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark --preset realistic
+```
+
+Без аргументов benchmark запускает preset `quick`. `realistic` предназначен
+для ручных измерений перед изменениями pull pagination или changelog indexing.
+
+Список presets:
+
+```bash
+tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark --list-presets
+```
+
+Один custom scenario:
+
+```bash
+tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark \
+    origins historical_chunks_per_origin new_chunks_per_origin \
+    ticks_per_chunk max_batches max_bytes
+```
+
+## CSV
+
+Каждый scenario печатает три фазы:
+
+- `full_cold_replica` проигрывает historical changelog в пустую replica.
+- `incremental_hot` добавляет новые chunks и делает pull без restart engines.
+- `incremental_after_restart` закрывает, заново открывает и реконструирует оба
+  engine, затем добавляет и тянет ещё один incremental range.
+
+`origin_index_entries` обычно должен совпадать с `origins` после historical
+seeding. Это подтверждает, что `_mdbxc_origins` заполнен и pull path может
+пропускать origins, которые уже находятся на cursor получателя, до точного seek
+по changelog key.
+
+Для сравнения sync-core изменений используйте `pull_ms`, `apply_ms`,
+`pull_pages` и `batches_per_sec`. `seed_ms` и `restart_ms` выводятся отдельно,
+чтобы не смешивать подготовку данных с pull/apply поведением.

--- a/benchmarks/README-sync.md
+++ b/benchmarks/README-sync.md
@@ -1,8 +1,11 @@
 # Sync Benchmark
 
-`sync_tick_hub_benchmark` measures the sync core for hub-style tick chunks. It
-uses `DirectSyncPeer` in one process, so the reported timings cover local
-changelog pull, pagination, decode, and local apply work, not network latency.
+`sync_tick_hub_benchmark` measures the core sync path for a hub-style workload:
+one central node stores tick-data chunks from many origins and one replica pulls
+those changes. The benchmark uses `DirectSyncPeer` in one process, so the
+reported timings cover local changelog reads, pagination, decoding, and local
+`handle_push()` work. They do not measure network latency or serialization in a
+real transport.
 
 ## Build
 
@@ -17,23 +20,34 @@ cmake -S . -B tmp/build-bench \
 cmake --build tmp/build-bench --target sync_tick_hub_benchmark
 ```
 
-## Run Presets
+The commands below use Linux/MSYS2 paths. On Windows the executable has the
+`.exe` suffix, for example:
+
+```powershell
+.\tmp\build-bench\bin\benchmarks\sync_tick_hub_benchmark.exe --preset quick
+```
+
+## Built-In Scenarios
+
+Without arguments the benchmark runs the `quick` preset.
 
 ```bash
 tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark --preset quick
 tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark --preset realistic
 ```
 
-Without arguments the benchmark runs the `quick` preset. `realistic` is intended
-for manual measurement before changing pull pagination or changelog indexing.
+| Preset | Purpose |
+| --- | --- |
+| `quick` | Short matrix for checking the build and comparing broad changes. |
+| `realistic` | Larger manual matrix with more origins and history. The name means "closer to a hub workload", not a universal production model. |
 
-List presets:
+List available presets:
 
 ```bash
 tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark --list-presets
 ```
 
-Run one custom scenario:
+## Custom Scenario
 
 ```bash
 tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark \
@@ -41,19 +55,67 @@ tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark \
     ticks_per_chunk max_batches max_bytes
 ```
 
-## CSV Notes
+Positional arguments are optional from left to right. Omitted trailing values
+use the defaults shown below.
+
+| Argument | Default | Meaning |
+| --- | ---: | --- |
+| `origins` | 16 | Number of independent origin nodes represented in the changelog. |
+| `historical_chunks_per_origin` | 512 | Number of already existing batches per origin before the first pull. |
+| `new_chunks_per_origin` | 8 | Number of new batches per origin in each incremental phase. This value is used twice: once for `incremental_hot` and once after restart. |
+| `ticks_per_chunk` | 128 | Number of tick records encoded inside one batch. |
+| `max_batches` | 64 | Maximum number of batches returned in one `PullResponse` page. |
+| `max_bytes` | 4194304 | Approximate byte budget for one response page. |
+
+## CSV Output
 
 Each scenario prints three phases:
 
-- `full_cold_replica` replays the historical changelog into an empty replica.
-- `incremental_hot` appends new chunks and pulls with already-open engines.
-- `incremental_after_restart` closes, reopens, and reconstructs both engines
-  before appending and pulling another incremental range.
+- `full_cold_replica` - initial sync of an empty replica from the accumulated
+  historical changelog.
+- `incremental_hot` - append new batches and sync again without closing
+  connections or reconstructing `SyncEngine`.
+- `incremental_after_restart` - close and reopen both databases, reconstruct
+  `SyncEngine`, append another range of new batches, and perform incremental
+  sync from the persisted receiver cursor.
 
-`origin_index_entries` should normally match `origins` after historical seeding.
-This confirms that `_mdbxc_origins` is populated and the pull path can skip
-origins already at the requester's cursor before seeking exact changelog keys.
+| Column | Meaning |
+| --- | --- |
+| `scenario` | Scenario name. |
+| `phase` | One of the three phases listed above. |
+| `origins` | Number of origin nodes in the scenario. |
+| `historical_chunks_per_origin` | Historical batches seeded per origin before the cold sync. |
+| `new_chunks_per_origin` | New batches per origin for each incremental phase. |
+| `chunks_per_origin` | Batches per origin present for the measured phase. |
+| `ticks_per_chunk` | Tick records encoded in each batch. |
+| `max_batches` | Page limit by batch count. |
+| `max_bytes` | Page limit by approximate encoded bytes. |
+| `seeded_batches` | Batches written locally before the measured pull. |
+| `pulled_batches` | Batches received through `PullResponse` pages. |
+| `applied_batches` | Batches applied through `SyncEngine::handle_push()`. |
+| `pull_pages` | Number of pull requests needed to finish the phase. |
+| `origin_index_entries` | Number of origins registered in `_mdbxc_origins` on the primary. |
+| `seed_ms` | Time spent writing local data for the phase. |
+| `restart_ms` | Time spent closing, reopening, and reconstructing objects for the restart phase. Zero in other phases. |
+| `pull_ms` | Time spent in `DirectSyncPeer::pull()` calls. |
+| `apply_ms` | Time spent in `SyncEngine::handle_push()` calls. |
+| `total_ms` | `seed_ms + restart_ms + pull_ms + apply_ms`. |
+| `batches_per_sec` | `applied_batches / (pull_ms + apply_ms)`. Seeding and restart time are excluded. |
+| `primary_bytes` | MDBX file usage reported for the primary after the phase. |
+| `replica_bytes` | MDBX file usage reported for the replica after the phase. |
 
-Use `pull_ms`, `apply_ms`, `pull_pages`, and `batches_per_sec` for comparing
-sync-core changes. `seed_ms` and `restart_ms` are reported separately so they do
-not hide pull/apply behavior.
+`origin_index_entries` normally matches `origins` after historical seeding. The
+index allows `SyncEngine::handle_pull()` to skip origins where the requester is
+already at the latest known sequence number. For lagging origins, the engine
+still seeks directly to `have_seq + 1`.
+
+## Comparing Results
+
+1. Build both versions in the same mode, preferably `Release`.
+2. Run the same preset or the same custom arguments at least five times.
+3. Treat the first run as a filesystem-cache warmup when results vary.
+4. Compare median `pull_ms`, `apply_ms`, `pull_pages`, and `batches_per_sec`.
+5. Do not compare runs with different compilers, MDBX settings, presets, or
+   scenario arguments.
+6. Use this benchmark for sync-core changes only. It does not estimate HTTP,
+   WebSocket, IPC, or encryption costs.

--- a/benchmarks/README-sync.md
+++ b/benchmarks/README-sync.md
@@ -1,0 +1,59 @@
+# Sync Benchmark
+
+`sync_tick_hub_benchmark` measures the sync core for hub-style tick chunks. It
+uses `DirectSyncPeer` in one process, so the reported timings cover local
+changelog pull, pagination, decode, and local apply work, not network latency.
+
+## Build
+
+```bash
+cmake -S . -B tmp/build-bench \
+    -DMDBXC_DEPS_MODE=BUNDLED \
+    -DMDBXC_BUILD_TESTS=OFF \
+    -DMDBXC_BUILD_EXAMPLES=OFF \
+    -DMDBXC_BUILD_BENCHMARKS=ON \
+    -DCMAKE_CXX_STANDARD=17
+
+cmake --build tmp/build-bench --target sync_tick_hub_benchmark
+```
+
+## Run Presets
+
+```bash
+tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark --preset quick
+tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark --preset realistic
+```
+
+Without arguments the benchmark runs the `quick` preset. `realistic` is intended
+for manual measurement before changing pull pagination or changelog indexing.
+
+List presets:
+
+```bash
+tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark --list-presets
+```
+
+Run one custom scenario:
+
+```bash
+tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark \
+    origins historical_chunks_per_origin new_chunks_per_origin \
+    ticks_per_chunk max_batches max_bytes
+```
+
+## CSV Notes
+
+Each scenario prints three phases:
+
+- `full_cold_replica` replays the historical changelog into an empty replica.
+- `incremental_hot` appends new chunks and pulls with already-open engines.
+- `incremental_after_restart` closes, reopens, and reconstructs both engines
+  before appending and pulling another incremental range.
+
+`origin_index_entries` should normally match `origins` after historical seeding.
+This confirms that `_mdbxc_origins` is populated and the pull path can skip
+origins already at the requester's cursor before seeking exact changelog keys.
+
+Use `pull_ms`, `apply_ms`, `pull_pages`, and `batches_per_sec` for comparing
+sync-core changes. `seed_ms` and `restart_ms` are reported separately so they do
+not hide pull/apply behavior.

--- a/benchmarks/sync_tick_hub_benchmark.cpp
+++ b/benchmarks/sync_tick_hub_benchmark.cpp
@@ -296,8 +296,11 @@ void print_usage() {
         << "ticks_per_chunk max_batches max_bytes]\n"
         << "       sync_tick_hub_benchmark --preset quick\n"
         << "       sync_tick_hub_benchmark --preset realistic\n"
+        << "       sync_tick_hub_benchmark --list-presets\n"
         << "\n"
         << "Without arguments, runs the quick built-in scenario matrix.\n"
+        << "Positional arguments are optional from left to right; omitted\n"
+        << "trailing values use the built-in custom-scenario defaults.\n"
         << "The new_chunks_per_origin value is used for both hot and "
         << "after-restart incremental phases.\n";
 }

--- a/benchmarks/sync_tick_hub_benchmark.cpp
+++ b/benchmarks/sync_tick_hub_benchmark.cpp
@@ -53,6 +53,7 @@ struct PhaseMetrics {
     std::uint64_t pulled_batches = 0;
     std::uint64_t applied_batches = 0;
     std::uint64_t pull_pages = 0;
+    std::uint64_t origin_index_entries = 0;
     double        seed_ms = 0.0;
     double        restart_ms = 0.0;
     double        pull_ms = 0.0;
@@ -242,21 +243,92 @@ std::vector<Scenario> default_scenarios() {
     return scenarios;
 }
 
+std::vector<Scenario> realistic_scenarios() {
+    std::vector<Scenario> scenarios;
+
+    Scenario large_history;
+    large_history.name = "hub_32_origins_large_history";
+    large_history.origins = 32;
+    large_history.historical_chunks_per_origin = 2048;
+    large_history.new_chunks_per_origin = 16;
+    large_history.ticks_per_chunk = 64;
+    large_history.max_batches = 128;
+    large_history.max_bytes = default_max_bytes;
+    scenarios.push_back(large_history);
+
+    Scenario sparse_hot;
+    sparse_hot.name = "hub_128_origins_sparse_hot";
+    sparse_hot.origins = 128;
+    sparse_hot.historical_chunks_per_origin = 512;
+    sparse_hot.new_chunks_per_origin = 2;
+    sparse_hot.ticks_per_chunk = 64;
+    sparse_hot.max_batches = 64;
+    sparse_hot.max_bytes = default_max_bytes;
+    scenarios.push_back(sparse_hot);
+
+    Scenario many_origins;
+    many_origins.name = "hub_256_origins_many_small_chunks";
+    many_origins.origins = 256;
+    many_origins.historical_chunks_per_origin = 256;
+    many_origins.new_chunks_per_origin = 1;
+    many_origins.ticks_per_chunk = 16;
+    many_origins.max_batches = 128;
+    many_origins.max_bytes = default_max_bytes;
+    scenarios.push_back(many_origins);
+
+    return scenarios;
+}
+
+std::vector<Scenario> preset_scenarios(const std::string& preset) {
+    if (preset == "quick") {
+        return default_scenarios();
+    }
+    if (preset == "realistic") {
+        return realistic_scenarios();
+    }
+    throw std::runtime_error("unknown benchmark preset: " + preset);
+}
+
+void print_usage() {
+    std::cout
+        << "usage: sync_tick_hub_benchmark "
+        << "[origins historical_chunks_per_origin new_chunks_per_origin "
+        << "ticks_per_chunk max_batches max_bytes]\n"
+        << "       sync_tick_hub_benchmark --preset quick\n"
+        << "       sync_tick_hub_benchmark --preset realistic\n"
+        << "\n"
+        << "Without arguments, runs the quick built-in scenario matrix.\n"
+        << "The new_chunks_per_origin value is used for both hot and "
+        << "after-restart incremental phases.\n";
+}
+
 std::vector<Scenario> parse_scenarios(int argc, char** argv) {
     if (argc == 1) {
-        return default_scenarios();
+        return preset_scenarios("quick");
     }
     if (std::string(argv[1]) == "--help" ||
         std::string(argv[1]) == "-h") {
-        std::cout
-            << "usage: sync_tick_hub_benchmark "
-            << "[origins historical_chunks_per_origin new_chunks_per_origin "
-            << "ticks_per_chunk max_batches max_bytes]\n"
-            << "\n"
-            << "Without arguments, runs a small built-in scenario matrix.\n"
-            << "The new_chunks_per_origin value is used for both hot and "
-            << "after-restart incremental phases.\n";
+        print_usage();
         std::exit(0);
+    }
+    if (std::string(argv[1]) == "--list-presets") {
+        if (argc != 2) {
+            throw std::runtime_error("--list-presets does not accept arguments");
+        }
+        std::cout << "quick\nrealistic\n";
+        std::exit(0);
+    }
+    if (std::string(argv[1]) == "--preset") {
+        if (argc != 3) {
+            throw std::runtime_error("--preset expects exactly one preset name");
+        }
+        return preset_scenarios(argv[2]);
+    }
+    if (argv[1][0] == '-') {
+        throw std::runtime_error(std::string("unknown option: ") + argv[1]);
+    }
+    if (argc > 7) {
+        throw std::runtime_error("too many positional arguments");
     }
 
     Scenario scenario;
@@ -522,6 +594,7 @@ PhaseMetrics run_sync_phase(const std::string& phase,
     metrics.pulled_batches = sync.pulled_batches;
     metrics.applied_batches = sync.applied_batches;
     metrics.pull_pages = sync.pull_pages;
+    metrics.origin_index_entries = count_origin_index_entries(primary_conn);
     metrics.seed_ms = seed_ms;
     metrics.restart_ms = restart_ms;
     metrics.pull_ms = sync.pull_ms;
@@ -542,7 +615,8 @@ void print_csv_header() {
         << "scenario,phase,origins,historical_chunks_per_origin,"
         << "new_chunks_per_origin,chunks_per_origin,ticks_per_chunk,"
         << "max_batches,max_bytes,seeded_batches,pulled_batches,"
-        << "applied_batches,pull_pages,seed_ms,restart_ms,pull_ms,"
+        << "applied_batches,pull_pages,origin_index_entries,"
+        << "seed_ms,restart_ms,pull_ms,"
         << "apply_ms,total_ms,batches_per_sec,primary_bytes,replica_bytes\n";
 }
 
@@ -568,6 +642,7 @@ void print_csv_row(const Scenario& scenario,
               << metrics.pulled_batches << ','
               << metrics.applied_batches << ','
               << metrics.pull_pages << ','
+              << metrics.origin_index_entries << ','
               << metrics.seed_ms << ','
               << metrics.restart_ms << ','
               << metrics.pull_ms << ','

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -1,0 +1,80 @@
+# Примеры Sync
+
+Эти примеры показывают sync v0.1 как transport-agnostic building blocks. Они
+используют `DirectSyncPeer` или маленький in-memory wire, чтобы поток протокола
+был виден без HTTP, WebSocket или IPC-кода.
+
+Sync включается явно. Примеры собираются с `MDBXC_SYNC_ENABLED=1`; приложениям,
+которые используют sync, тоже нужно компилировать соответствующий код с этим
+макросом.
+
+## Сборка И Запуск
+
+```bash
+cmake -S . -B tmp/build-examples \
+    -DMDBXC_DEPS_MODE=BUNDLED \
+    -DMDBXC_BUILD_TESTS=OFF \
+    -DMDBXC_BUILD_EXAMPLES=ON \
+    -DCMAKE_CXX_STANDARD=17
+
+cmake --build tmp/build-examples --target sync_01_lifecycle_direct_peer
+tmp/build-examples/bin/examples/sync_01_lifecycle_direct_peer
+```
+
+Замените имя target на любой пример из таблицы ниже. На Windows у executable
+будет суффикс `.exe`.
+
+## Порядок Чтения
+
+| Пример | Что показывает | Уровень |
+| --- | --- | --- |
+| `sync_01_lifecycle_direct_peer.cpp` | Один явный цикл write -> pull -> push -> read. | Начальный |
+| `sync_02_incremental_direct_peer.cpp` | Cursor получателя и incremental pulls. | Начальный |
+| `sync_03_multi_table.cpp` | Поддерживаемые типы таблиц и paginated pulls. | Средний |
+| `sync_04_primary_to_replicas.cpp` | Один primary и несколько независимых cursor-ов replica. | Средний |
+| `sync_05_three_node_mesh.cpp` | Pairwise exchange без forwarding remote-origin batches. | Продвинутый |
+| `sync_06_threaded_transport.cpp` | Thread ownership и in-memory pull/response wire. | Продвинутый |
+
+## Общие Правила
+
+- `NodeId` идентифицирует физического участника. Сгенерируйте его один раз,
+  сохраните и используйте повторно после restart.
+- `DbId` идентифицирует одну логическую реплицируемую БД. Все копии одной БД
+  должны использовать один и тот же `DbId`.
+- Подключайте `ThreadLocalChangeAccumulator` до записей через поддерживаемые
+  table API и отключайте его после локальной фазы записи.
+- `PullRequest`, `PullResponse`, `PushRequest` и `PushResponse` являются
+  detached DTO протокола. Именно эти данные нужно сериализовать в реальном
+  transport.
+- Не передавайте `Connection`, `Transaction`, table objects, raw MDBX handles
+  или cursors между потоками или процессами.
+- Получатель применяет страницу через `SyncEngine::handle_push()`. Одна
+  страница применяется в одной локальной transaction; multi-page pull не
+  является одной глобальной transaction.
+- Applied cursor получателя сохраняется в MDBX metadata. Следующий pull должен
+  использовать этот cursor, чтобы не проигрывать уже применённые batches.
+- Remote apply обновляет пользовательские таблицы, но не переписывает remote
+  batch в локальный changelog получателя. Обычный узел не становится forwarding
+  relay.
+- Sync v0.1 поддерживает `KeyValueTable`, `KeyTable`, `ValueTable`,
+  `SequenceTable` и `VectorStore` через его внутренние поддерживаемые таблицы.
+  `AnyValueTable`, `KeyMultiValueTable` и `HashedKeyValueStore` не
+  реплицируются, пока для них не описан wire format.
+
+## Граница Transport
+
+`DirectSyncPeer` удобен для tests, examples и in-process demos. Production-код
+должен рассматривать request/response structs как transport payload:
+
+```text
+replica builds PullRequest
+-> transport sends it to the source node
+-> source calls SyncEngine::handle_pull()
+-> transport returns PullResponse
+-> replica wraps batches in PushRequest
+-> replica calls SyncEngine::handle_push()
+```
+
+Threaded example держит два `Connection` и два `SyncEngine` в своих потоках и
+передаёт через wire buffer только sync DTO. Именно эту границу стоит сохранить
+при замене буфера на реальный transport.

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -1,14 +1,14 @@
-# Примеры Sync
+# Примеры синхронизации
 
-Эти примеры показывают sync v0.1 как transport-agnostic building blocks. Они
-используют `DirectSyncPeer` или маленький in-memory wire, чтобы поток протокола
-был виден без HTTP, WebSocket или IPC-кода.
+Эти примеры показывают API sync v0.1 как набор блоков, не привязанных к
+конкретному транспорту. Они используют `DirectSyncPeer` или небольшой буфер в
+памяти, чтобы поток протокола был виден без HTTP, WebSocket или IPC-кода.
 
-Sync включается явно. Примеры собираются с `MDBXC_SYNC_ENABLED=1`; приложениям,
-которые используют sync, тоже нужно компилировать соответствующий код с этим
-макросом.
+Синхронизация включается явно. Примеры собираются с `MDBXC_SYNC_ENABLED=1`;
+приложениям, которые используют sync, тоже нужно компилировать соответствующий
+код с этим макросом.
 
-## Сборка И Запуск
+## Сборка и запуск
 
 ```bash
 cmake -S . -B tmp/build-examples \
@@ -21,60 +21,68 @@ cmake --build tmp/build-examples --target sync_01_lifecycle_direct_peer
 tmp/build-examples/bin/examples/sync_01_lifecycle_direct_peer
 ```
 
-Замените имя target на любой пример из таблицы ниже. На Windows у executable
-будет суффикс `.exe`.
+Замените имя цели сборки на любой пример из таблицы ниже. На Windows имя
+исполняемого файла заканчивается на `.exe`, например:
 
-## Порядок Чтения
+```powershell
+.\tmp\build-examples\bin\examples\sync_01_lifecycle_direct_peer.exe
+```
+
+## Порядок чтения
 
 | Пример | Что показывает | Уровень |
 | --- | --- | --- |
 | `sync_01_lifecycle_direct_peer.cpp` | Один явный цикл write -> pull -> push -> read. | Начальный |
-| `sync_02_incremental_direct_peer.cpp` | Cursor получателя и incremental pulls. | Начальный |
-| `sync_03_multi_table.cpp` | Поддерживаемые типы таблиц и paginated pulls. | Средний |
-| `sync_04_primary_to_replicas.cpp` | Один primary и несколько независимых cursor-ов replica. | Средний |
-| `sync_05_three_node_mesh.cpp` | Pairwise exchange без forwarding remote-origin batches. | Продвинутый |
-| `sync_06_threaded_transport.cpp` | Thread ownership и in-memory pull/response wire. | Продвинутый |
+| `sync_02_incremental_direct_peer.cpp` | Курсор получателя и инкрементальные pull-запросы. | Начальный |
+| `sync_03_multi_table.cpp` | Поддерживаемые типы таблиц и постраничный pull. | Средний |
+| `sync_04_primary_to_replicas.cpp` | Один primary и несколько реплик с независимыми курсорами. | Средний |
+| `sync_05_three_node_mesh.cpp` | Попарный обмен без пересылки batches, полученных от других origin-узлов. | Продвинутый |
+| `sync_06_threaded_transport.cpp` | Владение объектами по потокам и буфер запросов и ответов в памяти. | Продвинутый |
 
-## Общие Правила
+## Общие правила
 
-- `NodeId` идентифицирует физического участника. Сгенерируйте его один раз,
-  сохраните и используйте повторно после restart.
-- `DbId` идентифицирует одну логическую реплицируемую БД. Все копии одной БД
-  должны использовать один и тот же `DbId`.
-- Подключайте `ThreadLocalChangeAccumulator` до записей через поддерживаемые
-  table API и отключайте его после локальной фазы записи.
-- `PullRequest`, `PullResponse`, `PushRequest` и `PushResponse` являются
-  detached DTO протокола. Именно эти данные нужно сериализовать в реальном
-  transport.
-- Не передавайте `Connection`, `Transaction`, table objects, raw MDBX handles
-  или cursors между потоками или процессами.
+- `NodeId` идентифицирует конкретный узел репликации. Сгенерируйте его один
+  раз, сохраните и используйте повторно после перезапуска.
+- `DbId` идентифицирует одну логическую реплицируемую БД. Все узлы,
+  реплицирующие эту логическую БД, должны использовать одинаковый `DbId`.
+- Перед локальными записями прикрепите `ThreadLocalChangeAccumulator` через
+  `attach_sync_capture()`. После завершения локальной фазы записи вызовите
+  `detach_sync_capture()`.
+- `PullRequest`, `PullResponse`, `PushRequest` и `PushResponse` - структуры
+  данных протокола. Именно эти значения нужно сериализовать и передавать через
+  транспорт приложения.
+- Не передавайте между потоками или процессами объекты `Connection`,
+  `Transaction` и таблиц, а также необёрнутые дескрипторы MDBX и курсоры.
 - Получатель применяет страницу через `SyncEngine::handle_push()`. Одна
-  страница применяется в одной локальной transaction; multi-page pull не
-  является одной глобальной transaction.
-- Applied cursor получателя сохраняется в MDBX metadata. Следующий pull должен
-  использовать этот cursor, чтобы не проигрывать уже применённые batches.
-- Remote apply обновляет пользовательские таблицы, но не переписывает remote
-  batch в локальный changelog получателя. Обычный узел не становится forwarding
-  relay.
+  страница применяется в одной локальной транзакции; многостраничный pull не
+  является одной глобальной транзакцией.
+- Курсор применённых изменений получателя сохраняется в MDBX metadata.
+  Следующий pull должен использовать этот курсор, чтобы не применять уже
+  обработанные batches повторно.
+- Применение удалённых изменений обновляет пользовательские таблицы, но не
+  записывает удалённый batch в локальный changelog получателя. Обычный узел не
+  становится транзитным relay-узлом.
 - Sync v0.1 поддерживает `KeyValueTable`, `KeyTable`, `ValueTable`,
   `SequenceTable` и `VectorStore` через его внутренние поддерживаемые таблицы.
   `AnyValueTable`, `KeyMultiValueTable` и `HashedKeyValueStore` не
-  реплицируются, пока для них не описан wire format.
+  реплицируются, пока для них не описан формат передачи.
 
-## Граница Transport
+## Граница транспорта
 
-`DirectSyncPeer` удобен для tests, examples и in-process demos. Production-код
-должен рассматривать request/response structs как transport payload:
+`DirectSyncPeer` удобен для тестов, примеров и демонстраций внутри одного
+процесса. Рабочий код приложения должен рассматривать структуры запросов и
+ответов как данные, которые передаются транспортом:
 
 ```text
-replica builds PullRequest
--> transport sends it to the source node
--> source calls SyncEngine::handle_pull()
--> transport returns PullResponse
--> replica wraps batches in PushRequest
--> replica calls SyncEngine::handle_push()
+replica формирует PullRequest
+-> транспорт передаёт его исходному узлу
+-> исходный узел вызывает SyncEngine::handle_pull()
+-> транспорт возвращает PullResponse
+-> replica помещает batches в PushRequest
+-> replica вызывает SyncEngine::handle_push()
 ```
 
-Threaded example держит два `Connection` и два `SyncEngine` в своих потоках и
-передаёт через wire buffer только sync DTO. Именно эту границу стоит сохранить
-при замене буфера на реальный transport.
+Многопоточный пример держит каждый `Connection` и `SyncEngine` в том потоке,
+который владеет соответствующей БД. Общий буфер передаёт только значения
+запросов и ответов протокола. Эту границу стоит сохранить при замене буфера на
+реальный транспорт.

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -1,13 +1,13 @@
 # Sync Examples
 
 These examples show the sync v0.1 API as transport-agnostic building blocks.
-They use `DirectSyncPeer` or a small in-memory wire so the protocol flow is
+They use `DirectSyncPeer` or a small in-memory buffer so the protocol flow is
 visible without adding HTTP, WebSocket, or IPC code.
 
 Sync is opt-in. The examples are built with `MDBXC_SYNC_ENABLED=1`; applications
 must also compile sync users with that macro enabled.
 
-## Build And Run
+## Build and Run
 
 ```bash
 cmake -S . -B tmp/build-examples \
@@ -21,7 +21,11 @@ tmp/build-examples/bin/examples/sync_01_lifecycle_direct_peer
 ```
 
 Replace the target name with any example from the table below. On Windows the
-executable has the `.exe` suffix.
+executable has the `.exe` suffix, for example:
+
+```powershell
+.\tmp\build-examples\bin\examples\sync_01_lifecycle_direct_peer.exe
+```
 
 ## Reading Order
 
@@ -32,18 +36,20 @@ executable has the `.exe` suffix.
 | `sync_03_multi_table.cpp` | Supported table types and paginated pulls. | Intermediate |
 | `sync_04_primary_to_replicas.cpp` | One primary, multiple independent replica cursors. | Intermediate |
 | `sync_05_three_node_mesh.cpp` | Pairwise exchange without forwarding remote-origin batches. | Advanced |
-| `sync_06_threaded_transport.cpp` | Thread ownership and an in-memory pull/response wire. | Advanced |
+| `sync_06_threaded_transport.cpp` | Thread ownership and an in-memory request/response buffer. | Advanced |
 
 ## Common Rules
 
-- `NodeId` identifies one physical participant. Generate it once, persist it,
-  and reuse it after restart.
-- `DbId` identifies one logical replicated database. All copies of the same
-  database must use the same `DbId`.
-- Attach `ThreadLocalChangeAccumulator` before writing through supported table
-  APIs, then detach it after the local write phase.
-- `PullRequest`, `PullResponse`, `PushRequest`, and `PushResponse` are detached
-  protocol DTOs. They are the data to serialize over a real transport.
+- `NodeId` identifies one replication node. Generate it once, persist it, and
+  reuse it after restart.
+- `DbId` identifies one logical replicated database. All nodes replicating the
+  same logical database must use the same `DbId`.
+- Before local writes, attach `ThreadLocalChangeAccumulator` with
+  `attach_sync_capture()`. After the local write phase, call
+  `detach_sync_capture()`.
+- `PullRequest`, `PullResponse`, `PushRequest`, and `PushResponse` are
+  transport payload structs. Serialize and deliver these values through the
+  transport used by your application.
 - Do not pass `Connection`, `Transaction`, table objects, raw MDBX handles, or
   cursors across threads or processes.
 - A receiver applies a page with `SyncEngine::handle_push()`. One page is
@@ -72,6 +78,7 @@ replica builds PullRequest
 -> replica calls SyncEngine::handle_push()
 ```
 
-The threaded example keeps two `Connection` and `SyncEngine` objects in their
-own threads and sends only sync DTOs through the wire buffer. That is the part
-to preserve when replacing the buffer with a real transport.
+The threaded example keeps each `Connection` and `SyncEngine` on the thread that
+owns its database. The shared buffer carries only sync request/response values.
+That is the boundary to preserve when replacing the buffer with a real
+transport.

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -7,6 +7,22 @@ visible without adding HTTP, WebSocket, or IPC code.
 Sync is opt-in. The examples are built with `MDBXC_SYNC_ENABLED=1`; applications
 must also compile sync users with that macro enabled.
 
+## Build And Run
+
+```bash
+cmake -S . -B tmp/build-examples \
+    -DMDBXC_DEPS_MODE=BUNDLED \
+    -DMDBXC_BUILD_TESTS=OFF \
+    -DMDBXC_BUILD_EXAMPLES=ON \
+    -DCMAKE_CXX_STANDARD=17
+
+cmake --build tmp/build-examples --target sync_01_lifecycle_direct_peer
+tmp/build-examples/bin/examples/sync_01_lifecycle_direct_peer
+```
+
+Replace the target name with any example from the table below. On Windows the
+executable has the `.exe` suffix.
+
 ## Reading Order
 
 | Example | What it demonstrates | Level |

--- a/guides/build-and-test.md
+++ b/guides/build-and-test.md
@@ -108,6 +108,14 @@ the sync core, pagination, and local apply path rather than network transport
 latency.
 CI also builds this benchmark target and runs a small custom scenario as a
 smoke check; full measurement runs remain manual.
+The benchmark supports named presets:
+
+```bash
+sync_tick_hub_benchmark --preset quick
+sync_tick_hub_benchmark --preset realistic
+sync_tick_hub_benchmark --list-presets
+```
+
 Pass positional arguments to run one custom scenario:
 
 ```bash

--- a/guides/build-and-test.md
+++ b/guides/build-and-test.md
@@ -30,8 +30,8 @@ FetchContent lookup. Parent-provided targets take precedence over
 
 Use `tmp/` inside the repository for local verification builds, installs,
 consumer projects, and other scratch outputs. Keep these directories untracked
-and disposable. Do not scatter verification directories beside the repository
-unless the user explicitly asks for an out-of-worktree location.
+and disposable. Use an external build directory only when isolation from the
+working tree is specifically required.
 
 Configure, build, and test C++17:
 
@@ -101,6 +101,12 @@ cmake --build tmp/build-bench --target sync_tick_hub_benchmark
 tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark
 ```
 
+On Windows the executable has the `.exe` suffix, for example:
+
+```powershell
+.\tmp\build-bench\bin\benchmarks\sync_tick_hub_benchmark.exe --preset quick
+```
+
 `sync_tick_hub_benchmark` prints CSV rows for full cold-replica sync,
 incremental hot sync, and incremental sync after restarting both connections
 and sync engines. It uses `DirectSyncPeer` in one process, so the timings measure
@@ -108,6 +114,8 @@ the sync core, pagination, and local apply path rather than network transport
 latency.
 CI also builds this benchmark target and runs a small custom scenario as a
 smoke check; full measurement runs remain manual.
+See [`benchmarks/README-sync.md`](../benchmarks/README-sync.md) for scenario
+parameters, CSV columns, and measurement guidelines.
 The benchmark supports named presets:
 
 ```bash


### PR DESCRIPTION
## Summary

- add `sync_tick_hub_benchmark --preset quick|realistic` and `--list-presets`
- add `origin_index_entries` to benchmark CSV so runs show whether `_mdbxc_origins` is populated for indexed pull
- document benchmark build/run commands and CSV interpretation in English and Russian
- add `examples/README-sync-RU.md`
- add example build/run commands to `examples/README-sync.md`
- update README and build guide links

Note: current `main` already uses `_mdbxc_origins` plus exact per-origin
`MDBX_SET_RANGE(have_seq + 1)` in `SyncEngine::handle_pull()`. This PR keeps
that production path unchanged and makes the hub/tick workload measurable before
any future pull/indexing changes.

## Validation

- `cmake -S . -B tmp/pr100-bench-cpp17 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=OFF -DMDBXC_BUILD_EXAMPLES=OFF -DMDBXC_BUILD_BENCHMARKS=ON -DCMAKE_CXX_STANDARD=17`
- `cmake --build tmp/pr100-bench-cpp17 --target sync_tick_hub_benchmark -- -j`
- `tmp/pr100-bench-cpp17/bin/benchmarks/sync_tick_hub_benchmark.exe --help`
- `tmp/pr100-bench-cpp17/bin/benchmarks/sync_tick_hub_benchmark.exe --list-presets`
- `tmp/pr100-bench-cpp17/bin/benchmarks/sync_tick_hub_benchmark.exe 3 8 3 4 2 4096`
- `tmp/pr100-bench-cpp17/bin/benchmarks/sync_tick_hub_benchmark.exe --preset quick`
- `tmp/pr100-bench-cpp17/bin/benchmarks/sync_tick_hub_benchmark.exe --preset realistic`
- `tmp/pr100-bench-cpp17/bin/benchmarks/sync_tick_hub_benchmark.exe --preset nope` rejected the unknown preset as expected
- `cmake -S . -B tmp/pr100-bench-cpp11 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=OFF -DMDBXC_BUILD_EXAMPLES=OFF -DMDBXC_BUILD_BENCHMARKS=ON -DCMAKE_CXX_STANDARD=11`
- `cmake --build tmp/pr100-bench-cpp11 --target sync_tick_hub_benchmark -- -j`
- `tmp/pr100-bench-cpp11/bin/benchmarks/sync_tick_hub_benchmark.exe 3 8 3 4 2 4096`
