### PR TITLE
bench(sync): add diagnostic timing ratios

### DIFF
--- a/benchmarks/README-sync-RU.md
+++ b/benchmarks/README-sync-RU.md
@@ -101,6 +101,10 @@ tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark \
 | `pull_ms` | Время, затраченное на вызовы `DirectSyncPeer::pull()`. |
 | `apply_ms` | Время, затраченное на вызовы `SyncEngine::handle_push()`. |
 | `total_ms` | `seed_ms + restart_ms + pull_ms + apply_ms`. |
+| `sync_ms` | `pull_ms + apply_ms`. Время подготовки данных и перезапуска не учитывается. |
+| `pull_pct` | Доля `sync_ms`, затраченная на pull-вызовы. |
+| `apply_pct` | Доля `sync_ms`, затраченная на локальное применение страниц. |
+| `batches_per_page` | Среднее значение `pulled_batches / pull_pages`. |
 | `batches_per_sec` | `applied_batches / (pull_ms + apply_ms)`. Время подготовки данных и перезапуска не учитывается. |
 | `primary_bytes` | Размер занятых страниц MDBX у primary после фазы. |
 | `replica_bytes` | Размер занятых страниц MDBX у replica после фазы. |
@@ -111,6 +115,11 @@ tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark \
 дошёл до последнего известного `seq`. Для отстающих origin-узлов
 движок выполняет точный поиск начиная с `have_seq + 1`.
 
+Перед выбором направления оптимизации смотрите на `pull_pct` и `apply_pct`.
+Если `pull_pct` низкий, текущий запуск в основном тратит время на локальное
+применение страниц; изменение алгоритма pull слабо повлияет на общую
+пропускную способность такой нагрузки.
+
 ## Как сравнивать результаты
 
 1. Соберите обе версии в одинаковом режиме, желательно `Release`.
@@ -118,8 +127,8 @@ tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark \
    раз.
 3. Первый запуск можно считать прогревом файлового кэша, если результаты
    заметно плавают.
-4. Сравнивайте медиану `pull_ms`, `apply_ms`, `pull_pages` и
-   `batches_per_sec`.
+4. Сравнивайте медиану `pull_ms`, `apply_ms`, `pull_pct`, `apply_pct`,
+   `pull_pages` и `batches_per_sec`.
 5. Не сравнивайте запуски с разными компиляторами, настройками MDBX,
    сценариями или аргументами.
 6. Используйте этот benchmark только для оценки изменений ядра синхронизации.

--- a/benchmarks/README-sync.md
+++ b/benchmarks/README-sync.md
@@ -100,6 +100,10 @@ Each scenario prints three phases:
 | `pull_ms` | Time spent in `DirectSyncPeer::pull()` calls. |
 | `apply_ms` | Time spent in `SyncEngine::handle_push()` calls. |
 | `total_ms` | `seed_ms + restart_ms + pull_ms + apply_ms`. |
+| `sync_ms` | `pull_ms + apply_ms`. This excludes seeding and restart time. |
+| `pull_pct` | Share of `sync_ms` spent in pull calls. |
+| `apply_pct` | Share of `sync_ms` spent applying pages locally. |
+| `batches_per_page` | Average `pulled_batches / pull_pages`. |
 | `batches_per_sec` | `applied_batches / (pull_ms + apply_ms)`. Seeding and restart time are excluded. |
 | `primary_bytes` | MDBX file usage reported for the primary after the phase. |
 | `replica_bytes` | MDBX file usage reported for the replica after the phase. |
@@ -109,12 +113,17 @@ index allows `SyncEngine::handle_pull()` to skip origins where the requester is
 already at the latest known sequence number. For lagging origins, the engine
 still seeks directly to `have_seq + 1`.
 
+Use `pull_pct` and `apply_pct` before choosing an optimization target. A low
+`pull_pct` means the current run is dominated by local apply work; changing the
+pull algorithm is unlikely to move total throughput for that workload.
+
 ## Comparing Results
 
 1. Build both versions in the same mode, preferably `Release`.
 2. Run the same preset or the same custom arguments at least five times.
 3. Treat the first run as a filesystem-cache warmup when results vary.
-4. Compare median `pull_ms`, `apply_ms`, `pull_pages`, and `batches_per_sec`.
+4. Compare median `pull_ms`, `apply_ms`, `pull_pct`, `apply_pct`,
+   `pull_pages`, and `batches_per_sec`.
 5. Do not compare runs with different compilers, MDBX settings, presets, or
    scenario arguments.
 6. Use this benchmark for sync-core changes only. It does not estimate HTTP,

--- a/benchmarks/sync_tick_hub_benchmark.cpp
+++ b/benchmarks/sync_tick_hub_benchmark.cpp
@@ -620,18 +620,29 @@ void print_csv_header() {
         << "max_batches,max_bytes,seeded_batches,pulled_batches,"
         << "applied_batches,pull_pages,origin_index_entries,"
         << "seed_ms,restart_ms,pull_ms,"
-        << "apply_ms,total_ms,batches_per_sec,primary_bytes,replica_bytes\n";
+        << "apply_ms,total_ms,sync_ms,pull_pct,apply_pct,"
+        << "batches_per_page,batches_per_sec,primary_bytes,replica_bytes\n";
 }
 
 void print_csv_row(const Scenario& scenario,
                    const PhaseMetrics& metrics) {
+    const double sync_ms = metrics.pull_ms + metrics.apply_ms;
     const double total_ms =
-        metrics.seed_ms + metrics.restart_ms + metrics.pull_ms + metrics.apply_ms;
+        metrics.seed_ms + metrics.restart_ms + sync_ms;
+    const double pull_pct =
+        sync_ms <= 0.0 ? 0.0 : (metrics.pull_ms * 100.0) / sync_ms;
+    const double apply_pct =
+        sync_ms <= 0.0 ? 0.0 : (metrics.apply_ms * 100.0) / sync_ms;
+    const double batches_per_page =
+        metrics.pull_pages == 0
+            ? 0.0
+            : static_cast<double>(metrics.pulled_batches) /
+              static_cast<double>(metrics.pull_pages);
     const double batches_per_sec =
-        (metrics.pull_ms + metrics.apply_ms) <= 0.0
+        sync_ms <= 0.0
             ? 0.0
             : (static_cast<double>(metrics.applied_batches) * 1000.0) /
-              (metrics.pull_ms + metrics.apply_ms);
+              sync_ms;
     std::cout << scenario.name << ','
               << metrics.phase << ','
               << scenario.origins << ','
@@ -651,6 +662,10 @@ void print_csv_row(const Scenario& scenario,
               << metrics.pull_ms << ','
               << metrics.apply_ms << ','
               << total_ms << ','
+              << sync_ms << ','
+              << pull_pct << ','
+              << apply_pct << ','
+              << batches_per_page << ','
               << batches_per_sec << ','
               << metrics.primary_bytes << ','
               << metrics.replica_bytes << '\n';


### PR DESCRIPTION
﻿## Summary

- add derived benchmark CSV columns: `sync_ms`, `pull_pct`, `apply_pct`, and `batches_per_page`
- document the new diagnostic columns in English and Russian benchmark READMEs
- explain how to use pull/apply shares before choosing an optimization target

## Baseline observation

A local Release MinGW C++17 run of `--preset realistic` on the current main showed `pull_pct` around 0.38%-3.58% across the preset rows. That means this workload is currently dominated by local apply time, so this PR does not change production `SyncEngine::handle_pull()` logic.

## Validation

- `cmake --build tmp/pr101-bench-release --target sync_tick_hub_benchmark -- -j`
- `cmake -S . -B tmp/pr101-bench-cpp11 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=OFF -DMDBXC_BUILD_EXAMPLES=OFF -DMDBXC_BUILD_BENCHMARKS=ON -DCMAKE_CXX_STANDARD=11`
- `cmake --build tmp/pr101-bench-cpp11 --target sync_tick_hub_benchmark -- -j`
- `tmp\pr101-bench-release\bin\benchmarks\sync_tick_hub_benchmark.exe 3 8 3 4 2 4096`
- `tmp\pr101-bench-cpp11\bin\benchmarks\sync_tick_hub_benchmark.exe 3 8 3 4 2 4096`
- `tmp\pr101-bench-release\bin\benchmarks\sync_tick_hub_benchmark.exe --preset quick`
- `tmp\pr101-bench-release\bin\benchmarks\sync_tick_hub_benchmark.exe --preset realistic`
- `git diff --check`
