### PR TITLE
feat(sync): add HTTP policy context

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -82,7 +82,9 @@
   `HttpSyncPeer` задаёт HTTP-shaped adapter seam, `WebSocketSyncPeer` задаёт
   binary message seam, а `SyncWorker` запускает фоновой polling. Пример HTTP
   на Simple-Web-Server собирается опционально; конкретные socket-bound
-  WebSocket binding-и и wire-format для специализированных таблиц отложены;
+  WebSocket binding-и и wire-format для специализированных таблиц отложены.
+  HTTP auth, remote-address checks и rate-limit headers живут в adapter-local
+  policy context, а не внутри sync DTO;
   см. `include/mdbx_containers/sync/DESIGN.md`.
 
 ### 🗄️ Структура и конфигурация

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@
   adapter seam, `WebSocketSyncPeer` defines a binary message seam, and
   `SyncWorker` is the background polling driver. A Simple-Web-Server HTTP
   example is optional; concrete socket-bound WebSocket bindings and specialized
-  table wire formats remain deferred. See
+  table wire formats remain deferred. HTTP auth, remote-address checks, and
+  rate-limit headers live in adapter-local policy context, not inside sync DTOs.
+  See
   `include/mdbx_containers/sync/DESIGN.md`.
 
 ### 🗄️ Structure & Configuration

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -64,6 +64,7 @@ tmp/build-http-example/bin/examples/sync_13_http_simple_web_server \
 | `sync_12_transport_middleware.cpp` | Allow-list, fixed-budget rate limit и metrics middleware вокруг транспортных адаптеров. | Продвинутый |
 | `sync_13_http_simple_web_server.cpp` | Опциональный настоящий HTTP binding через Simple-Web-Server и standalone Asio. | Продвинутый |
 | `sync_14_websocket_adapter.cpp` | Framework-neutral WebSocket binary-message seam поверх `TransportMessageCodec`. | Продвинутый |
+| `sync_15_http_policy_context.cpp` | Bearer-token, remote-address и `Retry-After` HTTP policy context. | Продвинутый |
 
 ## Общие правила
 
@@ -161,3 +162,8 @@ fixed-budget rate limits и metrics hooks; они не добавляют auth t
 limits перед `HttpSyncServer::handle()`. Метрики считают вызовы middleware
 hooks, поэтому общий observer на нескольких слоях может посчитать одно
 логическое действие по одному разу на каждом слое.
+
+`sync_15_http_policy_context.cpp` показывает request-context слой, который
+конкретный HTTP server binding может запускать перед `HttpSyncServer::handle()`.
+Он извлекает bearer token из headers, проверяет remote address и возвращает
+header `Retry-After`, когда fixed-window limiter отклоняет запрос.

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -63,6 +63,7 @@ tmp/build-http-example/bin/examples/sync_13_http_simple_web_server \
 | `sync_12_transport_middleware.cpp` | Allow-list, fixed-budget, and metrics middleware around transport adapters. | Advanced |
 | `sync_13_http_simple_web_server.cpp` | Optional real HTTP binding over Simple-Web-Server and standalone Asio. | Advanced |
 | `sync_14_websocket_adapter.cpp` | Framework-neutral WebSocket binary-message seam over `TransportMessageCodec`. | Advanced |
+| `sync_15_http_policy_context.cpp` | Bearer-token, remote-address, and `Retry-After` HTTP policy context. | Advanced |
 
 ## Common Rules
 
@@ -157,3 +158,8 @@ They do not replace server-framework authentication or per-remote-client rate
 limits before `HttpSyncServer::handle()`. Metrics count middleware hook
 invocations, so a shared observer installed at several stacked layers can count
 one logical action once per layer.
+
+`sync_15_http_policy_context.cpp` shows the request-context layer a concrete
+HTTP server binding can run before `HttpSyncServer::handle()`. It extracts a
+bearer token from headers, checks the remote address, and returns a `Retry-After`
+header when the fixed-window limiter rejects a request.

--- a/examples/sync_13_http_simple_web_server.cpp
+++ b/examples/sync_13_http_simple_web_server.cpp
@@ -110,6 +110,9 @@ void write_http_response(
                     out.content_type.empty()
                         ? "text/plain; charset=utf-8"
                         : out.content_type);
+    for (std::size_t i = 0; i < out.headers.size(); ++i) {
+        headers.emplace(out.headers[i].name, out.headers[i].value);
+    }
     response->write(to_simple_status(out.status_code),
                     bytes_to_string(out.body),
                     headers);
@@ -171,6 +174,13 @@ public:
                 static_cast<unsigned>(std::atoi(
                     received->status_code.c_str()));
             out.content_type = header_value(received->header, "Content-Type");
+            for (SimpleWeb::CaseInsensitiveMultimap::const_iterator it =
+                     received->header.begin();
+                 it != received->header.end();
+                 ++it) {
+                mdbxc::sync::http_add_header(
+                    out.headers, it->first, it->second);
+            }
             out.body = string_to_bytes(received->content.string());
             return out;
         } catch (const SimpleWeb::system_error& e) {
@@ -335,26 +345,37 @@ private:
             header_value(request->header, "Content-Type");
         const std::string content = request->content.string();
 
-        const mdbxc::sync::SyncTransportDecision decision =
-            m_policy.check_http_post(request->path,
-                                     content_type,
-                                     string_to_bytes(content));
-        if (!decision.allowed) {
-            mdbxc::sync::HttpSyncResponse out;
-            out.status_code =
-                decision.status_code == 0 ? 403 : decision.status_code;
-            out.content_type = "text/plain; charset=utf-8";
-            out.error = decision.error.empty() ? "rejected" : decision.error;
-            out.body = string_to_bytes(out.error);
-            write_http_response(response, out);
-            return;
-        }
-
         mdbxc::sync::HttpSyncRequest in;
         in.method = request->method;
         in.target = request->path;
         in.content_type = content_type;
         in.body = string_to_bytes(content);
+        for (SimpleWeb::CaseInsensitiveMultimap::const_iterator it =
+                 request->header.begin();
+             it != request->header.end();
+             ++it) {
+            mdbxc::sync::http_add_header(in.headers, it->first, it->second);
+        }
+        try {
+            in.remote_address =
+                request->remote_endpoint().address().to_string();
+        } catch (...) {
+            in.remote_address.clear();
+        }
+
+        const mdbxc::sync::SyncTransportDecision decision =
+            m_policy.check_http_request(in);
+        if (!decision.allowed) {
+            mdbxc::sync::HttpSyncResponse out;
+            out.status_code =
+                decision.status_code == 0 ? 403 : decision.status_code;
+            out.content_type = "text/plain; charset=utf-8";
+            out.headers = decision.response_headers;
+            out.error = decision.error.empty() ? "rejected" : decision.error;
+            out.body = string_to_bytes(out.error);
+            write_http_response(response, out);
+            return;
+        }
 
         write_http_response(response, m_handler.handle(in));
     }

--- a/examples/sync_15_http_policy_context.cpp
+++ b/examples/sync_15_http_policy_context.cpp
@@ -1,0 +1,164 @@
+/**
+ * \ingroup mdbxc_examples
+ * \brief HTTP request-context policies around the sync adapter seam.
+ *
+ * This example shows the adapter-local policy layer that a concrete HTTP
+ * server would run before `HttpSyncServer::handle()`: bearer token extraction,
+ * remote-address allow-listing, and rate-limit rejections with `Retry-After`.
+ *
+ * Expected output:
+ *   [http policy] authorized pull delivered 1 batch(es)
+ *   [http policy] second pull rejected with Retry-After=...
+ *   OK: sync_15_http_policy_context
+ */
+
+#include "sync_example_utils.hpp"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+class ContextHttpClient : public mdbxc::sync::IHttpSyncClient {
+public:
+    ContextHttpClient(mdbxc::sync::HttpSyncServerMiddleware& server,
+                      const std::string& bearer_token,
+                      const std::string& remote_address)
+        : m_server(server),
+          m_bearer_token(bearer_token),
+          m_remote_address(remote_address) {}
+
+    mdbxc::sync::HttpSyncResponse post(
+            const std::string& target,
+            const std::string& content_type,
+            const std::vector<std::uint8_t>& body,
+            const mdbxc::sync::CancellationToken& cancel_token) override {
+        (void)cancel_token;
+
+        mdbxc::sync::HttpSyncRequest request;
+        request.method = mdbxc::sync::HttpSyncRoutes::method_post();
+        request.target = target;
+        request.content_type = content_type;
+        request.remote_address = m_remote_address;
+        request.body = body;
+        mdbxc::sync::http_add_header(
+            request.headers, "Authorization",
+            std::string("Bearer ") + m_bearer_token);
+
+        m_last_response = m_server.handle(request);
+        return m_last_response;
+    }
+
+    const mdbxc::sync::HttpSyncResponse& last_response() const {
+        return m_last_response;
+    }
+
+private:
+    mdbxc::sync::HttpSyncServerMiddleware& m_server;
+    std::string m_bearer_token;
+    std::string m_remote_address;
+    mdbxc::sync::HttpSyncResponse m_last_response;
+};
+
+} // namespace
+
+int main() {
+    const std::string primary_path = "sync_15_primary.mdbx";
+    const std::string replica_path = "sync_15_replica.mdbx";
+    sync_example::cleanup(primary_path);
+    sync_example::cleanup(replica_path);
+
+    const mdbxc::sync::NodeId primary_node =
+        sync_example::make_node(0xA4);
+    const mdbxc::sync::NodeId replica_node =
+        sync_example::make_node(0xA5);
+    const mdbxc::sync::DbId db_id =
+        sync_example::make_node(0xA6);
+
+    try {
+        std::shared_ptr<mdbxc::Connection> primary =
+            sync_example::open(primary_path);
+        std::shared_ptr<mdbxc::Connection> replica =
+            sync_example::open(replica_path);
+
+        mdbxc::sync::SyncEngine primary_engine(primary);
+        mdbxc::sync::SyncEngine replica_engine(replica);
+        primary_engine.initialize_local_identity(primary_node, db_id);
+        replica_engine.initialize_local_identity(replica_node, db_id);
+
+        mdbxc::sync::ThreadLocalChangeAccumulator capture(primary);
+        mdbxc::KeyValueTable<int, std::string> primary_ticks(primary, "ticks");
+
+        primary->attach_sync_capture(&capture);
+        primary_ticks.insert_or_assign(1, "BTC/USD");
+        primary->detach_sync_capture();
+
+        mdbxc::sync::HttpRouteAllowListPolicy routes;
+        routes.allow_target(mdbxc::sync::HttpSyncRoutes::pull_target());
+        mdbxc::sync::HttpBearerTokenPolicy bearer;
+        bearer.allow_token("demo-token");
+        mdbxc::sync::HttpRemoteAddressAllowListPolicy remotes;
+        remotes.allow_remote_address("127.0.0.1");
+        mdbxc::sync::FixedWindowHttpRateLimitPolicy rate(
+            1, std::chrono::seconds(5));
+
+        mdbxc::sync::CompositeSyncTransportPolicy policy;
+        policy.add(routes);
+        policy.add(bearer);
+        policy.add(remotes);
+        policy.add(rate);
+
+        mdbxc::sync::HttpSyncServer primary_server(primary_engine);
+        mdbxc::sync::HttpSyncServerMiddleware guarded_server(
+            primary_server, &policy);
+        ContextHttpClient raw_client(
+            guarded_server, "demo-token", "127.0.0.1");
+        mdbxc::sync::HttpSyncPeer peer(raw_client);
+
+        mdbxc::sync::PullRequest pull;
+        pull.requester = replica_node;
+        pull.db_id = db_id;
+        pull.have = replica_engine.applied_cursor();
+        pull.max_batches = 100;
+
+        const mdbxc::sync::PullResponse pulled = peer.pull(pull);
+        sync_example::require(pulled.ok,
+                              "authorized pull failed: " + pulled.error);
+        std::printf("[http policy] authorized pull delivered %zu batch(es)\n",
+                    pulled.batches.size());
+
+        bool rejected = false;
+        try {
+            (void)peer.pull(pull);
+        } catch (const std::runtime_error& e) {
+            (void)e;
+            rejected = true;
+        }
+        sync_example::require(rejected,
+                              "second pull should hit rate limit");
+
+        const std::string retry_after =
+            mdbxc::sync::http_header_value(
+                raw_client.last_response().headers, "Retry-After");
+        sync_example::require(!retry_after.empty(),
+                              "rate limit must return Retry-After");
+        std::printf("[http policy] second pull rejected with Retry-After=%s\n",
+                    retry_after.c_str());
+
+        sync_example::disconnect_and_cleanup(primary, primary_path);
+        sync_example::disconnect_and_cleanup(replica, replica_path);
+        std::printf("OK: sync_15_http_policy_context\n");
+        return 0;
+    } catch (const std::exception& e) {
+        std::printf("FAIL: %s\n", e.what());
+        sync_example::cleanup(primary_path);
+        sync_example::cleanup(replica_path);
+        return 1;
+    }
+}

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -38,8 +38,9 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
   does not open sockets, own sessions, or depend on a WebSocket framework.
 - Transport middleware helpers: `SyncPeerMiddleware`,
   `HttpSyncClientMiddleware`, allow-list policies, fixed-budget rate limiting,
-  and a metrics observer. These wrap transport adapters and do not change the
-  sync DTO wire format.
+  HTTP request-context bearer/remote-address/fixed-window policies,
+  `Retry-After`/`WWW-Authenticate` rejection headers, and a metrics observer.
+  These wrap transport adapters and do not change the sync DTO wire format.
 - Change capture hooks: `Connection::attach_sync_capture()`,
   `BaseTable::record_op()`, and the transaction pre-commit hook route table
   writes into `ThreadLocalChangeAccumulator`, which appends one local
@@ -465,10 +466,17 @@ DTO header fields (`requester`, `sender`, `db_id`) before dispatching to
 `SyncEngine`. Do not put bearer tokens, ACL decisions, or rate-limit counters
 inside the sync DTO wire format.
 
-`SyncPeerMiddleware` and `HttpSyncClientMiddleware` are the v0.1 framework-free
+`SyncPeerMiddleware`, `HttpSyncClientMiddleware`, and
+`HttpSyncServerMiddleware` are the v0.1 framework-free
 building blocks for these wrappers. `NodeDbAllowListPolicy` checks decoded
 `requester` / `sender` and `db_id` values. `HttpRouteAllowListPolicy` checks
 HTTP-shaped targets before a concrete HTTP client sends bytes.
+`HttpSyncRequest` carries adapter-local `headers` and `remote_address` fields;
+they are not serialized by `TransportMessageCodec`. `HttpBearerTokenPolicy`,
+`HttpRemoteAddressAllowListPolicy`, and `FixedWindowHttpRateLimitPolicy` run on
+that context before dispatch. Rejections may carry response headers such as
+`WWW-Authenticate` or `Retry-After`; concrete HTTP bindings must write those
+headers to the real response.
 `FixedBudgetSyncTransportPolicy` is a deterministic fixed-budget limiter useful
 for tests, examples, and simple adapters; production adapters can replace it
 with a time-window or token-bucket policy while keeping the same middleware

--- a/include/mdbx_containers/sync/HttpTransport.hpp
+++ b/include/mdbx_containers/sync/HttpTransport.hpp
@@ -24,11 +24,61 @@
 namespace mdbxc {
 namespace sync {
 
+    /// \brief One HTTP header name/value pair preserved by adapter seams.
+    struct HttpSyncHeader {
+        std::string name;
+        std::string value;
+    };
+
+    inline char http_ascii_lower(char value) {
+        return value >= 'A' && value <= 'Z'
+            ? static_cast<char>(value - 'A' + 'a')
+            : value;
+    }
+
+    /// \brief Case-insensitive ASCII comparison for HTTP header names.
+    inline bool http_header_name_equals(const std::string& lhs,
+                                        const std::string& rhs) {
+        if (lhs.size() != rhs.size()) {
+            return false;
+        }
+        for (std::size_t i = 0; i < lhs.size(); ++i) {
+            if (http_ascii_lower(lhs[i]) != http_ascii_lower(rhs[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// \brief Returns the first matching HTTP header value or an empty string.
+    inline std::string http_header_value(
+            const std::vector<HttpSyncHeader>& headers,
+            const std::string& name) {
+        for (std::size_t i = 0; i < headers.size(); ++i) {
+            if (http_header_name_equals(headers[i].name, name)) {
+                return headers[i].value;
+            }
+        }
+        return std::string();
+    }
+
+    /// \brief Appends one response/request header.
+    inline void http_add_header(std::vector<HttpSyncHeader>& headers,
+                                const std::string& name,
+                                const std::string& value) {
+        HttpSyncHeader header;
+        header.name = name;
+        header.value = value;
+        headers.push_back(header);
+    }
+
     /// \brief Minimal request shape consumed by \c HttpSyncServer.
     struct HttpSyncRequest {
         std::string method;
         std::string target;
         std::string content_type;
+        std::vector<HttpSyncHeader> headers;
+        std::string remote_address;
         std::vector<std::uint8_t> body;
     };
 
@@ -40,6 +90,7 @@ namespace sync {
     struct HttpSyncResponse {
         unsigned status_code = 200;
         std::string content_type;
+        std::vector<HttpSyncHeader> headers;
         std::vector<std::uint8_t> body;
         std::string error;
     };

--- a/include/mdbx_containers/sync/TransportMiddleware.hpp
+++ b/include/mdbx_containers/sync/TransportMiddleware.hpp
@@ -9,12 +9,15 @@
 /// add credentials to sync DTOs and do not own sockets; concrete transports can
 /// use them to enforce allow lists, fixed request budgets, and metrics hooks.
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <exception>
 #include <limits>
+#include <map>
 #include <mutex>
 #include <set>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -36,6 +39,7 @@ namespace sync {
         bool allowed = true;
         unsigned status_code = 0;
         std::string error;
+        std::vector<HttpSyncHeader> response_headers;
 
         static SyncTransportDecision allow() {
             return SyncTransportDecision();
@@ -48,6 +52,11 @@ namespace sync {
             out.status_code = status;
             out.error = message;
             return out;
+        }
+
+        void add_response_header(const std::string& name,
+                                 const std::string& value) {
+            http_add_header(response_headers, name, value);
         }
     };
 
@@ -79,7 +88,33 @@ namespace sync {
             (void)body;
             return SyncTransportDecision::allow();
         }
+
+        virtual SyncTransportDecision check_http_request(
+                const HttpSyncRequest& request) {
+            return check_http_post(request.target,
+                                   request.content_type,
+                                   request.body);
+        }
     };
+
+    /// \brief Extracts a bearer token from an HTTP sync request.
+    inline std::string http_bearer_token(const HttpSyncRequest& request) {
+        static const char scheme[] = "bearer";
+        const std::string value =
+            http_header_value(request.headers, "Authorization");
+        if (value.size() <= sizeof(scheme)) {
+            return std::string();
+        }
+        for (std::size_t i = 0; i < sizeof(scheme) - 1u; ++i) {
+            if (http_ascii_lower(value[i]) != scheme[i]) {
+                return std::string();
+            }
+        }
+        if (value[sizeof(scheme) - 1u] != ' ') {
+            return std::string();
+        }
+        return value.substr(sizeof(scheme));
+    }
 
     /// \brief Allows only configured node ids and database ids.
     /// \details Empty allow-list means "allow any" for that dimension.
@@ -170,6 +205,172 @@ namespace sync {
     private:
         mutable std::mutex m_mutex;
         std::set<std::string> m_allowed_targets;
+    };
+
+    /// \brief Allows only configured bearer tokens on HTTP sync requests.
+    /// \details Empty allow-list means every token is allowed, but a token must
+    /// still be present.
+    class HttpBearerTokenPolicy : public ISyncTransportPolicy {
+    public:
+        void allow_token(const std::string& token) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_allowed_tokens.insert(token);
+        }
+
+        void clear() {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_allowed_tokens.clear();
+        }
+
+        SyncTransportDecision check_http_request(
+                const HttpSyncRequest& request) override {
+            const std::string token = http_bearer_token(request);
+            if (token.empty()) {
+                SyncTransportDecision decision =
+                    SyncTransportDecision::reject(
+                        "sync bearer token is missing", 401);
+                decision.add_response_header(
+                    "WWW-Authenticate",
+                    "Bearer realm=\"mdbx-containers-sync\"");
+                return decision;
+            }
+
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (!m_allowed_tokens.empty() &&
+                m_allowed_tokens.find(token) == m_allowed_tokens.end()) {
+                SyncTransportDecision decision =
+                    SyncTransportDecision::reject(
+                        "sync bearer token is not allowed", 401);
+                decision.add_response_header(
+                    "WWW-Authenticate",
+                    "Bearer realm=\"mdbx-containers-sync\"");
+                return decision;
+            }
+            return SyncTransportDecision::allow();
+        }
+
+    private:
+        mutable std::mutex m_mutex;
+        std::set<std::string> m_allowed_tokens;
+    };
+
+    /// \brief Allows only configured remote addresses on HTTP sync requests.
+    /// \details Empty allow-list means every remote address is allowed.
+    class HttpRemoteAddressAllowListPolicy : public ISyncTransportPolicy {
+    public:
+        void allow_remote_address(const std::string& remote_address) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_allowed_remote_addresses.insert(remote_address);
+        }
+
+        void clear() {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_allowed_remote_addresses.clear();
+        }
+
+        SyncTransportDecision check_http_request(
+                const HttpSyncRequest& request) override {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (!m_allowed_remote_addresses.empty() &&
+                m_allowed_remote_addresses.find(request.remote_address) ==
+                    m_allowed_remote_addresses.end()) {
+                return SyncTransportDecision::reject(
+                    "sync remote address is not allowed", 403);
+            }
+            return SyncTransportDecision::allow();
+        }
+
+    private:
+        mutable std::mutex m_mutex;
+        std::set<std::string> m_allowed_remote_addresses;
+    };
+
+    /// \brief Fixed-window HTTP request limiter keyed by token or remote address.
+    /// \details Uses the bearer token when present, otherwise \c remote_address,
+    /// otherwise the literal "anonymous". Rejections include a \c Retry-After
+    /// header with the remaining window time in seconds.
+    class FixedWindowHttpRateLimitPolicy : public ISyncTransportPolicy {
+    public:
+        FixedWindowHttpRateLimitPolicy(std::uint64_t max_requests,
+                                       std::chrono::seconds window)
+            : m_max_requests(max_requests), m_window(window) {
+            if (window.count() <= 0) {
+                throw std::invalid_argument(
+                    "HTTP rate-limit window must be positive");
+            }
+        }
+
+        void clear() {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_buckets.clear();
+        }
+
+        SyncTransportDecision check_http_request(
+                const HttpSyncRequest& request) override {
+            const std::chrono::steady_clock::time_point now =
+                std::chrono::steady_clock::now();
+            const std::string identity = client_identity(request);
+
+            std::lock_guard<std::mutex> lock(m_mutex);
+            Bucket& bucket = m_buckets[identity];
+            if (bucket.reset_at == std::chrono::steady_clock::time_point() ||
+                now >= bucket.reset_at) {
+                bucket.remaining = m_max_requests;
+                bucket.reset_at = now + m_window;
+            }
+
+            if (bucket.remaining == 0) {
+                SyncTransportDecision decision =
+                    SyncTransportDecision::reject(
+                        "sync HTTP rate limit exceeded", 429);
+                decision.add_response_header(
+                    "Retry-After",
+                    retry_after_seconds(now, bucket.reset_at));
+                return decision;
+            }
+            --bucket.remaining;
+            return SyncTransportDecision::allow();
+        }
+
+    private:
+        struct Bucket {
+            Bucket() : remaining(0), reset_at() {}
+
+            std::uint64_t remaining;
+            std::chrono::steady_clock::time_point reset_at;
+        };
+
+        static std::string client_identity(const HttpSyncRequest& request) {
+            const std::string token = http_bearer_token(request);
+            if (!token.empty()) {
+                return std::string("token:") + token;
+            }
+            if (!request.remote_address.empty()) {
+                return std::string("remote:") + request.remote_address;
+            }
+            return "anonymous";
+        }
+
+        static std::string retry_after_seconds(
+                std::chrono::steady_clock::time_point now,
+                std::chrono::steady_clock::time_point reset_at) {
+            if (reset_at <= now) {
+                return "0";
+            }
+            const std::chrono::seconds seconds =
+                std::chrono::duration_cast<std::chrono::seconds>(
+                    reset_at - now);
+            const std::uint64_t count =
+                seconds.count() <= 0 ? 1u
+                                     : static_cast<std::uint64_t>(
+                                           seconds.count());
+            return std::to_string(count);
+        }
+
+        mutable std::mutex m_mutex;
+        std::uint64_t m_max_requests;
+        std::chrono::seconds m_window;
+        std::map<std::string, Bucket> m_buckets;
     };
 
     /// \brief Fixed request-budget policy for deterministic rate-limit tests.
@@ -283,6 +484,18 @@ namespace sync {
             for (std::size_t i = 0; i < m_policies.size(); ++i) {
                 const SyncTransportDecision decision =
                     m_policies[i]->check_http_post(target, content_type, body);
+                if (!decision.allowed) {
+                    return decision;
+                }
+            }
+            return SyncTransportDecision::allow();
+        }
+
+        SyncTransportDecision check_http_request(
+                const HttpSyncRequest& request) override {
+            for (std::size_t i = 0; i < m_policies.size(); ++i) {
+                const SyncTransportDecision decision =
+                    m_policies[i]->check_http_request(request);
                 if (!decision.allowed) {
                     return decision;
                 }
@@ -468,6 +681,21 @@ namespace sync {
             } catch (...) {}
         }
 
+        inline HttpSyncResponse make_http_error_response(
+                const SyncTransportDecision& decision,
+                const char* fallback) {
+            HttpSyncResponse response;
+            response.status_code =
+                decision.status_code == 0 ? 403 : decision.status_code;
+            response.content_type = "text/plain; charset=utf-8";
+            response.headers = decision.response_headers;
+            response.error = decision.error.empty()
+                ? std::string(fallback)
+                : decision.error;
+            response.body.assign(response.error.begin(), response.error.end());
+            return response;
+        }
+
     } // namespace detail
 
     /// \brief \c ISyncPeer wrapper that applies policy and observer hooks.
@@ -584,6 +812,65 @@ namespace sync {
         ISyncTransportObserver* m_observer;
     };
 
+    /// \brief \c HttpSyncServer wrapper that applies request-context policy.
+    /// \details The wrapped server must outlive the middleware. The optional
+    /// policy and observer are non-owning pointers and must also outlive the
+    /// middleware when provided.
+    class HttpSyncServerMiddleware {
+    public:
+        explicit HttpSyncServerMiddleware(
+                HttpSyncServer& next,
+                ISyncTransportPolicy* policy = nullptr,
+                ISyncTransportObserver* observer = nullptr)
+            : m_next(next),
+              m_policy(policy),
+              m_observer(observer) {}
+
+        HttpSyncResponse handle(const HttpSyncRequest& request) {
+            if (m_policy != nullptr) {
+                const SyncTransportDecision decision =
+                    m_policy->check_http_request(request);
+                if (!decision.allowed) {
+                    detail::notify_transport_rejected(
+                        m_observer, SyncTransportOperation::HttpPost,
+                        decision.error);
+                    return detail::make_http_error_response(
+                        decision, "HTTP sync request rejected");
+                }
+            }
+
+            try {
+                const HttpSyncResponse response = m_next.handle(request);
+                notify_http_post_result(request.target, response);
+                return response;
+            } catch (const std::exception& e) {
+                detail::notify_transport_exception(
+                    m_observer, SyncTransportOperation::HttpPost, e.what());
+                throw;
+            } catch (...) {
+                detail::notify_transport_exception(
+                    m_observer, SyncTransportOperation::HttpPost,
+                    "unknown HTTP server exception");
+                throw;
+            }
+        }
+
+    private:
+        void notify_http_post_result(const std::string& target,
+                                     const HttpSyncResponse& response) const {
+            if (m_observer == nullptr) {
+                return;
+            }
+            try {
+                m_observer->on_sync_transport_http_post_result(target, response);
+            } catch (...) {}
+        }
+
+        HttpSyncServer& m_next;
+        ISyncTransportPolicy* m_policy;
+        ISyncTransportObserver* m_observer;
+    };
+
     /// \brief \c IHttpSyncClient wrapper that applies route-level policy.
     /// \details The wrapped client must outlive the middleware. The optional
     /// policy and observer are non-owning pointers and must also outlive the
@@ -603,14 +890,21 @@ namespace sync {
                 const std::string& content_type,
                 const std::vector<std::uint8_t>& body,
                 const CancellationToken& cancel_token) override {
+            HttpSyncRequest request;
+            request.method = HttpSyncRoutes::method_post();
+            request.target = target;
+            request.content_type = content_type;
+            request.body = body;
+
             if (m_policy != nullptr) {
                 const SyncTransportDecision decision =
-                    m_policy->check_http_post(target, content_type, body);
+                    m_policy->check_http_request(request);
                 if (!decision.allowed) {
                     detail::notify_transport_rejected(
                         m_observer, SyncTransportOperation::HttpPost,
                         decision.error);
-                    return make_http_error(decision);
+                    return detail::make_http_error_response(
+                        decision, "HTTP sync request rejected");
                 }
             }
 
@@ -637,19 +931,6 @@ namespace sync {
         }
 
     private:
-        static HttpSyncResponse make_http_error(
-                const SyncTransportDecision& decision) {
-            HttpSyncResponse response;
-            response.status_code =
-                decision.status_code == 0 ? 403 : decision.status_code;
-            response.content_type = "text/plain; charset=utf-8";
-            response.error = decision.error.empty()
-                ? "HTTP sync request rejected"
-                : decision.error;
-            response.body.assign(response.error.begin(), response.error.end());
-            return response;
-        }
-
         void notify_http_post_result(const std::string& target,
                                      const HttpSyncResponse& response) const {
             if (m_observer == nullptr) {

--- a/tests/test_transport_middleware.cpp
+++ b/tests/test_transport_middleware.cpp
@@ -1,6 +1,10 @@
+#include <mdbx_containers.hpp>
 #include <mdbx_containers/sync.hpp>
 
+#include <chrono>
+#include <cstdio>
 #include <cstdint>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -26,6 +30,23 @@ void require_true(bool condition, const std::string& message) {
     if (!condition) {
         throw std::runtime_error(message);
     }
+}
+
+void cleanup(const std::string& path) {
+    std::remove(path.c_str());
+    std::remove((path + "-lck").c_str());
+}
+
+mdbxc::Config config(const std::string& path) {
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.no_subdir = true;
+    cfg.max_dbs = 32;
+    return cfg;
+}
+
+std::shared_ptr<mdbxc::Connection> open_db(const std::string& path) {
+    return mdbxc::Connection::create(config(path));
 }
 
 class RecordingPeer : public mdbxc::sync::ISyncPeer {
@@ -272,6 +293,112 @@ void test_http_client_middleware_budget_policy() {
                  "rate-limited HTTP post reached downstream client");
 }
 
+void test_http_context_policies() {
+    mdbxc::sync::HttpSyncRequest request;
+    request.method = mdbxc::sync::HttpSyncRoutes::method_post();
+    request.target = mdbxc::sync::HttpSyncRoutes::pull_target();
+    request.content_type = mdbxc::sync::HttpSyncRoutes::content_type();
+    request.remote_address = "127.0.0.1";
+    mdbxc::sync::http_add_header(
+        request.headers, "Authorization", "Bearer token-a");
+
+    require_true(mdbxc::sync::http_header_value(
+                     request.headers, "authorization") == "Bearer token-a",
+                 "HTTP header lookup must be case-insensitive");
+    require_true(mdbxc::sync::http_bearer_token(request) == "token-a",
+                 "bearer token extraction mismatch");
+
+    mdbxc::sync::HttpBearerTokenPolicy bearer;
+    bearer.allow_token("token-a");
+    mdbxc::sync::HttpRemoteAddressAllowListPolicy remote;
+    remote.allow_remote_address("127.0.0.1");
+    mdbxc::sync::FixedWindowHttpRateLimitPolicy rate(
+        1, std::chrono::seconds(10));
+
+    mdbxc::sync::CompositeSyncTransportPolicy policy;
+    policy.add(bearer);
+    policy.add(remote);
+    policy.add(rate);
+
+    mdbxc::sync::SyncTransportDecision decision =
+        policy.check_http_request(request);
+    require_true(decision.allowed, "allowed HTTP context was rejected");
+
+    decision = policy.check_http_request(request);
+    require_true(!decision.allowed && decision.status_code == 429,
+                 "HTTP rate limit did not reject second request");
+    require_true(mdbxc::sync::http_header_value(
+                     decision.response_headers, "Retry-After") !=
+                     std::string(),
+                 "HTTP rate-limit rejection must include Retry-After");
+
+    mdbxc::sync::HttpSyncRequest missing_token = request;
+    missing_token.headers.clear();
+    decision = bearer.check_http_request(missing_token);
+    require_true(!decision.allowed && decision.status_code == 401,
+                 "missing bearer token must be unauthorized");
+    require_true(mdbxc::sync::http_header_value(
+                     decision.response_headers, "WWW-Authenticate") !=
+                     std::string(),
+                 "bearer rejection must include WWW-Authenticate");
+
+    request.remote_address = "203.0.113.7";
+    decision = remote.check_http_request(request);
+    require_true(!decision.allowed && decision.status_code == 403,
+                 "denied remote address was not rejected");
+}
+
+void test_http_client_middleware_copies_rejection_headers() {
+    mdbxc::sync::FixedWindowHttpRateLimitPolicy rate(
+        0, std::chrono::seconds(7));
+    RecordingHttpClient client;
+    mdbxc::sync::HttpSyncClientMiddleware wrapped(client, &rate);
+
+    const std::vector<std::uint8_t> body(1u, 0x22u);
+    const mdbxc::sync::HttpSyncResponse response = wrapped.post(
+        mdbxc::sync::HttpSyncRoutes::pull_target(),
+        mdbxc::sync::HttpSyncRoutes::content_type(),
+        body,
+        mdbxc::sync::CancellationToken());
+
+    require_true(response.status_code == 429,
+                 "client middleware did not return rate-limit status");
+    require_true(mdbxc::sync::http_header_value(
+                     response.headers, "Retry-After") != std::string(),
+                 "client middleware dropped Retry-After");
+    require_true(client.post_count() == 0u,
+                 "rate-limited HTTP post reached downstream client");
+}
+
+void test_http_server_middleware_copies_rejection_headers() {
+    const std::string path = "test_transport_middleware_http_server.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<mdbxc::Connection> db = open_db(path);
+    mdbxc::sync::SyncEngine engine(db);
+    engine.initialize_local_identity(make_node(0x70), make_node(0x71));
+    mdbxc::sync::HttpSyncServer server(engine);
+    mdbxc::sync::FixedWindowHttpRateLimitPolicy rate(
+        0, std::chrono::seconds(7));
+    mdbxc::sync::HttpSyncServerMiddleware wrapped(server, &rate);
+
+    mdbxc::sync::HttpSyncRequest request;
+    request.method = mdbxc::sync::HttpSyncRoutes::method_post();
+    request.target = mdbxc::sync::HttpSyncRoutes::pull_target();
+    request.content_type = mdbxc::sync::HttpSyncRoutes::content_type();
+    request.remote_address = "127.0.0.1";
+
+    const mdbxc::sync::HttpSyncResponse response = wrapped.handle(request);
+    require_true(response.status_code == 429,
+                 "server middleware did not return rate-limit status");
+    require_true(mdbxc::sync::http_header_value(
+                     response.headers, "Retry-After") != std::string(),
+                 "server middleware dropped Retry-After");
+
+    db->disconnect();
+    cleanup(path);
+}
+
 } // namespace
 
 int main() {
@@ -279,5 +406,8 @@ int main() {
     test_observer_exceptions_are_swallowed();
     test_http_client_middleware_route_policy();
     test_http_client_middleware_budget_policy();
+    test_http_context_policies();
+    test_http_client_middleware_copies_rejection_headers();
+    test_http_server_middleware_copies_rejection_headers();
     return 0;
 }


### PR DESCRIPTION
## Summary
- carry HTTP headers and remote address through adapter-local request context
- add bearer-token, remote-address, and fixed-window HTTP rate-limit policies with `WWW-Authenticate` / `Retry-After` rejection headers
- add server-side HTTP middleware plus tests and an executable policy-context example

## Validation
- `cmake -S . -B tmp/pr109-cpp11 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_HTTP_SYNC_EXAMPLE=OFF -DCMAKE_CXX_STANDARD=11`
- `mingw32-make -C tmp/pr109-cpp11 test_transport_middleware test_http_transport header_sync_umbrella_test sync_15_http_policy_context`
- `ctest --test-dir tmp/pr109-cpp11 -R "^(test_transport_middleware|test_http_transport|header_sync_umbrella_test)$" --output-on-failure`
- `tmp/pr109-cpp11/bin/examples/sync_15_http_policy_context.exe`
- `cmake -S . -B tmp/pr109-cpp17 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_HTTP_SYNC_EXAMPLE=OFF -DCMAKE_CXX_STANDARD=17`
- `mingw32-make -C tmp/pr109-cpp17 test_transport_middleware test_http_transport header_sync_umbrella_test sync_15_http_policy_context`
- `ctest --test-dir tmp/pr109-cpp17 -R "^(test_transport_middleware|test_http_transport|header_sync_umbrella_test)$" --output-on-failure`
- `tmp/pr109-cpp17/bin/examples/sync_15_http_policy_context.exe`
- `cmake -S . -B tmp/pr109-http-cpp11 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=OFF -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_HTTP_SYNC_EXAMPLE=ON -DCMAKE_CXX_STANDARD=11`
- `mingw32-make -C tmp/pr109-http-cpp11 sync_13_http_simple_web_server`
- `tmp/pr109-http-cpp11/bin/examples/sync_13_http_simple_web_server.exe demo 127.0.0.1 18084`
- `cmake -S . -B tmp/pr109-http-cpp17 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=OFF -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_HTTP_SYNC_EXAMPLE=ON -DCMAKE_CXX_STANDARD=17`
- `mingw32-make -C tmp/pr109-http-cpp17 sync_13_http_simple_web_server`
- `tmp/pr109-http-cpp17/bin/examples/sync_13_http_simple_web_server.exe demo 127.0.0.1 18085`

Stacked on PR #108.
