### PR TITLE
feat(sync): add WebSocket identity middleware

### DIFF
--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -194,5 +194,6 @@ primary аутентифицирует bearer token как `NodeId` replica пе
 
 `sync_17_websocket_simple_web_server.cpp` - socket-backed WebSocket-вариант.
 Он связывает `WebSocketSyncPeer` / `WebSocketSyncServer` с
-Simple-WebSocket-Server, отправляет binary frames и проверяет bearer token во
-время WebSocket handshake.
+Simple-WebSocket-Server, отправляет binary frames, проверяет bearer token во
+время WebSocket handshake и передаёт аутентифицированный `NodeId` replica в
+`WebSocketSyncServerMiddleware` перед dispatch.

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -190,5 +190,6 @@ before `HttpSyncServer` dispatches the request.
 
 `sync_17_websocket_simple_web_server.cpp` is the socket-backed WebSocket
 counterpart. It binds `WebSocketSyncPeer` / `WebSocketSyncServer` to
-Simple-WebSocket-Server, sends binary frames, and checks the bearer token during
-the WebSocket handshake.
+Simple-WebSocket-Server, sends binary frames, checks the bearer token during
+the WebSocket handshake, and passes the authenticated replica `NodeId` to
+`WebSocketSyncServerMiddleware` before dispatch.

--- a/examples/sync_17_websocket_simple_web_server.cpp
+++ b/examples/sync_17_websocket_simple_web_server.cpp
@@ -300,8 +300,11 @@ public:
                     connection->send(bytes_to_string(response),
                                      nullptr,
                                      kBinaryFrameOpcode);
+                } catch (const mdbxc::sync::WebSocketSyncRejected& e) {
+                    connection->send_close(
+                        static_cast<int>(e.close_code()), e.what());
                 } catch (const std::exception& e) {
-                    connection->send_close(1008, e.what());
+                    connection->send_close(1011, e.what());
                 }
             };
 

--- a/examples/sync_17_websocket_simple_web_server.cpp
+++ b/examples/sync_17_websocket_simple_web_server.cpp
@@ -248,12 +248,17 @@ private:
 
 class SimpleWebSocketSyncListener {
 public:
-    SimpleWebSocketSyncListener(mdbxc::sync::WebSocketSyncServer& server,
-                                const std::string& bearer_token,
-                                const std::string& host,
-                                std::uint16_t port)
+    SimpleWebSocketSyncListener(
+            mdbxc::sync::WebSocketSyncServerMiddleware& server,
+            const std::string& bearer_token,
+            const mdbxc::sync::NodeId& authenticated_node,
+            const mdbxc::sync::DbId& allowed_db,
+            const std::string& host,
+            std::uint16_t port)
         : m_server(server),
           m_bearer_token(bearer_token),
+          m_authenticated_node(authenticated_node),
+          m_allowed_db(allowed_db),
           m_host(host),
           m_port(port),
           m_running(false) {
@@ -284,9 +289,14 @@ public:
                 std::shared_ptr<WsServer::Connection> connection,
                 std::shared_ptr<WsServer::InMessage> in_message) {
                 try {
+                    mdbxc::sync::WebSocketSyncRequestContext context;
+                    context.has_authenticated_node = true;
+                    context.authenticated_node = m_authenticated_node;
+                    context.allowed_dbs.insert(m_allowed_db);
+                    context.binary_message =
+                        string_to_bytes(in_message->string());
                     const std::vector<std::uint8_t> response =
-                        m_server.handle_binary_message(
-                            string_to_bytes(in_message->string()));
+                        m_server.handle_binary_message(context);
                     connection->send(bytes_to_string(response),
                                      nullptr,
                                      kBinaryFrameOpcode);
@@ -362,8 +372,10 @@ public:
     }
 
 private:
-    mdbxc::sync::WebSocketSyncServer& m_server;
+    mdbxc::sync::WebSocketSyncServerMiddleware& m_server;
     std::string m_bearer_token;
+    mdbxc::sync::NodeId m_authenticated_node;
+    mdbxc::sync::DbId m_allowed_db;
     std::string m_host;
     std::uint16_t m_port;
     WsServer m_ws;
@@ -432,8 +444,11 @@ int main() {
         seed_primary_rows(primary);
 
         mdbxc::sync::WebSocketSyncServer ws_server(primary_engine);
+        mdbxc::sync::WebSocketAuthenticatedNodeIdentityPolicy ws_identity;
+        mdbxc::sync::WebSocketSyncServerMiddleware ws_middleware(
+            ws_server, &ws_identity);
         SimpleWebSocketSyncListener listener(
-            ws_server, bearer_token, host, port);
+            ws_middleware, bearer_token, replica_node, db_id, host, port);
         listener.start();
 
         SimpleWebSocketSyncChannel channel(host, port, bearer_token);

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -514,7 +514,9 @@ token, cookie, mTLS principal, or remote address stays outside the sync DTO;
 authenticated `NodeId`, optional per-session DB allow-list, and one complete
 binary message. It then requires `PullRequest::requester` or
 `PushRequest::sender` to match that authenticated node before dispatching to
-`WebSocketSyncServer`.
+`WebSocketSyncServer`. `WebSocketSyncServerMiddleware` preserves policy close
+codes by throwing `WebSocketSyncRejected`; concrete bindings should catch it
+and send `close_code()` as the WebSocket close frame status.
 Backpressure, reconnects, ping/pong, and pre-DTO rate limits remain
 binding-local.
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -42,8 +42,9 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
   dependencies.
 - Transport middleware helpers: `SyncPeerMiddleware`,
   `HttpSyncClientMiddleware`, allow-list policies, fixed-budget rate limiting,
-  HTTP request-context bearer/remote-address/fixed-window policies, bearer
-  token to `NodeId` binding, HTTP retry status classification,
+  HTTP request-context bearer/remote-address/fixed-window policies,
+  WebSocket session identity policy, bearer token to `NodeId` binding,
+  HTTP retry status classification,
   `Retry-After`/`WWW-Authenticate` rejection headers, and a metrics observer.
   These wrap transport adapters and do not change the sync DTO wire format.
 - Change capture hooks: `Connection::attach_sync_capture()`,
@@ -505,9 +506,17 @@ count middleware hook invocations: if one observer is installed at both the
 peer layer and HTTP client layer, a forwarded `request_cancel()` can be counted
 once per layer.
 For WebSocket, decoded DTO policy can wrap `WebSocketSyncPeer` through
-`SyncPeerMiddleware`; per-session authentication, remote address checks,
-backpressure, and rate limits remain binding-local before
-`WebSocketSyncServer::handle_binary_message()`.
+`SyncPeerMiddleware`. Server-side bindings can pass a
+`WebSocketSyncRequestContext` to `WebSocketSyncServerMiddleware` after the
+concrete WebSocket framework authenticates the session. The framework-specific
+token, cookie, mTLS principal, or remote address stays outside the sync DTO;
+`WebSocketAuthenticatedNodeIdentityPolicy` receives only the resulting
+authenticated `NodeId`, optional per-session DB allow-list, and one complete
+binary message. It then requires `PullRequest::requester` or
+`PushRequest::sender` to match that authenticated node before dispatching to
+`WebSocketSyncServer`.
+Backpressure, reconnects, ping/pong, and pre-DTO rate limits remain
+binding-local.
 
 Transport retry classification is adapter-level. HTTP 2xx means transport
 success; the decoded sync response still needs its own `ok/error` handling.

--- a/include/mdbx_containers/sync/TransportMiddleware.hpp
+++ b/include/mdbx_containers/sync/TransportMiddleware.hpp
@@ -23,6 +23,7 @@
 
 #include "HttpTransport.hpp"
 #include "ISyncPeer.hpp"
+#include "WebSocketTransport.hpp"
 
 namespace mdbxc {
 namespace sync {
@@ -31,7 +32,8 @@ namespace sync {
     enum class SyncTransportOperation : std::uint8_t {
         Pull,
         Push,
-        HttpPost
+        HttpPost,
+        WebSocketMessage
     };
 
     /// \brief Retry classification for adapter-level HTTP failures.
@@ -95,6 +97,18 @@ namespace sync {
         }
     };
 
+    /// \brief Adapter-local context for one WebSocket sync message.
+    /// \details Concrete WebSocket bindings authenticate the session during
+    /// handshake or with framework-specific metadata, then pass the resulting
+    /// node identity here before dispatching the binary sync message. The
+    /// identity and DB allow-list are not serialized in the sync DTO.
+    struct WebSocketSyncRequestContext {
+        bool has_authenticated_node = false;
+        NodeId authenticated_node{};
+        std::set<DbId> allowed_dbs;
+        std::vector<std::uint8_t> binary_message;
+    };
+
     /// \brief Policy hook for sync transport requests.
     /// \details Default methods allow every request. Implementations may
     /// inspect DTO metadata, route names, or message sizes before forwarding.
@@ -129,6 +143,12 @@ namespace sync {
             return check_http_post(request.target,
                                    request.content_type,
                                    request.body);
+        }
+
+        virtual SyncTransportDecision check_websocket_message(
+                const WebSocketSyncRequestContext& request) {
+            (void)request;
+            return SyncTransportDecision::allow();
         }
     };
 
@@ -430,6 +450,95 @@ namespace sync {
         std::map<std::string, Binding> m_bindings;
     };
 
+    /// \brief Binds a WebSocket session identity to sync \c NodeId values.
+    /// \details Concrete WebSocket bindings should authenticate the session
+    /// before constructing \c WebSocketSyncRequestContext. This policy then
+    /// decodes the binary DTO and requires \c PullRequest::requester or
+    /// \c PushRequest::sender to match the authenticated session node.
+    /// Optional per-session DB allow-lists validate \c db_id before dispatch.
+    /// Empty \c allowed_dbs means the authenticated session may access any
+    /// \c db_id. For WebSocket bindings, \c SyncTransportDecision::status_code
+    /// may be interpreted as a WebSocket close code by the concrete adapter.
+    class WebSocketAuthenticatedNodeIdentityPolicy
+        : public ISyncTransportPolicy {
+    public:
+        explicit WebSocketAuthenticatedNodeIdentityPolicy(
+                const CodecBounds& bounds = CodecBounds())
+            : m_bounds(bounds) {}
+
+        SyncTransportDecision check_websocket_message(
+                const WebSocketSyncRequestContext& request) override {
+            if (!request.has_authenticated_node) {
+                return SyncTransportDecision::reject(
+                    "sync WebSocket authenticated node is missing", 1008);
+            }
+
+            try {
+                const TransportMessageType type =
+                    TransportMessageCodec::peek_message_type(
+                        request.binary_message, &m_bounds);
+                switch (type) {
+                    case TransportMessageType::PullRequest:
+                        return check_pull_identity(request);
+                    case TransportMessageType::PushRequest:
+                        return check_push_identity(request);
+                    case TransportMessageType::PullResponse:
+                    case TransportMessageType::PushResponse:
+                        return SyncTransportDecision::reject(
+                            "sync WebSocket server received response message",
+                            1008);
+                }
+            } catch (const std::length_error& e) {
+                return SyncTransportDecision::reject(e.what(), 1009);
+            } catch (const std::exception& e) {
+                return SyncTransportDecision::reject(e.what(), 1007);
+            }
+            return SyncTransportDecision::reject(
+                "Unexpected WebSocket sync message type", 1008);
+        }
+
+    private:
+        SyncTransportDecision check_pull_identity(
+                const WebSocketSyncRequestContext& context) const {
+            const PullRequest request =
+                TransportMessageCodec::decode_pull_request(
+                    context.binary_message, &m_bounds);
+            if (request.requester != context.authenticated_node) {
+                return SyncTransportDecision::reject(
+                    "sync requester does not match authenticated WebSocket node",
+                    1008);
+            }
+            return check_db(context.allowed_dbs, request.db_id);
+        }
+
+        SyncTransportDecision check_push_identity(
+                const WebSocketSyncRequestContext& context) const {
+            const PushRequest request =
+                TransportMessageCodec::decode_push_request(
+                    context.binary_message, &m_bounds);
+            if (request.sender != context.authenticated_node) {
+                return SyncTransportDecision::reject(
+                    "sync sender does not match authenticated WebSocket node",
+                    1008);
+            }
+            return check_db(context.allowed_dbs, request.db_id);
+        }
+
+        static SyncTransportDecision check_db(
+                const std::set<DbId>& allowed_dbs,
+                const DbId& db_id) {
+            if (!allowed_dbs.empty() &&
+                allowed_dbs.find(db_id) == allowed_dbs.end()) {
+                return SyncTransportDecision::reject(
+                    "sync db_id is not allowed for authenticated WebSocket node",
+                    1008);
+            }
+            return SyncTransportDecision::allow();
+        }
+
+        CodecBounds m_bounds;
+    };
+
     /// \brief Allows only configured remote addresses on HTTP sync requests.
     /// \details Empty allow-list means every remote address is allowed.
     class HttpRemoteAddressAllowListPolicy : public ISyncTransportPolicy {
@@ -672,6 +781,18 @@ namespace sync {
             for (std::size_t i = 0; i < m_policies.size(); ++i) {
                 const SyncTransportDecision decision =
                     m_policies[i]->check_http_request(request);
+                if (!decision.allowed) {
+                    return decision;
+                }
+            }
+            return SyncTransportDecision::allow();
+        }
+
+        SyncTransportDecision check_websocket_message(
+                const WebSocketSyncRequestContext& request) override {
+            for (std::size_t i = 0; i < m_policies.size(); ++i) {
+                const SyncTransportDecision decision =
+                    m_policies[i]->check_websocket_message(request);
                 if (!decision.allowed) {
                     return decision;
                 }
@@ -1043,6 +1164,62 @@ namespace sync {
         }
 
         HttpSyncServer& m_next;
+        ISyncTransportPolicy* m_policy;
+        ISyncTransportObserver* m_observer;
+    };
+
+    /// \brief \c WebSocketSyncServer wrapper that applies session policy.
+    /// \details The wrapped server must outlive the middleware. Concrete
+    /// WebSocket bindings provide an adapter-local request context containing
+    /// the authenticated session node and one complete binary sync message.
+    class WebSocketSyncServerMiddleware {
+    public:
+        explicit WebSocketSyncServerMiddleware(
+                WebSocketSyncServer& next,
+                ISyncTransportPolicy* policy = nullptr,
+                ISyncTransportObserver* observer = nullptr)
+            : m_next(next),
+              m_policy(policy),
+              m_observer(observer) {}
+
+        std::vector<std::uint8_t> handle_binary_message(
+                const WebSocketSyncRequestContext& request) {
+            if (m_policy != nullptr) {
+                const SyncTransportDecision decision =
+                    m_policy->check_websocket_message(request);
+                if (!decision.allowed) {
+                    detail::notify_transport_rejected(
+                        m_observer, SyncTransportOperation::WebSocketMessage,
+                        decision.error);
+                    throw std::runtime_error(reject_message(
+                        decision, "WebSocket sync request rejected"));
+                }
+            }
+
+            try {
+                return m_next.handle_binary_message(request.binary_message);
+            } catch (const std::exception& e) {
+                detail::notify_transport_exception(
+                    m_observer, SyncTransportOperation::WebSocketMessage,
+                    e.what());
+                throw;
+            } catch (...) {
+                detail::notify_transport_exception(
+                    m_observer, SyncTransportOperation::WebSocketMessage,
+                    "unknown WebSocket server exception");
+                throw;
+            }
+        }
+
+    private:
+        static std::string reject_message(
+                const SyncTransportDecision& decision,
+                const char* fallback) {
+            return decision.error.empty() ? std::string(fallback)
+                                          : decision.error;
+        }
+
+        WebSocketSyncServer& m_next;
         ISyncTransportPolicy* m_policy;
         ISyncTransportObserver* m_observer;
     };

--- a/include/mdbx_containers/sync/TransportMiddleware.hpp
+++ b/include/mdbx_containers/sync/TransportMiddleware.hpp
@@ -539,6 +539,26 @@ namespace sync {
         CodecBounds m_bounds;
     };
 
+    /// \brief WebSocket policy rejection with a concrete close code.
+    /// \details Server-side WebSocket bindings should catch this exception and
+    /// send \c close_code() as the WebSocket close frame status. Other
+    /// exceptions from the binding or server path usually map to an internal
+    /// server error close code such as 1011.
+    class WebSocketSyncRejected : public std::runtime_error {
+    public:
+        WebSocketSyncRejected(unsigned close_code,
+                              const std::string& message)
+            : std::runtime_error(message),
+              m_close_code(close_code) {}
+
+        unsigned close_code() const {
+            return m_close_code;
+        }
+
+    private:
+        unsigned m_close_code;
+    };
+
     /// \brief Allows only configured remote addresses on HTTP sync requests.
     /// \details Empty allow-list means every remote address is allowed.
     class HttpRemoteAddressAllowListPolicy : public ISyncTransportPolicy {
@@ -1191,13 +1211,18 @@ namespace sync {
                     detail::notify_transport_rejected(
                         m_observer, SyncTransportOperation::WebSocketMessage,
                         decision.error);
-                    throw std::runtime_error(reject_message(
-                        decision, "WebSocket sync request rejected"));
+                    throw WebSocketSyncRejected(
+                        decision.status_code == 0 ? 1008
+                                                  : decision.status_code,
+                        reject_message(
+                            decision, "WebSocket sync request rejected"));
                 }
             }
 
             try {
                 return m_next.handle_binary_message(request.binary_message);
+            } catch (const WebSocketSyncRejected&) {
+                throw;
             } catch (const std::exception& e) {
                 detail::notify_transport_exception(
                     m_observer, SyncTransportOperation::WebSocketMessage,

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -63,6 +63,9 @@ int main() {
     mdbxc::sync::WebSocketAuthenticatedNodeIdentityPolicy websocket_policy;
     MDBXC_TEST_ASSERT(
         websocket_policy.check_websocket_message(websocket_context).allowed);
+    mdbxc::sync::WebSocketSyncRejected websocket_rejection(
+        1008u, "sync websocket rejected");
+    MDBXC_TEST_ASSERT(websocket_rejection.close_code() == 1008u);
     mdbxc::sync::NodeDbAllowListPolicy allow_list;
     allow_list.allow_node_id(node);
     allow_list.allow_db_id(node);

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -56,6 +56,13 @@ int main() {
     mdbxc::sync::WebSocketSyncServer* websocket_server = nullptr;
     (void)websocket_channel;
     (void)websocket_server;
+    mdbxc::sync::WebSocketSyncRequestContext websocket_context;
+    websocket_context.has_authenticated_node = true;
+    websocket_context.authenticated_node = node;
+    websocket_context.binary_message = wire;
+    mdbxc::sync::WebSocketAuthenticatedNodeIdentityPolicy websocket_policy;
+    MDBXC_TEST_ASSERT(
+        websocket_policy.check_websocket_message(websocket_context).allowed);
     mdbxc::sync::NodeDbAllowListPolicy allow_list;
     allow_list.allow_node_id(node);
     allow_list.allow_db_id(node);

--- a/tests/test_websocket_transport.cpp
+++ b/tests/test_websocket_transport.cpp
@@ -245,11 +245,142 @@ void test_websocket_server_rejects_malformed_messages() {
                  "WebSocket server must reject malformed messages");
 }
 
+void test_websocket_authenticated_node_policy() {
+    const mdbxc::sync::NodeId node_a = make_node(0x11);
+    const mdbxc::sync::NodeId node_b = make_node(0x22);
+    const mdbxc::sync::DbId db_a = make_node(0xD1);
+    const mdbxc::sync::DbId db_b = make_node(0xD2);
+
+    mdbxc::sync::WebSocketAuthenticatedNodeIdentityPolicy policy;
+    mdbxc::sync::WebSocketSyncRequestContext context;
+    context.has_authenticated_node = true;
+    context.authenticated_node = node_a;
+    context.allowed_dbs.insert(db_a);
+
+    mdbxc::sync::PullRequest pull;
+    pull.requester = node_a;
+    pull.db_id = db_a;
+    context.binary_message =
+        mdbxc::sync::TransportMessageCodec::encode_pull_request(pull);
+
+    mdbxc::sync::SyncTransportDecision decision =
+        policy.check_websocket_message(context);
+    require_true(decision.allowed,
+                 "matching WebSocket node identity was rejected");
+
+    pull.requester = node_b;
+    context.binary_message =
+        mdbxc::sync::TransportMessageCodec::encode_pull_request(pull);
+    decision = policy.check_websocket_message(context);
+    require_true(!decision.allowed && decision.status_code == 1008,
+                 "WebSocket requester mismatch was not rejected");
+
+    pull.requester = node_a;
+    pull.db_id = db_b;
+    context.binary_message =
+        mdbxc::sync::TransportMessageCodec::encode_pull_request(pull);
+    decision = policy.check_websocket_message(context);
+    require_true(!decision.allowed && decision.status_code == 1008,
+                 "WebSocket db_id mismatch was not rejected");
+
+    mdbxc::sync::PushRequest push;
+    push.sender = node_b;
+    push.db_id = db_a;
+    context.binary_message =
+        mdbxc::sync::TransportMessageCodec::encode_push_request(push);
+    decision = policy.check_websocket_message(context);
+    require_true(!decision.allowed && decision.status_code == 1008,
+                 "WebSocket sender mismatch was not rejected");
+
+    context.has_authenticated_node = false;
+    push.sender = node_a;
+    context.binary_message =
+        mdbxc::sync::TransportMessageCodec::encode_push_request(push);
+    decision = policy.check_websocket_message(context);
+    require_true(!decision.allowed && decision.status_code == 1008,
+                 "missing WebSocket authenticated node was not rejected");
+}
+
+void test_websocket_authenticated_node_policy_rejects_invalid_body() {
+    const mdbxc::sync::NodeId node = make_node(0x33);
+    const mdbxc::sync::DbId db_id = make_node(0xD3);
+
+    mdbxc::sync::CodecBounds bounds;
+    bounds.max_transport_message_bytes = 8;
+    mdbxc::sync::WebSocketAuthenticatedNodeIdentityPolicy policy(bounds);
+
+    mdbxc::sync::WebSocketSyncRequestContext context;
+    context.has_authenticated_node = true;
+    context.authenticated_node = node;
+    context.allowed_dbs.insert(db_id);
+
+    const std::uint8_t malformed_byte_1 = 0x01;
+    const std::uint8_t malformed_byte_2 = 0x02;
+    context.binary_message.push_back(malformed_byte_1);
+    context.binary_message.push_back(malformed_byte_2);
+
+    mdbxc::sync::SyncTransportDecision decision =
+        policy.check_websocket_message(context);
+    require_true(!decision.allowed && decision.status_code == 1007,
+                 "malformed WebSocket sync body was not rejected as 1007");
+
+    mdbxc::sync::PullRequest pull;
+    pull.requester = node;
+    pull.db_id = db_id;
+    context.binary_message =
+        mdbxc::sync::TransportMessageCodec::encode_pull_request(pull);
+
+    decision = policy.check_websocket_message(context);
+    require_true(!decision.allowed && decision.status_code == 1009,
+                 "oversized WebSocket sync body was not rejected as 1009");
+}
+
+void test_websocket_server_middleware_rejects_spoofed_identity() {
+    const std::string path = "test_websocket_transport_policy.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<mdbxc::Connection> db = open_db(path);
+    mdbxc::sync::SyncEngine engine(db);
+    engine.initialize_local_identity(make_node(0x44), make_node(0xD4));
+
+    mdbxc::sync::WebSocketSyncServer server(engine);
+    mdbxc::sync::WebSocketAuthenticatedNodeIdentityPolicy policy;
+    mdbxc::sync::WebSocketSyncServerMiddleware wrapped(server, &policy);
+
+    const mdbxc::sync::NodeId authenticated = make_node(0x55);
+    mdbxc::sync::PullRequest pull;
+    pull.requester = make_node(0x66);
+    pull.db_id = make_node(0xD4);
+
+    mdbxc::sync::WebSocketSyncRequestContext context;
+    context.has_authenticated_node = true;
+    context.authenticated_node = authenticated;
+    context.binary_message =
+        mdbxc::sync::TransportMessageCodec::encode_pull_request(pull);
+
+    bool caught = false;
+    try {
+        (void)wrapped.handle_binary_message(context);
+    } catch (const std::runtime_error& e) {
+        caught = std::string(e.what()).find("requester does not match") !=
+                 std::string::npos;
+    }
+
+    db->disconnect();
+    cleanup(path);
+
+    require_true(caught,
+                 "WebSocket server middleware allowed spoofed requester");
+}
+
 } // namespace
 
 int main() {
     test_websocket_peer_pull_and_push_roundtrip();
     test_websocket_server_rejects_response_messages();
     test_websocket_server_rejects_malformed_messages();
+    test_websocket_authenticated_node_policy();
+    test_websocket_authenticated_node_policy_rejects_invalid_body();
+    test_websocket_server_middleware_rejects_spoofed_identity();
     return 0;
 }

--- a/tests/test_websocket_transport.cpp
+++ b/tests/test_websocket_transport.cpp
@@ -373,6 +373,55 @@ void test_websocket_server_middleware_rejects_spoofed_identity() {
                  "WebSocket server middleware allowed spoofed requester");
 }
 
+void test_websocket_server_middleware_preserves_close_code() {
+    const std::string path = "test_websocket_transport_close_code.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<mdbxc::Connection> db = open_db(path);
+    mdbxc::sync::SyncEngine engine(db);
+    engine.initialize_local_identity(make_node(0x77), make_node(0xD7));
+
+    mdbxc::sync::CodecBounds bounds;
+    bounds.max_transport_message_bytes = 8;
+    mdbxc::sync::WebSocketSyncServer server(engine, bounds);
+    mdbxc::sync::WebSocketAuthenticatedNodeIdentityPolicy policy(bounds);
+    mdbxc::sync::SyncTransportMetricsObserver metrics;
+    mdbxc::sync::WebSocketSyncServerMiddleware wrapped(
+        server, &policy, &metrics);
+
+    mdbxc::sync::PullRequest pull;
+    pull.requester = make_node(0x88);
+    pull.db_id = make_node(0xD7);
+
+    mdbxc::sync::WebSocketSyncRequestContext context;
+    context.has_authenticated_node = true;
+    context.authenticated_node = pull.requester;
+    context.binary_message =
+        mdbxc::sync::TransportMessageCodec::encode_pull_request(pull);
+
+    bool caught = false;
+    try {
+        (void)wrapped.handle_binary_message(context);
+    } catch (const mdbxc::sync::WebSocketSyncRejected& e) {
+        caught = true;
+        require_true(e.close_code() == 1009u,
+                     "WebSocket middleware lost oversized close code");
+    }
+
+    db->disconnect();
+    cleanup(path);
+
+    require_true(caught,
+                 "WebSocket middleware did not throw typed rejection");
+
+    const mdbxc::sync::SyncTransportMetricsSnapshot snapshot =
+        metrics.snapshot();
+    require_true(snapshot.rejected_calls == 1u,
+                 "WebSocket rejection metric was not recorded");
+    require_true(snapshot.failed_calls == 0u,
+                 "WebSocket policy rejection was counted as exception");
+}
+
 } // namespace
 
 int main() {
@@ -382,5 +431,6 @@ int main() {
     test_websocket_authenticated_node_policy();
     test_websocket_authenticated_node_policy_rejects_invalid_body();
     test_websocket_server_middleware_rejects_spoofed_identity();
+    test_websocket_server_middleware_preserves_close_code();
     return 0;
 }


### PR DESCRIPTION
## Summary
- add WebSocketSyncRequestContext and WebSocketAuthenticatedNodeIdentityPolicy for session NodeId vs DTO identity checks
- add WebSocketSyncServerMiddleware for server-side binary-message dispatch with policy hooks
- update the Simple-WebSocket-Server example to pass authenticated replica NodeId through the middleware

## Verification
- C++17: build and run test_websocket_transport, test_transport_middleware, header_sync_umbrella_test
- C++11: build and run test_websocket_transport, test_transport_middleware, header_sync_umbrella_test
- C++17 opt-in: build and run sync_17_websocket_simple_web_server with MDBXC_WEBSOCKET_SYNC_EXAMPLE=ON
- C++11 opt-in: build and run sync_17_websocket_simple_web_server with MDBXC_WEBSOCKET_SYNC_EXAMPLE=ON
