### PR TITLE
feat(sync): add transport middleware policies

### DIFF
--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -130,3 +130,7 @@ replica формирует PullRequest
 вокруг HTTP-shaped обмена bytes. В такие обёртки помещаются простые allow-lists,
 fixed-budget rate limits и metrics hooks; они не добавляют auth tokens или
 счётчики в wire format sync DTO.
+Они не заменяют server-framework authentication или per-remote-client rate
+limits перед `HttpSyncServer::handle()`. Метрики считают вызовы middleware
+hooks, поэтому общий observer на нескольких слоях может посчитать одно
+логическое действие по одному разу на каждом слое.

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -43,6 +43,7 @@ tmp/build-examples/bin/examples/sync_01_lifecycle_direct_peer
 | `sync_09_transport_codec.cpp` | Версионированный бинарный `TransportMessageCodec` для DTO запросов и ответов. | Продвинутый |
 | `sync_10_custom_transport.cpp` | Минимальный кастомный `ISyncPeer` поверх закодированных byte buffers. | Продвинутый |
 | `sync_11_http_adapter.cpp` | Фреймворк-независимый HTTP-адаптер поверх `TransportMessageCodec`. | Продвинутый |
+| `sync_12_transport_middleware.cpp` | Allow-list, fixed-budget rate limit и metrics middleware вокруг транспортных адаптеров. | Продвинутый |
 
 ## Общие правила
 
@@ -122,3 +123,10 @@ replica формирует PullRequest
 `HttpSyncServer` передаёт уже разобранные HTTP method/target/content-type/body
 значения в `SyncEngine`. Реальная HTTP-библиотека добавляет сетевой слой вокруг
 этой границы.
+
+`sync_12_transport_middleware.cpp` показывает adapter-local policy wrappers.
+`SyncPeerMiddleware` может проверять декодированные `NodeId` / `DbId` перед
+вызовом peer-а, а `HttpSyncClientMiddleware` может применять route-level policy
+вокруг HTTP-shaped обмена bytes. В такие обёртки помещаются простые allow-lists,
+fixed-budget rate limits и metrics hooks; они не добавляют auth tokens или
+счётчики в wire format sync DTO.

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -42,6 +42,7 @@ executable has the `.exe` suffix, for example:
 | `sync_09_transport_codec.cpp` | Versioned binary `TransportMessageCodec` for request/response DTOs. | Advanced |
 | `sync_10_custom_transport.cpp` | Minimal custom `ISyncPeer` over encoded byte buffers. | Advanced |
 | `sync_11_http_adapter.cpp` | Framework-neutral HTTP-shaped adapter over `TransportMessageCodec`. | Advanced |
+| `sync_12_transport_middleware.cpp` | Allow-list, fixed-budget, and metrics middleware around transport adapters. | Advanced |
 
 ## Common Rules
 
@@ -118,3 +119,10 @@ implements `ISyncPeer` over an abstract `IHttpSyncClient`, and
 `HttpSyncServer` dispatches already-parsed HTTP method/target/content-type/body
 values to `SyncEngine`. A real HTTP library supplies the socket layer around
 that seam.
+
+`sync_12_transport_middleware.cpp` shows adapter-local policy wrappers.
+`SyncPeerMiddleware` can inspect decoded `NodeId` / `DbId` values before a peer
+call, while `HttpSyncClientMiddleware` can enforce route-level policy around an
+HTTP-shaped byte exchange. These wrappers are where simple allow-lists,
+fixed-budget rate limits, and metrics hooks belong; they do not add auth tokens
+or counters to the sync DTO wire format.

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -126,3 +126,7 @@ call, while `HttpSyncClientMiddleware` can enforce route-level policy around an
 HTTP-shaped byte exchange. These wrappers are where simple allow-lists,
 fixed-budget rate limits, and metrics hooks belong; they do not add auth tokens
 or counters to the sync DTO wire format.
+They do not replace server-framework authentication or per-remote-client rate
+limits before `HttpSyncServer::handle()`. Metrics count middleware hook
+invocations, so a shared observer installed at several stacked layers can count
+one logical action once per layer.

--- a/examples/sync_12_transport_middleware.cpp
+++ b/examples/sync_12_transport_middleware.cpp
@@ -1,0 +1,209 @@
+/**
+ * \ingroup mdbxc_examples
+ * \brief Transport middleware for allow-lists, rate limits, and metrics.
+ *
+ * This example stacks two framework-neutral middleware layers:
+ *
+ *   SyncPeerMiddleware
+ *     -> HttpSyncPeer
+ *        -> HttpSyncClientMiddleware
+ *           -> application HTTP client
+ *
+ * `SyncPeerMiddleware` sees decoded DTOs and can inspect `NodeId` / `DbId`.
+ * `HttpSyncClientMiddleware` sees HTTP-shaped target/content-type/body values
+ * and can enforce route-level policy before a real HTTP library sends bytes.
+ *
+ * Expected output:
+ *   [middleware] allowed pull applied 2 batch(es)
+ *   [middleware] db policy rejected pull: sync db_id is not allowed
+ *   [middleware] rate limit rejected pull: sync pull rate limit exceeded
+ *   [middleware] HTTP route rejected with 403
+ *   [middleware] metrics pull=1 http=1 rejected=3
+ *   OK: sync_12_transport_middleware
+ */
+
+#include "sync_example_utils.hpp"
+
+#include <cstdio>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+class LoopbackHttpClient : public mdbxc::sync::IHttpSyncClient {
+public:
+    explicit LoopbackHttpClient(mdbxc::sync::HttpSyncServer& server)
+        : m_server(server), m_cancel_count(0) {}
+
+    mdbxc::sync::HttpSyncResponse post(
+            const std::string& target,
+            const std::string& content_type,
+            const std::vector<std::uint8_t>& body,
+            const mdbxc::sync::CancellationToken& cancel_token) override {
+        (void)cancel_token;
+        mdbxc::sync::HttpSyncRequest request;
+        request.method = mdbxc::sync::HttpSyncRoutes::method_post();
+        request.target = target;
+        request.content_type = content_type;
+        request.body = body;
+        return m_server.handle(request);
+    }
+
+    void request_cancel() override {
+        ++m_cancel_count;
+    }
+
+    std::size_t cancel_count() const { return m_cancel_count; }
+
+private:
+    mdbxc::sync::HttpSyncServer& m_server;
+    std::size_t m_cancel_count;
+};
+
+} // namespace
+
+int main() {
+    const std::string primary_path = "sync_12_primary.mdbx";
+    const std::string replica_path = "sync_12_replica.mdbx";
+    sync_example::cleanup(primary_path);
+    sync_example::cleanup(replica_path);
+
+    const mdbxc::sync::NodeId primary_node =
+        sync_example::make_node(0xC0);
+    const mdbxc::sync::NodeId replica_node =
+        sync_example::make_node(0xC1);
+    const mdbxc::sync::DbId db_id =
+        sync_example::make_node(0xC2);
+    const mdbxc::sync::DbId denied_db_id =
+        sync_example::make_node(0xC3);
+
+    try {
+        std::shared_ptr<mdbxc::Connection> primary =
+            sync_example::open(primary_path);
+        std::shared_ptr<mdbxc::Connection> replica =
+            sync_example::open(replica_path);
+
+        mdbxc::sync::SyncEngine primary_engine(primary);
+        mdbxc::sync::SyncEngine replica_engine(replica);
+        primary_engine.initialize_local_identity(primary_node, db_id);
+        replica_engine.initialize_local_identity(replica_node, db_id);
+
+        mdbxc::sync::ThreadLocalChangeAccumulator capture(primary);
+        mdbxc::KeyValueTable<int, std::string> primary_ticks(primary, "ticks");
+
+        primary->attach_sync_capture(&capture);
+        primary_ticks.insert_or_assign(1, "BTC/USD");
+        primary_ticks.insert_or_assign(2, "ETH/USD");
+        primary->detach_sync_capture();
+
+        mdbxc::sync::SyncTransportMetricsObserver metrics;
+
+        mdbxc::sync::HttpRouteAllowListPolicy routes;
+        routes.allow_target(mdbxc::sync::HttpSyncRoutes::pull_target());
+
+        mdbxc::sync::HttpSyncServer primary_server(primary_engine);
+        LoopbackHttpClient raw_http(primary_server);
+        mdbxc::sync::HttpSyncClientMiddleware guarded_http(
+            raw_http, &routes, &metrics);
+        mdbxc::sync::HttpSyncPeer http_peer(guarded_http);
+
+        mdbxc::sync::NodeDbAllowListPolicy allow_list;
+        allow_list.allow_node_id(replica_node);
+        allow_list.allow_db_id(db_id);
+
+        mdbxc::sync::FixedBudgetSyncTransportPolicy budget(1, 100);
+        mdbxc::sync::CompositeSyncTransportPolicy peer_policy;
+        peer_policy.add(allow_list);
+        peer_policy.add(budget);
+
+        mdbxc::sync::SyncPeerMiddleware guarded_peer(
+            http_peer, &peer_policy, &metrics);
+
+        mdbxc::sync::PullRequest pull;
+        pull.requester = replica_node;
+        pull.db_id = db_id;
+        pull.have = replica_engine.applied_cursor();
+        pull.max_batches = 100;
+
+        const mdbxc::sync::PullResponse pulled = guarded_peer.pull(pull);
+        sync_example::require(pulled.ok,
+                              "allowed pull failed: " + pulled.error);
+
+        mdbxc::sync::PushRequest local_apply;
+        local_apply.sender = primary_node;
+        local_apply.db_id = db_id;
+        local_apply.batches = pulled.batches;
+        const mdbxc::sync::PushResponse applied =
+            replica_engine.handle_push(local_apply);
+        sync_example::require(applied.ok,
+                              "local apply failed: " + applied.error);
+        std::printf("[middleware] allowed pull applied %zu batch(es)\n",
+                    pulled.batches.size());
+
+        pull.db_id = denied_db_id;
+        const mdbxc::sync::PullResponse denied_by_db =
+            guarded_peer.pull(pull);
+        sync_example::require(!denied_by_db.ok,
+                              "denied db_id was allowed");
+        std::printf("[middleware] db policy rejected pull: %s\n",
+                    denied_by_db.error.c_str());
+
+        pull.db_id = db_id;
+        const mdbxc::sync::PullResponse denied_by_budget =
+            guarded_peer.pull(pull);
+        sync_example::require(!denied_by_budget.ok,
+                              "rate-limited pull was allowed");
+        std::printf("[middleware] rate limit rejected pull: %s\n",
+                    denied_by_budget.error.c_str());
+
+        const mdbxc::sync::HttpSyncResponse denied_route =
+            guarded_http.post(mdbxc::sync::HttpSyncRoutes::push_target(),
+                              mdbxc::sync::HttpSyncRoutes::content_type(),
+                              std::vector<std::uint8_t>(),
+                              mdbxc::sync::CancellationToken());
+        sync_example::require(denied_route.status_code == 403,
+                              "denied HTTP route was allowed");
+        std::printf("[middleware] HTTP route rejected with %u\n",
+                    denied_route.status_code);
+
+        guarded_peer.request_cancel();
+        sync_example::require(raw_http.cancel_count() == 1u,
+                              "request_cancel was not forwarded");
+
+        mdbxc::KeyValueTable<int, std::string> replica_ticks(replica, "ticks");
+        sync_example::require(
+            sync_example::kv_or_throw(replica, replica_ticks, 1,
+                                      "ticks[1]") == "BTC/USD",
+            "replica ticks[1] mismatch");
+        sync_example::require(
+            sync_example::kv_or_throw(replica, replica_ticks, 2,
+                                      "ticks[2]") == "ETH/USD",
+            "replica ticks[2] mismatch");
+
+        const mdbxc::sync::SyncTransportMetricsSnapshot snapshot =
+            metrics.snapshot();
+        sync_example::require(snapshot.pull_calls == 1u,
+                              "pull metric mismatch");
+        sync_example::require(snapshot.http_post_calls == 1u,
+                              "HTTP post metric mismatch");
+        sync_example::require(snapshot.rejected_calls == 3u,
+                              "rejection metric mismatch");
+        std::printf("[middleware] metrics pull=%llu http=%llu rejected=%llu\n",
+                    static_cast<unsigned long long>(snapshot.pull_calls),
+                    static_cast<unsigned long long>(snapshot.http_post_calls),
+                    static_cast<unsigned long long>(snapshot.rejected_calls));
+
+        sync_example::disconnect_and_cleanup(primary, primary_path);
+        sync_example::disconnect_and_cleanup(replica, replica_path);
+        std::printf("OK: sync_12_transport_middleware\n");
+        return 0;
+    } catch (const std::exception& e) {
+        std::printf("FAIL: %s\n", e.what());
+        sync_example::cleanup(primary_path);
+        sync_example::cleanup(replica_path);
+        return 1;
+    }
+}

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -32,6 +32,7 @@
 #include "sync/SyncWorker.hpp"
 #include "sync/DirectSyncPeer.hpp"
 #include "sync/HttpTransport.hpp"
+#include "sync/TransportMiddleware.hpp"
 #include "sync/stores/MetaStore.hpp"
 #include "sync/stores/OriginIndexStore.hpp"
 #include "sync/stores/ChangeLogStore.hpp"

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -466,6 +466,12 @@ with a time-window or token-bucket policy while keeping the same middleware
 shape. `SyncTransportMetricsObserver` records basic call, rejection, failure,
 cancel, and batch counters without changing transport behavior.
 
+These helpers do not replace server-framework authentication or
+per-remote-client rate limiting before `HttpSyncServer::handle()`. They also
+count middleware hook invocations: if one observer is installed at both the
+peer layer and HTTP client layer, a forwarded `request_cancel()` can be counted
+once per layer.
+
 `ChangeBatchCodec` already rejects `BATCH_COMPRESSED_ZSTD` at both
 encode and decode paths. Adding a real `zstd` backend is a codec
 change and belongs in a separate design pass; it is not part of the

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -32,6 +32,10 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
   `IHttpSyncClient`, `HttpSyncServer`, and `HttpSyncRoutes`. It defines
   route/content-type/body/status mapping over `TransportMessageCodec` but does
   not open sockets or depend on an HTTP framework.
+- Transport middleware helpers: `SyncPeerMiddleware`,
+  `HttpSyncClientMiddleware`, allow-list policies, fixed-budget rate limiting,
+  and a metrics observer. These wrap transport adapters and do not change the
+  sync DTO wire format.
 - Change capture hooks: `Connection::attach_sync_capture()`,
   `BaseTable::record_op()`, and the transaction pre-commit hook route table
   writes into `ThreadLocalChangeAccumulator`, which appends one local
@@ -451,6 +455,16 @@ request handling: inspect transport metadata and, when needed, the decoded
 DTO header fields (`requester`, `sender`, `db_id`) before dispatching to
 `SyncEngine`. Do not put bearer tokens, ACL decisions, or rate-limit counters
 inside the sync DTO wire format.
+
+`SyncPeerMiddleware` and `HttpSyncClientMiddleware` are the v0.1 framework-free
+building blocks for these wrappers. `NodeDbAllowListPolicy` checks decoded
+`requester` / `sender` and `db_id` values. `HttpRouteAllowListPolicy` checks
+HTTP-shaped targets before a concrete HTTP client sends bytes.
+`FixedBudgetSyncTransportPolicy` is a deterministic fixed-budget limiter useful
+for tests, examples, and simple adapters; production adapters can replace it
+with a time-window or token-bucket policy while keeping the same middleware
+shape. `SyncTransportMetricsObserver` records basic call, rejection, failure,
+cancel, and batch counters without changing transport behavior.
 
 `ChangeBatchCodec` already rejects `BATCH_COMPRESSED_ZSTD` at both
 encode and decode paths. Adding a real `zstd` backend is a codec

--- a/include/mdbx_containers/sync/TransportMiddleware.hpp
+++ b/include/mdbx_containers/sync/TransportMiddleware.hpp
@@ -1,0 +1,655 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_TRANSPORT_MIDDLEWARE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_TRANSPORT_MIDDLEWARE_HPP_INCLUDED
+
+/// \file TransportMiddleware.hpp
+/// \brief Policy and metrics wrappers for sync transport adapters.
+/// \details
+/// These helpers sit around \c ISyncPeer or \c IHttpSyncClient. They do not
+/// add credentials to sync DTOs and do not own sockets; concrete transports can
+/// use them to enforce allow lists, fixed request budgets, and metrics hooks.
+
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <limits>
+#include <mutex>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "HttpTransport.hpp"
+#include "ISyncPeer.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Transport operation observed by middleware.
+    enum class SyncTransportOperation : std::uint8_t {
+        Pull,
+        Push,
+        HttpPost
+    };
+
+    /// \brief Result returned by a transport policy.
+    struct SyncTransportDecision {
+        bool allowed = true;
+        unsigned status_code = 0;
+        std::string error;
+
+        static SyncTransportDecision allow() {
+            return SyncTransportDecision();
+        }
+
+        static SyncTransportDecision reject(const std::string& message,
+                                            unsigned status = 403) {
+            SyncTransportDecision out;
+            out.allowed = false;
+            out.status_code = status;
+            out.error = message;
+            return out;
+        }
+    };
+
+    /// \brief Policy hook for sync transport requests.
+    /// \details Default methods allow every request. Implementations may
+    /// inspect DTO metadata, route names, or message sizes before forwarding.
+    class ISyncTransportPolicy {
+    public:
+        virtual ~ISyncTransportPolicy() {}
+
+        virtual SyncTransportDecision check_pull(
+                const PullRequest& request) {
+            (void)request;
+            return SyncTransportDecision::allow();
+        }
+
+        virtual SyncTransportDecision check_push(
+                const PushRequest& request) {
+            (void)request;
+            return SyncTransportDecision::allow();
+        }
+
+        virtual SyncTransportDecision check_http_post(
+                const std::string& target,
+                const std::string& content_type,
+                const std::vector<std::uint8_t>& body) {
+            (void)target;
+            (void)content_type;
+            (void)body;
+            return SyncTransportDecision::allow();
+        }
+    };
+
+    /// \brief Allows only configured node ids and database ids.
+    /// \details Empty allow-list means "allow any" for that dimension.
+    class NodeDbAllowListPolicy : public ISyncTransportPolicy {
+    public:
+        void allow_node_id(const NodeId& node_id) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_allowed_nodes.insert(node_id);
+        }
+
+        void allow_db_id(const DbId& db_id) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_allowed_dbs.insert(db_id);
+        }
+
+        void clear() {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_allowed_nodes.clear();
+            m_allowed_dbs.clear();
+        }
+
+        SyncTransportDecision check_pull(
+                const PullRequest& request) override {
+            return check_node_and_db(request.requester,
+                                     request.db_id,
+                                     "sync requester is not allowed");
+        }
+
+        SyncTransportDecision check_push(
+                const PushRequest& request) override {
+            return check_node_and_db(request.sender,
+                                     request.db_id,
+                                     "sync sender is not allowed");
+        }
+
+    private:
+        SyncTransportDecision check_node_and_db(
+                const NodeId& node_id,
+                const DbId& db_id,
+                const char* node_error) const {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (!m_allowed_dbs.empty() &&
+                m_allowed_dbs.find(db_id) == m_allowed_dbs.end()) {
+                return SyncTransportDecision::reject(
+                    "sync db_id is not allowed", 403);
+            }
+            if (!m_allowed_nodes.empty() &&
+                m_allowed_nodes.find(node_id) == m_allowed_nodes.end()) {
+                return SyncTransportDecision::reject(node_error, 403);
+            }
+            return SyncTransportDecision::allow();
+        }
+
+        mutable std::mutex m_mutex;
+        std::set<NodeId> m_allowed_nodes;
+        std::set<DbId> m_allowed_dbs;
+    };
+
+    /// \brief Allows only configured HTTP sync targets.
+    /// \details Empty allow-list means every target is allowed.
+    class HttpRouteAllowListPolicy : public ISyncTransportPolicy {
+    public:
+        void allow_target(const std::string& target) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_allowed_targets.insert(target);
+        }
+
+        void clear() {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_allowed_targets.clear();
+        }
+
+        SyncTransportDecision check_http_post(
+                const std::string& target,
+                const std::string& content_type,
+                const std::vector<std::uint8_t>& body) override {
+            (void)content_type;
+            (void)body;
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (!m_allowed_targets.empty() &&
+                m_allowed_targets.find(target) == m_allowed_targets.end()) {
+                return SyncTransportDecision::reject(
+                    "sync HTTP route is not allowed", 403);
+            }
+            return SyncTransportDecision::allow();
+        }
+
+    private:
+        mutable std::mutex m_mutex;
+        std::set<std::string> m_allowed_targets;
+    };
+
+    /// \brief Fixed request-budget policy for deterministic rate-limit tests.
+    /// \details Each accepted operation consumes one budget unit. Use
+    /// \c unlimited_budget() for dimensions that should not be limited.
+    class FixedBudgetSyncTransportPolicy : public ISyncTransportPolicy {
+    public:
+        static std::uint64_t unlimited_budget() {
+            return std::numeric_limits<std::uint64_t>::max();
+        }
+
+        FixedBudgetSyncTransportPolicy(
+                std::uint64_t pull_budget,
+                std::uint64_t push_budget,
+                std::uint64_t http_post_budget = unlimited_budget())
+            : m_pull_remaining(pull_budget),
+              m_push_remaining(push_budget),
+              m_http_post_remaining(http_post_budget) {}
+
+        void reset(std::uint64_t pull_budget,
+                   std::uint64_t push_budget,
+                   std::uint64_t http_post_budget = unlimited_budget()) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_pull_remaining = pull_budget;
+            m_push_remaining = push_budget;
+            m_http_post_remaining = http_post_budget;
+        }
+
+        SyncTransportDecision check_pull(
+                const PullRequest& request) override {
+            (void)request;
+            return consume(m_pull_remaining, "sync pull rate limit exceeded");
+        }
+
+        SyncTransportDecision check_push(
+                const PushRequest& request) override {
+            (void)request;
+            return consume(m_push_remaining, "sync push rate limit exceeded");
+        }
+
+        SyncTransportDecision check_http_post(
+                const std::string& target,
+                const std::string& content_type,
+                const std::vector<std::uint8_t>& body) override {
+            (void)target;
+            (void)content_type;
+            (void)body;
+            return consume(m_http_post_remaining,
+                           "sync HTTP post rate limit exceeded");
+        }
+
+    private:
+        SyncTransportDecision consume(std::uint64_t& remaining,
+                                      const char* error) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (remaining == unlimited_budget()) {
+                return SyncTransportDecision::allow();
+            }
+            if (remaining == 0) {
+                return SyncTransportDecision::reject(error, 429);
+            }
+            --remaining;
+            return SyncTransportDecision::allow();
+        }
+
+        mutable std::mutex m_mutex;
+        std::uint64_t m_pull_remaining;
+        std::uint64_t m_push_remaining;
+        std::uint64_t m_http_post_remaining;
+    };
+
+    /// \brief Runs several policies in insertion order.
+    class CompositeSyncTransportPolicy : public ISyncTransportPolicy {
+    public:
+        void add(ISyncTransportPolicy& policy) {
+            m_policies.push_back(&policy);
+        }
+
+        SyncTransportDecision check_pull(
+                const PullRequest& request) override {
+            for (std::size_t i = 0; i < m_policies.size(); ++i) {
+                const SyncTransportDecision decision =
+                    m_policies[i]->check_pull(request);
+                if (!decision.allowed) {
+                    return decision;
+                }
+            }
+            return SyncTransportDecision::allow();
+        }
+
+        SyncTransportDecision check_push(
+                const PushRequest& request) override {
+            for (std::size_t i = 0; i < m_policies.size(); ++i) {
+                const SyncTransportDecision decision =
+                    m_policies[i]->check_push(request);
+                if (!decision.allowed) {
+                    return decision;
+                }
+            }
+            return SyncTransportDecision::allow();
+        }
+
+        SyncTransportDecision check_http_post(
+                const std::string& target,
+                const std::string& content_type,
+                const std::vector<std::uint8_t>& body) override {
+            for (std::size_t i = 0; i < m_policies.size(); ++i) {
+                const SyncTransportDecision decision =
+                    m_policies[i]->check_http_post(target, content_type, body);
+                if (!decision.allowed) {
+                    return decision;
+                }
+            }
+            return SyncTransportDecision::allow();
+        }
+
+    private:
+        std::vector<ISyncTransportPolicy*> m_policies;
+    };
+
+    /// \brief Snapshot of counters recorded by \c SyncTransportMetricsObserver.
+    struct SyncTransportMetricsSnapshot {
+        std::uint64_t pull_calls = 0;
+        std::uint64_t push_calls = 0;
+        std::uint64_t http_post_calls = 0;
+        std::uint64_t rejected_calls = 0;
+        std::uint64_t failed_calls = 0;
+        std::uint64_t request_cancel_calls = 0;
+        std::uint64_t pulled_batches = 0;
+        std::uint64_t pushed_batches = 0;
+    };
+
+    /// \brief Best-effort observer for transport middleware events.
+    /// \details Middleware wrappers swallow observer exceptions so logging or
+    /// metrics hooks cannot change transport behavior.
+    class ISyncTransportObserver {
+    public:
+        virtual ~ISyncTransportObserver() {}
+
+        virtual void on_sync_transport_rejected(
+                SyncTransportOperation operation,
+                const std::string& error) {
+            (void)operation;
+            (void)error;
+        }
+
+        virtual void on_sync_transport_pull_result(
+                const PullRequest& request,
+                const PullResponse& response) {
+            (void)request;
+            (void)response;
+        }
+
+        virtual void on_sync_transport_push_result(
+                const PushRequest& request,
+                const PushResponse& response) {
+            (void)request;
+            (void)response;
+        }
+
+        virtual void on_sync_transport_http_post_result(
+                const std::string& target,
+                const HttpSyncResponse& response) {
+            (void)target;
+            (void)response;
+        }
+
+        virtual void on_sync_transport_exception(
+                SyncTransportOperation operation,
+                const std::string& error) {
+            (void)operation;
+            (void)error;
+        }
+
+        virtual void on_sync_transport_cancel_requested() {}
+    };
+
+    /// \brief Thread-safe counter observer for basic transport metrics.
+    class SyncTransportMetricsObserver : public ISyncTransportObserver {
+    public:
+        SyncTransportMetricsSnapshot snapshot() const {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            return m_snapshot;
+        }
+
+        void reset() {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_snapshot = SyncTransportMetricsSnapshot();
+        }
+
+        void on_sync_transport_rejected(
+                SyncTransportOperation operation,
+                const std::string& error) override {
+            (void)operation;
+            (void)error;
+            std::lock_guard<std::mutex> lock(m_mutex);
+            ++m_snapshot.rejected_calls;
+        }
+
+        void on_sync_transport_pull_result(
+                const PullRequest& request,
+                const PullResponse& response) override {
+            (void)request;
+            std::lock_guard<std::mutex> lock(m_mutex);
+            ++m_snapshot.pull_calls;
+            if (!response.ok) {
+                ++m_snapshot.failed_calls;
+            }
+            m_snapshot.pulled_batches += response.batches.size();
+        }
+
+        void on_sync_transport_push_result(
+                const PushRequest& request,
+                const PushResponse& response) override {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            ++m_snapshot.push_calls;
+            if (!response.ok) {
+                ++m_snapshot.failed_calls;
+            }
+            m_snapshot.pushed_batches += request.batches.size();
+        }
+
+        void on_sync_transport_http_post_result(
+                const std::string& target,
+                const HttpSyncResponse& response) override {
+            (void)target;
+            std::lock_guard<std::mutex> lock(m_mutex);
+            ++m_snapshot.http_post_calls;
+            if (response.status_code < 200 || response.status_code >= 300) {
+                ++m_snapshot.failed_calls;
+            }
+        }
+
+        void on_sync_transport_exception(
+                SyncTransportOperation operation,
+                const std::string& error) override {
+            (void)operation;
+            (void)error;
+            std::lock_guard<std::mutex> lock(m_mutex);
+            ++m_snapshot.failed_calls;
+        }
+
+        void on_sync_transport_cancel_requested() override {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            ++m_snapshot.request_cancel_calls;
+        }
+
+    private:
+        mutable std::mutex m_mutex;
+        SyncTransportMetricsSnapshot m_snapshot;
+    };
+
+    namespace detail {
+
+        inline void notify_transport_rejected(
+                ISyncTransportObserver* observer,
+                SyncTransportOperation operation,
+                const std::string& error) {
+            if (observer == nullptr) {
+                return;
+            }
+            try {
+                observer->on_sync_transport_rejected(operation, error);
+            } catch (...) {}
+        }
+
+        inline void notify_transport_exception(
+                ISyncTransportObserver* observer,
+                SyncTransportOperation operation,
+                const std::string& error) {
+            if (observer == nullptr) {
+                return;
+            }
+            try {
+                observer->on_sync_transport_exception(operation, error);
+            } catch (...) {}
+        }
+
+        inline void notify_transport_cancel_requested(
+                ISyncTransportObserver* observer) {
+            if (observer == nullptr) {
+                return;
+            }
+            try {
+                observer->on_sync_transport_cancel_requested();
+            } catch (...) {}
+        }
+
+    } // namespace detail
+
+    /// \brief \c ISyncPeer wrapper that applies policy and observer hooks.
+    class SyncPeerMiddleware : public ISyncPeer {
+    public:
+        explicit SyncPeerMiddleware(
+                ISyncPeer& next,
+                ISyncTransportPolicy* policy = nullptr,
+                ISyncTransportObserver* observer = nullptr)
+            : m_next(next),
+              m_policy(policy),
+              m_observer(observer) {}
+
+        PullResponse pull(const PullRequest& request) override {
+            if (m_policy != nullptr) {
+                const SyncTransportDecision decision =
+                    m_policy->check_pull(request);
+                if (!decision.allowed) {
+                    detail::notify_transport_rejected(
+                        m_observer, SyncTransportOperation::Pull,
+                        decision.error);
+                    PullResponse response;
+                    response.ok = false;
+                    response.error = reject_message(decision, "pull rejected");
+                    return response;
+                }
+            }
+
+            try {
+                const PullResponse response = m_next.pull(request);
+                notify_pull_result(request, response);
+                return response;
+            } catch (const std::exception& e) {
+                detail::notify_transport_exception(
+                    m_observer, SyncTransportOperation::Pull, e.what());
+                throw;
+            } catch (...) {
+                detail::notify_transport_exception(
+                    m_observer, SyncTransportOperation::Pull,
+                    "unknown pull exception");
+                throw;
+            }
+        }
+
+        PushResponse push(const PushRequest& request) override {
+            if (m_policy != nullptr) {
+                const SyncTransportDecision decision =
+                    m_policy->check_push(request);
+                if (!decision.allowed) {
+                    detail::notify_transport_rejected(
+                        m_observer, SyncTransportOperation::Push,
+                        decision.error);
+                    PushResponse response;
+                    response.ok = false;
+                    response.error = reject_message(decision, "push rejected");
+                    return response;
+                }
+            }
+
+            try {
+                const PushResponse response = m_next.push(request);
+                notify_push_result(request, response);
+                return response;
+            } catch (const std::exception& e) {
+                detail::notify_transport_exception(
+                    m_observer, SyncTransportOperation::Push, e.what());
+                throw;
+            } catch (...) {
+                detail::notify_transport_exception(
+                    m_observer, SyncTransportOperation::Push,
+                    "unknown push exception");
+                throw;
+            }
+        }
+
+        void request_cancel() override {
+            detail::notify_transport_cancel_requested(m_observer);
+            m_next.request_cancel();
+        }
+
+    private:
+        static std::string reject_message(
+                const SyncTransportDecision& decision,
+                const char* fallback) {
+            return decision.error.empty() ? std::string(fallback)
+                                          : decision.error;
+        }
+
+        void notify_pull_result(const PullRequest& request,
+                                const PullResponse& response) const {
+            if (m_observer == nullptr) {
+                return;
+            }
+            try {
+                m_observer->on_sync_transport_pull_result(request, response);
+            } catch (...) {}
+        }
+
+        void notify_push_result(const PushRequest& request,
+                                const PushResponse& response) const {
+            if (m_observer == nullptr) {
+                return;
+            }
+            try {
+                m_observer->on_sync_transport_push_result(request, response);
+            } catch (...) {}
+        }
+
+        ISyncPeer& m_next;
+        ISyncTransportPolicy* m_policy;
+        ISyncTransportObserver* m_observer;
+    };
+
+    /// \brief \c IHttpSyncClient wrapper that applies route-level policy.
+    class HttpSyncClientMiddleware : public IHttpSyncClient {
+    public:
+        explicit HttpSyncClientMiddleware(
+                IHttpSyncClient& next,
+                ISyncTransportPolicy* policy = nullptr,
+                ISyncTransportObserver* observer = nullptr)
+            : m_next(next),
+              m_policy(policy),
+              m_observer(observer) {}
+
+        HttpSyncResponse post(
+                const std::string& target,
+                const std::string& content_type,
+                const std::vector<std::uint8_t>& body,
+                const CancellationToken& cancel_token) override {
+            if (m_policy != nullptr) {
+                const SyncTransportDecision decision =
+                    m_policy->check_http_post(target, content_type, body);
+                if (!decision.allowed) {
+                    detail::notify_transport_rejected(
+                        m_observer, SyncTransportOperation::HttpPost,
+                        decision.error);
+                    return make_http_error(decision);
+                }
+            }
+
+            try {
+                const HttpSyncResponse response =
+                    m_next.post(target, content_type, body, cancel_token);
+                notify_http_post_result(target, response);
+                return response;
+            } catch (const std::exception& e) {
+                detail::notify_transport_exception(
+                    m_observer, SyncTransportOperation::HttpPost, e.what());
+                throw;
+            } catch (...) {
+                detail::notify_transport_exception(
+                    m_observer, SyncTransportOperation::HttpPost,
+                    "unknown HTTP post exception");
+                throw;
+            }
+        }
+
+        void request_cancel() override {
+            detail::notify_transport_cancel_requested(m_observer);
+            m_next.request_cancel();
+        }
+
+    private:
+        static HttpSyncResponse make_http_error(
+                const SyncTransportDecision& decision) {
+            HttpSyncResponse response;
+            response.status_code =
+                decision.status_code == 0 ? 403 : decision.status_code;
+            response.content_type = "text/plain; charset=utf-8";
+            response.error = decision.error.empty()
+                ? "HTTP sync request rejected"
+                : decision.error;
+            response.body.assign(response.error.begin(), response.error.end());
+            return response;
+        }
+
+        void notify_http_post_result(const std::string& target,
+                                     const HttpSyncResponse& response) const {
+            if (m_observer == nullptr) {
+                return;
+            }
+            try {
+                m_observer->on_sync_transport_http_post_result(target, response);
+            } catch (...) {}
+        }
+
+        IHttpSyncClient& m_next;
+        ISyncTransportPolicy* m_policy;
+        ISyncTransportObserver* m_observer;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_TRANSPORT_MIDDLEWARE_HPP_INCLUDED

--- a/include/mdbx_containers/sync/TransportMiddleware.hpp
+++ b/include/mdbx_containers/sync/TransportMiddleware.hpp
@@ -242,6 +242,10 @@ namespace sync {
     };
 
     /// \brief Runs several policies in insertion order.
+    /// \details Added policies are non-owning references and must outlive the
+    /// composite. Build the policy list before publishing the composite to
+    /// worker threads; calling \c add() concurrently with \c check_*() is not
+    /// supported.
     class CompositeSyncTransportPolicy : public ISyncTransportPolicy {
     public:
         void add(ISyncTransportPolicy& policy) {
@@ -291,6 +295,9 @@ namespace sync {
     };
 
     /// \brief Snapshot of counters recorded by \c SyncTransportMetricsObserver.
+    /// \details Counters represent middleware hook invocations. If the same
+    /// observer is installed at several stacked middleware layers, one logical
+    /// user action may increment more than one counter.
     struct SyncTransportMetricsSnapshot {
         std::uint64_t pull_calls = 0;
         std::uint64_t push_calls = 0;
@@ -348,6 +355,9 @@ namespace sync {
     };
 
     /// \brief Thread-safe counter observer for basic transport metrics.
+    /// \details Counts middleware hook invocations, not necessarily distinct
+    /// logical user operations. Use separate observers when peer-level and
+    /// HTTP-level layers should be reported independently.
     class SyncTransportMetricsObserver : public ISyncTransportObserver {
     public:
         SyncTransportMetricsSnapshot snapshot() const {
@@ -461,6 +471,9 @@ namespace sync {
     } // namespace detail
 
     /// \brief \c ISyncPeer wrapper that applies policy and observer hooks.
+    /// \details The wrapped peer must outlive the middleware. The optional
+    /// policy and observer are non-owning pointers and must also outlive the
+    /// middleware when provided.
     class SyncPeerMiddleware : public ISyncPeer {
     public:
         explicit SyncPeerMiddleware(
@@ -572,6 +585,9 @@ namespace sync {
     };
 
     /// \brief \c IHttpSyncClient wrapper that applies route-level policy.
+    /// \details The wrapped client must outlive the middleware. The optional
+    /// policy and observer are non-owning pointers and must also outlive the
+    /// middleware when provided.
     class HttpSyncClientMiddleware : public IHttpSyncClient {
     public:
         explicit HttpSyncClientMiddleware(

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -49,6 +49,10 @@ int main() {
     MDBXC_TEST_ASSERT(decoded_pull.have.last_seq_for(node) == 1u);
     MDBXC_TEST_ASSERT(std::string(mdbxc::sync::HttpSyncRoutes::pull_target())
                       == "/mdbxc/sync/v1/pull");
+    mdbxc::sync::NodeDbAllowListPolicy allow_list;
+    allow_list.allow_node_id(node);
+    allow_list.allow_db_id(node);
+    MDBXC_TEST_ASSERT(allow_list.check_pull(pull).allowed);
 
     mdbxc::sync::CancellationSource source;
     const mdbxc::sync::CancellationToken token = source.token();

--- a/tests/test_transport_middleware.cpp
+++ b/tests/test_transport_middleware.cpp
@@ -1,0 +1,283 @@
+#include <mdbx_containers/sync.hpp>
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+mdbxc::sync::NodeId make_node(std::uint8_t seed) {
+    mdbxc::sync::NodeId node{};
+    for (int i = 0; i < 16; ++i) {
+        node[i] = static_cast<std::uint8_t>(seed + i);
+    }
+    return node;
+}
+
+mdbxc::sync::ChangeBatch make_batch(std::uint8_t seed, std::uint64_t seq) {
+    mdbxc::sync::ChangeBatch batch;
+    batch.origin_node_id = make_node(seed);
+    batch.seq = seq;
+    return batch;
+}
+
+void require_true(bool condition, const std::string& message) {
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+class RecordingPeer : public mdbxc::sync::ISyncPeer {
+public:
+    RecordingPeer() : m_pull_count(0), m_push_count(0), m_cancel_count(0) {}
+
+    mdbxc::sync::PullResponse pull(
+            const mdbxc::sync::PullRequest& request) override {
+        ++m_pull_count;
+        m_last_pull = request;
+        mdbxc::sync::PullResponse response;
+        response.batches.push_back(make_batch(0xA0, m_pull_count));
+        return response;
+    }
+
+    mdbxc::sync::PushResponse push(
+            const mdbxc::sync::PushRequest& request) override {
+        ++m_push_count;
+        m_last_push = request;
+        mdbxc::sync::PushResponse response;
+        response.receiver_have.last_seq_by_origin[request.sender] =
+            request.batches.size();
+        return response;
+    }
+
+    void request_cancel() override {
+        ++m_cancel_count;
+    }
+
+    std::size_t pull_count() const { return m_pull_count; }
+    std::size_t push_count() const { return m_push_count; }
+    std::size_t cancel_count() const { return m_cancel_count; }
+
+private:
+    std::size_t m_pull_count;
+    std::size_t m_push_count;
+    std::size_t m_cancel_count;
+    mdbxc::sync::PullRequest m_last_pull;
+    mdbxc::sync::PushRequest m_last_push;
+};
+
+class RecordingHttpClient : public mdbxc::sync::IHttpSyncClient {
+public:
+    RecordingHttpClient() : m_post_count(0), m_cancel_count(0) {}
+
+    mdbxc::sync::HttpSyncResponse post(
+            const std::string& target,
+            const std::string& content_type,
+            const std::vector<std::uint8_t>& body,
+            const mdbxc::sync::CancellationToken& cancel_token) override {
+        (void)cancel_token;
+        ++m_post_count;
+        m_last_target = target;
+        mdbxc::sync::HttpSyncResponse response;
+        response.status_code = 200;
+        response.content_type = content_type;
+        response.body = body;
+        return response;
+    }
+
+    void request_cancel() override {
+        ++m_cancel_count;
+    }
+
+    std::size_t post_count() const { return m_post_count; }
+    std::size_t cancel_count() const { return m_cancel_count; }
+    const std::string& last_target() const { return m_last_target; }
+
+private:
+    std::size_t m_post_count;
+    std::size_t m_cancel_count;
+    std::string m_last_target;
+};
+
+class ThrowingObserver : public mdbxc::sync::ISyncTransportObserver {
+public:
+    void on_sync_transport_pull_result(
+            const mdbxc::sync::PullRequest& request,
+            const mdbxc::sync::PullResponse& response) override {
+        (void)request;
+        (void)response;
+        throw std::runtime_error("observer failure");
+    }
+
+    void on_sync_transport_rejected(
+            mdbxc::sync::SyncTransportOperation operation,
+            const std::string& error) override {
+        (void)operation;
+        (void)error;
+        throw std::runtime_error("observer rejection failure");
+    }
+};
+
+void test_peer_middleware_allows_limits_and_observes() {
+    const mdbxc::sync::NodeId requester = make_node(0x10);
+    const mdbxc::sync::DbId db_id = make_node(0x20);
+
+    mdbxc::sync::NodeDbAllowListPolicy allow_list;
+    allow_list.allow_node_id(requester);
+    allow_list.allow_db_id(db_id);
+
+    mdbxc::sync::FixedBudgetSyncTransportPolicy budget(1, 1);
+    mdbxc::sync::CompositeSyncTransportPolicy policy;
+    policy.add(allow_list);
+    policy.add(budget);
+
+    mdbxc::sync::SyncTransportMetricsObserver metrics;
+    RecordingPeer peer;
+    mdbxc::sync::SyncPeerMiddleware wrapped(peer, &policy, &metrics);
+
+    mdbxc::sync::PullRequest pull;
+    pull.requester = requester;
+    pull.db_id = db_id;
+    mdbxc::sync::PullResponse pulled = wrapped.pull(pull);
+    require_true(pulled.ok, "allowed pull was rejected");
+    require_true(peer.pull_count() == 1u, "allowed pull was not forwarded");
+
+    pulled = wrapped.pull(pull);
+    require_true(!pulled.ok, "rate-limited pull was allowed");
+    require_true(peer.pull_count() == 1u,
+                 "rate-limited pull reached downstream peer");
+
+    mdbxc::sync::PushRequest push;
+    push.sender = requester;
+    push.db_id = db_id;
+    push.batches.push_back(make_batch(0x10, 1));
+    mdbxc::sync::PushResponse pushed = wrapped.push(push);
+    require_true(pushed.ok, "allowed push was rejected");
+    require_true(peer.push_count() == 1u, "allowed push was not forwarded");
+
+    push.db_id = make_node(0x99);
+    pushed = wrapped.push(push);
+    require_true(!pushed.ok, "db-denied push was allowed");
+    require_true(peer.push_count() == 1u,
+                 "db-denied push reached downstream peer");
+
+    wrapped.request_cancel();
+    require_true(peer.cancel_count() == 1u,
+                 "request_cancel was not forwarded");
+
+    const mdbxc::sync::SyncTransportMetricsSnapshot snapshot =
+        metrics.snapshot();
+    require_true(snapshot.pull_calls == 1u, "pull metric mismatch");
+    require_true(snapshot.push_calls == 1u, "push metric mismatch");
+    require_true(snapshot.rejected_calls == 2u, "rejection metric mismatch");
+    require_true(snapshot.request_cancel_calls == 1u,
+                 "cancel metric mismatch");
+    require_true(snapshot.pulled_batches == 1u,
+                 "pulled batch metric mismatch");
+    require_true(snapshot.pushed_batches == 1u,
+                 "pushed batch metric mismatch");
+}
+
+void test_observer_exceptions_are_swallowed() {
+    RecordingPeer peer;
+    ThrowingObserver observer;
+    mdbxc::sync::SyncPeerMiddleware wrapped(peer, nullptr, &observer);
+
+    mdbxc::sync::PullRequest pull;
+    pull.requester = make_node(0x50);
+    pull.db_id = make_node(0x51);
+
+    const mdbxc::sync::PullResponse response = wrapped.pull(pull);
+    require_true(response.ok, "observer exception changed pull result");
+    require_true(peer.pull_count() == 1u,
+                 "observer exception prevented downstream pull");
+
+    mdbxc::sync::NodeDbAllowListPolicy deny_db;
+    deny_db.allow_db_id(make_node(0x99));
+    mdbxc::sync::SyncPeerMiddleware denying(peer, &deny_db, &observer);
+    const mdbxc::sync::PullResponse denied = denying.pull(pull);
+    require_true(!denied.ok, "observer rejection exception allowed pull");
+    require_true(peer.pull_count() == 1u,
+                 "denied pull reached downstream peer");
+}
+
+void test_http_client_middleware_route_policy() {
+    mdbxc::sync::HttpRouteAllowListPolicy route_policy;
+    route_policy.allow_target(mdbxc::sync::HttpSyncRoutes::pull_target());
+
+    mdbxc::sync::SyncTransportMetricsObserver metrics;
+    RecordingHttpClient client;
+    mdbxc::sync::HttpSyncClientMiddleware wrapped(
+        client, &route_policy, &metrics);
+
+    const std::vector<std::uint8_t> body(3u, 0x42u);
+    mdbxc::sync::HttpSyncResponse response = wrapped.post(
+        mdbxc::sync::HttpSyncRoutes::pull_target(),
+        mdbxc::sync::HttpSyncRoutes::content_type(),
+        body,
+        mdbxc::sync::CancellationToken());
+    require_true(response.status_code == 200, "allowed HTTP post failed");
+    require_true(client.post_count() == 1u, "HTTP post was not forwarded");
+
+    response = wrapped.post(
+        "/forbidden",
+        mdbxc::sync::HttpSyncRoutes::content_type(),
+        body,
+        mdbxc::sync::CancellationToken());
+    require_true(response.status_code == 403,
+                 "forbidden HTTP route was not rejected");
+    require_true(client.post_count() == 1u,
+                 "forbidden HTTP route reached downstream client");
+
+    wrapped.request_cancel();
+    require_true(client.cancel_count() == 1u,
+                 "HTTP request_cancel was not forwarded");
+
+    const mdbxc::sync::SyncTransportMetricsSnapshot snapshot =
+        metrics.snapshot();
+    require_true(snapshot.http_post_calls == 1u,
+                 "HTTP post metric mismatch");
+    require_true(snapshot.rejected_calls == 1u,
+                 "HTTP rejection metric mismatch");
+    require_true(snapshot.request_cancel_calls == 1u,
+                 "HTTP cancel metric mismatch");
+}
+
+void test_http_client_middleware_budget_policy() {
+    mdbxc::sync::FixedBudgetSyncTransportPolicy budget(
+        mdbxc::sync::FixedBudgetSyncTransportPolicy::unlimited_budget(),
+        mdbxc::sync::FixedBudgetSyncTransportPolicy::unlimited_budget(),
+        1);
+    RecordingHttpClient client;
+    mdbxc::sync::HttpSyncClientMiddleware wrapped(client, &budget);
+
+    const std::vector<std::uint8_t> body(1u, 0x11u);
+    mdbxc::sync::HttpSyncResponse response = wrapped.post(
+        mdbxc::sync::HttpSyncRoutes::pull_target(),
+        mdbxc::sync::HttpSyncRoutes::content_type(),
+        body,
+        mdbxc::sync::CancellationToken());
+    require_true(response.status_code == 200,
+                 "first budgeted HTTP post failed");
+
+    response = wrapped.post(
+        mdbxc::sync::HttpSyncRoutes::pull_target(),
+        mdbxc::sync::HttpSyncRoutes::content_type(),
+        body,
+        mdbxc::sync::CancellationToken());
+    require_true(response.status_code == 429,
+                 "rate-limited HTTP post was not rejected");
+    require_true(client.post_count() == 1u,
+                 "rate-limited HTTP post reached downstream client");
+}
+
+} // namespace
+
+int main() {
+    test_peer_middleware_allows_limits_and_observes();
+    test_observer_exceptions_are_swallowed();
+    test_http_client_middleware_route_policy();
+    test_http_client_middleware_budget_policy();
+    return 0;
+}


### PR DESCRIPTION
﻿## Summary

- add framework-neutral sync transport middleware for `ISyncPeer` and `IHttpSyncClient`
- add allow-list, fixed-budget rate-limit, composite policy, and metrics observer helpers
- document the adapter-local policy boundary and add `sync_12_transport_middleware` example

## Why

The HTTP/WebSocket layer needs a place for authorization, route allow-lists, rate limits, and metrics without putting transport policy into the sync DTO wire format. These wrappers provide that adapter seam while keeping concrete socket frameworks out of the core API.

## Validation

- `mingw32-make -C tmp/pr106-middleware-cpp17 test_transport_middleware header_sync_umbrella_test sync_12_transport_middleware`
- `mingw32-make -C tmp/pr106-middleware-cpp11 test_transport_middleware header_sync_umbrella_test sync_12_transport_middleware`
- `ctest --test-dir tmp/pr106-middleware-cpp17 -R "test_transport_middleware|header_sync_umbrella_test|sync_12_transport_middleware" --output-on-failure`
- `ctest --test-dir tmp/pr106-middleware-cpp11 -R "test_transport_middleware|header_sync_umbrella_test|sync_12_transport_middleware" --output-on-failure`
- `tmp/pr106-middleware-cpp17/bin/examples/sync_12_transport_middleware.exe`
- `tmp/pr106-middleware-cpp11/bin/examples/sync_12_transport_middleware.exe`
- `git diff --check`
- `git diff --cached --check`
