### PR TITLE
feat(sync): add WebSocket adapter seam

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -79,9 +79,10 @@
   DUPSORT duplicate framing и hash-index identity semantics.
 - `SyncEngine` предоставляет pull/push/apply primitives, `DirectSyncPeer`
   используется для in-process синхронизации в тестах и примерах,
-  `HttpSyncPeer` задаёт HTTP-shaped adapter seam, а `SyncWorker` запускает
-  фоновой polling. Пример HTTP на Simple-Web-Server собирается опционально;
-  WebSocket транспорты и wire-format для специализированных таблиц отложены;
+  `HttpSyncPeer` задаёт HTTP-shaped adapter seam, `WebSocketSyncPeer` задаёт
+  binary message seam, а `SyncWorker` запускает фоновой polling. Пример HTTP
+  на Simple-Web-Server собирается опционально; конкретные socket-bound
+  WebSocket binding-и и wire-format для специализированных таблиц отложены;
   см. `include/mdbx_containers/sync/DESIGN.md`.
 
 ### 🗄️ Структура и конфигурация

--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@
   DUPSORT duplicate framing, and hash-index identity semantics are specified.
 - `SyncEngine` exposes pull/push/apply primitives, `DirectSyncPeer` provides
   in-process sync for tests and examples, `HttpSyncPeer` defines an HTTP-shaped
-  adapter seam, and `SyncWorker` is the background polling driver. A
-  Simple-Web-Server HTTP example is optional; WebSocket transports and
-  specialized table wire formats remain deferred. See
+  adapter seam, `WebSocketSyncPeer` defines a binary message seam, and
+  `SyncWorker` is the background polling driver. A Simple-Web-Server HTTP
+  example is optional; concrete socket-bound WebSocket bindings and specialized
+  table wire formats remain deferred. See
   `include/mdbx_containers/sync/DESIGN.md`.
 
 ### 🗄️ Structure & Configuration

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -3,8 +3,8 @@
 Эти примеры показывают API sync v0.1 как набор блоков, не привязанных к
 конкретному транспорту. Большинство примеров используют `DirectSyncPeer` или
 небольшой буфер в памяти, чтобы поток протокола был виден без HTTP, WebSocket
-или IPC-кода. Последний опциональный пример связывает HTTP seam с
-Simple-Web-Server и standalone Asio.
+или IPC-кода. Опциональный HTTP-пример связывает HTTP seam с Simple-Web-Server
+и standalone Asio, а WebSocket-пример остаётся framework-neutral.
 
 Синхронизация включается явно. Примеры собираются с `MDBXC_SYNC_ENABLED=1`;
 приложениям, которые используют sync, тоже нужно компилировать соответствующий
@@ -63,6 +63,7 @@ tmp/build-http-example/bin/examples/sync_13_http_simple_web_server \
 | `sync_11_http_adapter.cpp` | Фреймворк-независимый HTTP-адаптер поверх `TransportMessageCodec`. | Продвинутый |
 | `sync_12_transport_middleware.cpp` | Allow-list, fixed-budget rate limit и metrics middleware вокруг транспортных адаптеров. | Продвинутый |
 | `sync_13_http_simple_web_server.cpp` | Опциональный настоящий HTTP binding через Simple-Web-Server и standalone Asio. | Продвинутый |
+| `sync_14_websocket_adapter.cpp` | Framework-neutral WebSocket binary-message seam поверх `TransportMessageCodec`. | Продвинутый |
 
 ## Общие правила
 
@@ -142,6 +143,13 @@ replica формирует PullRequest
 `HttpSyncServer` передаёт уже разобранные HTTP method/target/content-type/body
 значения в `SyncEngine`. Реальная HTTP-библиотека добавляет сетевой слой вокруг
 этой границы.
+
+`sync_14_websocket_adapter.cpp` показывает границу WebSocket-адаптера.
+`WebSocketSyncPeer` реализует `ISyncPeer` поверх абстрактного
+`IWebSocketSyncChannel`, а `WebSocketSyncServer` передаёт полные бинарные
+сообщения в `SyncEngine`. Реальная WebSocket-библиотека добавляет вокруг этой
+границы подключение, сборку фрагментов, ping/pong, backpressure и mapping
+close/error.
 
 `sync_12_transport_middleware.cpp` показывает adapter-local policy wrappers.
 `SyncPeerMiddleware` может проверять декодированные `NodeId` / `DbId` перед

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -2,8 +2,9 @@
 
 These examples show the sync v0.1 API as transport-agnostic building blocks.
 Most use `DirectSyncPeer` or a small in-memory buffer so the protocol flow is
-visible without adding HTTP, WebSocket, or IPC code. The final optional example
-binds the HTTP seam to Simple-Web-Server and standalone Asio.
+visible without adding HTTP, WebSocket, or IPC code. The optional HTTP example
+binds the HTTP seam to Simple-Web-Server and standalone Asio, while the
+WebSocket example stays framework-neutral.
 
 Sync is opt-in. The examples are built with `MDBXC_SYNC_ENABLED=1`; applications
 must also compile sync users with that macro enabled.
@@ -61,6 +62,7 @@ tmp/build-http-example/bin/examples/sync_13_http_simple_web_server \
 | `sync_11_http_adapter.cpp` | Framework-neutral HTTP-shaped adapter over `TransportMessageCodec`. | Advanced |
 | `sync_12_transport_middleware.cpp` | Allow-list, fixed-budget, and metrics middleware around transport adapters. | Advanced |
 | `sync_13_http_simple_web_server.cpp` | Optional real HTTP binding over Simple-Web-Server and standalone Asio. | Advanced |
+| `sync_14_websocket_adapter.cpp` | Framework-neutral WebSocket binary-message seam over `TransportMessageCodec`. | Advanced |
 
 ## Common Rules
 
@@ -136,6 +138,13 @@ channel's own interruption primitive.
 implements `ISyncPeer` over an abstract `IHttpSyncClient`, and
 `HttpSyncServer` dispatches already-parsed HTTP method/target/content-type/body
 values to `SyncEngine`. A real HTTP library supplies the socket layer around
+that seam.
+
+`sync_14_websocket_adapter.cpp` shows the WebSocket-shaped adapter seam.
+`WebSocketSyncPeer` implements `ISyncPeer` over an abstract
+`IWebSocketSyncChannel`, and `WebSocketSyncServer` dispatches complete binary
+messages to `SyncEngine`. A real WebSocket library supplies connection setup,
+fragment reassembly, ping/pong, backpressure, and close/error mapping around
 that seam.
 
 `sync_12_transport_middleware.cpp` shows adapter-local policy wrappers.

--- a/examples/sync_14_websocket_adapter.cpp
+++ b/examples/sync_14_websocket_adapter.cpp
@@ -1,0 +1,165 @@
+/**
+ * \ingroup mdbxc_examples
+ * \brief WebSocket-shaped sync adapter without choosing a WebSocket framework.
+ *
+ * `WebSocketSyncPeer` implements `ISyncPeer` by sending one complete binary
+ * request message through an `IWebSocketSyncChannel`. `WebSocketSyncServer`
+ * handles the matching server-side binary message and returns one binary
+ * response message.
+ *
+ * This example uses an in-process loopback channel so the code stays portable.
+ * Replace `LoopbackWebSocketChannel::exchange_binary()` with
+ * Simple-WebSocket-Server, Boost.Beast, uWebSockets, websocketpp, or another
+ * framework. The
+ * concrete binding should reassemble WebSocket fragments before calling the
+ * server seam and should send the returned bytes as one binary message.
+ *
+ * Expected output:
+ *   [websocket adapter] pull delivered 2 batch(es)
+ *   [websocket adapter] push delivered 1 batch(es)
+ *   OK: sync_14_websocket_adapter
+ */
+
+#include "sync_example_utils.hpp"
+
+#include <cstdio>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+class LoopbackWebSocketChannel : public mdbxc::sync::IWebSocketSyncChannel {
+public:
+    explicit LoopbackWebSocketChannel(
+            mdbxc::sync::WebSocketSyncServer& server)
+        : m_server(server), m_cancel_count(0) {}
+
+    std::vector<std::uint8_t> exchange_binary(
+            const std::vector<std::uint8_t>& binary_message,
+            const mdbxc::sync::CancellationToken& cancel_token) override {
+        // A real WebSocket client would send `binary_message` as one binary
+        // frame/message, wait for the response message, and map cancel_token
+        // plus request_cancel() to the framework's close/interrupt primitive.
+        (void)cancel_token;
+        return m_server.handle_binary_message(binary_message);
+    }
+
+    void request_cancel() override {
+        // A real implementation would interrupt the active exchange here.
+        ++m_cancel_count;
+    }
+
+    std::size_t cancel_count() const { return m_cancel_count; }
+
+private:
+    mdbxc::sync::WebSocketSyncServer& m_server;
+    std::size_t m_cancel_count;
+};
+
+} // namespace
+
+int main() {
+    const std::string primary_path = "sync_14_primary.mdbx";
+    const std::string replica_path = "sync_14_replica.mdbx";
+    sync_example::cleanup(primary_path);
+    sync_example::cleanup(replica_path);
+
+    const mdbxc::sync::NodeId primary_node =
+        sync_example::make_node(0xF0);
+    const mdbxc::sync::NodeId replica_node =
+        sync_example::make_node(0xF1);
+    const mdbxc::sync::DbId db_id =
+        sync_example::make_node(0xF2);
+
+    try {
+        std::shared_ptr<mdbxc::Connection> primary =
+            sync_example::open(primary_path);
+        std::shared_ptr<mdbxc::Connection> replica =
+            sync_example::open(replica_path);
+
+        mdbxc::sync::SyncEngine primary_engine(primary);
+        mdbxc::sync::SyncEngine replica_engine(replica);
+        primary_engine.initialize_local_identity(primary_node, db_id);
+        replica_engine.initialize_local_identity(replica_node, db_id);
+
+        mdbxc::sync::ThreadLocalChangeAccumulator capture(primary);
+        mdbxc::KeyValueTable<int, std::string> primary_ticks(primary, "ticks");
+
+        primary->attach_sync_capture(&capture);
+        primary_ticks.insert_or_assign(1, "BTC/USD");
+        primary_ticks.insert_or_assign(2, "ETH/USD");
+        primary->detach_sync_capture();
+
+        mdbxc::sync::WebSocketSyncServer primary_server(primary_engine);
+        LoopbackWebSocketChannel primary_channel(primary_server);
+        mdbxc::sync::WebSocketSyncPeer primary_peer(primary_channel);
+
+        mdbxc::sync::PullRequest pull;
+        pull.requester = replica_node;
+        pull.db_id = db_id;
+        pull.have = replica_engine.applied_cursor();
+        pull.max_batches = 100;
+
+        const mdbxc::sync::PullResponse pulled = primary_peer.pull(pull);
+        sync_example::require(pulled.ok,
+                              "WebSocket pull failed: " + pulled.error);
+
+        mdbxc::sync::PushRequest local_apply;
+        local_apply.sender = primary_node;
+        local_apply.db_id = db_id;
+        local_apply.batches = pulled.batches;
+        const mdbxc::sync::PushResponse applied =
+            replica_engine.handle_push(local_apply);
+        sync_example::require(applied.ok,
+                              "local apply failed: " + applied.error);
+        std::printf("[websocket adapter] pull delivered %zu batch(es)\n",
+                    pulled.batches.size());
+
+        primary->attach_sync_capture(&capture);
+        primary_ticks.insert_or_assign(3, "SOL/USD");
+        primary->detach_sync_capture();
+
+        mdbxc::sync::WebSocketSyncServer replica_server(replica_engine);
+        LoopbackWebSocketChannel replica_channel(replica_server);
+        mdbxc::sync::WebSocketSyncPeer replica_peer(replica_channel);
+
+        const mdbxc::sync::PushRequest push =
+            primary_engine.make_push_request(3, 0);
+        const mdbxc::sync::PushResponse pushed = replica_peer.push(push);
+        sync_example::require(pushed.ok,
+                              "WebSocket push failed: " + pushed.error);
+        std::printf("[websocket adapter] push delivered %zu batch(es)\n",
+                    push.batches.size());
+
+        replica_peer.request_cancel();
+        sync_example::require(replica_channel.cancel_count() == 1u,
+                              "request_cancel was not forwarded");
+
+        mdbxc::KeyValueTable<int, std::string> replica_ticks(replica, "ticks");
+        sync_example::require(
+            sync_example::kv_or_throw(replica, replica_ticks, 1,
+                                      "ticks[1]") == "BTC/USD",
+            "replica ticks[1] mismatch");
+        sync_example::require(
+            sync_example::kv_or_throw(replica, replica_ticks, 2,
+                                      "ticks[2]") == "ETH/USD",
+            "replica ticks[2] mismatch");
+        sync_example::require(
+            sync_example::kv_or_throw(replica, replica_ticks, 3,
+                                      "ticks[3]") == "SOL/USD",
+            "replica ticks[3] mismatch");
+
+        sync_example::disconnect_and_cleanup(primary, primary_path);
+        sync_example::disconnect_and_cleanup(replica, replica_path);
+        std::printf("OK: sync_14_websocket_adapter\n");
+        return 0;
+    } catch (const std::exception& e) {
+        std::printf("FAIL: %s\n", e.what());
+        sync_example::cleanup(primary_path);
+        sync_example::cleanup(replica_path);
+        return 1;
+    }
+}

--- a/examples/sync_14_websocket_adapter.cpp
+++ b/examples/sync_14_websocket_adapter.cpp
@@ -41,7 +41,7 @@ public:
             const std::vector<std::uint8_t>& binary_message,
             const mdbxc::sync::CancellationToken& cancel_token) override {
         // A real WebSocket client would send `binary_message` as one binary
-        // frame/message, wait for the response message, and map cancel_token
+        // message, wait for the response message, and map cancel_token
         // plus request_cancel() to the framework's close/interrupt primitive.
         (void)cancel_token;
         return m_server.handle_binary_message(binary_message);

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -32,6 +32,7 @@
 #include "sync/SyncWorker.hpp"
 #include "sync/DirectSyncPeer.hpp"
 #include "sync/HttpTransport.hpp"
+#include "sync/WebSocketTransport.hpp"
 #include "sync/TransportMiddleware.hpp"
 #include "sync/stores/MetaStore.hpp"
 #include "sync/stores/OriginIndexStore.hpp"

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -32,6 +32,10 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
   `IHttpSyncClient`, `HttpSyncServer`, and `HttpSyncRoutes`. It defines
   route/content-type/body/status mapping over `TransportMessageCodec` but does
   not open sockets or depend on an HTTP framework.
+- Framework-neutral WebSocket-shaped adapter seam: `WebSocketSyncPeer`,
+  `IWebSocketSyncChannel`, and `WebSocketSyncServer`. It defines a complete
+  binary-message request/response contract over `TransportMessageCodec` but
+  does not open sockets, own sessions, or depend on a WebSocket framework.
 - Transport middleware helpers: `SyncPeerMiddleware`,
   `HttpSyncClientMiddleware`, allow-list policies, fixed-budget rate limiting,
   and a metrics observer. These wrap transport adapters and do not change the
@@ -100,10 +104,9 @@ new wire-format semantics.
   use `LastWriterWins` in a non-test path.
 - `Custom` conflict resolver — schema-level callback; deferred until the
   first real consumer needs it.
-- Concrete socket-bound HTTP and WebSocket transports (`Simple-Web-Server`,
-  `Simple-WebSocket-Server`, Boost.Beast, libcurl, or another framework) with
-  guarded build flags. The current HTTP-shaped adapter seam does not own
-  sockets.
+- Additional concrete socket-bound HTTP and WebSocket transports
+  (`Simple-WebSocket-Server`, Boost.Beast, libcurl, or another framework) with
+  guarded build flags. The HTTP and WebSocket adapter seams do not own sockets.
 - `zstd` compression — reserved flag, encoder throws, decoder rejects.
 
 ## Endianness policy (do not change)
@@ -241,6 +244,10 @@ Locked contract:
 - Decoders reject trailing bytes, truncated messages, invalid boolean values,
   wrong message types, unsupported versions, and configured size-limit
   violations.
+- `peek_message_type()` validates the shared envelope and returns only the
+  message kind. It is for message-oriented adapters such as WebSocket servers
+  that dispatch complete binary messages before decoding the type-specific
+  payload.
 - A null `CodecBounds` argument uses the default `CodecBounds` limits at this
   transport layer; adapters may pass stricter limits for their deployment.
 
@@ -362,9 +369,11 @@ in place until a real adapter shows that core cannot support it.
   process and is suitable for tests, examples, and in-process demos.
   `HttpSyncPeer` is a framework-neutral HTTP-shaped adapter over an abstract
   `IHttpSyncClient`; it defines the route/body contract but does not own a
-  socket. Production code that crosses a process boundary must bind this seam
-  to a transport implementation that owns its own connection, threading, and
-  lifecycle.
+  socket. `WebSocketSyncPeer` is a framework-neutral binary-message adapter
+  over an abstract `IWebSocketSyncChannel`; it defines the complete-message
+  request/response contract but does not own a socket or session. Production
+  code that crosses a process boundary must bind these seams to a transport
+  implementation that owns its own connection, threading, and lifecycle.
 - A transport adapter does not own the caller's `SyncEngine`. The
   receiver-side `SyncEngine` (the one whose state changed because of a
   remote write) must live on the thread that owns the receiver
@@ -471,6 +480,10 @@ per-remote-client rate limiting before `HttpSyncServer::handle()`. They also
 count middleware hook invocations: if one observer is installed at both the
 peer layer and HTTP client layer, a forwarded `request_cancel()` can be counted
 once per layer.
+For WebSocket, decoded DTO policy can wrap `WebSocketSyncPeer` through
+`SyncPeerMiddleware`; per-session authentication, remote address checks,
+backpressure, and rate limits remain binding-local before
+`WebSocketSyncServer::handle_binary_message()`.
 
 `ChangeBatchCodec` already rejects `BATCH_COMPRESSED_ZSTD` at both
 encode and decode paths. Adding a real `zstd` backend is a codec
@@ -496,16 +509,16 @@ A concrete socket-bound transport adapter ships as a separate pair of headers
 
 - implements or reuses `ISyncPeer` on the client side;
 - wraps `SyncEngine::handle_pull()` / `handle_push()` on the server
-  side, directly or through `HttpSyncServer`;
+  side, directly, through `HttpSyncServer`, or through `WebSocketSyncServer`;
 - owns its own threading model (one acceptor thread, thread pool,
   per-connection thread, ...);
 - owns its own timeout configuration;
 - documents how its `request_cancel()` translates into the
   underlying transport's interrupt primitive.
 
-The framework-neutral `HttpSyncPeer` / `HttpSyncServer` seam is part of v0.1.
-Concrete HTTP server/client bindings and WebSocket bindings remain separate
-optional integrations.
+The framework-neutral `HttpSyncPeer` / `HttpSyncServer` and
+`WebSocketSyncPeer` / `WebSocketSyncServer` seams are part of v0.1. Concrete
+server/client bindings remain separate optional integrations.
 
 ## Why `prune_up_to` uses cursor walk + `MDBX_NEXT`
 

--- a/include/mdbx_containers/sync/TransportMessageCodec.hpp
+++ b/include/mdbx_containers/sync/TransportMessageCodec.hpp
@@ -63,6 +63,17 @@ namespace sync {
         /// \brief Supported transport codec version.
         static std::uint16_t codec_version() { return 1; }
 
+        /// \brief Reads the message type from a transport envelope.
+        /// \details Validates magic, codec version, and mandatory flags but
+        /// does not decode or validate the type-specific payload.
+        static TransportMessageType peek_message_type(
+                const std::vector<std::uint8_t>& data,
+                const CodecBounds* bounds = nullptr) {
+            bounds = effective_bounds(bounds);
+            Cursor cur = make_cursor(data, bounds);
+            return read_header_type(cur);
+        }
+
         /// \brief Encodes a pull request.
         static std::vector<std::uint8_t> encode_pull_request(
                 const PullRequest& request,
@@ -227,7 +238,7 @@ namespace sync {
             return cur;
         }
 
-        static void check_header(Cursor& cur, TransportMessageType expected) {
+        static TransportMessageType read_header_type(Cursor& cur) {
             check_bounds(cur, magic_size());
             if (std::memcmp(cur.data + cur.pos, magic(), magic_size()) != 0) {
                 throw std::runtime_error("Transport codec magic mismatch");
@@ -239,13 +250,34 @@ namespace sync {
                 throw std::runtime_error("Unsupported transport codec_version");
             }
             const std::uint8_t type = read_u8(cur);
-            if (type != static_cast<std::uint8_t>(expected)) {
-                throw std::runtime_error("Unexpected transport message type");
-            }
             const std::uint32_t flags = read_u32_le(cur);
             if (flags != 0) {
                 throw std::runtime_error(
                     "Unknown mandatory transport message flags");
+            }
+            switch (type) {
+                case static_cast<std::uint8_t>(
+                        TransportMessageType::PullRequest):
+                    return TransportMessageType::PullRequest;
+                case static_cast<std::uint8_t>(
+                        TransportMessageType::PullResponse):
+                    return TransportMessageType::PullResponse;
+                case static_cast<std::uint8_t>(
+                        TransportMessageType::PushRequest):
+                    return TransportMessageType::PushRequest;
+                case static_cast<std::uint8_t>(
+                        TransportMessageType::PushResponse):
+                    return TransportMessageType::PushResponse;
+                default:
+                    throw std::runtime_error(
+                        "Unexpected transport message type");
+            }
+        }
+
+        static void check_header(Cursor& cur, TransportMessageType expected) {
+            const TransportMessageType type = read_header_type(cur);
+            if (type != expected) {
+                throw std::runtime_error("Unexpected transport message type");
             }
         }
 

--- a/include/mdbx_containers/sync/WebSocketTransport.hpp
+++ b/include/mdbx_containers/sync/WebSocketTransport.hpp
@@ -1,0 +1,143 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_WEB_SOCKET_TRANSPORT_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_WEB_SOCKET_TRANSPORT_HPP_INCLUDED
+
+/// \file WebSocketTransport.hpp
+/// \brief Framework-neutral WebSocket-shaped adapter for sync transport DTOs.
+/// \details
+/// This header does not open sockets and does not depend on any WebSocket
+/// library. It defines a synchronous request/response message seam over
+/// complete binary WebSocket messages encoded by \c TransportMessageCodec.
+/// Concrete bindings own connection setup, authentication headers, ping/pong,
+/// fragmentation/reassembly, backpressure, retries, and socket cancellation.
+
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+#include "ISyncPeer.hpp"
+#include "SyncEngine.hpp"
+#include "TransportMessageCodec.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Client-side bridge implemented by a concrete WebSocket library.
+    /// \details \p binary_message must contain exactly one
+    /// \c TransportMessageCodec request. Implementations return exactly one
+    /// encoded response message or throw on transport failure.
+    class IWebSocketSyncChannel {
+    public:
+        virtual ~IWebSocketSyncChannel() {}
+
+        /// \brief Sends one binary sync message and waits for its response.
+        /// \param binary_message Encoded pull or push request.
+        /// \param cancel_token Local call-control token; it is not serialized.
+        /// \return Encoded pull or push response.
+        virtual std::vector<std::uint8_t> exchange_binary(
+                const std::vector<std::uint8_t>& binary_message,
+                const CancellationToken& cancel_token) = 0;
+
+        /// \brief Best-effort cancellation hook for an in-flight exchange.
+        virtual void request_cancel() {}
+    };
+
+    /// \brief Server-side dispatcher from binary WebSocket messages to
+    /// \c SyncEngine.
+    class WebSocketSyncServer {
+    public:
+        explicit WebSocketSyncServer(SyncEngine& engine,
+                                     const CodecBounds& bounds = CodecBounds())
+            : m_engine(engine), m_bounds(bounds) {}
+
+        /// \brief Handles one complete binary WebSocket message.
+        /// \details Request messages produce response messages. Response
+        /// messages are rejected because this server is not a forwarding relay.
+        /// Malformed messages throw; concrete WebSocket bindings should map
+        /// those failures to their close/error policy.
+        std::vector<std::uint8_t> handle_binary_message(
+                const std::vector<std::uint8_t>& binary_message) const {
+            const TransportMessageType type =
+                TransportMessageCodec::peek_message_type(
+                    binary_message, &m_bounds);
+            switch (type) {
+                case TransportMessageType::PullRequest:
+                    return handle_pull(binary_message);
+                case TransportMessageType::PushRequest:
+                    return handle_push(binary_message);
+                case TransportMessageType::PullResponse:
+                case TransportMessageType::PushResponse:
+                    throw std::runtime_error(
+                        "WebSocket sync server received response message");
+            }
+            throw std::runtime_error("Unexpected WebSocket sync message type");
+        }
+
+    private:
+        std::vector<std::uint8_t> handle_pull(
+                const std::vector<std::uint8_t>& binary_message) const {
+            const PullRequest request =
+                TransportMessageCodec::decode_pull_request(
+                    binary_message, &m_bounds);
+            const PullResponse response = m_engine.handle_pull(request);
+            return TransportMessageCodec::encode_pull_response(
+                response, &m_bounds);
+        }
+
+        std::vector<std::uint8_t> handle_push(
+                const std::vector<std::uint8_t>& binary_message) const {
+            const PushRequest request =
+                TransportMessageCodec::decode_push_request(
+                    binary_message, &m_bounds);
+            const PushResponse response = m_engine.handle_push(request);
+            return TransportMessageCodec::encode_push_response(
+                response, &m_bounds);
+        }
+
+        SyncEngine& m_engine;
+        CodecBounds m_bounds;
+    };
+
+    /// \brief \c ISyncPeer implementation over an abstract WebSocket channel.
+    class WebSocketSyncPeer : public ISyncPeer {
+    public:
+        explicit WebSocketSyncPeer(
+                IWebSocketSyncChannel& channel,
+                const CodecBounds& bounds = CodecBounds())
+            : m_channel(channel), m_bounds(bounds) {}
+
+        PullResponse pull(const PullRequest& request) override {
+            const std::vector<std::uint8_t> request_message =
+                TransportMessageCodec::encode_pull_request(
+                    request, &m_bounds);
+            const std::vector<std::uint8_t> response_message =
+                m_channel.exchange_binary(request_message,
+                                          request.cancel_token);
+            return TransportMessageCodec::decode_pull_response(
+                response_message, &m_bounds);
+        }
+
+        PushResponse push(const PushRequest& request) override {
+            const std::vector<std::uint8_t> request_message =
+                TransportMessageCodec::encode_push_request(
+                    request, &m_bounds);
+            const std::vector<std::uint8_t> response_message =
+                m_channel.exchange_binary(request_message,
+                                          request.cancel_token);
+            return TransportMessageCodec::decode_push_response(
+                response_message, &m_bounds);
+        }
+
+        void request_cancel() override {
+            m_channel.request_cancel();
+        }
+
+    private:
+        IWebSocketSyncChannel& m_channel;
+        CodecBounds m_bounds;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_WEB_SOCKET_TRANSPORT_HPP_INCLUDED

--- a/include/mdbx_containers/sync/WebSocketTransport.hpp
+++ b/include/mdbx_containers/sync/WebSocketTransport.hpp
@@ -34,6 +34,9 @@ namespace sync {
         /// \param binary_message Encoded pull or push request.
         /// \param cancel_token Local call-control token; it is not serialized.
         /// \return Encoded pull or push response.
+        /// \note The v0.1 wire DTOs have no request id. Implementations must
+        /// serialize concurrent exchanges on one connection unless the
+        /// concrete WebSocket binding adds its own correlation layer.
         virtual std::vector<std::uint8_t> exchange_binary(
                 const std::vector<std::uint8_t>& binary_message,
                 const CancellationToken& cancel_token) = 0;

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -47,8 +47,15 @@ int main() {
         mdbxc::sync::TransportMessageCodec::decode_pull_request(wire);
     MDBXC_TEST_ASSERT(decoded_pull.requester == node);
     MDBXC_TEST_ASSERT(decoded_pull.have.last_seq_for(node) == 1u);
+    MDBXC_TEST_ASSERT(
+        mdbxc::sync::TransportMessageCodec::peek_message_type(wire) ==
+        mdbxc::sync::TransportMessageType::PullRequest);
     MDBXC_TEST_ASSERT(std::string(mdbxc::sync::HttpSyncRoutes::pull_target())
                       == "/mdbxc/sync/v1/pull");
+    mdbxc::sync::IWebSocketSyncChannel* websocket_channel = nullptr;
+    mdbxc::sync::WebSocketSyncServer* websocket_server = nullptr;
+    (void)websocket_channel;
+    (void)websocket_server;
     mdbxc::sync::NodeDbAllowListPolicy allow_list;
     allow_list.allow_node_id(node);
     allow_list.allow_db_id(node);

--- a/tests/test_transport_codec.cpp
+++ b/tests/test_transport_codec.cpp
@@ -164,6 +164,31 @@ void test_push_response_roundtrip() {
     require_true(decoded.error == response.error, "PushResponse error mismatch");
 }
 
+void test_peek_message_type() {
+    using namespace mdbxc::sync;
+
+    require_true(
+        TransportMessageCodec::peek_message_type(
+            TransportMessageCodec::encode_pull_request(PullRequest())) ==
+            TransportMessageType::PullRequest,
+        "PullRequest peek mismatch");
+    require_true(
+        TransportMessageCodec::peek_message_type(
+            TransportMessageCodec::encode_pull_response(PullResponse())) ==
+            TransportMessageType::PullResponse,
+        "PullResponse peek mismatch");
+    require_true(
+        TransportMessageCodec::peek_message_type(
+            TransportMessageCodec::encode_push_request(PushRequest())) ==
+            TransportMessageType::PushRequest,
+        "PushRequest peek mismatch");
+    require_true(
+        TransportMessageCodec::peek_message_type(
+            TransportMessageCodec::encode_push_response(PushResponse())) ==
+            TransportMessageType::PushResponse,
+        "PushResponse peek mismatch");
+}
+
 void test_message_header_rejections() {
     using namespace mdbxc::sync;
     const std::vector<std::uint8_t> bytes =
@@ -299,6 +324,7 @@ int main() {
     test_pull_response_roundtrip();
     test_push_request_roundtrip();
     test_push_response_roundtrip();
+    test_peek_message_type();
     test_message_header_rejections();
     test_bounds_rejections();
     test_golden_header_shape();

--- a/tests/test_websocket_transport.cpp
+++ b/tests/test_websocket_transport.cpp
@@ -216,10 +216,40 @@ void test_websocket_server_rejects_response_messages() {
     cleanup(path);
 }
 
+void test_websocket_server_rejects_malformed_messages() {
+    const std::string path = "test_websocket_transport_malformed.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<mdbxc::Connection> db = open_db(path);
+    mdbxc::sync::SyncEngine engine(db);
+    engine.initialize_local_identity(make_node(0x40), make_node(0xD2));
+    mdbxc::sync::WebSocketSyncServer server(engine);
+
+    const std::uint8_t malformed_byte_1 = 0x01;
+    const std::uint8_t malformed_byte_2 = 0x02;
+    std::vector<std::uint8_t> malformed_message;
+    malformed_message.push_back(malformed_byte_1);
+    malformed_message.push_back(malformed_byte_2);
+
+    bool caught = false;
+    try {
+        (void)server.handle_binary_message(malformed_message);
+    } catch (const std::runtime_error&) {
+        caught = true;
+    }
+
+    db->disconnect();
+    cleanup(path);
+
+    require_true(caught,
+                 "WebSocket server must reject malformed messages");
+}
+
 } // namespace
 
 int main() {
     test_websocket_peer_pull_and_push_roundtrip();
     test_websocket_server_rejects_response_messages();
+    test_websocket_server_rejects_malformed_messages();
     return 0;
 }

--- a/tests/test_websocket_transport.cpp
+++ b/tests/test_websocket_transport.cpp
@@ -1,0 +1,225 @@
+#include <mdbx_containers.hpp>
+#include <mdbx_containers/sync.hpp>
+
+#include <cstdio>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+mdbxc::sync::NodeId make_node(std::uint8_t seed) {
+    mdbxc::sync::NodeId node{};
+    for (int i = 0; i < 16; ++i) {
+        node[i] = static_cast<std::uint8_t>(seed + i);
+    }
+    return node;
+}
+
+void cleanup(const std::string& path) {
+    std::remove(path.c_str());
+    std::remove((path + "-lck").c_str());
+}
+
+mdbxc::Config config(const std::string& path) {
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.no_subdir = true;
+    cfg.max_dbs = 32;
+    return cfg;
+}
+
+std::shared_ptr<mdbxc::Connection> open_db(const std::string& path) {
+    return mdbxc::Connection::create(config(path));
+}
+
+void require_true(bool condition, const std::string& message) {
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+std::string get_value(const std::shared_ptr<mdbxc::Connection>& conn,
+                      mdbxc::KeyValueTable<int, std::string>& table,
+                      int key) {
+    std::string out;
+    auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+    if (!table.try_get(key, out, txn.handle())) {
+        throw std::runtime_error("missing replicated value");
+    }
+    return out;
+}
+
+class LoopbackWebSocketChannel : public mdbxc::sync::IWebSocketSyncChannel {
+public:
+    explicit LoopbackWebSocketChannel(
+            mdbxc::sync::WebSocketSyncServer& server)
+        : m_server(server),
+          m_exchange_count(0),
+          m_cancel_count(0),
+          m_last_token_cancellable(false),
+          m_last_type(mdbxc::sync::TransportMessageType::PullRequest) {}
+
+    std::vector<std::uint8_t> exchange_binary(
+            const std::vector<std::uint8_t>& binary_message,
+            const mdbxc::sync::CancellationToken& cancel_token) override {
+        ++m_exchange_count;
+        m_last_token_cancellable = cancel_token.can_be_cancelled();
+        m_last_type =
+            mdbxc::sync::TransportMessageCodec::peek_message_type(
+                binary_message);
+        return m_server.handle_binary_message(binary_message);
+    }
+
+    void request_cancel() override {
+        ++m_cancel_count;
+    }
+
+    std::size_t exchange_count() const { return m_exchange_count; }
+    std::size_t cancel_count() const { return m_cancel_count; }
+    bool last_token_cancellable() const { return m_last_token_cancellable; }
+    mdbxc::sync::TransportMessageType last_type() const {
+        return m_last_type;
+    }
+
+private:
+    mdbxc::sync::WebSocketSyncServer& m_server;
+    std::size_t m_exchange_count;
+    std::size_t m_cancel_count;
+    bool m_last_token_cancellable;
+    mdbxc::sync::TransportMessageType m_last_type;
+};
+
+void test_websocket_peer_pull_and_push_roundtrip() {
+    const std::string primary_path = "test_websocket_transport_primary.mdbx";
+    const std::string replica_path = "test_websocket_transport_replica.mdbx";
+    cleanup(primary_path);
+    cleanup(replica_path);
+
+    std::shared_ptr<mdbxc::Connection> primary = open_db(primary_path);
+    std::shared_ptr<mdbxc::Connection> replica = open_db(replica_path);
+
+    const mdbxc::sync::NodeId primary_node = make_node(0x10);
+    const mdbxc::sync::NodeId replica_node = make_node(0x20);
+    const mdbxc::sync::DbId db_id = make_node(0xD0);
+
+    mdbxc::sync::SyncEngine primary_engine(primary);
+    mdbxc::sync::SyncEngine replica_engine(replica);
+    primary_engine.initialize_local_identity(primary_node, db_id);
+    replica_engine.initialize_local_identity(replica_node, db_id);
+
+    mdbxc::sync::ThreadLocalChangeAccumulator capture(primary);
+    mdbxc::KeyValueTable<int, std::string> primary_ticks(primary, "ticks");
+
+    primary->attach_sync_capture(&capture);
+    primary_ticks.insert_or_assign(1, "BTC/USD");
+    primary_ticks.insert_or_assign(2, "ETH/USD");
+    primary->detach_sync_capture();
+
+    mdbxc::sync::WebSocketSyncServer primary_server(primary_engine);
+    LoopbackWebSocketChannel primary_channel(primary_server);
+    mdbxc::sync::WebSocketSyncPeer primary_peer(primary_channel);
+
+    mdbxc::sync::CancellationSource pull_cancel;
+    mdbxc::sync::PullRequest pull;
+    pull.requester = replica_node;
+    pull.db_id = db_id;
+    pull.have = replica_engine.applied_cursor();
+    pull.max_batches = 100;
+    pull.cancel_token = pull_cancel.token();
+
+    const mdbxc::sync::PullResponse pulled = primary_peer.pull(pull);
+    require_true(pulled.ok, "WebSocket pull failed: " + pulled.error);
+    require_true(pulled.batches.size() == 2u,
+                 "WebSocket pull expected two batches");
+    require_true(primary_channel.last_type() ==
+                     mdbxc::sync::TransportMessageType::PullRequest,
+                 "WebSocket pull sent wrong message type");
+    require_true(primary_channel.exchange_count() == 1u,
+                 "WebSocket pull exchange count mismatch");
+    require_true(primary_channel.last_token_cancellable(),
+                 "WebSocket channel did not receive cancellation token");
+
+    mdbxc::sync::PushRequest local_apply;
+    local_apply.sender = primary_node;
+    local_apply.db_id = db_id;
+    local_apply.batches = pulled.batches;
+    const mdbxc::sync::PushResponse applied =
+        replica_engine.handle_push(local_apply);
+    require_true(applied.ok, "local apply failed: " + applied.error);
+
+    primary->attach_sync_capture(&capture);
+    primary_ticks.insert_or_assign(3, "SOL/USD");
+    primary->detach_sync_capture();
+
+    mdbxc::sync::WebSocketSyncServer replica_server(replica_engine);
+    LoopbackWebSocketChannel replica_channel(replica_server);
+    mdbxc::sync::WebSocketSyncPeer replica_peer(replica_channel);
+
+    mdbxc::sync::PushRequest push = primary_engine.make_push_request(3, 0);
+    require_true(push.batches.size() == 1u,
+                 "WebSocket push expected one batch");
+    const mdbxc::sync::PushResponse pushed = replica_peer.push(push);
+    require_true(pushed.ok, "WebSocket push failed: " + pushed.error);
+    require_true(pushed.receiver_have.last_seq_for(primary_node) == 3u,
+                 "WebSocket push cursor mismatch");
+    require_true(replica_channel.last_type() ==
+                     mdbxc::sync::TransportMessageType::PushRequest,
+                 "WebSocket push sent wrong message type");
+    require_true(replica_channel.exchange_count() == 1u,
+                 "WebSocket push exchange count mismatch");
+
+    replica_peer.request_cancel();
+    require_true(replica_channel.cancel_count() == 1u,
+                 "WebSocket peer did not forward request_cancel()");
+
+    mdbxc::KeyValueTable<int, std::string> replica_ticks(replica, "ticks");
+    require_true(get_value(replica, replica_ticks, 1) == "BTC/USD",
+                 "replica value 1 mismatch");
+    require_true(get_value(replica, replica_ticks, 2) == "ETH/USD",
+                 "replica value 2 mismatch");
+    require_true(get_value(replica, replica_ticks, 3) == "SOL/USD",
+                 "replica value 3 mismatch");
+
+    primary->disconnect();
+    replica->disconnect();
+    cleanup(primary_path);
+    cleanup(replica_path);
+}
+
+void test_websocket_server_rejects_response_messages() {
+    const std::string path = "test_websocket_transport_reject.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<mdbxc::Connection> db = open_db(path);
+    mdbxc::sync::SyncEngine engine(db);
+    engine.initialize_local_identity(make_node(0x30), make_node(0xD1));
+    mdbxc::sync::WebSocketSyncServer server(engine);
+
+    const std::vector<std::uint8_t> response_message =
+        mdbxc::sync::TransportMessageCodec::encode_pull_response(
+            mdbxc::sync::PullResponse());
+
+    bool caught = false;
+    try {
+        (void)server.handle_binary_message(response_message);
+    } catch (const std::runtime_error& e) {
+        caught = std::string(e.what()).find("response message") !=
+                 std::string::npos;
+    }
+    require_true(caught,
+                 "WebSocket server must reject response messages");
+
+    db->disconnect();
+    cleanup(path);
+}
+
+} // namespace
+
+int main() {
+    test_websocket_peer_pull_and_push_roundtrip();
+    test_websocket_server_rejects_response_messages();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a framework-neutral `WebSocketSyncPeer` / `WebSocketSyncServer` seam over complete binary `TransportMessageCodec` messages
- add `TransportMessageCodec::peek_message_type()` for message-oriented server dispatch
- add a WebSocket loopback example and C++11/C++17 regression coverage

## Validation
- `cmake -S . -B tmp/pr108-cpp11 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_HTTP_SYNC_EXAMPLE=OFF -DCMAKE_CXX_STANDARD=11`
- `mingw32-make -C tmp/pr108-cpp11 test_transport_codec test_websocket_transport header_sync_umbrella_test sync_14_websocket_adapter`
- `ctest --test-dir tmp/pr108-cpp11 -R "^(test_transport_codec|test_websocket_transport|header_sync_umbrella_test)$" --output-on-failure`
- `tmp/pr108-cpp11/bin/examples/sync_14_websocket_adapter.exe`
- `cmake -S . -B tmp/pr108-cpp17 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_HTTP_SYNC_EXAMPLE=OFF -DCMAKE_CXX_STANDARD=17`
- `mingw32-make -C tmp/pr108-cpp17 test_transport_codec test_websocket_transport header_sync_umbrella_test sync_14_websocket_adapter`
- `ctest --test-dir tmp/pr108-cpp17 -R "^(test_transport_codec|test_websocket_transport|header_sync_umbrella_test)$" --output-on-failure`
- `tmp/pr108-cpp17/bin/examples/sync_14_websocket_adapter.exe`

Stacked on PR #107.
