### PR TITLE
feat(sync): add Simple-Web-Server HTTP example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ if(MDBXC_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
     set_target_properties(sync_13_http_simple_web_server PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples
     )
-    target_compile_features(sync_13_http_simple_web_server PRIVATE cxx_std_17)
+    target_compile_features(sync_13_http_simple_web_server PRIVATE cxx_std_11)
     target_compile_definitions(sync_13_http_simple_web_server PRIVATE
         MDBXC_SYNC_ENABLED=1
         ASIO_STANDALONE=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,11 @@ option(MDBXC_BUILD_BENCHMARKS   "Build benchmark executables"                   
 option(MDBXC_ENABLE_STRESS_TESTS "Register long stress tests with CTest"           OFF)
 option(MDBXC_USE_ASAN "Enable AddressSanitizer for tests/examples (not for libmdbx)" ON)
 
+# Optional transport-binding example that pulls a third-party HTTP backend
+# (Simple-Web-Server). Off by default to keep the default build free of
+# network-stack dependencies. See examples/README-sync.md for usage.
+option(MDBXC_HTTP_SYNC_EXAMPLE "Build the Simple-Web-Server HTTP binding example" OFF)
+
 # Three-mode dependency policy for MDBX: AUTO | SYSTEM | BUNDLED
 set(MDBXC_DEPS_MODE "AUTO" CACHE STRING "Dependency mode for MDBX: AUTO|SYSTEM|BUNDLED")
 set_property(CACHE MDBXC_DEPS_MODE PROPERTY STRINGS AUTO SYSTEM BUNDLED)
@@ -29,6 +34,7 @@ message(STATUS "MDBXC_BUILD_EXAMPLES    = ${MDBXC_BUILD_EXAMPLES}")
 message(STATUS "MDBXC_BUILD_TESTS       = ${MDBXC_BUILD_TESTS}")
 message(STATUS "MDBXC_BUILD_BENCHMARKS  = ${MDBXC_BUILD_BENCHMARKS}")
 message(STATUS "MDBXC_ENABLE_STRESS_TESTS = ${MDBXC_ENABLE_STRESS_TESTS}")
+message(STATUS "MDBXC_HTTP_SYNC_EXAMPLE = ${MDBXC_HTTP_SYNC_EXAMPLE}")
 message(STATUS "MDBXC_USE_ASAN          = ${MDBXC_USE_ASAN}")
 
 set(MDBXC_HAS_ASAN OFF CACHE BOOL "Compiler+linker support -fsanitize=address")
@@ -128,6 +134,8 @@ set_target_properties(${_PKG_EXPORT_TARGET} PROPERTIES
 # ---------------------------------------
 if(MDBXC_BUILD_EXAMPLES)
     file(GLOB EXAMPLES CONFIGURE_DEPENDS examples/*.cpp)
+    list(FILTER EXAMPLES EXCLUDE REGEX
+        "sync_13_http_simple_web_server\\.cpp$")
     foreach(example_file IN LISTS EXAMPLES)
         get_filename_component(example_name ${example_file} NAME_WE)
         add_executable(${example_name} ${example_file})
@@ -145,6 +153,36 @@ if(MDBXC_BUILD_EXAMPLES)
         # To enable pause-on-Enter in examples only (not in tests), uncomment:
         # target_compile_definitions(${example_name} PRIVATE INTERACTIVE_TEST)
     endforeach()
+endif()
+
+# ---------------------------------------
+# Optional HTTP transport binding example
+# ---------------------------------------
+# Pulls Simple-Web-Server through FetchContent and adds one example that
+# shows a real loopback HTTP server + client wiring around HttpSyncServer
+# and HttpSyncPeer. The default build does not touch this section; the
+# example is built only when MDBXC_HTTP_SYNC_EXAMPLE is ON.
+if(MDBXC_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/deps)
+    include(cmake/deps/simple-web-server.cmake)
+
+    simple_web_server_provide(OUT_TARGET _MDBXC_SWS_TARGET)
+
+    add_executable(sync_13_http_simple_web_server
+        examples/sync_13_http_simple_web_server.cpp)
+    set_target_properties(sync_13_http_simple_web_server PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples
+    )
+    target_compile_features(sync_13_http_simple_web_server PRIVATE cxx_std_17)
+    target_compile_definitions(sync_13_http_simple_web_server PRIVATE
+        MDBXC_SYNC_ENABLED=1
+        ASIO_STANDALONE=1
+        USE_STANDALONE_ASIO=1)
+    target_link_libraries(sync_13_http_simple_web_server PRIVATE
+        ${_PKG_TARGET}
+        ${_MDBXC_SWS_TARGET})
+    message(STATUS "HTTP binding example sync_13_http_simple_web_server -> "
+        "${_MDBXC_SWS_TARGET}")
 endif()
 
 # ---------------------------------------

--- a/README-RU.md
+++ b/README-RU.md
@@ -78,10 +78,11 @@
   реплицируются в v0.1. Их wire-format отложен до явного описания type tags,
   DUPSORT duplicate framing и hash-index identity semantics.
 - `SyncEngine` предоставляет pull/push/apply primitives, `DirectSyncPeer`
-  используется для in-process синхронизации в тестах и примерах, а
-  `SyncWorker` запускает фоновой polling. HTTP/WebSocket транспорты и
-  wire-format для специализированных таблиц отложены; см.
-  `include/mdbx_containers/sync/DESIGN.md`.
+  используется для in-process синхронизации в тестах и примерах,
+  `HttpSyncPeer` задаёт HTTP-shaped adapter seam, а `SyncWorker` запускает
+  фоновой polling. Пример HTTP на Simple-Web-Server собирается опционально;
+  WebSocket транспорты и wire-format для специализированных таблиц отложены;
+  см. `include/mdbx_containers/sync/DESIGN.md`.
 
 ### 🗄️ Структура и конфигурация
 - Несколько логических таблиц внутри одного MDBX-файла.

--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@
   replicated in v0.1. Their wire formats are deferred until type tags,
   DUPSORT duplicate framing, and hash-index identity semantics are specified.
 - `SyncEngine` exposes pull/push/apply primitives, `DirectSyncPeer` provides
-  in-process sync for tests and examples, and `SyncWorker` is the background
-  polling driver. HTTP/WebSocket transports and specialized table wire formats
-  remain deferred; see `include/mdbx_containers/sync/DESIGN.md`.
+  in-process sync for tests and examples, `HttpSyncPeer` defines an HTTP-shaped
+  adapter seam, and `SyncWorker` is the background polling driver. A
+  Simple-Web-Server HTTP example is optional; WebSocket transports and
+  specialized table wire formats remain deferred. See
+  `include/mdbx_containers/sync/DESIGN.md`.
 
 ### 🗄️ Structure & Configuration
 - Multiple logical tables inside one MDBX file.

--- a/cmake/deps/simple-web-server.cmake
+++ b/cmake/deps/simple-web-server.cmake
@@ -12,10 +12,12 @@
 include(CMakeParseArguments)
 include(FetchContent)
 
-set(MDBXC_ASIO_GIT_TAG "asio-1-30-2" CACHE STRING
-    "Asio tag used by the optional Simple-Web-Server HTTP example.")
-set(MDBXC_SIMPLE_WEB_SERVER_GIT_TAG "v3.1.1" CACHE STRING
-    "Simple-Web-Server tag used by the optional HTTP sync example.")
+set(MDBXC_ASIO_GIT_TAG
+    "12e0ce9e0500bf0f247dbd1ae894272656456079" CACHE STRING
+    "Asio commit used by the optional HTTP example; corresponds to asio-1-30-2.")
+set(MDBXC_SIMPLE_WEB_SERVER_GIT_TAG
+    "898b6abd1be568ff9de4390d44288962e3fac337" CACHE STRING
+    "Simple-Web-Server commit used by the optional HTTP example; corresponds to v3.1.1.")
 
 function(_mdbxc_fetchcontent_populate name)
     if(POLICY CMP0169)

--- a/cmake/deps/simple-web-server.cmake
+++ b/cmake/deps/simple-web-server.cmake
@@ -1,0 +1,97 @@
+# cmake/deps/simple-web-server.cmake
+# Provides a header-only Simple-Web-Server target for the optional HTTP sync
+# example. The target deliberately uses standalone Asio and does not run the
+# upstream Simple-Web-Server CMakeLists, because that path may search for Boost
+# before the standalone Asio include directory is visible.
+#
+# Public API:
+#   simple_web_server_provide(
+#       OUT_TARGET <var>     # returns the INTERFACE target name to link against
+#   )
+
+include(CMakeParseArguments)
+include(FetchContent)
+
+set(MDBXC_ASIO_GIT_TAG "asio-1-30-2" CACHE STRING
+    "Asio tag used by the optional Simple-Web-Server HTTP example.")
+set(MDBXC_SIMPLE_WEB_SERVER_GIT_TAG "v3.1.1" CACHE STRING
+    "Simple-Web-Server tag used by the optional HTTP sync example.")
+
+function(_mdbxc_fetchcontent_populate name)
+    if(POLICY CMP0169)
+        cmake_policy(PUSH)
+        cmake_policy(SET CMP0169 OLD)
+    endif()
+    FetchContent_Populate(${name})
+    if(POLICY CMP0169)
+        cmake_policy(POP)
+    endif()
+endfunction()
+
+function(simple_web_server_provide)
+    set(_options)
+    set(_one_value OUT_TARGET)
+    set(_multi_value)
+    cmake_parse_arguments(SWS "${_options}" "${_one_value}"
+        "${_multi_value}" ${ARGN})
+
+    if(NOT SWS_OUT_TARGET)
+        message(FATAL_ERROR
+            "simple_web_server_provide requires OUT_TARGET <var>")
+    endif()
+
+    FetchContent_Declare(
+        mdbxc_asio
+        GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
+        GIT_TAG        ${MDBXC_ASIO_GIT_TAG}
+        GIT_SHALLOW    TRUE
+    )
+    FetchContent_GetProperties(mdbxc_asio)
+    if(NOT mdbxc_asio_POPULATED)
+        _mdbxc_fetchcontent_populate(mdbxc_asio)
+        FetchContent_GetProperties(mdbxc_asio)
+    endif()
+
+    FetchContent_Declare(
+        mdbxc_simple_web_server_source
+        GIT_REPOSITORY https://gitlab.com/eidheim/Simple-Web-Server.git
+        GIT_TAG        ${MDBXC_SIMPLE_WEB_SERVER_GIT_TAG}
+        GIT_SHALLOW    TRUE
+    )
+    FetchContent_GetProperties(mdbxc_simple_web_server_source)
+    if(NOT mdbxc_simple_web_server_source_POPULATED)
+        _mdbxc_fetchcontent_populate(mdbxc_simple_web_server_source)
+        FetchContent_GetProperties(mdbxc_simple_web_server_source)
+    endif()
+
+    if(NOT EXISTS "${mdbxc_asio_SOURCE_DIR}/asio/include/asio.hpp")
+        message(FATAL_ERROR
+            "Standalone Asio headers were not found after FetchContent")
+    endif()
+    if(NOT EXISTS
+            "${mdbxc_simple_web_server_source_SOURCE_DIR}/server_http.hpp")
+        message(FATAL_ERROR
+            "Simple-Web-Server headers were not found after FetchContent")
+    endif()
+
+    if(NOT TARGET mdbxc_simple_web_server)
+        add_library(mdbxc_simple_web_server INTERFACE)
+        target_include_directories(mdbxc_simple_web_server INTERFACE
+            "${mdbxc_simple_web_server_source_SOURCE_DIR}"
+            "${mdbxc_asio_SOURCE_DIR}/asio/include")
+        target_compile_definitions(mdbxc_simple_web_server INTERFACE
+            ASIO_STANDALONE=1
+            USE_STANDALONE_ASIO=1)
+
+        find_package(Threads REQUIRED)
+        target_link_libraries(mdbxc_simple_web_server INTERFACE
+            Threads::Threads)
+        if(WIN32)
+            target_link_libraries(mdbxc_simple_web_server INTERFACE
+                ws2_32
+                wsock32)
+        endif()
+    endif()
+
+    set(${SWS_OUT_TARGET} mdbxc_simple_web_server PARENT_SCOPE)
+endfunction()

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -17,7 +17,7 @@ cmake -S . -B tmp/build-examples \
     -DMDBXC_DEPS_MODE=BUNDLED \
     -DMDBXC_BUILD_TESTS=OFF \
     -DMDBXC_BUILD_EXAMPLES=ON \
-    -DCMAKE_CXX_STANDARD=17
+    -DCMAKE_CXX_STANDARD=11
 
 cmake --build tmp/build-examples --target sync_01_lifecycle_direct_peer
 tmp/build-examples/bin/examples/sync_01_lifecycle_direct_peer
@@ -39,7 +39,7 @@ cmake -S . -B tmp/build-http-example \
     -DMDBXC_BUILD_TESTS=OFF \
     -DMDBXC_BUILD_EXAMPLES=ON \
     -DMDBXC_HTTP_SYNC_EXAMPLE=ON \
-    -DCMAKE_CXX_STANDARD=17
+    -DCMAKE_CXX_STANDARD=11
 
 cmake --build tmp/build-http-example --target sync_13_http_simple_web_server
 tmp/build-http-example/bin/examples/sync_13_http_simple_web_server \

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -1,8 +1,10 @@
 # Примеры синхронизации
 
 Эти примеры показывают API sync v0.1 как набор блоков, не привязанных к
-конкретному транспорту. Они используют `DirectSyncPeer` или небольшой буфер в
-памяти, чтобы поток протокола был виден без HTTP, WebSocket или IPC-кода.
+конкретному транспорту. Большинство примеров используют `DirectSyncPeer` или
+небольшой буфер в памяти, чтобы поток протокола был виден без HTTP, WebSocket
+или IPC-кода. Последний опциональный пример связывает HTTP seam с
+Simple-Web-Server и standalone Asio.
 
 Синхронизация включается явно. Примеры собираются с `MDBXC_SYNC_ENABLED=1`;
 приложениям, которые используют sync, тоже нужно компилировать соответствующий
@@ -28,6 +30,22 @@ tmp/build-examples/bin/examples/sync_01_lifecycle_direct_peer
 .\tmp\build-examples\bin\examples\sync_01_lifecycle_direct_peer.exe
 ```
 
+Реальный HTTP binding example включается отдельно, потому что он скачивает
+headers standalone Asio и Simple-Web-Server:
+
+```bash
+cmake -S . -B tmp/build-http-example \
+    -DMDBXC_DEPS_MODE=BUNDLED \
+    -DMDBXC_BUILD_TESTS=OFF \
+    -DMDBXC_BUILD_EXAMPLES=ON \
+    -DMDBXC_HTTP_SYNC_EXAMPLE=ON \
+    -DCMAKE_CXX_STANDARD=17
+
+cmake --build tmp/build-http-example --target sync_13_http_simple_web_server
+tmp/build-http-example/bin/examples/sync_13_http_simple_web_server \
+    demo 127.0.0.1 18080
+```
+
 ## Порядок чтения
 
 | Пример | Что показывает | Уровень |
@@ -44,6 +62,7 @@ tmp/build-examples/bin/examples/sync_01_lifecycle_direct_peer
 | `sync_10_custom_transport.cpp` | Минимальный кастомный `ISyncPeer` поверх закодированных byte buffers. | Продвинутый |
 | `sync_11_http_adapter.cpp` | Фреймворк-независимый HTTP-адаптер поверх `TransportMessageCodec`. | Продвинутый |
 | `sync_12_transport_middleware.cpp` | Allow-list, fixed-budget rate limit и metrics middleware вокруг транспортных адаптеров. | Продвинутый |
+| `sync_13_http_simple_web_server.cpp` | Опциональный настоящий HTTP binding через Simple-Web-Server и standalone Asio. | Продвинутый |
 
 ## Общие правила
 

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -1,8 +1,9 @@
 # Sync Examples
 
 These examples show the sync v0.1 API as transport-agnostic building blocks.
-They use `DirectSyncPeer` or a small in-memory buffer so the protocol flow is
-visible without adding HTTP, WebSocket, or IPC code.
+Most use `DirectSyncPeer` or a small in-memory buffer so the protocol flow is
+visible without adding HTTP, WebSocket, or IPC code. The final optional example
+binds the HTTP seam to Simple-Web-Server and standalone Asio.
 
 Sync is opt-in. The examples are built with `MDBXC_SYNC_ENABLED=1`; applications
 must also compile sync users with that macro enabled.
@@ -27,6 +28,22 @@ executable has the `.exe` suffix, for example:
 .\tmp\build-examples\bin\examples\sync_01_lifecycle_direct_peer.exe
 ```
 
+The real HTTP binding example is opt-in because it fetches standalone Asio and
+Simple-Web-Server headers:
+
+```bash
+cmake -S . -B tmp/build-http-example \
+    -DMDBXC_DEPS_MODE=BUNDLED \
+    -DMDBXC_BUILD_TESTS=OFF \
+    -DMDBXC_BUILD_EXAMPLES=ON \
+    -DMDBXC_HTTP_SYNC_EXAMPLE=ON \
+    -DCMAKE_CXX_STANDARD=17
+
+cmake --build tmp/build-http-example --target sync_13_http_simple_web_server
+tmp/build-http-example/bin/examples/sync_13_http_simple_web_server \
+    demo 127.0.0.1 18080
+```
+
 ## Reading Order
 
 | Example | What it demonstrates | Level |
@@ -43,6 +60,7 @@ executable has the `.exe` suffix, for example:
 | `sync_10_custom_transport.cpp` | Minimal custom `ISyncPeer` over encoded byte buffers. | Advanced |
 | `sync_11_http_adapter.cpp` | Framework-neutral HTTP-shaped adapter over `TransportMessageCodec`. | Advanced |
 | `sync_12_transport_middleware.cpp` | Allow-list, fixed-budget, and metrics middleware around transport adapters. | Advanced |
+| `sync_13_http_simple_web_server.cpp` | Optional real HTTP binding over Simple-Web-Server and standalone Asio. | Advanced |
 
 ## Common Rules
 

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -15,7 +15,7 @@ cmake -S . -B tmp/build-examples \
     -DMDBXC_DEPS_MODE=BUNDLED \
     -DMDBXC_BUILD_TESTS=OFF \
     -DMDBXC_BUILD_EXAMPLES=ON \
-    -DCMAKE_CXX_STANDARD=17
+    -DCMAKE_CXX_STANDARD=11
 
 cmake --build tmp/build-examples --target sync_01_lifecycle_direct_peer
 tmp/build-examples/bin/examples/sync_01_lifecycle_direct_peer
@@ -37,7 +37,7 @@ cmake -S . -B tmp/build-http-example \
     -DMDBXC_BUILD_TESTS=OFF \
     -DMDBXC_BUILD_EXAMPLES=ON \
     -DMDBXC_HTTP_SYNC_EXAMPLE=ON \
-    -DCMAKE_CXX_STANDARD=17
+    -DCMAKE_CXX_STANDARD=11
 
 cmake --build tmp/build-http-example --target sync_13_http_simple_web_server
 tmp/build-http-example/bin/examples/sync_13_http_simple_web_server \

--- a/examples/sync_13_http_simple_web_server.cpp
+++ b/examples/sync_13_http_simple_web_server.cpp
@@ -14,7 +14,7 @@
  *       -DMDBXC_BUILD_TESTS=OFF \
  *       -DMDBXC_BUILD_EXAMPLES=ON \
  *       -DMDBXC_HTTP_SYNC_EXAMPLE=ON \
- *       -DCMAKE_CXX_STANDARD=17
+ *       -DCMAKE_CXX_STANDARD=11
  *   cmake --build tmp/build-http-example \
  *       --target sync_13_http_simple_web_server
  *
@@ -132,7 +132,7 @@ public:
                             std::chrono::seconds timeout)
         : m_endpoint(endpoint(host, port)),
           m_timeout(timeout),
-          m_cancel_requested(false),
+          m_cancel_generation(0),
           m_active_client(nullptr),
           m_cancel_count(0) {}
 
@@ -145,12 +145,19 @@ public:
             return make_cancelled_response("cancelled before HTTP request");
         }
 
-        m_cancel_requested.store(false, std::memory_order_release);
+        const std::uint64_t call_generation =
+            m_cancel_generation.load(std::memory_order_acquire);
 
         HttpClient client(m_endpoint);
         client.config.timeout = static_cast<long>(m_timeout.count());
         client.config.timeout_connect = static_cast<long>(m_timeout.count());
         ActiveClientGuard active(*this, client);
+
+        if (cancel_token.is_cancellation_requested() ||
+            m_cancel_generation.load(std::memory_order_acquire) !=
+                call_generation) {
+            return make_cancelled_response("cancelled before HTTP request");
+        }
 
         try {
             SimpleWeb::CaseInsensitiveMultimap headers;
@@ -167,7 +174,8 @@ public:
             out.body = string_to_bytes(received->content.string());
             return out;
         } catch (const SimpleWeb::system_error& e) {
-            if (m_cancel_requested.load(std::memory_order_acquire) ||
+            if (m_cancel_generation.load(std::memory_order_acquire) !=
+                    call_generation ||
                 cancel_token.is_cancellation_requested()) {
                 return make_cancelled_response(e.what());
             }
@@ -176,8 +184,8 @@ public:
     }
 
     void request_cancel() override {
-        m_cancel_requested.store(true, std::memory_order_release);
-        ++m_cancel_count;
+        m_cancel_generation.fetch_add(1, std::memory_order_acq_rel);
+        m_cancel_count.fetch_add(1, std::memory_order_acq_rel);
 
         std::lock_guard<std::mutex> lock(m_mutex);
         if (m_active_client != nullptr) {
@@ -186,7 +194,7 @@ public:
     }
 
     std::size_t cancel_count() const {
-        return m_cancel_count;
+        return m_cancel_count.load(std::memory_order_acquire);
     }
 
 private:
@@ -224,10 +232,10 @@ private:
 
     std::string m_endpoint;
     std::chrono::seconds m_timeout;
-    std::atomic<bool> m_cancel_requested;
+    std::atomic<std::uint64_t> m_cancel_generation;
     mutable std::mutex m_mutex;
     HttpClient* m_active_client;
-    std::size_t m_cancel_count;
+    std::atomic<std::size_t> m_cancel_count;
 };
 
 class SimpleWebHttpSyncServer {
@@ -273,16 +281,35 @@ public:
             return;
         }
 
-        std::promise<unsigned short> started;
-        std::future<unsigned short> started_future = started.get_future();
+        std::shared_ptr<std::promise<unsigned short> > started(
+            new std::promise<unsigned short>());
+        std::future<unsigned short> started_future = started->get_future();
         m_thread = std::thread(
-            [this, &started]() {
-                m_server.start(
-                    [&started](unsigned short assigned_port) {
-                        started.set_value(assigned_port);
-                    });
+            [this, started]() {
+                bool started_callback_called = false;
+                try {
+                    m_server.start(
+                        [started, &started_callback_called](
+                            unsigned short assigned_port) {
+                            started_callback_called = true;
+                            started->set_value(assigned_port);
+                        });
+                } catch (...) {
+                    if (!started_callback_called) {
+                        try {
+                            started->set_exception(std::current_exception());
+                        } catch (...) {}
+                    }
+                }
             });
-        m_port = started_future.get();
+        try {
+            m_port = started_future.get();
+        } catch (...) {
+            if (m_thread.joinable()) {
+                m_thread.join();
+            }
+            throw;
+        }
         m_running = true;
         std::printf("[server] listening on %s:%u\n",
                     m_host.c_str(),

--- a/examples/sync_13_http_simple_web_server.cpp
+++ b/examples/sync_13_http_simple_web_server.cpp
@@ -1,0 +1,590 @@
+/**
+ * \ingroup mdbxc_examples
+ * \brief HTTP binding over Simple-Web-Server and standalone Asio.
+ *
+ * This example is the first real socket-backed transport for the sync v0.1
+ * DTOs. It binds the framework-neutral \c HttpSyncServer / \c HttpSyncPeer /
+ * \c TransportMessageCodec seam to eidheim/Simple-Web-Server with
+ * chriskohlhoff standalone Asio.
+ *
+ * Build it explicitly:
+ *
+ *   cmake -S . -B tmp/build-http-example \
+ *       -DMDBXC_DEPS_MODE=BUNDLED \
+ *       -DMDBXC_BUILD_TESTS=OFF \
+ *       -DMDBXC_BUILD_EXAMPLES=ON \
+ *       -DMDBXC_HTTP_SYNC_EXAMPLE=ON \
+ *       -DCMAKE_CXX_STANDARD=17
+ *   cmake --build tmp/build-http-example \
+ *       --target sync_13_http_simple_web_server
+ *
+ * Run the self-contained demo:
+ *
+ *   ./tmp/build-http-example/bin/examples/sync_13_http_simple_web_server \
+ *       demo 127.0.0.1 18080
+ *
+ * Manual two-process run:
+ *
+ *   ./sync_13_http_simple_web_server server 127.0.0.1 18080
+ *   ./sync_13_http_simple_web_server client 127.0.0.1 18080
+ *
+ * Expected demo output:
+ *
+ *   [server] listening on 127.0.0.1:18080
+ *   [client] HTTP pull applied 2 batch(es)
+ *   [client] HTTP push sent 1 batch(es)
+ *   [client] request_cancel forwarded once
+ *   [client] metrics pull=1 push=1 http=2 rejected=0
+ *   [demo] server received pushed quote: SOL/USD
+ *   OK: sync_13_http_simple_web_server
+ */
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <exception>
+#include <future>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#ifndef ASIO_STANDALONE
+#define ASIO_STANDALONE 1
+#endif
+#ifndef USE_STANDALONE_ASIO
+#define USE_STANDALONE_ASIO 1
+#endif
+#include <client_http.hpp>
+#include <server_http.hpp>
+
+#include "sync_example_utils.hpp"
+
+namespace {
+
+using HttpClient = SimpleWeb::Client<SimpleWeb::HTTP>;
+using HttpServer = SimpleWeb::Server<SimpleWeb::HTTP>;
+
+// Demo-only seeds. They have no protocol meaning; they just make the two node
+// ids and one db id deterministic and visibly distinct.
+const std::uint8_t kServerNodeSeed = 0xA0;
+const std::uint8_t kClientNodeSeed = 0xB0;
+const std::uint8_t kDatabaseSeed = 0xA1;
+
+std::string endpoint(const std::string& host, std::uint16_t port) {
+    return host + ":" + std::to_string(static_cast<unsigned>(port));
+}
+
+std::string bytes_to_string(const std::vector<std::uint8_t>& bytes) {
+    if (bytes.empty()) {
+        return std::string();
+    }
+    return std::string(reinterpret_cast<const char*>(&bytes[0]),
+                       bytes.size());
+}
+
+std::vector<std::uint8_t> string_to_bytes(const std::string& text) {
+    return std::vector<std::uint8_t>(text.begin(), text.end());
+}
+
+std::string header_value(const SimpleWeb::CaseInsensitiveMultimap& headers,
+                         const std::string& name) {
+    const auto it = headers.find(name);
+    return it == headers.end() ? std::string() : it->second;
+}
+
+SimpleWeb::StatusCode to_simple_status(unsigned status) {
+    return SimpleWeb::status_code(std::to_string(status));
+}
+
+void write_http_response(
+        const std::shared_ptr<HttpServer::Response>& response,
+        const mdbxc::sync::HttpSyncResponse& out) {
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    headers.emplace("Content-Type",
+                    out.content_type.empty()
+                        ? "text/plain; charset=utf-8"
+                        : out.content_type);
+    response->write(to_simple_status(out.status_code),
+                    bytes_to_string(out.body),
+                    headers);
+}
+
+mdbxc::sync::HttpSyncResponse make_cancelled_response(
+        const std::string& diagnostic) {
+    mdbxc::sync::HttpSyncResponse out;
+    out.status_code = 503;
+    out.content_type = "text/plain; charset=utf-8";
+    out.error = diagnostic.empty() ? "cancelled" : diagnostic;
+    out.body = string_to_bytes(out.error);
+    return out;
+}
+
+class SimpleWebHttpSyncClient : public mdbxc::sync::IHttpSyncClient {
+public:
+    SimpleWebHttpSyncClient(const std::string& host,
+                            std::uint16_t port,
+                            std::chrono::seconds timeout)
+        : m_endpoint(endpoint(host, port)),
+          m_timeout(timeout),
+          m_cancel_requested(false),
+          m_active_client(nullptr),
+          m_cancel_count(0) {}
+
+    mdbxc::sync::HttpSyncResponse post(
+            const std::string& target,
+            const std::string& content_type,
+            const std::vector<std::uint8_t>& body,
+            const mdbxc::sync::CancellationToken& cancel_token) override {
+        if (cancel_token.is_cancellation_requested()) {
+            return make_cancelled_response("cancelled before HTTP request");
+        }
+
+        m_cancel_requested.store(false, std::memory_order_release);
+
+        HttpClient client(m_endpoint);
+        client.config.timeout = static_cast<long>(m_timeout.count());
+        client.config.timeout_connect = static_cast<long>(m_timeout.count());
+        ActiveClientGuard active(*this, client);
+
+        try {
+            SimpleWeb::CaseInsensitiveMultimap headers;
+            headers.emplace("Content-Type", content_type);
+
+            const std::shared_ptr<HttpClient::Response> received =
+                client.request("POST", target, bytes_to_string(body), headers);
+
+            mdbxc::sync::HttpSyncResponse out;
+            out.status_code =
+                static_cast<unsigned>(std::atoi(
+                    received->status_code.c_str()));
+            out.content_type = header_value(received->header, "Content-Type");
+            out.body = string_to_bytes(received->content.string());
+            return out;
+        } catch (const SimpleWeb::system_error& e) {
+            if (m_cancel_requested.load(std::memory_order_acquire) ||
+                cancel_token.is_cancellation_requested()) {
+                return make_cancelled_response(e.what());
+            }
+            throw;
+        }
+    }
+
+    void request_cancel() override {
+        m_cancel_requested.store(true, std::memory_order_release);
+        ++m_cancel_count;
+
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_active_client != nullptr) {
+            m_active_client->stop();
+        }
+    }
+
+    std::size_t cancel_count() const {
+        return m_cancel_count;
+    }
+
+private:
+    class ActiveClientGuard {
+    public:
+        ActiveClientGuard(SimpleWebHttpSyncClient& owner,
+                          HttpClient& client)
+            : m_owner(owner), m_client(&client) {
+            m_owner.set_active_client(m_client);
+        }
+
+        ~ActiveClientGuard() {
+            m_owner.clear_active_client(m_client);
+        }
+
+        ActiveClientGuard(const ActiveClientGuard&) = delete;
+        ActiveClientGuard& operator=(const ActiveClientGuard&) = delete;
+
+    private:
+        SimpleWebHttpSyncClient& m_owner;
+        HttpClient* m_client;
+    };
+
+    void set_active_client(HttpClient* client) {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_active_client = client;
+    }
+
+    void clear_active_client(HttpClient* client) {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_active_client == client) {
+            m_active_client = nullptr;
+        }
+    }
+
+    std::string m_endpoint;
+    std::chrono::seconds m_timeout;
+    std::atomic<bool> m_cancel_requested;
+    mutable std::mutex m_mutex;
+    HttpClient* m_active_client;
+    std::size_t m_cancel_count;
+};
+
+class SimpleWebHttpSyncServer {
+public:
+    SimpleWebHttpSyncServer(mdbxc::sync::HttpSyncServer& handler,
+                            mdbxc::sync::ISyncTransportPolicy& policy,
+                            const std::string& host,
+                            std::uint16_t port)
+        : m_handler(handler),
+          m_policy(policy),
+          m_host(host),
+          m_port(port),
+          m_running(false) {
+        m_server.config.address = host;
+        m_server.config.port = port;
+        m_server.config.thread_pool_size = 1;
+
+        m_server.resource["^/mdbxc/sync/v1/(pull|push)$"]["POST"] =
+            [this](std::shared_ptr<HttpServer::Response> response,
+                   std::shared_ptr<HttpServer::Request> request) {
+                handle_post(response, request);
+            };
+
+        m_server.default_resource["POST"] =
+            [](std::shared_ptr<HttpServer::Response> response,
+               std::shared_ptr<HttpServer::Request> request) {
+                (void)request;
+                mdbxc::sync::HttpSyncResponse out;
+                out.status_code = 404;
+                out.content_type = "text/plain; charset=utf-8";
+                out.error = "unknown sync route";
+                out.body = string_to_bytes(out.error);
+                write_http_response(response, out);
+            };
+    }
+
+    ~SimpleWebHttpSyncServer() {
+        stop();
+    }
+
+    void start() {
+        if (m_running) {
+            return;
+        }
+
+        std::promise<unsigned short> started;
+        std::future<unsigned short> started_future = started.get_future();
+        m_thread = std::thread(
+            [this, &started]() {
+                m_server.start(
+                    [&started](unsigned short assigned_port) {
+                        started.set_value(assigned_port);
+                    });
+            });
+        m_port = started_future.get();
+        m_running = true;
+        std::printf("[server] listening on %s:%u\n",
+                    m_host.c_str(),
+                    static_cast<unsigned>(m_port));
+    }
+
+    void stop() {
+        if (!m_running) {
+            return;
+        }
+        m_server.stop();
+        if (m_thread.joinable()) {
+            m_thread.join();
+        }
+        m_running = false;
+    }
+
+private:
+    void handle_post(
+            const std::shared_ptr<HttpServer::Response>& response,
+            const std::shared_ptr<HttpServer::Request>& request) {
+        const std::string content_type =
+            header_value(request->header, "Content-Type");
+        const std::string content = request->content.string();
+
+        const mdbxc::sync::SyncTransportDecision decision =
+            m_policy.check_http_post(request->path,
+                                     content_type,
+                                     string_to_bytes(content));
+        if (!decision.allowed) {
+            mdbxc::sync::HttpSyncResponse out;
+            out.status_code =
+                decision.status_code == 0 ? 403 : decision.status_code;
+            out.content_type = "text/plain; charset=utf-8";
+            out.error = decision.error.empty() ? "rejected" : decision.error;
+            out.body = string_to_bytes(out.error);
+            write_http_response(response, out);
+            return;
+        }
+
+        mdbxc::sync::HttpSyncRequest in;
+        in.method = request->method;
+        in.target = request->path;
+        in.content_type = content_type;
+        in.body = string_to_bytes(content);
+
+        write_http_response(response, m_handler.handle(in));
+    }
+
+    mdbxc::sync::HttpSyncServer& m_handler;
+    mdbxc::sync::ISyncTransportPolicy& m_policy;
+    std::string m_host;
+    std::uint16_t m_port;
+    HttpServer m_server;
+    std::thread m_thread;
+    bool m_running;
+};
+
+void seed_server_rows(const std::shared_ptr<mdbxc::Connection>& db) {
+    mdbxc::sync::ThreadLocalChangeAccumulator sink(db);
+    mdbxc::KeyValueTable<int, std::string> quotes(db, "quotes");
+    db->attach_sync_capture(&sink);
+    quotes.insert_or_assign(1, "BTC/USD");
+    quotes.insert_or_assign(2, "ETH/USD");
+    db->detach_sync_capture();
+}
+
+void seed_client_rows(const std::shared_ptr<mdbxc::Connection>& db) {
+    mdbxc::sync::ThreadLocalChangeAccumulator sink(db);
+    mdbxc::KeyValueTable<int, std::string> quotes(db, "quotes");
+    db->attach_sync_capture(&sink);
+    quotes.insert_or_assign(3, "SOL/USD");
+    db->detach_sync_capture();
+}
+
+void require_quote(const std::shared_ptr<mdbxc::Connection>& db,
+                   int key,
+                   const std::string& expected) {
+    mdbxc::KeyValueTable<int, std::string> quotes(db, "quotes");
+    const std::string actual =
+        sync_example::kv_or_throw(db, quotes, key, "quotes");
+    sync_example::require(actual == expected,
+                          "quote mismatch for key " +
+                          std::to_string(key));
+}
+
+void run_client_session(const std::shared_ptr<mdbxc::Connection>& db,
+                        mdbxc::sync::SyncEngine& engine,
+                        const std::string& host,
+                        std::uint16_t port) {
+    SimpleWebHttpSyncClient raw_client(
+        host, port, std::chrono::seconds(2));
+
+    mdbxc::sync::HttpRouteAllowListPolicy routes;
+    routes.allow_target(mdbxc::sync::HttpSyncRoutes::pull_target());
+    routes.allow_target(mdbxc::sync::HttpSyncRoutes::push_target());
+
+    mdbxc::sync::FixedBudgetSyncTransportPolicy http_budget(
+        mdbxc::sync::FixedBudgetSyncTransportPolicy::unlimited_budget(),
+        mdbxc::sync::FixedBudgetSyncTransportPolicy::unlimited_budget(),
+        8);
+    mdbxc::sync::CompositeSyncTransportPolicy http_policy;
+    http_policy.add(routes);
+    http_policy.add(http_budget);
+
+    mdbxc::sync::SyncTransportMetricsObserver metrics;
+    mdbxc::sync::HttpSyncClientMiddleware http_client(
+        raw_client, &http_policy, &metrics);
+    mdbxc::sync::HttpSyncPeer http_peer(http_client);
+
+    mdbxc::sync::FixedBudgetSyncTransportPolicy peer_budget(4, 4);
+    mdbxc::sync::SyncPeerMiddleware peer(
+        http_peer, &peer_budget, &metrics);
+
+    const mdbxc::sync::NodeId server_node =
+        sync_example::make_node(kServerNodeSeed);
+    const mdbxc::sync::NodeId client_node =
+        sync_example::make_node(kClientNodeSeed);
+    const mdbxc::sync::DbId db_id =
+        sync_example::make_node(kDatabaseSeed);
+
+    mdbxc::sync::PullRequest pull;
+    pull.requester = client_node;
+    pull.db_id = db_id;
+    pull.have = engine.applied_cursor();
+    pull.max_batches = 100;
+
+    const mdbxc::sync::PullResponse pulled = peer.pull(pull);
+    sync_example::require(pulled.ok,
+                          "HTTP pull failed: " + pulled.error);
+
+    mdbxc::sync::PushRequest local_apply;
+    local_apply.sender = server_node;
+    local_apply.db_id = db_id;
+    local_apply.batches = pulled.batches;
+    const mdbxc::sync::PushResponse applied =
+        engine.handle_push(local_apply);
+    sync_example::require(applied.ok,
+                          "client local apply failed: " + applied.error);
+    std::printf("[client] HTTP pull applied %zu batch(es)\n",
+                pulled.batches.size());
+
+    seed_client_rows(db);
+    const mdbxc::sync::PushRequest push =
+        engine.make_push_request(1, 0);
+    const mdbxc::sync::PushResponse pushed = peer.push(push);
+    sync_example::require(pushed.ok,
+                          "HTTP push failed: " + pushed.error);
+    std::printf("[client] HTTP push sent %zu batch(es)\n",
+                push.batches.size());
+
+    peer.request_cancel();
+    sync_example::require(raw_client.cancel_count() == 1u,
+                          "request_cancel was not forwarded");
+    std::printf("[client] request_cancel forwarded once\n");
+
+    require_quote(db, 1, "BTC/USD");
+    require_quote(db, 2, "ETH/USD");
+
+    const mdbxc::sync::SyncTransportMetricsSnapshot snapshot =
+        metrics.snapshot();
+    std::printf("[client] metrics pull=%llu push=%llu http=%llu "
+                "rejected=%llu\n",
+                static_cast<unsigned long long>(snapshot.pull_calls),
+                static_cast<unsigned long long>(snapshot.push_calls),
+                static_cast<unsigned long long>(snapshot.http_post_calls),
+                static_cast<unsigned long long>(snapshot.rejected_calls));
+}
+
+int run_demo(const std::string& host, std::uint16_t port) {
+    const std::string server_path = "sync_13_server_demo.mdbx";
+    const std::string client_path = "sync_13_client_demo.mdbx";
+    sync_example::cleanup(server_path);
+    sync_example::cleanup(client_path);
+
+    std::shared_ptr<mdbxc::Connection> server_db =
+        sync_example::open(server_path);
+    std::shared_ptr<mdbxc::Connection> client_db =
+        sync_example::open(client_path);
+
+    const mdbxc::sync::NodeId server_node =
+        sync_example::make_node(kServerNodeSeed);
+    const mdbxc::sync::NodeId client_node =
+        sync_example::make_node(kClientNodeSeed);
+    const mdbxc::sync::DbId db_id =
+        sync_example::make_node(kDatabaseSeed);
+
+    mdbxc::sync::SyncEngine server_engine(server_db);
+    mdbxc::sync::SyncEngine client_engine(client_db);
+    server_engine.initialize_local_identity(server_node, db_id);
+    client_engine.initialize_local_identity(client_node, db_id);
+
+    seed_server_rows(server_db);
+
+    mdbxc::sync::HttpSyncServer handler(server_engine);
+    mdbxc::sync::HttpRouteAllowListPolicy route_policy;
+    route_policy.allow_target(mdbxc::sync::HttpSyncRoutes::pull_target());
+    route_policy.allow_target(mdbxc::sync::HttpSyncRoutes::push_target());
+
+    SimpleWebHttpSyncServer listener(handler, route_policy, host, port);
+    listener.start();
+
+    run_client_session(client_db, client_engine, host, port);
+    require_quote(server_db, 3, "SOL/USD");
+    std::printf("[demo] server received pushed quote: SOL/USD\n");
+
+    listener.stop();
+    sync_example::disconnect_and_cleanup(server_db, server_path);
+    sync_example::disconnect_and_cleanup(client_db, client_path);
+    std::printf("OK: sync_13_http_simple_web_server\n");
+    return 0;
+}
+
+int run_server(const std::string& host, std::uint16_t port) {
+    const std::string path = "sync_13_server.mdbx";
+    sync_example::cleanup(path);
+    std::shared_ptr<mdbxc::Connection> db = sync_example::open(path);
+
+    const mdbxc::sync::NodeId server_node =
+        sync_example::make_node(kServerNodeSeed);
+    const mdbxc::sync::DbId db_id =
+        sync_example::make_node(kDatabaseSeed);
+
+    mdbxc::sync::SyncEngine engine(db);
+    engine.initialize_local_identity(server_node, db_id);
+    seed_server_rows(db);
+
+    mdbxc::sync::HttpSyncServer handler(engine);
+    mdbxc::sync::HttpRouteAllowListPolicy route_policy;
+    route_policy.allow_target(mdbxc::sync::HttpSyncRoutes::pull_target());
+    route_policy.allow_target(mdbxc::sync::HttpSyncRoutes::push_target());
+
+    SimpleWebHttpSyncServer listener(handler, route_policy, host, port);
+    listener.start();
+
+    std::printf("[server] press Enter to stop\n");
+    std::string line;
+    std::getline(std::cin, line);
+
+    listener.stop();
+    sync_example::disconnect_and_cleanup(db, path);
+    std::printf("OK: sync_13_http_simple_web_server (server)\n");
+    return 0;
+}
+
+int run_client(const std::string& host, std::uint16_t port) {
+    const std::string path = "sync_13_client.mdbx";
+    sync_example::cleanup(path);
+    std::shared_ptr<mdbxc::Connection> db = sync_example::open(path);
+
+    const mdbxc::sync::NodeId client_node =
+        sync_example::make_node(kClientNodeSeed);
+    const mdbxc::sync::DbId db_id =
+        sync_example::make_node(kDatabaseSeed);
+
+    mdbxc::sync::SyncEngine engine(db);
+    engine.initialize_local_identity(client_node, db_id);
+
+    run_client_session(db, engine, host, port);
+
+    sync_example::disconnect_and_cleanup(db, path);
+    std::printf("OK: sync_13_http_simple_web_server (client)\n");
+    return 0;
+}
+
+std::uint16_t parse_port(const char* text) {
+    const int value = std::atoi(text);
+    if (value <= 0 || value > 65535) {
+        throw std::invalid_argument("port must be in 1..65535");
+    }
+    return static_cast<std::uint16_t>(value);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        if (argc != 4) {
+            std::fprintf(stderr,
+                "usage: %s (demo|server|client) <host> <port>\n",
+                argv[0]);
+            return 2;
+        }
+
+        const std::string mode = argv[1];
+        const std::string host = argv[2];
+        const std::uint16_t port = parse_port(argv[3]);
+
+        if (mode == "demo") {
+            return run_demo(host, port);
+        }
+        if (mode == "server") {
+            return run_server(host, port);
+        }
+        if (mode == "client") {
+            return run_client(host, port);
+        }
+
+        std::fprintf(stderr, "unknown mode: %s\n", mode.c_str());
+        return 2;
+    } catch (const std::exception& e) {
+        std::printf("FAIL: %s\n", e.what());
+        return 1;
+    }
+}

--- a/guides/build-and-test.md
+++ b/guides/build-and-test.md
@@ -18,6 +18,7 @@ All project options use the `MDBXC_` prefix.
 | `MDBXC_BUILD_TESTS` | `ON` | Build tests from `tests/` and register them with CTest. |
 | `MDBXC_BUILD_BENCHMARKS` | `OFF` | Build manual benchmark executables from `benchmarks/`. |
 | `MDBXC_ENABLE_STRESS_TESTS` | `OFF` | Register long stress tests with CTest. Stress executables are still built when tests are enabled. |
+| `MDBXC_HTTP_SYNC_EXAMPLE` | `OFF` | Build the optional Simple-Web-Server HTTP sync example and fetch standalone Asio/Simple-Web-Server headers. |
 | `MDBXC_USE_ASAN` | `ON` | Enable AddressSanitizer for tests/examples when supported. |
 
 When `mdbx-containers` is added as a subproject, existing parent-provided


### PR DESCRIPTION
﻿## Summary

- add an optional `sync_13_http_simple_web_server` example over Simple-Web-Server and standalone Asio
- add a local FetchContent helper that creates an INTERFACE target without invoking upstream Simple-Web-Server CMake or Boost lookup
- keep the new HTTP binding out of default example builds unless `MDBXC_HTTP_SYNC_EXAMPLE=ON`
- document the opt-in build/demo flow in sync examples docs and build guide

## Why

PR #105/#106 added the framework-neutral HTTP seam and middleware, but they still used loopback clients. This example checks the seam against a real socket-backed HTTP library while keeping the dependency optional and outside the core headers.

## Notes

- Simple-Web-Server is built with `USE_STANDALONE_ASIO=1` and `ASIO_STANDALONE=1`.
- The helper fetches `chriskohlhoff/asio` and `eidheim/Simple-Web-Server` headers, then exposes a local `mdbxc_simple_web_server` interface target.
- The demo performs real HTTP pull and push against a local server and verifies both MDBX databases.

## Validation

- `cmake -S . -B tmp/pr107-default -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=OFF -DMDBXC_BUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=17`
- `mingw32-make -C tmp/pr107-default sync_12_transport_middleware`
- `cmake -S . -B tmp/pr107-http-clean -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=OFF -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_HTTP_SYNC_EXAMPLE=ON -DCMAKE_CXX_STANDARD=17`
- `mingw32-make -C tmp/pr107-http-clean sync_13_http_simple_web_server`
- `tmp/pr107-http-clean/bin/examples/sync_13_http_simple_web_server.exe demo 127.0.0.1 18080`
- `cmake -S . -B tmp/pr107-http-cpp11 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=OFF -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_HTTP_SYNC_EXAMPLE=ON -DCMAKE_CXX_STANDARD=11`
- `mingw32-make -C tmp/pr107-http-cpp11 sync_13_http_simple_web_server`
- `tmp/pr107-http-cpp11/bin/examples/sync_13_http_simple_web_server.exe demo 127.0.0.1 18081`
- `git diff --check`
- `git diff --cached --check`
