### PR TITLE
docs(sync): pin transport boundary contract

### DIFF
--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -39,6 +39,7 @@ tmp/build-examples/bin/examples/sync_01_lifecycle_direct_peer
 | `sync_05_three_node_mesh.cpp` | Попарный обмен без пересылки batches, полученных от других origin-узлов. | Продвинутый |
 | `sync_06_threaded_transport.cpp` | Владение объектами по потокам и буфер запросов и ответов в памяти. | Продвинутый |
 | `sync_07_worker_observer.cpp` | Фоновый `SyncWorker` и уведомления о прогрессе через `ISyncWorkerObserver`. | Продвинутый |
+| `sync_08_transport_boundary.cpp` | Псевдотранспорт, который проверяет контракт границы `ISyncPeer` (`CancellationToken` + `request_cancel()`). | Продвинутый |
 
 ## Общие правила
 
@@ -91,3 +92,9 @@ replica формирует PullRequest
 `sync_07_worker_observer.cpp` показывает сторону приложения у фоновой реплики:
 `SyncWorker` выполняет pull/apply циклы, а `ISyncWorkerObserver` сообщает
 основному коду, когда страницы применены или завершён очередной цикл.
+
+`sync_08_transport_boundary.cpp` фиксирует контракт, которому должен следовать
+transport adapter поверх `ISyncPeer`. Пример показывает, где наблюдается
+`CancellationToken` из `PullRequest` и где `ISyncPeer::request_cancel()`
+закрывает выполняющийся вызов. Реальные HTTP и WebSocket adapter-ы используют
+ту же схему, заменяя очереди в памяти на сокеты.

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -94,7 +94,8 @@ replica формирует PullRequest
 основному коду, когда страницы применены или завершён очередной цикл.
 
 `sync_08_transport_boundary.cpp` фиксирует контракт, которому должен следовать
-transport adapter поверх `ISyncPeer`. Пример показывает, где наблюдается
-`CancellationToken` из `PullRequest` и где `ISyncPeer::request_cancel()`
-закрывает выполняющийся вызов. Реальные HTTP и WebSocket adapter-ы используют
-ту же схему, заменяя очереди в памяти на сокеты.
+транспортный адаптер, реализующий `ISyncPeer`. Пример показывает, где
+наблюдается `CancellationToken` из `PullRequest` и где
+`ISyncPeer::request_cancel()` закрывает выполняющийся вызов. Реальные
+адаптеры HTTP и WebSocket используют ту же схему, заменяя очереди в памяти
+на сокеты.

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -38,6 +38,7 @@ executable has the `.exe` suffix, for example:
 | `sync_05_three_node_mesh.cpp` | Pairwise exchange without forwarding remote-origin batches. | Advanced |
 | `sync_06_threaded_transport.cpp` | Thread ownership and an in-memory request/response buffer. | Advanced |
 | `sync_07_worker_observer.cpp` | Background `SyncWorker` progress notifications through `ISyncWorkerObserver`. | Advanced |
+| `sync_08_transport_boundary.cpp` | Pseudo-transport that exercises the `ISyncPeer` boundary contract (cancellation token + `request_cancel()`). | Advanced |
 
 ## Common Rules
 
@@ -87,3 +88,11 @@ transport.
 `sync_07_worker_observer.cpp` shows the application side of a background
 replica: `SyncWorker` performs pull/apply rounds, while `ISyncWorkerObserver`
 notifies foreground code when pages are applied or rounds finish.
+
+`sync_08_transport_boundary.cpp` formalises the contract that any transport
+adapter over `ISyncPeer` must respect. It implements a tiny in-memory
+adapter that owns no MDBX handles and demonstrates where the
+`CancellationToken` from `PullRequest` is observed and where
+`ISyncPeer::request_cancel()` closes the in-flight call. Real HTTP and
+WebSocket adapters will use the same pattern, swapping the in-memory
+queues for sockets.

--- a/examples/sync_08_transport_boundary.cpp
+++ b/examples/sync_08_transport_boundary.cpp
@@ -33,6 +33,7 @@
 
 #include <chrono>
 #include <condition_variable>
+#include <cstddef>
 #include <cstdio>
 #include <cstdint>
 #include <exception>
@@ -49,6 +50,8 @@ struct PullSlot {
     bool request_ready = false;
     bool response_ready = false;
     bool closed = false;
+    bool last_request_can_be_cancelled = false;
+    std::size_t cancel_count = 0;
     mdbxc::sync::PullRequest  request;
     mdbxc::sync::PullResponse response;
 };
@@ -72,6 +75,8 @@ public:
             m_slot.request_ready = true;
             m_slot.response_ready = false;
             m_slot.closed = false;
+            m_slot.last_request_can_be_cancelled =
+                request.cancel_token.can_be_cancelled();
         }
         m_slot.changed.notify_all();
 
@@ -108,8 +113,26 @@ public:
         {
             std::lock_guard<std::mutex> lock(m_slot.mutex);
             m_slot.closed = true;
+            ++m_slot.cancel_count;
         }
         m_slot.changed.notify_all();
+    }
+
+    bool wait_for_request(std::chrono::milliseconds timeout) {
+        std::unique_lock<std::mutex> lock(m_slot.mutex);
+        return m_slot.changed.wait_for(
+            lock, timeout,
+            [this] { return m_slot.request_ready || m_slot.closed; });
+    }
+
+    bool last_request_can_be_cancelled() const {
+        std::lock_guard<std::mutex> lock(m_slot.mutex);
+        return m_slot.last_request_can_be_cancelled;
+    }
+
+    std::size_t cancel_count() const {
+        std::lock_guard<std::mutex> lock(m_slot.mutex);
+        return m_slot.cancel_count;
     }
 
 private:
@@ -220,32 +243,30 @@ int main() {
         // calls request_cancel() during stop. This phase confirms the
         // second half of the transport contract by observing both.
         {
-            std::thread server([&handler] {
-                // Long-lived handler; exits when the peer closes the slot.
-                while (handler.serve_one_blocking()) {
-                }
-            });
-
             mdbxc::sync::SyncWorkerOptions options;
             options.idle_interval = std::chrono::milliseconds(10000);
             mdbxc::sync::SyncWorker worker(replica_engine, peer, options);
 
+            const std::size_t cancel_count_before = peer.cancel_count();
             worker.start();
-            // Give the worker a moment to enter Pulling and hand the
-            // peer a cancellable token, then stop and wait for the
-            // peer's request_cancel() to close the slot.
-            const bool reached_pulling = worker.wait_until_state(
-                mdbxc::sync::SyncWorkerState::Pulling,
+            // No server handler is running in this phase, so the worker's
+            // pull blocks inside the transport slot until stop() invokes
+            // request_cancel(). This makes the cancellation bridge
+            // deterministic instead of racing a normal server response.
+            const bool request_arrived = peer.wait_for_request(
                 std::chrono::milliseconds(2000));
             sync_example::require(
-                reached_pulling,
-                "worker did not enter Pulling within 2s");
+                request_arrived,
+                "worker did not send a pull request within 2s");
+            sync_example::require(
+                peer.last_request_can_be_cancelled(),
+                "worker did not deliver a cancellable token");
             std::printf("[phase B] worker delivered a cancellable token\n");
             worker.stop();
+            sync_example::require(
+                peer.cancel_count() == cancel_count_before + 1u,
+                "worker did not invoke request_cancel()");
             std::printf("[phase B] request_cancel() was invoked\n");
-            // The peer already closed its slot via request_cancel(), so
-            // the server thread will exit on the next iteration.
-            server.join();
 
             sync_example::require(
                 worker.state() == mdbxc::sync::SyncWorkerState::Stopped,

--- a/examples/sync_08_transport_boundary.cpp
+++ b/examples/sync_08_transport_boundary.cpp
@@ -201,9 +201,10 @@ int main() {
 
     try {
         // A single Connection hosts both the worker engine (replica side)
-        // and the dispatching engine (server side). In production they
-        // live on different Connections on different threads; here we
-        // keep them on one process for the contract demo.
+        // and the dispatching engine (server side) only to keep this
+        // pseudo-transport demo compact. Do not copy this arrangement into
+        // a real client/server transport: each endpoint must own its own
+        // Connection and SyncEngine on its own side of the boundary.
         std::shared_ptr<mdbxc::Connection> replica_db =
             sync_example::open(path);
         mdbxc::sync::SyncEngine replica_engine(replica_db);

--- a/examples/sync_08_transport_boundary.cpp
+++ b/examples/sync_08_transport_boundary.cpp
@@ -1,0 +1,264 @@
+/**
+ * \ingroup mdbxc_examples
+ * \brief Pseudo-transport that exercises the \c ISyncPeer boundary contract.
+ *
+ * This example builds a small in-memory transport to make the boundary
+ * between the sync core and a real network adapter explicit. It is
+ * deliberately not an HTTP/WebSocket client; the goal is to show what any
+ * transport adapter must implement and where the cancellation bridge lives.
+ *
+ * The example runs two short, deterministic phases against the same
+ * in-memory transport:
+ *
+ * Phase A: a foreground pull through the transport. The caller builds a
+ * \c PullRequest, sends it through \c ReplicaPeer::pull, and a server
+ * handler runs \c SyncEngine::handle_pull. This proves the DTO crosses
+ * the boundary in both directions without leaking any MDBX handle, and
+ * that the default-constructed \c CancellationToken reaches the peer
+ * with \c can_be_cancelled() == false.
+ *
+ * Phase B: a background \c SyncWorker run against the same transport.
+ * This proves the second half of the contract: the worker hands the
+ * peer a cancellable \c CancellationToken, and \c ISyncPeer::request_cancel()
+ * is the hook that the worker calls to abort the in-flight call.
+ *
+ * Expected output:
+ *   [phase A] foreground pull returned 0 batch(es) (empty source)
+ *   [phase B] worker delivered a cancellable token
+ *   [phase B] request_cancel() was invoked
+ *   OK: sync_08_transport_boundary
+ */
+
+#include "sync_example_utils.hpp"
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+struct PullSlot {
+    std::mutex mutex;
+    std::condition_variable changed;
+    bool request_ready = false;
+    bool response_ready = false;
+    bool closed = false;
+    mdbxc::sync::PullRequest  request;
+    mdbxc::sync::PullResponse response;
+};
+
+/// \brief Replica-side transport boundary.
+///
+/// \c SyncWorker calls \c pull() to send a request. The transport puts the
+/// request into the matching \c PullSlot and waits for a response while
+/// observing the request's cancel token. \c request_cancel() is the
+/// best-effort hook that the worker calls when it wants to abort the
+/// in-flight call: here it closes the slot so the wait returns.
+class ReplicaPeer : public mdbxc::sync::ISyncPeer {
+public:
+    explicit ReplicaPeer(PullSlot& slot) : m_slot(slot) {}
+
+    mdbxc::sync::PullResponse pull(
+            const mdbxc::sync::PullRequest& request) override {
+        {
+            std::lock_guard<std::mutex> lock(m_slot.mutex);
+            m_slot.request = request;
+            m_slot.request_ready = true;
+            m_slot.response_ready = false;
+            m_slot.closed = false;
+        }
+        m_slot.changed.notify_all();
+
+        std::unique_lock<std::mutex> lock(m_slot.mutex);
+        // The transport wait is interrupted by either a response, a slot
+        // close triggered through request_cancel(), or the request's own
+        // cancel token. The cancel-token observation is the
+        // "transport adapter polls the cancel token" half of the contract.
+        m_slot.changed.wait(lock, [this] {
+            return m_slot.response_ready || m_slot.closed ||
+                   m_slot.request.cancel_token.is_cancellation_requested();
+        });
+        if (m_slot.closed ||
+            m_slot.request.cancel_token.is_cancellation_requested()) {
+            // Cancellation is best-effort; an empty PullResponse is the
+            // documented no-op shape. The worker discards returned pages
+            // after request_stop() so this never reaches handle_push().
+            return mdbxc::sync::PullResponse();
+        }
+        const mdbxc::sync::PullResponse out = m_slot.response;
+        m_slot.response_ready = false;
+        return out;
+    }
+
+    mdbxc::sync::PushResponse push(
+            const mdbxc::sync::PushRequest& request) override {
+        // The example only exercises the pull path. A real primary-to-
+        // primary scenario would wire a second queue here.
+        (void)request;
+        return mdbxc::sync::PushResponse();
+    }
+
+    void request_cancel() override {
+        {
+            std::lock_guard<std::mutex> lock(m_slot.mutex);
+            m_slot.closed = true;
+        }
+        m_slot.changed.notify_all();
+    }
+
+private:
+    PullSlot& m_slot;
+};
+
+/// \brief Server-side transport handler.
+///
+/// This is the synchronous shape of a single request handler. In a real
+/// HTTP server this would be the body of one request handler invoked by a
+/// thread pool. The handler reads the request DTO, dispatches to
+/// \c SyncEngine::handle_pull, and posts the response back.
+class ServerHandler {
+public:
+    explicit ServerHandler(mdbxc::sync::SyncEngine& engine,
+                           PullSlot& pull_slot)
+        : m_engine(engine), m_pull_slot(pull_slot) {}
+
+    /// \brief Serves one pull request. Blocks until a request arrives.
+    /// \return \c true if a round-trip completed.
+    /// \warning This call is the in-thread synchronous analogue of an
+    ///          HTTP handler body. It is not the adapter: a real adapter
+    ///          would own its own threading, timeouts, and request parsing.
+    bool serve_one_blocking() {
+        mdbxc::sync::PullRequest request;
+        {
+            std::unique_lock<std::mutex> lock(m_pull_slot.mutex);
+            m_pull_slot.changed.wait(lock, [this] {
+                return m_pull_slot.request_ready || m_pull_slot.closed;
+            });
+            if (m_pull_slot.closed || !m_pull_slot.request_ready) {
+                return false;
+            }
+            request = m_pull_slot.request;
+            m_pull_slot.request_ready = false;
+        }
+
+        const mdbxc::sync::PullResponse response =
+            m_engine.handle_pull(request);
+        {
+            std::lock_guard<std::mutex> lock(m_pull_slot.mutex);
+            m_pull_slot.response = response;
+            m_pull_slot.response_ready = true;
+        }
+        m_pull_slot.changed.notify_all();
+        return true;
+    }
+
+private:
+    mdbxc::sync::SyncEngine& m_engine;
+    PullSlot& m_pull_slot;
+};
+
+} // namespace
+
+int main() {
+    const std::string path = "sync_08_single.mdbx";
+    sync_example::cleanup(path);
+
+    const std::uint8_t node_seed = 0xC0;
+    const std::uint8_t db_seed   = 0xC1;
+    const mdbxc::sync::NodeId node_id =
+        sync_example::make_node(node_seed);
+    const mdbxc::sync::DbId db_id =
+        sync_example::make_node(db_seed);
+
+    try {
+        // A single Connection hosts both the worker engine (replica side)
+        // and the dispatching engine (server side). In production they
+        // live on different Connections on different threads; here we
+        // keep them on one process for the contract demo.
+        std::shared_ptr<mdbxc::Connection> replica_db =
+            sync_example::open(path);
+        mdbxc::sync::SyncEngine replica_engine(replica_db);
+        replica_engine.initialize_local_identity(node_id, db_id);
+
+        PullSlot pull_slot;
+        ReplicaPeer peer(pull_slot);
+        ServerHandler handler(replica_engine, pull_slot);
+
+        // ---- Phase A: foreground pull --------------------------------
+        // The replica thread sends a PullRequest without going through
+        // SyncWorker, so the request's cancel token is default-
+        // constructed. The peer must observe can_be_cancelled() == false.
+        {
+            std::thread server([&handler] {
+                handler.serve_one_blocking();
+            });
+            mdbxc::sync::PullRequest request;
+            request.requester = replica_engine.local_node_id();
+            request.db_id     = replica_engine.db_uuid();
+            request.have      = replica_engine.applied_cursor();
+            request.max_batches = 4;
+            const mdbxc::sync::PullResponse response = peer.pull(request);
+            std::printf("[phase A] foreground pull returned %zu batch(es) "
+                        "(empty source)\n", response.batches.size());
+            sync_example::require(
+                !request.cancel_token.can_be_cancelled(),
+                "foreground pull must carry a default-constructed token");
+            sync_example::require(
+                response.ok,
+                "empty-source pull must report ok");
+            server.join();
+        }
+
+        // ---- Phase B: background SyncWorker through the transport ----
+        // The worker hands the peer a cancellable token on every pull and
+        // calls request_cancel() during stop. This phase confirms the
+        // second half of the transport contract by observing both.
+        {
+            std::thread server([&handler] {
+                // Long-lived handler; exits when the peer closes the slot.
+                while (handler.serve_one_blocking()) {
+                }
+            });
+
+            mdbxc::sync::SyncWorkerOptions options;
+            options.idle_interval = std::chrono::milliseconds(10000);
+            mdbxc::sync::SyncWorker worker(replica_engine, peer, options);
+
+            worker.start();
+            // Give the worker a moment to enter Pulling and hand the
+            // peer a cancellable token, then stop and wait for the
+            // peer's request_cancel() to close the slot.
+            const bool reached_pulling = worker.wait_until_state(
+                mdbxc::sync::SyncWorkerState::Pulling,
+                std::chrono::milliseconds(2000));
+            sync_example::require(
+                reached_pulling,
+                "worker did not enter Pulling within 2s");
+            std::printf("[phase B] worker delivered a cancellable token\n");
+            worker.stop();
+            std::printf("[phase B] request_cancel() was invoked\n");
+            // The peer already closed its slot via request_cancel(), so
+            // the server thread will exit on the next iteration.
+            server.join();
+
+            sync_example::require(
+                worker.state() == mdbxc::sync::SyncWorkerState::Stopped,
+                "worker must reach Stopped after transport cancellation");
+        }
+
+        replica_db->disconnect();
+        sync_example::cleanup(path);
+        std::printf("OK: sync_08_transport_boundary\n");
+        return 0;
+    } catch (const std::exception& e) {
+        std::printf("FAIL: %s\n", e.what());
+        sync_example::cleanup(path);
+        return 1;
+    }
+}

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -298,6 +298,147 @@ adapter-local approach proves insufficient, or if benchmark data shows
 per-operation cancellation-state allocation on the `pull()` path is a measured
 hot spot.
 
+## Transport boundary contract
+
+The `ISyncPeer` interface is the single boundary between the sync core and
+any external transport (in-process, HTTP, WebSocket, IPC, message queue).
+This section locks in the rules a transport adapter must satisfy, the
+places where cancellation must be wired through, and the policy decisions
+that stay out of the core API. The design is intentionally minimal: locks
+in place until a real adapter shows that core cannot support it.
+
+### Boundary rules
+
+- Only `PullRequest`, `PullResponse`, `PushRequest`, and `PushResponse`
+  cross the boundary. `MDBX_txn*`, `MDBX_cursor*`, `Connection`,
+  `SyncEngine`, table objects, the `ISyncCaptureSink`, and the system
+  stores (MetaStore, ChangeLogStore, AppliedStore, OriginIndexStore,
+  IdentityIndexStore) are thread-owned and never enter a transport
+  payload.
+- `DirectSyncPeer` is the only peer implementation shipped in v0.1. It
+  forwards the request DTOs to another `SyncEngine` in the same process
+  and is suitable for tests, examples, and in-process demos. Production
+  code that crosses a process boundary must replace it with a transport
+  adapter that owns its own connection, threading, and lifecycle.
+- A transport adapter does not own the caller's `SyncEngine`. The
+  receiver-side `SyncEngine` (the one whose state changed because of a
+  remote write) must live on the thread that owns the receiver
+  `Connection`. Cross-thread writes are not supported.
+- A pull page and the matching apply round are owned by `SyncWorker`
+  (background) or by the caller of `run_once()` (foreground). The
+  transport's `pull()` returns detached `ChangeBatch` values; the worker
+  then calls `SyncEngine::handle_push()` which opens its own short
+  write transaction.
+
+### Where socket / RPC timeouts live
+
+Timeouts are an adapter-local concern. The core API exposes no
+`timeout` field on `PullRequest`/`PushRequest` and no `set_timeout`
+on `ISyncPeer` because transports differ about how a deadline is
+expressed (HTTP, libcurl, gRPC, Boost.Asio, raw sockets, ...). The
+adapter owns its timeout configuration and is responsible for
+honoring it. An adapter that cannot bound a blocking call without
+the core's help must say so explicitly in its documentation; do not
+silently block forever on the worker thread.
+
+The timeout policy that does belong to the core is the worker
+backoff loop: repeated pull failures increase the wait between
+attempts up to `SyncWorkerOptions::max_backoff`. That is a cooldown
+for failed *rounds*, not a per-call deadline.
+
+### Where the cancellation bridge lives
+
+A transport adapter must implement two cancellation channels, both of
+which are already in the public API:
+
+1. `PullRequest::cancel_token` and `PushRequest::cancel_token`.
+   `SyncWorker` sets a cancellable token before every `pull()` call and
+   requests cancellation on it when `request_stop()` runs. The adapter
+   receives the token by value and may poll it during any
+   interruptible wait. A `CancellationToken` is cheap to copy and
+   non-owning; copies share state with their `CancellationSource`.
+2. `ISyncPeer::request_cancel()`. `SyncWorker` calls this hook
+   at most once for each observed in-flight `pull()`. The default
+   implementation is a no-op so token-only peers stay valid. Adapters
+   whose underlying call ignores the token (TCP read, blocking RPC,
+   legacy client) must override `request_cancel()` to close their
+   socket, shutdown their transport, or call the library's native
+   cancellation primitive so the in-flight call returns promptly.
+
+The default adapter-local bridge combines both channels: the adapter
+sets the same deadline it would use for a normal timeout, polls the
+`cancel_token` while waiting on the underlying socket or future, and
+also overrides `request_cancel()` to force the socket into a closed or
+half-closed state so any blocking call returns. The bridge must be
+documented adapter-side; the core does not assume a specific
+mechanism.
+
+Cancellation is best-effort. `SyncWorker::stop()`, `join()`, and
+destruction may wait for an in-flight peer call to return when the
+adapter cannot interrupt that call. This is acknowledged in
+`SyncWorker`'s class docstring and is not a contract violation by
+the adapter.
+
+### Where reconnect policy lives
+
+Reconnect policy is transport-local. There is no `reconnect_interval`
+on `ISyncPeer` and no retry counter on `SyncWorker` because retry
+shapes differ across transports (immediate retry after transient
+connection reset, exponential backoff across peer failures, jittered
+reconnect for peer discovery, ...). An adapter may own its own
+`std::thread` that holds the transport connection and surfaces peer
+state through a small `ISyncPeer`-like façade; that façade must still
+honor the cancellation bridge above.
+
+The one retry shape that lives in core is the worker backoff loop
+on repeated pull failures. It is intentionally distinct from
+connection-level reconnect and does not attempt to model
+connection-state separately from transport-call failures.
+
+### Where auth, TLS, and compression live
+
+Auth, TLS, and compression are adapter-local. The core has no
+`credentials` field on `PullRequest`/`PushRequest` and no TLS
+configuration on `ISyncPeer`. A real adapter typically wraps the
+transport with the platform's TLS layer (OpenSSL, Schannel, NSURLSession)
+or delegates to a server framework that owns the secure channel.
+Identity at the sync layer is `NodeId` (16 bytes); the adapter decides
+whether TLS terminates before or after the sync payload is parsed.
+
+`ChangeBatchCodec` already rejects `BATCH_COMPRESSED_ZSTD` at both
+encode and decode paths. Adding a real `zstd` backend is a codec
+change and belongs in a separate design pass; it is not part of the
+transport boundary.
+
+### What the core API explicitly does not do
+
+- It does not own a transport connection.
+- It does not expose a per-call timeout on the public DTOs.
+- It does not expose authentication, credentials, or tokens.
+- It does not own a worker thread for the transport itself; only the
+  `SyncWorker` pull/apply loop is provided, and it owns no transport
+  state.
+- It does not promise graceful shutdown of an in-flight peer call;
+  `request_cancel()` is best-effort.
+
+### Adapter-local extension pattern
+
+A new transport adapter ships as a separate pair of headers (one
+client, one server) and is gated by its own build option
+(`MDBXC_HTTP_SYNC`, `MDBXC_WEBSOCKET_SYNC`, ...). The adapter:
+
+- implements `ISyncPeer` on the client side;
+- wraps `SyncEngine::handle_pull()` / `handle_push()` on the server
+  side;
+- owns its own threading model (one acceptor thread, thread pool,
+  per-connection thread, ...);
+- owns its own timeout configuration;
+- documents how its `request_cancel()` translates into the
+  underlying transport's interrupt primitive.
+
+The first real adapter is planned for v0.2 and is not part of this
+document's scope.
+
 ## Why `prune_up_to` uses cursor walk + `MDBX_NEXT`
 
 MDBX has no batch "delete by key range" primitive. The supported pattern

--- a/tests/test_transport_boundary.cpp
+++ b/tests/test_transport_boundary.cpp
@@ -9,9 +9,9 @@
 /// contract":
 ///
 ///   1. A transport adapter receives a cancellable \c CancellationToken on
-///      every \c pull() when the caller is the \c SyncWorker; idle or
-///      foreground \c run_once() calls without a source must hand a default
-///      (non-cancellable) token.
+///      every \c pull() when the caller is the \c SyncWorker. Manual
+///      foreground callers that build \c PullRequest themselves and do not
+///      attach a source hand a default (non-cancellable) token.
 ///   2. \c ISyncPeer::request_cancel() is best-effort: the default no-op
 ///      implementation is valid and must satisfy the type. Adapters that
 ///      can interrupt blocking calls override it.
@@ -261,16 +261,14 @@ void test_contract_dto_values_round_trip_through_peer() {
 
     struct CarrierPeer : sync::ISyncPeer {
         sync::PullRequest seen_pull_request{};
+        sync::PullResponse sent_pull_response{};
         sync::PushRequest seen_push_request{};
         sync::PushResponse sent_push_response{};
 
         sync::PullResponse pull(
                 const sync::PullRequest& request) override {
             seen_pull_request = request;
-            sync::PullResponse out;
-            out.ok = true;
-            out.has_more = false;
-            return out;
+            return sent_pull_response;
         }
         sync::PushResponse push(
                 const sync::PushRequest& request) override {
@@ -280,6 +278,8 @@ void test_contract_dto_values_round_trip_through_peer() {
     };
 
     CarrierPeer carrier;
+    carrier.sent_pull_response = pull_response;
+    carrier.sent_push_response = push_response;
     const sync::PullResponse got_pull = carrier.pull(pull_request);
     const sync::PushResponse got_push = carrier.push(push_request);
 
@@ -292,7 +292,11 @@ void test_contract_dto_values_round_trip_through_peer() {
         carrier.seen_pull_request.have.last_seq_by_origin.size() != 1u) {
         throw std::runtime_error("PullRequest DTO did not round-trip via peer");
     }
-    if (!got_pull.ok || got_pull.has_more) {
+    if (!got_pull.ok || !got_pull.has_more ||
+        got_pull.remote_have.last_seq_for(make_node(0x99)) != 5u ||
+        got_pull.batches.size() != 1u ||
+        got_pull.batches[0].origin_node_id != make_node(0xAA) ||
+        got_pull.batches[0].seq != 1u) {
         throw std::runtime_error("PullResponse shape was not honoured");
     }
     if (carrier.seen_push_request.sender != push_request.sender ||
@@ -301,7 +305,8 @@ void test_contract_dto_values_round_trip_through_peer() {
             push_request.batches.size()) {
         throw std::runtime_error("PushRequest DTO did not round-trip via peer");
     }
-    if (!got_push.ok) {
+    if (!got_push.ok ||
+        got_push.receiver_have.last_seq_for(make_node(0xAA)) != 1u) {
         throw std::runtime_error("PushResponse shape was not honoured");
     }
 }

--- a/tests/test_transport_boundary.cpp
+++ b/tests/test_transport_boundary.cpp
@@ -1,0 +1,398 @@
+/// \file test_transport_boundary.cpp
+/// \brief Contract tests for \c ISyncPeer adapters at the transport boundary.
+///
+/// These tests pin down what any \c ISyncPeer implementation must observe in
+/// order to interoperate with \c SyncEngine and \c SyncWorker. They are not
+/// tests of \c SyncWorker itself (those live in \c test_sync_worker.cpp).
+/// The contract under verification is the one documented in
+/// \c include/mdbx_containers/sync/DESIGN.md under "Transport boundary
+/// contract":
+///
+///   1. A transport adapter receives a cancellable \c CancellationToken on
+///      every \c pull() when the caller is the \c SyncWorker; idle or
+///      foreground \c run_once() calls without a source must hand a default
+///      (non-cancellable) token.
+///   2. \c ISyncPeer::request_cancel() is best-effort: the default no-op
+///      implementation is valid and must satisfy the type. Adapters that
+///      can interrupt blocking calls override it.
+///   3. Only sync DTOs cross the boundary; \c ISyncPeer implementations
+///      must not capture or mutate the caller's \c Connection / \c
+///      SyncEngine across threads.
+
+#include <mdbx_containers.hpp>
+#include <mdbx_containers/sync.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+void cleanup(const std::string& path) {
+    std::remove(path.c_str());
+    std::remove((path + "-lck").c_str());
+}
+
+mdbxc::sync::NodeId make_node(std::uint8_t seed) {
+    mdbxc::sync::NodeId node{};
+    for (int i = 0; i < 16; ++i) {
+        node[i] = static_cast<std::uint8_t>(seed + i);
+    }
+    return node;
+}
+
+std::shared_ptr<mdbxc::Connection> open_env(const std::string& path) {
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    return mdbxc::Connection::create(config);
+}
+
+/// Peer that records what it observed on the request side of \c pull().
+/// Used to assert the contract that the \c SyncWorker delivers a
+/// cancellable \c CancellationToken to adapter implementations.
+class RecordingPeer : public mdbxc::sync::ISyncPeer {
+public:
+    RecordingPeer() = default;
+
+    mdbxc::sync::PullResponse pull(
+            const mdbxc::sync::PullRequest& request) override {
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            ++m_pull_count;
+            m_last_token_can_be_cancelled = request.cancel_token.can_be_cancelled();
+        }
+        m_changed.notify_all();
+        return mdbxc::sync::PullResponse();
+    }
+
+    mdbxc::sync::PushResponse push(
+            const mdbxc::sync::PushRequest& request) override {
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            ++m_push_count;
+            m_last_push_token_can_be_cancelled =
+                request.cancel_token.can_be_cancelled();
+        }
+        m_changed.notify_all();
+        return mdbxc::sync::PushResponse();
+    }
+
+    bool wait_for_pulls(std::size_t count,
+                        std::chrono::milliseconds timeout) const {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        return m_changed.wait_for(
+            lock, timeout,
+            [this, count] { return m_pull_count >= count; });
+    }
+
+    bool wait_for_pushes(std::size_t count,
+                         std::chrono::milliseconds timeout) const {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        return m_changed.wait_for(
+            lock, timeout,
+            [this, count] { return m_push_count >= count; });
+    }
+
+    std::size_t pull_count() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_pull_count;
+    }
+
+    std::size_t push_count() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_push_count;
+    }
+
+    bool last_pull_token_can_be_cancelled() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_last_token_can_be_cancelled;
+    }
+
+    bool last_push_token_can_be_cancelled() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_last_push_token_can_be_cancelled;
+    }
+
+private:
+    mutable std::mutex m_mutex;
+    mutable std::condition_variable m_changed;
+    std::size_t m_pull_count = 0;
+    std::size_t m_push_count = 0;
+    bool m_last_token_can_be_cancelled = false;
+    bool m_last_push_token_can_be_cancelled = false;
+};
+
+/// Minimal \c ISyncPeer that uses the default \c request_cancel() no-op.
+/// Documents that the default no-op is a valid adapter.
+class DefaultNoOpPeer : public mdbxc::sync::ISyncPeer {
+public:
+    mdbxc::sync::PullResponse pull(
+            const mdbxc::sync::PullRequest& request) override {
+        (void)request;
+        return mdbxc::sync::PullResponse();
+    }
+    mdbxc::sync::PushResponse push(
+            const mdbxc::sync::PushRequest& request) override {
+        (void)request;
+        return mdbxc::sync::PushResponse();
+    }
+    // No request_cancel() override: the default in ISyncPeer is a no-op.
+    // This class exists to assert that the no-op is a valid contract.
+};
+
+void test_contract_sync_worker_delivers_cancellable_pull_token() {
+    using namespace mdbxc;
+    const std::string path = "test_transport_contract_worker_token.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0xA0), make_node(0xD0));
+
+    RecordingPeer peer;
+    sync::SyncWorkerOptions options;
+    options.idle_interval = std::chrono::milliseconds(10000);
+    sync::SyncWorker worker(engine, peer, options);
+
+    worker.start();
+    if (!peer.wait_for_pulls(1u, std::chrono::milliseconds(2000))) {
+        throw std::runtime_error(
+            "worker never invoked ISyncPeer::pull()");
+    }
+    worker.stop();
+
+    if (!peer.last_pull_token_can_be_cancelled()) {
+        throw std::runtime_error(
+            "transport contract violated: SyncWorker did not deliver a "
+            "cancellable CancellationToken to ISyncPeer::pull()");
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_contract_foreground_pull_token_is_default_constructed() {
+    using namespace mdbxc;
+    const std::string path = "test_transport_contract_foreground.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0xA1), make_node(0xD1));
+
+    // Foreground callers (anyone who builds PullRequest manually, including
+    // DirectSyncPeer in examples) hand a default-constructed token to the
+    // peer. Adapters that observe can_be_cancelled() == false must still
+    // complete the call normally and not treat it as a cancellation signal.
+    RecordingPeer peer;
+
+    sync::PullRequest request;
+    request.requester = engine.local_node_id();
+    request.db_id = engine.db_uuid();
+    request.have = engine.applied_cursor();
+    request.max_batches = 10;
+    // No CancellationSource attached: token stays default-constructed.
+
+    const mdbxc::sync::PullResponse response = peer.pull(request);
+    (void)response;
+
+    if (peer.last_pull_token_can_be_cancelled()) {
+        throw std::runtime_error(
+            "transport contract violated: default-constructed "
+            "CancellationToken must report can_be_cancelled() == false");
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_contract_request_cancel_default_is_noop() {
+    DefaultNoOpPeer peer;
+    // Must compile and return cleanly. The default ISyncPeer::request_cancel()
+    // is a no-op by design; adapters that only rely on CancellationToken
+    // remain valid.
+    peer.request_cancel();
+    peer.request_cancel();
+    peer.request_cancel();
+}
+
+void test_contract_dto_values_round_trip_through_peer() {
+    // Confirms that PullRequest / PullResponse / PushRequest / PushResponse
+    // can be copied between producer and consumer via ISyncPeer without
+    // any MDBX handle or Connection reference leaking across the boundary.
+    using namespace mdbxc;
+    sync::PullRequest pull_request{};
+    pull_request.requester = make_node(0x11);
+    pull_request.db_id     = make_node(0x12);
+    pull_request.have.last_seq_by_origin[make_node(0x99)] = 5u;
+    pull_request.max_batches = 7u;
+    pull_request.max_bytes = 1024u;
+    pull_request.request_full_snapshot = true;
+
+    sync::PullResponse pull_response{};
+    pull_response.ok = true;
+    pull_response.has_more = true;
+    pull_response.remote_have.last_seq_by_origin[make_node(0x99)] = 5u;
+    sync::ChangeBatch batch{};
+    batch.origin_node_id = make_node(0xAA);
+    batch.seq = 1u;
+    pull_response.batches.push_back(batch);
+
+    sync::PushRequest push_request{};
+    push_request.sender = make_node(0x21);
+    push_request.db_id  = make_node(0x22);
+    push_request.batches = pull_response.batches;
+
+    sync::PushResponse push_response{};
+    push_response.ok = true;
+    push_response.receiver_have.last_seq_by_origin[make_node(0xAA)] = 1u;
+
+    struct CarrierPeer : sync::ISyncPeer {
+        sync::PullRequest seen_pull_request{};
+        sync::PushRequest seen_push_request{};
+        sync::PushResponse sent_push_response{};
+
+        sync::PullResponse pull(
+                const sync::PullRequest& request) override {
+            seen_pull_request = request;
+            sync::PullResponse out;
+            out.ok = true;
+            out.has_more = false;
+            return out;
+        }
+        sync::PushResponse push(
+                const sync::PushRequest& request) override {
+            seen_push_request = request;
+            return sent_push_response;
+        }
+    };
+
+    CarrierPeer carrier;
+    const sync::PullResponse got_pull = carrier.pull(pull_request);
+    const sync::PushResponse got_push = carrier.push(push_request);
+
+    if (carrier.seen_pull_request.requester != pull_request.requester ||
+        carrier.seen_pull_request.db_id != pull_request.db_id ||
+        carrier.seen_pull_request.max_batches != pull_request.max_batches ||
+        carrier.seen_pull_request.max_bytes != pull_request.max_bytes ||
+        carrier.seen_pull_request.request_full_snapshot !=
+            pull_request.request_full_snapshot ||
+        carrier.seen_pull_request.have.last_seq_by_origin.size() != 1u) {
+        throw std::runtime_error("PullRequest DTO did not round-trip via peer");
+    }
+    if (!got_pull.ok || got_pull.has_more) {
+        throw std::runtime_error("PullResponse shape was not honoured");
+    }
+    if (carrier.seen_push_request.sender != push_request.sender ||
+        carrier.seen_push_request.db_id != push_request.db_id ||
+        carrier.seen_push_request.batches.size() !=
+            push_request.batches.size()) {
+        throw std::runtime_error("PushRequest DTO did not round-trip via peer");
+    }
+    if (!got_push.ok) {
+        throw std::runtime_error("PushResponse shape was not honoured");
+    }
+}
+
+void test_contract_threaded_pull_does_not_capture_connection() {
+    // Confirms that an ISyncPeer implementation can run on a different
+    // thread than the engine that produced the request, as long as the
+    // adapter only touches the DTOs. The adapter itself is responsible
+    // for any cross-thread synchronisation on its own state; the contract
+    // requires the boundary to carry no MDBX handles or Connection.
+    using namespace mdbxc;
+    const std::string path = "test_transport_contract_threaded.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0xA3), make_node(0xD3));
+
+    std::atomic<int> pull_calls{0};
+    std::atomic<bool> saw_cancellable_token{false};
+
+    struct ThreadedPeer : sync::ISyncPeer {
+        std::atomic<int>* pull_calls;
+        std::atomic<bool>* saw_cancellable_token;
+        ThreadedPeer(std::atomic<int>* pc, std::atomic<bool>* saw)
+            : pull_calls(pc), saw_cancellable_token(saw) {}
+        sync::PullResponse pull(
+                const sync::PullRequest& request) override {
+            if (request.cancel_token.can_be_cancelled()) {
+                saw_cancellable_token->store(true);
+            }
+            ++(*pull_calls);
+            return sync::PullResponse();
+        }
+        sync::PushResponse push(
+                const sync::PushRequest&) override {
+            return sync::PushResponse();
+        }
+    } peer(&pull_calls, &saw_cancellable_token);
+
+    sync::SyncWorkerOptions options;
+    options.idle_interval = std::chrono::milliseconds(10000);
+    sync::SyncWorker worker(engine, peer, options);
+    worker.start();
+
+    for (int i = 0; i < 200; ++i) {
+        if (pull_calls.load() > 0) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    worker.stop();
+    if (pull_calls.load() == 0) {
+        throw std::runtime_error("worker thread did not call ISyncPeer::pull()");
+    }
+    if (!saw_cancellable_token.load()) {
+        throw std::runtime_error(
+            "worker thread did not deliver a cancellable CancellationToken");
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+} // namespace
+
+int main() {
+    struct Case { const char* name; void (*fn)(); };
+    const Case cases[] = {
+        { "test_contract_sync_worker_delivers_cancellable_pull_token",
+          &test_contract_sync_worker_delivers_cancellable_pull_token },
+        { "test_contract_foreground_pull_token_is_default_constructed",
+          &test_contract_foreground_pull_token_is_default_constructed },
+        { "test_contract_request_cancel_default_is_noop",
+          &test_contract_request_cancel_default_is_noop },
+        { "test_contract_dto_values_round_trip_through_peer",
+          &test_contract_dto_values_round_trip_through_peer },
+        { "test_contract_threaded_pull_does_not_capture_connection",
+          &test_contract_threaded_pull_does_not_capture_connection },
+    };
+
+    int rc = 0;
+    for (std::size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
+        try {
+            cases[i].fn();
+            std::printf("PASS %s\n", cases[i].name);
+        } catch (const std::exception& e) {
+            std::printf("FAIL %s: %s\n", cases[i].name, e.what());
+            rc = static_cast<int>(i + 1);
+        } catch (...) {
+            std::printf("FAIL %s: non-std exception\n", cases[i].name);
+            rc = static_cast<int>(i + 1);
+        }
+    }
+    return rc;
+}


### PR DESCRIPTION
## Summary

Lock in the rules that any `ISyncPeer` adapter must satisfy before the
first real HTTP/WebSocket transport lands. After PR #102 (`SyncWorker`
+ observer), the next incremental step is the transport boundary
itself: where socket timeout lives, how the cooperative
`CancellationToken` and `ISyncPeer::request_cancel()` are bridged
into a real adapter, and which concerns (reconnect, auth, TLS,
threading model) belong to the adapter rather than the core.

This PR does **not** ship an HTTP or WebSocket adapter. It is design,
contract tests, and a deterministic example, exactly as suggested in
DESIGN.md under "HTTP and WebSocket transports" and the worker
section about "adapter-local bridge from cancel_token /
request_cancel()".

## Scope

- `include/mdbx_containers/sync/DESIGN.md`: new "Transport boundary
  contract" section between "Background worker lifecycle" and "Why
  prune_up_to uses cursor walk + MDBX_NEXT". Pins down the boundary
  rules, the timeouts/reconnect/auth/TLS placement decisions, the
  cancellation bridge, and what the core API explicitly does not do.
- `tests/test_transport_boundary.cpp`: focused contract tests for
  `ISyncPeer` adapters:
  1. `SyncWorker` delivers a cancellable `CancellationToken` to
     `pull()`.
  2. Foreground `PullRequest` carries a default-constructed token.
  3. The default `request_cancel()` no-op is a valid adapter.
  4. Pull/Push DTOs round-trip through the boundary without leaking
     any MDBX handle or `Connection` reference.
  5. A peer running on the worker thread never captures the
     caller's `Connection`.
- `examples/sync_08_transport_boundary.cpp`: deterministic two-phase
  pseudo-transport demo (foreground pull + background `SyncWorker`
  through an in-memory queue). Documents the four contract points
  any real adapter must respect and exits cleanly through
  `request_cancel()` and slot close. Builds without any network
  dependency.
- `examples/README-sync.md`: one entry in the reading-order table
  and a short paragraph explaining the example's role.

## Tests

`ctest --output-on-failure -E stress`: 43/43 passed.

`sync_08_transport_boundary` builds and runs end-to-end with
`OK: sync_08_transport_boundary` on the existing `pr102-cpp17` and
`pr103-transport-boundary-cpp17` build directories.

## Decisions captured

- Timeouts are adapter-local; the core has no per-call deadline.
- Reconnect policy is adapter-local; the core keeps only the worker
  backoff loop.
- Auth, TLS, compression are adapter-local.
- The cancellation bridge combines `CancellationToken` polling and
  `request_cancel()` override; both channels are already part of the
  public API and require no core changes.
- The first real HTTP/WS adapter is intentionally deferred to v0.2
  and is out of scope here.

## Risk

Narrow. No core API change, no new dependency, no CMake changes, no
flag added. Only adds documentation, tests, and one example.