### PR TITLE
feat(sync): define transport identity policy

### DIFF
--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -38,7 +38,8 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
   does not open sockets, own sessions, or depend on a WebSocket framework.
 - Transport middleware helpers: `SyncPeerMiddleware`,
   `HttpSyncClientMiddleware`, allow-list policies, fixed-budget rate limiting,
-  HTTP request-context bearer/remote-address/fixed-window policies,
+  HTTP request-context bearer/remote-address/fixed-window policies, bearer
+  token to `NodeId` binding, HTTP retry status classification,
   `Retry-After`/`WWW-Authenticate` rejection headers, and a metrics observer.
   These wrap transport adapters and do not change the sync DTO wire format.
 - Change capture hooks: `Connection::attach_sync_capture()`,
@@ -473,10 +474,19 @@ building blocks for these wrappers. `NodeDbAllowListPolicy` checks decoded
 HTTP-shaped targets before a concrete HTTP client sends bytes.
 `HttpSyncRequest` carries adapter-local `headers` and `remote_address` fields;
 they are not serialized by `TransportMessageCodec`. `HttpBearerTokenPolicy`,
-`HttpRemoteAddressAllowListPolicy`, and `FixedWindowHttpRateLimitPolicy` run on
-that context before dispatch. Rejections may carry response headers such as
-`WWW-Authenticate` or `Retry-After`; concrete HTTP bindings must write those
-headers to the real response.
+`HttpBearerNodeIdentityPolicy`, `HttpRemoteAddressAllowListPolicy`, and
+`FixedWindowHttpRateLimitPolicy` run on that context before dispatch.
+`HttpBearerNodeIdentityPolicy` is the v0.1 authenticated-identity contract:
+the bearer token maps to one `NodeId`; a pull request is allowed only when
+`PullRequest::requester` matches that authenticated node, and a push request is
+allowed only when `PushRequest::sender` matches that authenticated node.
+Optional per-token DB allow-lists validate `db_id` before dispatch. Empty
+per-token DB allow-list means the token may access any `db_id`. This keeps the
+sync DTOs self-describing while preventing a transport principal from claiming
+another node id inside the binary payload.
+Rejections may carry response headers such as `WWW-Authenticate` or
+`Retry-After`; concrete HTTP bindings must write those headers to the real
+response.
 `FixedBudgetSyncTransportPolicy` is a deterministic fixed-budget limiter useful
 for tests, examples, and simple adapters; production adapters can replace it
 with a time-window or token-bucket policy while keeping the same middleware
@@ -492,6 +502,16 @@ For WebSocket, decoded DTO policy can wrap `WebSocketSyncPeer` through
 `SyncPeerMiddleware`; per-session authentication, remote address checks,
 backpressure, and rate limits remain binding-local before
 `WebSocketSyncServer::handle_binary_message()`.
+
+Transport retry classification is adapter-level. HTTP 2xx means transport
+success; the decoded sync response still needs its own `ok/error` handling.
+HTTP `408`, `425`, `429`, `500`, `502`, `503`, and `504` are retryable
+transport statuses by default. Auth, authorization, routing, content-type,
+payload-size, and malformed-body errors (`400`, `401`, `403`, `404`, `405`,
+`413`, `415`) are permanent for the current request unless a higher-level
+adapter refreshes credentials or changes the request. `Retry-After` is advisory
+transport metadata; `SyncWorker` backoff remains the core retry loop for failed
+sync rounds.
 
 `ChangeBatchCodec` already rejects `BATCH_COMPRESSED_ZSTD` at both
 encode and decode paths. Adding a real `zstd` backend is a codec

--- a/include/mdbx_containers/sync/TransportMiddleware.hpp
+++ b/include/mdbx_containers/sync/TransportMiddleware.hpp
@@ -34,6 +34,41 @@ namespace sync {
         HttpPost
     };
 
+    /// \brief Retry classification for adapter-level HTTP failures.
+    enum class HttpSyncRetryClass : std::uint8_t {
+        Success,
+        Retryable,
+        Permanent
+    };
+
+    /// \brief Classifies HTTP status codes for sync transport retry policy.
+    /// \details This helper classifies transport-level response status only.
+    /// Sync DTO responses with HTTP 200 still carry their own \c ok/error
+    /// fields and must be handled by the caller.
+    inline HttpSyncRetryClass classify_http_sync_status(unsigned status_code) {
+        if (status_code >= 200 && status_code < 300) {
+            return HttpSyncRetryClass::Success;
+        }
+        switch (status_code) {
+            case 408:
+            case 425:
+            case 429:
+            case 500:
+            case 502:
+            case 503:
+            case 504:
+                return HttpSyncRetryClass::Retryable;
+            default:
+                return HttpSyncRetryClass::Permanent;
+        }
+    }
+
+    /// \brief Returns true when an HTTP sync status is retryable.
+    inline bool http_sync_status_is_retryable(unsigned status_code) {
+        return classify_http_sync_status(status_code) ==
+               HttpSyncRetryClass::Retryable;
+    }
+
     /// \brief Result returned by a transport policy.
     struct SyncTransportDecision {
         bool allowed = true;
@@ -252,6 +287,147 @@ namespace sync {
     private:
         mutable std::mutex m_mutex;
         std::set<std::string> m_allowed_tokens;
+    };
+
+    /// \brief Binds HTTP bearer tokens to sync \c NodeId values.
+    /// \details This policy enforces the production-facing identity contract:
+    /// the authenticated bearer principal must match
+    /// \c PullRequest::requester for pull and \c PushRequest::sender for push.
+    /// Optional per-token DB allow-lists validate \c db_id before dispatch.
+    /// Empty per-token DB allow-list means any \c db_id is allowed for that
+    /// token. The policy decodes request DTOs only after the bearer token is
+    /// accepted; adapter-local headers and remote addresses are not serialized.
+    class HttpBearerNodeIdentityPolicy : public ISyncTransportPolicy {
+    public:
+        explicit HttpBearerNodeIdentityPolicy(
+                const CodecBounds& bounds = CodecBounds())
+            : m_bounds(bounds) {}
+
+        void allow_token_for_node(const std::string& token,
+                                  const NodeId& node_id) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            Binding& binding = m_bindings[token];
+            binding.node_id = node_id;
+        }
+
+        void allow_db_id_for_token(const std::string& token,
+                                   const DbId& db_id) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            std::map<std::string, Binding>::iterator it =
+                m_bindings.find(token);
+            if (it == m_bindings.end()) {
+                throw std::invalid_argument(
+                    "sync bearer token identity is not registered");
+            }
+            it->second.allowed_dbs.insert(db_id);
+        }
+
+        void clear() {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_bindings.clear();
+        }
+
+        SyncTransportDecision check_http_request(
+                const HttpSyncRequest& request) override {
+            const std::string token = http_bearer_token(request);
+            if (token.empty()) {
+                return unauthorized("sync bearer token is missing");
+            }
+
+            Binding binding;
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                std::map<std::string, Binding>::const_iterator it =
+                    m_bindings.find(token);
+                if (it == m_bindings.end()) {
+                    return unauthorized(
+                        "sync bearer token identity is not allowed");
+                }
+                binding = it->second;
+            }
+
+            if (request.content_type != HttpSyncRoutes::content_type()) {
+                return SyncTransportDecision::allow();
+            }
+            if (request.target == HttpSyncRoutes::pull_target()) {
+                return check_pull_identity(request.body, binding);
+            }
+            if (request.target == HttpSyncRoutes::push_target()) {
+                return check_push_identity(request.body, binding);
+            }
+            return SyncTransportDecision::allow();
+        }
+
+    private:
+        struct Binding {
+            NodeId node_id{};
+            std::set<DbId> allowed_dbs;
+        };
+
+        static SyncTransportDecision unauthorized(
+                const std::string& message) {
+            SyncTransportDecision decision =
+                SyncTransportDecision::reject(message, 401);
+            decision.add_response_header(
+                "WWW-Authenticate",
+                "Bearer realm=\"mdbx-containers-sync\"");
+            return decision;
+        }
+
+        SyncTransportDecision check_pull_identity(
+                const std::vector<std::uint8_t>& body,
+                const Binding& binding) const {
+            try {
+                const PullRequest request =
+                    TransportMessageCodec::decode_pull_request(
+                        body, &m_bounds);
+                if (request.requester != binding.node_id) {
+                    return SyncTransportDecision::reject(
+                        "sync requester does not match authenticated node",
+                        403);
+                }
+                return check_db(binding, request.db_id);
+            } catch (const std::length_error& e) {
+                return SyncTransportDecision::reject(e.what(), 413);
+            } catch (const std::exception& e) {
+                return SyncTransportDecision::reject(e.what(), 400);
+            }
+        }
+
+        SyncTransportDecision check_push_identity(
+                const std::vector<std::uint8_t>& body,
+                const Binding& binding) const {
+            try {
+                const PushRequest request =
+                    TransportMessageCodec::decode_push_request(
+                        body, &m_bounds);
+                if (request.sender != binding.node_id) {
+                    return SyncTransportDecision::reject(
+                        "sync sender does not match authenticated node",
+                        403);
+                }
+                return check_db(binding, request.db_id);
+            } catch (const std::length_error& e) {
+                return SyncTransportDecision::reject(e.what(), 413);
+            } catch (const std::exception& e) {
+                return SyncTransportDecision::reject(e.what(), 400);
+            }
+        }
+
+        static SyncTransportDecision check_db(const Binding& binding,
+                                              const DbId& db_id) {
+            if (!binding.allowed_dbs.empty() &&
+                binding.allowed_dbs.find(db_id) ==
+                    binding.allowed_dbs.end()) {
+                return SyncTransportDecision::reject(
+                    "sync db_id is not allowed for authenticated node", 403);
+            }
+            return SyncTransportDecision::allow();
+        }
+
+        mutable std::mutex m_mutex;
+        CodecBounds m_bounds;
+        std::map<std::string, Binding> m_bindings;
     };
 
     /// \brief Allows only configured remote addresses on HTTP sync requests.

--- a/tests/test_transport_middleware.cpp
+++ b/tests/test_transport_middleware.cpp
@@ -348,6 +348,86 @@ void test_http_context_policies() {
                  "denied remote address was not rejected");
 }
 
+void test_http_bearer_node_identity_policy() {
+    const mdbxc::sync::NodeId node_a = make_node(0x11);
+    const mdbxc::sync::NodeId node_b = make_node(0x22);
+    const mdbxc::sync::DbId db_a = make_node(0xD1);
+    const mdbxc::sync::DbId db_b = make_node(0xD2);
+
+    mdbxc::sync::HttpBearerNodeIdentityPolicy policy;
+    policy.allow_token_for_node("token-a", node_a);
+    policy.allow_db_id_for_token("token-a", db_a);
+
+    mdbxc::sync::PullRequest pull;
+    pull.requester = node_a;
+    pull.db_id = db_a;
+
+    mdbxc::sync::HttpSyncRequest request;
+    request.method = mdbxc::sync::HttpSyncRoutes::method_post();
+    request.target = mdbxc::sync::HttpSyncRoutes::pull_target();
+    request.content_type = mdbxc::sync::HttpSyncRoutes::content_type();
+    request.body = mdbxc::sync::TransportMessageCodec::encode_pull_request(
+        pull);
+    mdbxc::sync::http_add_header(
+        request.headers, "Authorization", "Bearer token-a");
+
+    mdbxc::sync::SyncTransportDecision decision =
+        policy.check_http_request(request);
+    require_true(decision.allowed,
+                 "matching bearer identity was rejected");
+
+    pull.requester = node_b;
+    request.body = mdbxc::sync::TransportMessageCodec::encode_pull_request(
+        pull);
+    decision = policy.check_http_request(request);
+    require_true(!decision.allowed && decision.status_code == 403,
+                 "requester mismatch was not rejected");
+
+    pull.requester = node_a;
+    pull.db_id = db_b;
+    request.body = mdbxc::sync::TransportMessageCodec::encode_pull_request(
+        pull);
+    decision = policy.check_http_request(request);
+    require_true(!decision.allowed && decision.status_code == 403,
+                 "db_id mismatch was not rejected");
+
+    mdbxc::sync::PushRequest push;
+    push.sender = node_b;
+    push.db_id = db_a;
+    request.target = mdbxc::sync::HttpSyncRoutes::push_target();
+    request.body = mdbxc::sync::TransportMessageCodec::encode_push_request(
+        push);
+    decision = policy.check_http_request(request);
+    require_true(!decision.allowed && decision.status_code == 403,
+                 "sender mismatch was not rejected");
+
+    request.headers.clear();
+    push.sender = node_a;
+    request.body = mdbxc::sync::TransportMessageCodec::encode_push_request(
+        push);
+    decision = policy.check_http_request(request);
+    require_true(!decision.allowed && decision.status_code == 401,
+                 "missing bearer identity was not rejected");
+    require_true(mdbxc::sync::http_header_value(
+                     decision.response_headers, "WWW-Authenticate") !=
+                     std::string(),
+                 "identity rejection must include WWW-Authenticate");
+}
+
+void test_http_retry_status_classification() {
+    require_true(mdbxc::sync::classify_http_sync_status(200) ==
+                     mdbxc::sync::HttpSyncRetryClass::Success,
+                 "HTTP 200 must be success");
+    require_true(mdbxc::sync::http_sync_status_is_retryable(429),
+                 "HTTP 429 must be retryable");
+    require_true(mdbxc::sync::http_sync_status_is_retryable(503),
+                 "HTTP 503 must be retryable");
+    require_true(!mdbxc::sync::http_sync_status_is_retryable(401),
+                 "HTTP 401 must be permanent");
+    require_true(!mdbxc::sync::http_sync_status_is_retryable(413),
+                 "HTTP 413 must be permanent");
+}
+
 void test_http_client_middleware_copies_rejection_headers() {
     mdbxc::sync::FixedWindowHttpRateLimitPolicy rate(
         0, std::chrono::seconds(7));
@@ -407,6 +487,8 @@ int main() {
     test_http_client_middleware_route_policy();
     test_http_client_middleware_budget_policy();
     test_http_context_policies();
+    test_http_bearer_node_identity_policy();
+    test_http_retry_status_classification();
     test_http_client_middleware_copies_rejection_headers();
     test_http_server_middleware_copies_rejection_headers();
     return 0;

--- a/tests/test_transport_middleware.cpp
+++ b/tests/test_transport_middleware.cpp
@@ -414,6 +414,45 @@ void test_http_bearer_node_identity_policy() {
                  "identity rejection must include WWW-Authenticate");
 }
 
+void test_http_bearer_node_identity_policy_rejects_invalid_body() {
+    const mdbxc::sync::NodeId node = make_node(0x33);
+    const mdbxc::sync::DbId db_id = make_node(0xD3);
+
+    mdbxc::sync::CodecBounds bounds;
+    bounds.max_transport_message_bytes = 8;
+
+    mdbxc::sync::HttpBearerNodeIdentityPolicy bounded_policy(bounds);
+    bounded_policy.allow_token_for_node("token-a", node);
+    bounded_policy.allow_db_id_for_token("token-a", db_id);
+
+    mdbxc::sync::HttpSyncRequest request;
+    request.method = mdbxc::sync::HttpSyncRoutes::method_post();
+    request.target = mdbxc::sync::HttpSyncRoutes::pull_target();
+    request.content_type = mdbxc::sync::HttpSyncRoutes::content_type();
+    mdbxc::sync::http_add_header(
+        request.headers, "Authorization", "Bearer token-a");
+
+    const std::uint8_t malformed_byte_1 = 0x01;
+    const std::uint8_t malformed_byte_2 = 0x02;
+    request.body.push_back(malformed_byte_1);
+    request.body.push_back(malformed_byte_2);
+
+    mdbxc::sync::SyncTransportDecision decision =
+        bounded_policy.check_http_request(request);
+    require_true(!decision.allowed && decision.status_code == 400,
+                 "malformed pull body was not rejected as HTTP 400");
+
+    mdbxc::sync::PullRequest pull;
+    pull.requester = node;
+    pull.db_id = db_id;
+    request.body = mdbxc::sync::TransportMessageCodec::encode_pull_request(
+        pull);
+
+    decision = bounded_policy.check_http_request(request);
+    require_true(!decision.allowed && decision.status_code == 413,
+                 "oversized pull body was not rejected as HTTP 413");
+}
+
 void test_http_retry_status_classification() {
     require_true(mdbxc::sync::classify_http_sync_status(200) ==
                      mdbxc::sync::HttpSyncRetryClass::Success,
@@ -488,6 +527,7 @@ int main() {
     test_http_client_middleware_budget_policy();
     test_http_context_policies();
     test_http_bearer_node_identity_policy();
+    test_http_bearer_node_identity_policy_rejects_invalid_body();
     test_http_retry_status_classification();
     test_http_client_middleware_copies_rejection_headers();
     test_http_server_middleware_copies_rejection_headers();


### PR DESCRIPTION
## Summary
- add HTTP bearer-token to NodeId identity policy for pull requester / push sender validation
- add optional per-token db_id allow-list validation before dispatch
- add HTTP retry status classification helpers and document the transport contract

## Verification
- C++17 MinGW: configure, build test_transport_middleware, run ctest -R test_transport_middleware
- C++11 MinGW: configure, build test_transport_middleware, run ctest -R test_transport_middleware
