### PR TITLE
feat(sync): add HTTP transport adapter seam

### DIFF
--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -41,6 +41,8 @@ tmp/build-examples/bin/examples/sync_01_lifecycle_direct_peer
 | `sync_07_worker_observer.cpp` | Фоновый `SyncWorker` и уведомления о прогрессе через `ISyncWorkerObserver`. | Продвинутый |
 | `sync_08_transport_boundary.cpp` | Псевдотранспорт, который проверяет контракт границы `ISyncPeer` (`CancellationToken` + `request_cancel()`). | Продвинутый |
 | `sync_09_transport_codec.cpp` | Версионированный бинарный `TransportMessageCodec` для DTO запросов и ответов. | Продвинутый |
+| `sync_10_custom_transport.cpp` | Минимальный кастомный `ISyncPeer` поверх закодированных byte buffers. | Продвинутый |
+| `sync_11_http_adapter.cpp` | Фреймворк-независимый HTTP-адаптер поверх `TransportMessageCodec`. | Продвинутый |
 
 ## Общие правила
 
@@ -109,3 +111,14 @@ replica формирует PullRequest
 `TransportMessageCodec` до пересечения границы. Политики адаптера, такие как
 авторизация, rate limit, allow/deny lists, маршрутизация и TLS, должны
 оборачивать этот обмен bytes, а не попадать внутрь sync DTO.
+
+`sync_10_custom_transport.cpp` показывает минимальную форму кастомного
+транспорта: реализовать `ISyncPeer`, закодировать DTO запроса, отправить bytes
+через канал приложения, декодировать DTO ответа и реализовать
+`request_cancel()` через собственный механизм прерывания канала.
+
+`sync_11_http_adapter.cpp` показывает границу HTTP-адаптера. `HttpSyncPeer`
+реализует `ISyncPeer` поверх абстрактного `IHttpSyncClient`, а
+`HttpSyncServer` передаёт уже разобранные HTTP method/target/content-type/body
+значения в `SyncEngine`. Реальная HTTP-библиотека добавляет сетевой слой вокруг
+этой границы.

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -40,6 +40,8 @@ executable has the `.exe` suffix, for example:
 | `sync_07_worker_observer.cpp` | Background `SyncWorker` progress notifications through `ISyncWorkerObserver`. | Advanced |
 | `sync_08_transport_boundary.cpp` | Pseudo-transport that exercises the `ISyncPeer` boundary contract (cancellation token + `request_cancel()`). | Advanced |
 | `sync_09_transport_codec.cpp` | Versioned binary `TransportMessageCodec` for request/response DTOs. | Advanced |
+| `sync_10_custom_transport.cpp` | Minimal custom `ISyncPeer` over encoded byte buffers. | Advanced |
+| `sync_11_http_adapter.cpp` | Framework-neutral HTTP-shaped adapter over `TransportMessageCodec`. | Advanced |
 
 ## Common Rules
 
@@ -105,3 +107,14 @@ queues for sockets.
 with `TransportMessageCodec` before they cross the boundary. Adapter policy
 such as authorization, rate limits, allow/deny lists, routing, and TLS belongs
 around that byte exchange, not inside the sync DTOs themselves.
+
+`sync_10_custom_transport.cpp` shows the minimal custom transport shape:
+implement `ISyncPeer`, encode request DTOs, send bytes through the application
+channel, decode response DTOs, and implement `request_cancel()` with the
+channel's own interruption primitive.
+
+`sync_11_http_adapter.cpp` shows the HTTP-shaped adapter seam. `HttpSyncPeer`
+implements `ISyncPeer` over an abstract `IHttpSyncClient`, and
+`HttpSyncServer` dispatches already-parsed HTTP method/target/content-type/body
+values to `SyncEngine`. A real HTTP library supplies the socket layer around
+that seam.

--- a/examples/sync_10_custom_transport.cpp
+++ b/examples/sync_10_custom_transport.cpp
@@ -1,0 +1,205 @@
+/**
+ * \ingroup mdbxc_examples
+ * \brief Minimal custom ISyncPeer over byte buffers.
+ *
+ * This is the smallest useful shape for an application-specific transport:
+ * implement `ISyncPeer`, encode request DTOs with `TransportMessageCodec`,
+ * send the bytes through the application channel, then decode response DTOs.
+ *
+ * The example keeps the "remote channel" in-process so it can run everywhere.
+ * Replace `send_pull_bytes()` / `send_push_bytes()` with a socket, IPC, file,
+ * message queue, or another application transport.
+ *
+ * Expected output:
+ *   [custom transport pull] applied 2 batch(es)
+ *   [custom transport push] applied 1 batch(es)
+ *   OK: sync_10_custom_transport
+ */
+
+#include "sync_example_utils.hpp"
+
+#include <cstdio>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+class EncodedLoopbackPeer : public mdbxc::sync::ISyncPeer {
+public:
+    explicit EncodedLoopbackPeer(mdbxc::sync::SyncEngine& remote)
+        : m_remote(remote),
+          m_cancel_count(0),
+          m_last_pull_token_cancellable(false) {}
+
+    mdbxc::sync::PullResponse pull(
+            const mdbxc::sync::PullRequest& request) override {
+        m_last_pull_token_cancellable =
+            request.cancel_token.can_be_cancelled();
+
+        const std::vector<std::uint8_t> request_bytes =
+            mdbxc::sync::TransportMessageCodec::encode_pull_request(
+                request);
+        const std::vector<std::uint8_t> response_bytes =
+            send_pull_bytes(request_bytes);
+        return mdbxc::sync::TransportMessageCodec::decode_pull_response(
+            response_bytes);
+    }
+
+    mdbxc::sync::PushResponse push(
+            const mdbxc::sync::PushRequest& request) override {
+        const std::vector<std::uint8_t> request_bytes =
+            mdbxc::sync::TransportMessageCodec::encode_push_request(
+                request);
+        const std::vector<std::uint8_t> response_bytes =
+            send_push_bytes(request_bytes);
+        return mdbxc::sync::TransportMessageCodec::decode_push_response(
+            response_bytes);
+    }
+
+    void request_cancel() override {
+        // A real transport would interrupt the in-flight channel operation.
+        ++m_cancel_count;
+    }
+
+    bool last_pull_token_cancellable() const {
+        return m_last_pull_token_cancellable;
+    }
+
+    std::size_t cancel_count() const { return m_cancel_count; }
+
+private:
+    std::vector<std::uint8_t> send_pull_bytes(
+            const std::vector<std::uint8_t>& request_bytes) {
+        // Remote side: decode bytes, dispatch to SyncEngine, encode response.
+        const mdbxc::sync::PullRequest request =
+            mdbxc::sync::TransportMessageCodec::decode_pull_request(
+                request_bytes);
+        const mdbxc::sync::PullResponse response =
+            m_remote.handle_pull(request);
+        return mdbxc::sync::TransportMessageCodec::encode_pull_response(
+            response);
+    }
+
+    std::vector<std::uint8_t> send_push_bytes(
+            const std::vector<std::uint8_t>& request_bytes) {
+        // Remote side: decode bytes, dispatch to SyncEngine, encode response.
+        const mdbxc::sync::PushRequest request =
+            mdbxc::sync::TransportMessageCodec::decode_push_request(
+                request_bytes);
+        const mdbxc::sync::PushResponse response =
+            m_remote.handle_push(request);
+        return mdbxc::sync::TransportMessageCodec::encode_push_response(
+            response);
+    }
+
+    mdbxc::sync::SyncEngine& m_remote;
+    std::size_t m_cancel_count;
+    bool m_last_pull_token_cancellable;
+};
+
+} // namespace
+
+int main() {
+    const std::string primary_path = "sync_10_primary.mdbx";
+    const std::string replica_path = "sync_10_replica.mdbx";
+    sync_example::cleanup(primary_path);
+    sync_example::cleanup(replica_path);
+
+    const mdbxc::sync::NodeId primary_node =
+        sync_example::make_node(0xF0);
+    const mdbxc::sync::NodeId replica_node =
+        sync_example::make_node(0xF1);
+    const mdbxc::sync::DbId db_id =
+        sync_example::make_node(0xF2);
+
+    try {
+        std::shared_ptr<mdbxc::Connection> primary =
+            sync_example::open(primary_path);
+        std::shared_ptr<mdbxc::Connection> replica =
+            sync_example::open(replica_path);
+
+        mdbxc::sync::SyncEngine primary_engine(primary);
+        mdbxc::sync::SyncEngine replica_engine(replica);
+        primary_engine.initialize_local_identity(primary_node, db_id);
+        replica_engine.initialize_local_identity(replica_node, db_id);
+
+        mdbxc::sync::ThreadLocalChangeAccumulator capture(primary);
+        mdbxc::KeyValueTable<int, std::string> primary_ticks(primary, "ticks");
+
+        primary->attach_sync_capture(&capture);
+        primary_ticks.insert_or_assign(1, "BTC/USD");
+        primary_ticks.insert_or_assign(2, "ETH/USD");
+        primary->detach_sync_capture();
+
+        EncodedLoopbackPeer primary_peer(primary_engine);
+
+        mdbxc::sync::CancellationSource pull_cancel;
+        mdbxc::sync::PullRequest pull;
+        pull.requester = replica_node;
+        pull.db_id = db_id;
+        pull.have = replica_engine.applied_cursor();
+        pull.max_batches = 100;
+        pull.cancel_token = pull_cancel.token();
+
+        const mdbxc::sync::PullResponse pulled = primary_peer.pull(pull);
+        sync_example::require(pulled.ok,
+                              "custom pull failed: " + pulled.error);
+        sync_example::require(primary_peer.last_pull_token_cancellable(),
+                              "custom peer did not receive cancel token");
+
+        mdbxc::sync::PushRequest local_apply;
+        local_apply.sender = primary_node;
+        local_apply.db_id = db_id;
+        local_apply.batches = pulled.batches;
+        const mdbxc::sync::PushResponse applied =
+            replica_engine.handle_push(local_apply);
+        sync_example::require(applied.ok,
+                              "local apply failed: " + applied.error);
+        std::printf("[custom transport pull] applied %zu batch(es)\n",
+                    pulled.batches.size());
+
+        primary->attach_sync_capture(&capture);
+        primary_ticks.insert_or_assign(3, "SOL/USD");
+        primary->detach_sync_capture();
+
+        EncodedLoopbackPeer replica_peer(replica_engine);
+        const mdbxc::sync::PushRequest push =
+            primary_engine.make_push_request(3, 0);
+        const mdbxc::sync::PushResponse pushed = replica_peer.push(push);
+        sync_example::require(pushed.ok,
+                              "custom push failed: " + pushed.error);
+        std::printf("[custom transport push] applied %zu batch(es)\n",
+                    push.batches.size());
+
+        replica_peer.request_cancel();
+        sync_example::require(replica_peer.cancel_count() == 1u,
+                              "custom peer did not forward cancellation");
+
+        mdbxc::KeyValueTable<int, std::string> replica_ticks(replica, "ticks");
+        sync_example::require(
+            sync_example::kv_or_throw(replica, replica_ticks, 1,
+                                      "ticks[1]") == "BTC/USD",
+            "replica ticks[1] mismatch");
+        sync_example::require(
+            sync_example::kv_or_throw(replica, replica_ticks, 2,
+                                      "ticks[2]") == "ETH/USD",
+            "replica ticks[2] mismatch");
+        sync_example::require(
+            sync_example::kv_or_throw(replica, replica_ticks, 3,
+                                      "ticks[3]") == "SOL/USD",
+            "replica ticks[3] mismatch");
+
+        sync_example::disconnect_and_cleanup(primary, primary_path);
+        sync_example::disconnect_and_cleanup(replica, replica_path);
+        std::printf("OK: sync_10_custom_transport\n");
+        return 0;
+    } catch (const std::exception& e) {
+        std::printf("FAIL: %s\n", e.what());
+        sync_example::cleanup(primary_path);
+        sync_example::cleanup(replica_path);
+        return 1;
+    }
+}

--- a/examples/sync_11_http_adapter.cpp
+++ b/examples/sync_11_http_adapter.cpp
@@ -1,0 +1,170 @@
+/**
+ * \ingroup mdbxc_examples
+ * \brief HTTP-shaped sync adapter without choosing an HTTP framework.
+ *
+ * `HttpSyncPeer` implements `ISyncPeer` by sending binary request bodies to an
+ * `IHttpSyncClient`. `HttpSyncServer` handles the matching server-side route
+ * after a real HTTP framework has parsed method, target, content type, and
+ * body.
+ *
+ * This example uses an in-process loopback client so the code stays portable.
+ * Replace `LoopbackHttpClient::post()` with libcurl, Boost.Beast,
+ * Simple-Web-Server, cpp-httplib, or another framework, and keep the same
+ * route/body contract.
+ *
+ * Expected output:
+ *   [http adapter] pull delivered 2 batch(es)
+ *   [http adapter] push delivered 1 batch(es)
+ *   OK: sync_11_http_adapter
+ */
+
+#include "sync_example_utils.hpp"
+
+#include <cstdio>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+class LoopbackHttpClient : public mdbxc::sync::IHttpSyncClient {
+public:
+    explicit LoopbackHttpClient(mdbxc::sync::HttpSyncServer& server)
+        : m_server(server), m_cancel_count(0) {}
+
+    mdbxc::sync::HttpSyncResponse post(
+            const std::string& target,
+            const std::string& content_type,
+            const std::vector<std::uint8_t>& body,
+            const mdbxc::sync::CancellationToken& cancel_token) override {
+        // A real HTTP client would put `content_type` into the Content-Type
+        // header, write `body` as the request body, and map `cancel_token` plus
+        // request_cancel() to its timeout/socket cancellation primitive.
+        (void)cancel_token;
+
+        mdbxc::sync::HttpSyncRequest request;
+        request.method = mdbxc::sync::HttpSyncRoutes::method_post();
+        request.target = target;
+        request.content_type = content_type;
+        request.body = body;
+        return m_server.handle(request);
+    }
+
+    void request_cancel() override {
+        // A real implementation would interrupt the active HTTP request here.
+        ++m_cancel_count;
+    }
+
+    std::size_t cancel_count() const { return m_cancel_count; }
+
+private:
+    mdbxc::sync::HttpSyncServer& m_server;
+    std::size_t m_cancel_count;
+};
+
+} // namespace
+
+int main() {
+    const std::string primary_path = "sync_11_primary.mdbx";
+    const std::string replica_path = "sync_11_replica.mdbx";
+    sync_example::cleanup(primary_path);
+    sync_example::cleanup(replica_path);
+
+    const mdbxc::sync::NodeId primary_node =
+        sync_example::make_node(0xE0);
+    const mdbxc::sync::NodeId replica_node =
+        sync_example::make_node(0xE1);
+    const mdbxc::sync::DbId db_id =
+        sync_example::make_node(0xE2);
+
+    try {
+        std::shared_ptr<mdbxc::Connection> primary =
+            sync_example::open(primary_path);
+        std::shared_ptr<mdbxc::Connection> replica =
+            sync_example::open(replica_path);
+
+        mdbxc::sync::SyncEngine primary_engine(primary);
+        mdbxc::sync::SyncEngine replica_engine(replica);
+        primary_engine.initialize_local_identity(primary_node, db_id);
+        replica_engine.initialize_local_identity(replica_node, db_id);
+
+        mdbxc::sync::ThreadLocalChangeAccumulator capture(primary);
+        mdbxc::KeyValueTable<int, std::string> primary_ticks(primary, "ticks");
+
+        primary->attach_sync_capture(&capture);
+        primary_ticks.insert_or_assign(1, "BTC/USD");
+        primary_ticks.insert_or_assign(2, "ETH/USD");
+        primary->detach_sync_capture();
+
+        mdbxc::sync::HttpSyncServer primary_server(primary_engine);
+        LoopbackHttpClient primary_http(primary_server);
+        mdbxc::sync::HttpSyncPeer primary_peer(primary_http);
+
+        mdbxc::sync::PullRequest pull;
+        pull.requester = replica_node;
+        pull.db_id = db_id;
+        pull.have = replica_engine.applied_cursor();
+        pull.max_batches = 100;
+
+        const mdbxc::sync::PullResponse pulled = primary_peer.pull(pull);
+        sync_example::require(pulled.ok,
+                              "HTTP pull failed: " + pulled.error);
+
+        mdbxc::sync::PushRequest local_apply;
+        local_apply.sender = primary_node;
+        local_apply.db_id = db_id;
+        local_apply.batches = pulled.batches;
+        const mdbxc::sync::PushResponse applied =
+            replica_engine.handle_push(local_apply);
+        sync_example::require(applied.ok,
+                              "local apply failed: " + applied.error);
+        std::printf("[http adapter] pull delivered %zu batch(es)\n",
+                    pulled.batches.size());
+
+        primary->attach_sync_capture(&capture);
+        primary_ticks.insert_or_assign(3, "SOL/USD");
+        primary->detach_sync_capture();
+
+        mdbxc::sync::HttpSyncServer replica_server(replica_engine);
+        LoopbackHttpClient replica_http(replica_server);
+        mdbxc::sync::HttpSyncPeer replica_peer(replica_http);
+
+        const mdbxc::sync::PushRequest push =
+            primary_engine.make_push_request(3, 0);
+        const mdbxc::sync::PushResponse pushed = replica_peer.push(push);
+        sync_example::require(pushed.ok,
+                              "HTTP push failed: " + pushed.error);
+        std::printf("[http adapter] push delivered %zu batch(es)\n",
+                    push.batches.size());
+
+        replica_peer.request_cancel();
+        sync_example::require(replica_http.cancel_count() == 1u,
+                              "request_cancel was not forwarded");
+
+        mdbxc::KeyValueTable<int, std::string> replica_ticks(replica, "ticks");
+        sync_example::require(
+            sync_example::kv_or_throw(replica, replica_ticks, 1,
+                                      "ticks[1]") == "BTC/USD",
+            "replica ticks[1] mismatch");
+        sync_example::require(
+            sync_example::kv_or_throw(replica, replica_ticks, 2,
+                                      "ticks[2]") == "ETH/USD",
+            "replica ticks[2] mismatch");
+        sync_example::require(
+            sync_example::kv_or_throw(replica, replica_ticks, 3,
+                                      "ticks[3]") == "SOL/USD",
+            "replica ticks[3] mismatch");
+
+        sync_example::disconnect_and_cleanup(primary, primary_path);
+        sync_example::disconnect_and_cleanup(replica, replica_path);
+        std::printf("OK: sync_11_http_adapter\n");
+        return 0;
+    } catch (const std::exception& e) {
+        std::printf("FAIL: %s\n", e.what());
+        sync_example::cleanup(primary_path);
+        sync_example::cleanup(replica_path);
+        return 1;
+    }
+}

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -31,6 +31,7 @@
 #include "sync/SyncEngine.hpp"
 #include "sync/SyncWorker.hpp"
 #include "sync/DirectSyncPeer.hpp"
+#include "sync/HttpTransport.hpp"
 #include "sync/stores/MetaStore.hpp"
 #include "sync/stores/OriginIndexStore.hpp"
 #include "sync/stores/ChangeLogStore.hpp"

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -28,6 +28,10 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
   `PullRequest`, `PullResponse`, `PushRequest`, and `PushResponse`.
   It length-prefixes nested `ChangeBatchCodec` payloads and does not
   serialize operation-local `CancellationToken` state.
+- Framework-neutral HTTP-shaped adapter seam: `HttpSyncPeer`,
+  `IHttpSyncClient`, `HttpSyncServer`, and `HttpSyncRoutes`. It defines
+  route/content-type/body/status mapping over `TransportMessageCodec` but does
+  not open sockets or depend on an HTTP framework.
 - Change capture hooks: `Connection::attach_sync_capture()`,
   `BaseTable::record_op()`, and the transaction pre-commit hook route table
   writes into `ThreadLocalChangeAccumulator`, which appends one local
@@ -92,10 +96,10 @@ new wire-format semantics.
   use `LastWriterWins` in a non-test path.
 - `Custom` conflict resolver — schema-level callback; deferred until the
   first real consumer needs it.
-- HTTP and WebSocket transports (`Simple-Web-Server`,
-  `Simple-WebSocket-Server`) — guarded build flags; first adapter lands after
-  the transport boundary and cancellation bridge are designed against a real
-  adapter.
+- Concrete socket-bound HTTP and WebSocket transports (`Simple-Web-Server`,
+  `Simple-WebSocket-Server`, Boost.Beast, libcurl, or another framework) with
+  guarded build flags. The current HTTP-shaped adapter seam does not own
+  sockets.
 - `zstd` compression — reserved flag, encoder throws, decoder rejects.
 
 ## Endianness policy (do not change)
@@ -350,11 +354,13 @@ in place until a real adapter shows that core cannot support it.
   stores (MetaStore, ChangeLogStore, AppliedStore, OriginIndexStore,
   IdentityIndexStore) are thread-owned and never enter a transport
   payload.
-- `DirectSyncPeer` is the only peer implementation shipped in v0.1. It
-  forwards the request DTOs to another `SyncEngine` in the same process
-  and is suitable for tests, examples, and in-process demos. Production
-  code that crosses a process boundary must replace it with a transport
-  adapter that owns its own connection, threading, and lifecycle.
+- `DirectSyncPeer` forwards request DTOs to another `SyncEngine` in the same
+  process and is suitable for tests, examples, and in-process demos.
+  `HttpSyncPeer` is a framework-neutral HTTP-shaped adapter over an abstract
+  `IHttpSyncClient`; it defines the route/body contract but does not own a
+  socket. Production code that crosses a process boundary must bind this seam
+  to a transport implementation that owns its own connection, threading, and
+  lifecycle.
 - A transport adapter does not own the caller's `SyncEngine`. The
   receiver-side `SyncEngine` (the one whose state changed because of a
   remote write) must live on the thread that owns the receiver
@@ -464,21 +470,22 @@ transport boundary.
 
 ### Adapter-local extension pattern
 
-A new transport adapter ships as a separate pair of headers (one
-client, one server) and is gated by its own build option
+A concrete socket-bound transport adapter ships as a separate pair of headers
+(one client, one server) and is gated by its own build option
 (`MDBXC_HTTP_SYNC`, `MDBXC_WEBSOCKET_SYNC`, ...). The adapter:
 
-- implements `ISyncPeer` on the client side;
+- implements or reuses `ISyncPeer` on the client side;
 - wraps `SyncEngine::handle_pull()` / `handle_push()` on the server
-  side;
+  side, directly or through `HttpSyncServer`;
 - owns its own threading model (one acceptor thread, thread pool,
   per-connection thread, ...);
 - owns its own timeout configuration;
 - documents how its `request_cancel()` translates into the
   underlying transport's interrupt primitive.
 
-The first real adapter is planned for v0.2 and is not part of this
-document's scope.
+The framework-neutral `HttpSyncPeer` / `HttpSyncServer` seam is part of v0.1.
+Concrete HTTP server/client bindings and WebSocket bindings remain separate
+optional integrations.
 
 ## Why `prune_up_to` uses cursor walk + `MDBX_NEXT`
 

--- a/include/mdbx_containers/sync/HttpTransport.hpp
+++ b/include/mdbx_containers/sync/HttpTransport.hpp
@@ -1,0 +1,257 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_HTTP_TRANSPORT_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_HTTP_TRANSPORT_HPP_INCLUDED
+
+/// \file HttpTransport.hpp
+/// \brief Framework-neutral HTTP-shaped adapter for sync transport DTOs.
+/// \details
+/// This header does not open sockets and does not depend on any HTTP library.
+/// It defines the stable route/content-type/body contract that a concrete HTTP
+/// client or server binding can adapt to its framework. Authorization, rate
+/// limits, allow/deny lists, TLS, and routing middleware belong around this
+/// adapter layer.
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "ISyncPeer.hpp"
+#include "SyncEngine.hpp"
+#include "TransportMessageCodec.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Minimal request shape consumed by \c HttpSyncServer.
+    struct HttpSyncRequest {
+        std::string method;
+        std::string target;
+        std::string content_type;
+        std::vector<std::uint8_t> body;
+    };
+
+    /// \brief Minimal response shape produced by \c HttpSyncServer.
+    /// \details Successful sync responses use the binary sync content type and
+    /// a \c TransportMessageCodec body. Non-200 responses use \c text/plain
+    /// and carry the diagnostic text in \c body; \c error mirrors the text for
+    /// in-process adapters that do not serialize the response object.
+    struct HttpSyncResponse {
+        unsigned status_code = 200;
+        std::string content_type;
+        std::vector<std::uint8_t> body;
+        std::string error;
+    };
+
+    /// \brief Client-side bridge implemented by a concrete HTTP library.
+    class IHttpSyncClient {
+    public:
+        virtual ~IHttpSyncClient() {}
+
+        /// \brief Sends one binary sync request body to \p target.
+        /// \details Implementations own connection pooling, timeouts, TLS,
+        /// authorization headers, rate-limit retries, and socket cancellation.
+        virtual HttpSyncResponse post(
+                const std::string& target,
+                const std::string& content_type,
+                const std::vector<std::uint8_t>& body,
+                const CancellationToken& cancel_token) = 0;
+
+        /// \brief Best-effort cancellation hook for an in-flight \c post().
+        virtual void request_cancel() {}
+    };
+
+    /// \brief Shared constants for HTTP sync adapters.
+    class HttpSyncRoutes {
+    public:
+        static const char* method_post() {
+            return "POST";
+        }
+
+        static const char* content_type() {
+            return "application/vnd.mdbx-containers.sync.v1+octet-stream";
+        }
+
+        static const char* pull_target() {
+            return "/mdbxc/sync/v1/pull";
+        }
+
+        static const char* push_target() {
+            return "/mdbxc/sync/v1/push";
+        }
+    };
+
+    /// \brief Server-side dispatcher from HTTP-shaped requests to SyncEngine.
+    class HttpSyncServer {
+    public:
+        explicit HttpSyncServer(SyncEngine& engine,
+                                const CodecBounds& bounds = CodecBounds())
+            : m_engine(engine), m_bounds(bounds) {}
+
+        /// \brief Handles one already-parsed HTTP request.
+        /// \details Returns HTTP-style status codes for transport/framing
+        /// failures. Sync-level failures such as db_id mismatch are encoded
+        /// inside the binary PullResponse/PushResponse with status 200.
+        HttpSyncResponse handle(const HttpSyncRequest& request) const {
+            if (request.method != HttpSyncRoutes::method_post()) {
+                return make_error(405, "method not allowed");
+            }
+            if (request.content_type != HttpSyncRoutes::content_type()) {
+                return make_error(415, "unsupported content type");
+            }
+            if (request.target == HttpSyncRoutes::pull_target()) {
+                return handle_pull(request.body);
+            }
+            if (request.target == HttpSyncRoutes::push_target()) {
+                return handle_push(request.body);
+            }
+            return make_error(404, "unknown sync route");
+        }
+
+    private:
+        HttpSyncResponse handle_pull(
+                const std::vector<std::uint8_t>& body) const {
+            PullRequest decoded;
+            try {
+                decoded = TransportMessageCodec::decode_pull_request(
+                    body, &m_bounds);
+            } catch (const std::length_error& e) {
+                return make_error(413, e.what());
+            } catch (const std::exception& e) {
+                return make_error(400, e.what());
+            }
+
+            try {
+                const PullResponse response = m_engine.handle_pull(decoded);
+                return make_binary(
+                    TransportMessageCodec::encode_pull_response(
+                        response, &m_bounds));
+            } catch (const std::exception& e) {
+                return make_error(500, e.what());
+            }
+        }
+
+        HttpSyncResponse handle_push(
+                const std::vector<std::uint8_t>& body) const {
+            PushRequest decoded;
+            try {
+                decoded = TransportMessageCodec::decode_push_request(
+                    body, &m_bounds);
+            } catch (const std::length_error& e) {
+                return make_error(413, e.what());
+            } catch (const std::exception& e) {
+                return make_error(400, e.what());
+            }
+
+            try {
+                const PushResponse response = m_engine.handle_push(decoded);
+                return make_binary(
+                    TransportMessageCodec::encode_push_response(
+                        response, &m_bounds));
+            } catch (const std::exception& e) {
+                return make_error(500, e.what());
+            }
+        }
+
+        static HttpSyncResponse make_binary(
+                const std::vector<std::uint8_t>& body) {
+            HttpSyncResponse response;
+            response.status_code = 200;
+            response.content_type = HttpSyncRoutes::content_type();
+            response.body = body;
+            return response;
+        }
+
+        static HttpSyncResponse make_error(unsigned status,
+                                           const std::string& error) {
+            HttpSyncResponse response;
+            response.status_code = status;
+            response.content_type = "text/plain; charset=utf-8";
+            response.error = error;
+            response.body.assign(error.begin(), error.end());
+            return response;
+        }
+
+        SyncEngine& m_engine;
+        CodecBounds m_bounds;
+    };
+
+    /// \brief \c ISyncPeer implementation over an abstract HTTP client.
+    class HttpSyncPeer : public ISyncPeer {
+    public:
+        explicit HttpSyncPeer(IHttpSyncClient& client,
+                              const CodecBounds& bounds = CodecBounds())
+            : m_client(client), m_bounds(bounds) {}
+
+        PullResponse pull(const PullRequest& request) override {
+            const std::vector<std::uint8_t> body =
+                TransportMessageCodec::encode_pull_request(
+                    request, &m_bounds);
+            const HttpSyncResponse response = m_client.post(
+                HttpSyncRoutes::pull_target(),
+                HttpSyncRoutes::content_type(),
+                body,
+                request.cancel_token);
+            require_ok_response(response, "pull");
+            return TransportMessageCodec::decode_pull_response(
+                response.body, &m_bounds);
+        }
+
+        PushResponse push(const PushRequest& request) override {
+            const std::vector<std::uint8_t> body =
+                TransportMessageCodec::encode_push_request(
+                    request, &m_bounds);
+            const HttpSyncResponse response = m_client.post(
+                HttpSyncRoutes::push_target(),
+                HttpSyncRoutes::content_type(),
+                body,
+                request.cancel_token);
+            require_ok_response(response, "push");
+            return TransportMessageCodec::decode_push_response(
+                response.body, &m_bounds);
+        }
+
+        void request_cancel() override {
+            m_client.request_cancel();
+        }
+
+    private:
+        static void require_ok_response(const HttpSyncResponse& response,
+                                        const char* operation) {
+            if (response.status_code != 200) {
+                const std::string diagnostic = response_diagnostic(response);
+                throw std::runtime_error(
+                    std::string("HTTP sync ") + operation +
+                    " failed with status " +
+                    std::to_string(response.status_code) + ": " +
+                    diagnostic);
+            }
+            if (response.content_type != HttpSyncRoutes::content_type()) {
+                throw std::runtime_error(
+                    std::string("HTTP sync ") + operation +
+                    " returned unexpected content type");
+            }
+        }
+
+        static std::string response_diagnostic(
+                const HttpSyncResponse& response) {
+            if (!response.error.empty()) {
+                return response.error;
+            }
+            if (response.body.empty()) {
+                return std::string();
+            }
+            return std::string(
+                reinterpret_cast<const char*>(&response.body[0]),
+                response.body.size());
+        }
+
+        IHttpSyncClient& m_client;
+        CodecBounds m_bounds;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_HTTP_TRANSPORT_HPP_INCLUDED

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -47,6 +47,8 @@ int main() {
         mdbxc::sync::TransportMessageCodec::decode_pull_request(wire);
     MDBXC_TEST_ASSERT(decoded_pull.requester == node);
     MDBXC_TEST_ASSERT(decoded_pull.have.last_seq_for(node) == 1u);
+    MDBXC_TEST_ASSERT(std::string(mdbxc::sync::HttpSyncRoutes::pull_target())
+                      == "/mdbxc/sync/v1/pull");
 
     mdbxc::sync::CancellationSource source;
     const mdbxc::sync::CancellationToken token = source.token();

--- a/tests/test_http_transport.cpp
+++ b/tests/test_http_transport.cpp
@@ -1,0 +1,283 @@
+#include <mdbx_containers.hpp>
+#include <mdbx_containers/sync.hpp>
+
+#include <cstdio>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+mdbxc::sync::NodeId make_node(std::uint8_t seed) {
+    mdbxc::sync::NodeId node{};
+    for (int i = 0; i < 16; ++i) {
+        node[i] = static_cast<std::uint8_t>(seed + i);
+    }
+    return node;
+}
+
+void cleanup(const std::string& path) {
+    std::remove(path.c_str());
+    std::remove((path + "-lck").c_str());
+}
+
+mdbxc::Config config(const std::string& path) {
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.no_subdir = true;
+    cfg.max_dbs = 32;
+    return cfg;
+}
+
+std::shared_ptr<mdbxc::Connection> open_db(const std::string& path) {
+    return mdbxc::Connection::create(config(path));
+}
+
+void require_true(bool condition, const std::string& message) {
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+std::string get_value(const std::shared_ptr<mdbxc::Connection>& conn,
+                      mdbxc::KeyValueTable<int, std::string>& table,
+                      int key) {
+    std::string out;
+    auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+    if (!table.try_get(key, out, txn.handle())) {
+        throw std::runtime_error("missing replicated value");
+    }
+    return out;
+}
+
+class LoopbackHttpClient : public mdbxc::sync::IHttpSyncClient {
+public:
+    explicit LoopbackHttpClient(mdbxc::sync::HttpSyncServer& server)
+        : m_server(server),
+          m_cancel_count(0),
+          m_last_token_cancellable(false) {}
+
+    mdbxc::sync::HttpSyncResponse post(
+            const std::string& target,
+            const std::string& content_type,
+            const std::vector<std::uint8_t>& body,
+            const mdbxc::sync::CancellationToken& cancel_token) override {
+        m_last_target = target;
+        m_last_content_type = content_type;
+        m_last_token_cancellable = cancel_token.can_be_cancelled();
+
+        mdbxc::sync::HttpSyncRequest request;
+        request.method = mdbxc::sync::HttpSyncRoutes::method_post();
+        request.target = target;
+        request.content_type = content_type;
+        request.body = body;
+        return m_server.handle(request);
+    }
+
+    void request_cancel() override {
+        ++m_cancel_count;
+    }
+
+    const std::string& last_target() const { return m_last_target; }
+    const std::string& last_content_type() const {
+        return m_last_content_type;
+    }
+    bool last_token_cancellable() const { return m_last_token_cancellable; }
+    std::size_t cancel_count() const { return m_cancel_count; }
+
+private:
+    mdbxc::sync::HttpSyncServer& m_server;
+    std::size_t m_cancel_count;
+    bool m_last_token_cancellable;
+    std::string m_last_target;
+    std::string m_last_content_type;
+};
+
+class ErrorHttpClient : public mdbxc::sync::IHttpSyncClient {
+public:
+    mdbxc::sync::HttpSyncResponse post(
+            const std::string& target,
+            const std::string& content_type,
+            const std::vector<std::uint8_t>& body,
+            const mdbxc::sync::CancellationToken& cancel_token) override {
+        (void)target;
+        (void)content_type;
+        (void)body;
+        (void)cancel_token;
+        mdbxc::sync::HttpSyncResponse response;
+        response.status_code = 503;
+        response.content_type = "text/plain; charset=utf-8";
+        const std::string text = "upstream unavailable";
+        response.body.assign(text.begin(), text.end());
+        return response;
+    }
+};
+
+void test_http_peer_pull_and_push_roundtrip() {
+    const std::string primary_path = "test_http_transport_primary.mdbx";
+    const std::string replica_path = "test_http_transport_replica.mdbx";
+    cleanup(primary_path);
+    cleanup(replica_path);
+
+    std::shared_ptr<mdbxc::Connection> primary = open_db(primary_path);
+    std::shared_ptr<mdbxc::Connection> replica = open_db(replica_path);
+
+    const mdbxc::sync::NodeId primary_node = make_node(0x10);
+    const mdbxc::sync::NodeId replica_node = make_node(0x20);
+    const mdbxc::sync::DbId db_id = make_node(0xD0);
+
+    mdbxc::sync::SyncEngine primary_engine(primary);
+    mdbxc::sync::SyncEngine replica_engine(replica);
+    primary_engine.initialize_local_identity(primary_node, db_id);
+    replica_engine.initialize_local_identity(replica_node, db_id);
+
+    mdbxc::sync::ThreadLocalChangeAccumulator capture(primary);
+    mdbxc::KeyValueTable<int, std::string> primary_ticks(primary, "ticks");
+
+    primary->attach_sync_capture(&capture);
+    primary_ticks.insert_or_assign(1, "BTC/USD");
+    primary_ticks.insert_or_assign(2, "ETH/USD");
+    primary->detach_sync_capture();
+
+    mdbxc::sync::HttpSyncServer primary_server(primary_engine);
+    LoopbackHttpClient primary_http(primary_server);
+    mdbxc::sync::HttpSyncPeer primary_peer(primary_http);
+
+    mdbxc::sync::CancellationSource pull_cancel;
+    mdbxc::sync::PullRequest pull;
+    pull.requester = replica_node;
+    pull.db_id = db_id;
+    pull.have = replica_engine.applied_cursor();
+    pull.max_batches = 100;
+    pull.cancel_token = pull_cancel.token();
+
+    const mdbxc::sync::PullResponse pulled = primary_peer.pull(pull);
+    require_true(pulled.ok, "HTTP pull failed: " + pulled.error);
+    require_true(pulled.batches.size() == 2u,
+                 "HTTP pull expected two batches");
+    require_true(primary_http.last_target() ==
+                     mdbxc::sync::HttpSyncRoutes::pull_target(),
+                 "HTTP pull target mismatch");
+    require_true(primary_http.last_content_type() ==
+                     mdbxc::sync::HttpSyncRoutes::content_type(),
+                 "HTTP pull content type mismatch");
+    require_true(primary_http.last_token_cancellable(),
+                 "HTTP client did not receive cancellation token");
+
+    mdbxc::sync::PushRequest local_apply;
+    local_apply.sender = primary_node;
+    local_apply.db_id = db_id;
+    local_apply.batches = pulled.batches;
+    const mdbxc::sync::PushResponse applied =
+        replica_engine.handle_push(local_apply);
+    require_true(applied.ok, "local apply failed: " + applied.error);
+
+    primary->attach_sync_capture(&capture);
+    primary_ticks.insert_or_assign(3, "SOL/USD");
+    primary->detach_sync_capture();
+
+    mdbxc::sync::HttpSyncServer replica_server(replica_engine);
+    LoopbackHttpClient replica_http(replica_server);
+    mdbxc::sync::HttpSyncPeer replica_peer(replica_http);
+
+    mdbxc::sync::PushRequest push = primary_engine.make_push_request(3, 0);
+    require_true(push.batches.size() == 1u,
+                 "HTTP push expected one batch");
+    const mdbxc::sync::PushResponse pushed = replica_peer.push(push);
+    require_true(pushed.ok, "HTTP push failed: " + pushed.error);
+    require_true(pushed.receiver_have.last_seq_for(primary_node) == 3u,
+                 "HTTP push cursor mismatch");
+    require_true(replica_http.last_target() ==
+                     mdbxc::sync::HttpSyncRoutes::push_target(),
+                 "HTTP push target mismatch");
+
+    replica_peer.request_cancel();
+    require_true(replica_http.cancel_count() == 1u,
+                 "HTTP peer did not forward request_cancel()");
+
+    mdbxc::KeyValueTable<int, std::string> replica_ticks(replica, "ticks");
+    require_true(get_value(replica, replica_ticks, 1) == "BTC/USD",
+                 "replica value 1 mismatch");
+    require_true(get_value(replica, replica_ticks, 2) == "ETH/USD",
+                 "replica value 2 mismatch");
+    require_true(get_value(replica, replica_ticks, 3) == "SOL/USD",
+                 "replica value 3 mismatch");
+
+    primary->disconnect();
+    replica->disconnect();
+    cleanup(primary_path);
+    cleanup(replica_path);
+}
+
+void test_http_server_status_mapping() {
+    const std::string path = "test_http_transport_status.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<mdbxc::Connection> db = open_db(path);
+    mdbxc::sync::SyncEngine engine(db);
+    engine.initialize_local_identity(make_node(0x30), make_node(0xD1));
+    mdbxc::sync::HttpSyncServer server(engine);
+
+    mdbxc::sync::HttpSyncRequest request;
+    request.method = "GET";
+    request.target = mdbxc::sync::HttpSyncRoutes::pull_target();
+    request.content_type = mdbxc::sync::HttpSyncRoutes::content_type();
+    mdbxc::sync::HttpSyncResponse response = server.handle(request);
+    require_true(response.status_code == 405, "GET must be rejected");
+    require_true(!response.body.empty(), "GET rejection must carry body text");
+
+    request.method = mdbxc::sync::HttpSyncRoutes::method_post();
+    request.content_type = "application/octet-stream";
+    response = server.handle(request);
+    require_true(response.status_code == 415,
+                 "wrong content type must be rejected");
+
+    request.content_type = mdbxc::sync::HttpSyncRoutes::content_type();
+    request.target = "/unknown";
+    response = server.handle(request);
+    require_true(response.status_code == 404,
+                 "unknown route must be rejected");
+
+    request.target = mdbxc::sync::HttpSyncRoutes::pull_target();
+    request.body.assign(3u, 0xFFu);
+    response = server.handle(request);
+    require_true(response.status_code == 400,
+                 "malformed body must be rejected");
+
+    mdbxc::sync::CodecBounds bounds;
+    bounds.max_transport_message_bytes = 16;
+    mdbxc::sync::HttpSyncServer bounded_server(engine, bounds);
+    request.body = mdbxc::sync::TransportMessageCodec::encode_pull_request(
+        mdbxc::sync::PullRequest());
+    response = bounded_server.handle(request);
+    require_true(response.status_code == 413,
+                 "oversized body must be rejected");
+
+    db->disconnect();
+    cleanup(path);
+}
+
+void test_http_peer_rejects_transport_error() {
+    ErrorHttpClient client;
+    mdbxc::sync::HttpSyncPeer peer(client);
+    bool caught = false;
+    try {
+        (void)peer.pull(mdbxc::sync::PullRequest());
+    } catch (const std::runtime_error& e) {
+        const std::string message = e.what();
+        caught = message.find("503") != std::string::npos &&
+                 message.find("upstream unavailable") != std::string::npos;
+    }
+    require_true(caught, "HTTP peer must surface non-200 status");
+}
+
+} // namespace
+
+int main() {
+    test_http_peer_pull_and_push_roundtrip();
+    test_http_server_status_mapping();
+    test_http_peer_rejects_transport_error();
+    return 0;
+}


### PR DESCRIPTION
﻿## Summary

- Add a framework-neutral HTTP-shaped sync adapter seam over `TransportMessageCodec`.
- Provide `HttpSyncPeer`, `IHttpSyncClient`, `HttpSyncServer`, and `HttpSyncRoutes` for route/content-type/body/status mapping without adding a socket/framework dependency to public persistence headers.
- Store `CodecBounds` by value in adapter objects, so callers cannot accidentally pass a dangling config pointer.
- Define non-200 HTTP diagnostics as `text/plain` response body, with `response.error` as an in-process mirror/fallback.
- Keep authorization, rate limits, allow/deny lists, TLS, routing, and real socket cancellation as adapter/framework policy around this seam.
- Add loopback tests for pull, push, status mapping, cancellation forwarding, and examples for a custom `ISyncPeer` plus the HTTP-shaped adapter.

## Notes

This is intentionally not a concrete HTTP server/client binding. A real binding can implement `IHttpSyncClient::post()` and route incoming HTTP requests to `HttpSyncServer::handle()` using libcurl, Boost.Beast, Simple-Web-Server, cpp-httplib, or another framework.

`sync_10_custom_transport.cpp` shows how to implement an application-specific `ISyncPeer` directly over encoded byte buffers. `sync_11_http_adapter.cpp` shows the HTTP-shaped seam on top of the same codec.

## Validation

- `cmake -S . -B tmp/pr104-cpp17 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=17`
- `mingw32-make -C tmp/pr104-cpp17 test_http_transport header_sync_umbrella_test sync_10_custom_transport sync_11_http_adapter`
- `ctest --test-dir tmp/pr104-cpp17 -R "test_http_transport|header_sync_umbrella_test" --output-on-failure`
- `./tmp/pr104-cpp17/bin/examples/sync_10_custom_transport.exe`
- `./tmp/pr104-cpp17/bin/examples/sync_11_http_adapter.exe`
- `cmake -S . -B tmp/pr104-cpp11 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=11`
- `mingw32-make -C tmp/pr104-cpp11 test_http_transport header_sync_umbrella_test sync_10_custom_transport sync_11_http_adapter`
- `ctest --test-dir tmp/pr104-cpp11 -R "test_http_transport|header_sync_umbrella_test" --output-on-failure`
- `./tmp/pr104-cpp11/bin/examples/sync_10_custom_transport.exe`
- `./tmp/pr104-cpp11/bin/examples/sync_11_http_adapter.exe`
- `git diff --check`
