### PR TITLE
feat(sync): make transport DB access explicit

### DIFF
--- a/examples/sync_17_websocket_simple_web_server.cpp
+++ b/examples/sync_17_websocket_simple_web_server.cpp
@@ -292,7 +292,7 @@ public:
                     mdbxc::sync::WebSocketSyncRequestContext context;
                     context.has_authenticated_node = true;
                     context.authenticated_node = m_authenticated_node;
-                    context.allowed_dbs.insert(m_allowed_db);
+                    context.db_access.allow_db_id(m_allowed_db);
                     context.binary_message =
                         string_to_bytes(in_message->string());
                     const std::vector<std::uint8_t> response =

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -487,10 +487,13 @@ they are not serialized by `TransportMessageCodec`. `HttpBearerTokenPolicy`,
 the bearer token maps to one `NodeId`; a pull request is allowed only when
 `PullRequest::requester` matches that authenticated node, and a push request is
 allowed only when `PushRequest::sender` matches that authenticated node.
-Optional per-token DB allow-lists validate `db_id` before dispatch. Empty
-per-token DB allow-list means the token may access any `db_id`. This keeps the
-sync DTOs self-describing while preventing a transport principal from claiming
-another node id inside the binary payload.
+Optional per-token DB access rules validate `db_id` before dispatch.
+`SyncDbAccess` makes the intent explicit: a token binding may allow any DB,
+deny every DB, or allow only listed DB ids. `HttpBearerNodeIdentityPolicy`
+keeps token bindings in `allow any DB` mode until
+`allow_db_id_for_token()` switches that token to a restricted list. This keeps
+the sync DTOs self-describing while preventing a transport principal from
+claiming another node id inside the binary payload.
 Rejections may carry response headers such as `WWW-Authenticate` or
 `Retry-After`; concrete HTTP bindings must write those headers to the real
 response.
@@ -511,8 +514,10 @@ For WebSocket, decoded DTO policy can wrap `WebSocketSyncPeer` through
 concrete WebSocket framework authenticates the session. The framework-specific
 token, cookie, mTLS principal, or remote address stays outside the sync DTO;
 `WebSocketAuthenticatedNodeIdentityPolicy` receives only the resulting
-authenticated `NodeId`, optional per-session DB allow-list, and one complete
-binary message. It then requires `PullRequest::requester` or
+authenticated `NodeId`, an explicit `SyncDbAccess` rule, and one complete
+binary message. WebSocket request contexts default to `deny every DB`, so a
+binding must opt into `SyncDbAccess::any()` or allow concrete DB ids for that
+session. The policy then requires `PullRequest::requester` or
 `PushRequest::sender` to match that authenticated node before dispatching to
 `WebSocketSyncServer`. `WebSocketSyncServerMiddleware` preserves policy close
 codes by throwing `WebSocketSyncRejected`; concrete bindings should catch it

--- a/include/mdbx_containers/sync/TransportMiddleware.hpp
+++ b/include/mdbx_containers/sync/TransportMiddleware.hpp
@@ -97,15 +97,62 @@ namespace sync {
         }
     };
 
+    /// \brief Explicit DB access rule used by transport identity policies.
+    /// \details \c any() permits every \c db_id, \c none() permits none, and
+    /// \c only() starts a restricted allow-list. This avoids giving an empty
+    /// container a hidden meaning in session contexts.
+    struct SyncDbAccess {
+        bool allow_all_dbs = false;
+        std::set<DbId> db_ids;
+
+        static SyncDbAccess any() {
+            SyncDbAccess out;
+            out.allow_all_dbs = true;
+            return out;
+        }
+
+        static SyncDbAccess none() {
+            return SyncDbAccess();
+        }
+
+        static SyncDbAccess only(const DbId& db_id) {
+            SyncDbAccess out;
+            out.allow_db_id(db_id);
+            return out;
+        }
+
+        void set_allow_any() {
+            allow_all_dbs = true;
+            db_ids.clear();
+        }
+
+        void set_deny_all() {
+            allow_all_dbs = false;
+            db_ids.clear();
+        }
+
+        void allow_db_id(const DbId& db_id) {
+            allow_all_dbs = false;
+            db_ids.insert(db_id);
+        }
+
+        bool allows_db_id(const DbId& db_id) const {
+            return allow_all_dbs ||
+                   db_ids.find(db_id) != db_ids.end();
+        }
+    };
+
     /// \brief Adapter-local context for one WebSocket sync message.
     /// \details Concrete WebSocket bindings authenticate the session during
     /// handshake or with framework-specific metadata, then pass the resulting
     /// node identity here before dispatching the binary sync message. The
-    /// identity and DB allow-list are not serialized in the sync DTO.
+    /// identity and DB access rule are not serialized in the sync DTO. The
+    /// default \c db_access denies every DB until the binding explicitly fills
+    /// it with \c SyncDbAccess::any() or a restricted allow-list.
     struct WebSocketSyncRequestContext {
         bool has_authenticated_node = false;
         NodeId authenticated_node{};
-        std::set<DbId> allowed_dbs;
+        SyncDbAccess db_access;
         std::vector<std::uint8_t> binary_message;
     };
 
@@ -172,9 +219,13 @@ namespace sync {
     }
 
     /// \brief Allows only configured node ids and database ids.
-    /// \details Empty allow-list means "allow any" for that dimension.
+    /// \details Node allow-list defaults to "allow any". DB access defaults to
+    /// "allow any" for compatibility with simple peer-level policies.
     class NodeDbAllowListPolicy : public ISyncTransportPolicy {
     public:
+        NodeDbAllowListPolicy()
+            : m_db_access(SyncDbAccess::any()) {}
+
         void allow_node_id(const NodeId& node_id) {
             std::lock_guard<std::mutex> lock(m_mutex);
             m_allowed_nodes.insert(node_id);
@@ -182,13 +233,23 @@ namespace sync {
 
         void allow_db_id(const DbId& db_id) {
             std::lock_guard<std::mutex> lock(m_mutex);
-            m_allowed_dbs.insert(db_id);
+            m_db_access.allow_db_id(db_id);
+        }
+
+        void allow_any_db_id() {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_db_access.set_allow_any();
+        }
+
+        void deny_all_db_ids() {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_db_access.set_deny_all();
         }
 
         void clear() {
             std::lock_guard<std::mutex> lock(m_mutex);
             m_allowed_nodes.clear();
-            m_allowed_dbs.clear();
+            m_db_access = SyncDbAccess::any();
         }
 
         SyncTransportDecision check_pull(
@@ -211,8 +272,7 @@ namespace sync {
                 const DbId& db_id,
                 const char* node_error) const {
             std::lock_guard<std::mutex> lock(m_mutex);
-            if (!m_allowed_dbs.empty() &&
-                m_allowed_dbs.find(db_id) == m_allowed_dbs.end()) {
+            if (!m_db_access.allows_db_id(db_id)) {
                 return SyncTransportDecision::reject(
                     "sync db_id is not allowed", 403);
             }
@@ -225,7 +285,7 @@ namespace sync {
 
         mutable std::mutex m_mutex;
         std::set<NodeId> m_allowed_nodes;
-        std::set<DbId> m_allowed_dbs;
+        SyncDbAccess m_db_access;
     };
 
     /// \brief Allows only configured HTTP sync targets.
@@ -313,9 +373,10 @@ namespace sync {
     /// \details This policy enforces the production-facing identity contract:
     /// the authenticated bearer principal must match
     /// \c PullRequest::requester for pull and \c PushRequest::sender for push.
-    /// Optional per-token DB allow-lists validate \c db_id before dispatch.
-    /// Empty per-token DB allow-list means any \c db_id is allowed for that
-    /// token. The policy decodes request DTOs only after the bearer token is
+    /// Optional per-token DB access rules validate \c db_id before dispatch.
+    /// Token bindings default to \c SyncDbAccess::any(); calling
+    /// \c allow_db_id_for_token() switches that token to a restricted list.
+    /// The policy decodes request DTOs only after the bearer token is
     /// accepted; adapter-local headers and remote addresses are not serialized.
     class HttpBearerNodeIdentityPolicy : public ISyncTransportPolicy {
     public:
@@ -339,7 +400,29 @@ namespace sync {
                 throw std::invalid_argument(
                     "sync bearer token identity is not registered");
             }
-            it->second.allowed_dbs.insert(db_id);
+            it->second.db_access.allow_db_id(db_id);
+        }
+
+        void allow_any_db_id_for_token(const std::string& token) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            std::map<std::string, Binding>::iterator it =
+                m_bindings.find(token);
+            if (it == m_bindings.end()) {
+                throw std::invalid_argument(
+                    "sync bearer token identity is not registered");
+            }
+            it->second.db_access.set_allow_any();
+        }
+
+        void deny_all_db_ids_for_token(const std::string& token) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            std::map<std::string, Binding>::iterator it =
+                m_bindings.find(token);
+            if (it == m_bindings.end()) {
+                throw std::invalid_argument(
+                    "sync bearer token identity is not registered");
+            }
+            it->second.db_access.set_deny_all();
         }
 
         void clear() {
@@ -380,8 +463,11 @@ namespace sync {
 
     private:
         struct Binding {
+            Binding()
+                : db_access(SyncDbAccess::any()) {}
+
             NodeId node_id{};
-            std::set<DbId> allowed_dbs;
+            SyncDbAccess db_access;
         };
 
         static SyncTransportDecision unauthorized(
@@ -436,9 +522,7 @@ namespace sync {
 
         static SyncTransportDecision check_db(const Binding& binding,
                                               const DbId& db_id) {
-            if (!binding.allowed_dbs.empty() &&
-                binding.allowed_dbs.find(db_id) ==
-                    binding.allowed_dbs.end()) {
+            if (!binding.db_access.allows_db_id(db_id)) {
                 return SyncTransportDecision::reject(
                     "sync db_id is not allowed for authenticated node", 403);
             }
@@ -455,9 +539,10 @@ namespace sync {
     /// before constructing \c WebSocketSyncRequestContext. This policy then
     /// decodes the binary DTO and requires \c PullRequest::requester or
     /// \c PushRequest::sender to match the authenticated session node.
-    /// Optional per-session DB allow-lists validate \c db_id before dispatch.
-    /// Empty \c allowed_dbs means the authenticated session may access any
-    /// \c db_id. For WebSocket bindings, \c SyncTransportDecision::status_code
+    /// Optional per-session DB access rules validate \c db_id before dispatch.
+    /// \c WebSocketSyncRequestContext::db_access defaults to deny all, so
+    /// bindings must explicitly set \c SyncDbAccess::any() or allow specific
+    /// DB ids. For WebSocket bindings, \c SyncTransportDecision::status_code
     /// may be interpreted as a WebSocket close code by the concrete adapter.
     class WebSocketAuthenticatedNodeIdentityPolicy
         : public ISyncTransportPolicy {
@@ -508,7 +593,7 @@ namespace sync {
                     "sync requester does not match authenticated WebSocket node",
                     1008);
             }
-            return check_db(context.allowed_dbs, request.db_id);
+            return check_db(context.db_access, request.db_id);
         }
 
         SyncTransportDecision check_push_identity(
@@ -521,14 +606,13 @@ namespace sync {
                     "sync sender does not match authenticated WebSocket node",
                     1008);
             }
-            return check_db(context.allowed_dbs, request.db_id);
+            return check_db(context.db_access, request.db_id);
         }
 
         static SyncTransportDecision check_db(
-                const std::set<DbId>& allowed_dbs,
+                const SyncDbAccess& db_access,
                 const DbId& db_id) {
-            if (!allowed_dbs.empty() &&
-                allowed_dbs.find(db_id) == allowed_dbs.end()) {
+            if (!db_access.allows_db_id(db_id)) {
                 return SyncTransportDecision::reject(
                     "sync db_id is not allowed for authenticated WebSocket node",
                     1008);

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -59,6 +59,7 @@ int main() {
     mdbxc::sync::WebSocketSyncRequestContext websocket_context;
     websocket_context.has_authenticated_node = true;
     websocket_context.authenticated_node = node;
+    websocket_context.db_access = mdbxc::sync::SyncDbAccess::only(node);
     websocket_context.binary_message = wire;
     mdbxc::sync::WebSocketAuthenticatedNodeIdentityPolicy websocket_policy;
     MDBXC_TEST_ASSERT(

--- a/tests/test_transport_middleware.cpp
+++ b/tests/test_transport_middleware.cpp
@@ -356,7 +356,6 @@ void test_http_bearer_node_identity_policy() {
 
     mdbxc::sync::HttpBearerNodeIdentityPolicy policy;
     policy.allow_token_for_node("token-a", node_a);
-    policy.allow_db_id_for_token("token-a", db_a);
 
     mdbxc::sync::PullRequest pull;
     pull.requester = node_a;
@@ -375,6 +374,21 @@ void test_http_bearer_node_identity_policy() {
         policy.check_http_request(request);
     require_true(decision.allowed,
                  "matching bearer identity was rejected");
+
+    pull.db_id = db_b;
+    request.body = mdbxc::sync::TransportMessageCodec::encode_pull_request(
+        pull);
+    decision = policy.check_http_request(request);
+    require_true(decision.allowed,
+                 "default bearer DB access should allow any db_id");
+
+    policy.allow_db_id_for_token("token-a", db_a);
+    pull.db_id = db_a;
+    request.body = mdbxc::sync::TransportMessageCodec::encode_pull_request(
+        pull);
+    decision = policy.check_http_request(request);
+    require_true(decision.allowed,
+                 "restricted bearer DB access rejected allowed db_id");
 
     pull.requester = node_b;
     request.body = mdbxc::sync::TransportMessageCodec::encode_pull_request(

--- a/tests/test_websocket_transport.cpp
+++ b/tests/test_websocket_transport.cpp
@@ -255,7 +255,6 @@ void test_websocket_authenticated_node_policy() {
     mdbxc::sync::WebSocketSyncRequestContext context;
     context.has_authenticated_node = true;
     context.authenticated_node = node_a;
-    context.allowed_dbs.insert(db_a);
 
     mdbxc::sync::PullRequest pull;
     pull.requester = node_a;
@@ -265,6 +264,11 @@ void test_websocket_authenticated_node_policy() {
 
     mdbxc::sync::SyncTransportDecision decision =
         policy.check_websocket_message(context);
+    require_true(!decision.allowed && decision.status_code == 1008,
+                 "default WebSocket DB access should deny db_id");
+
+    context.db_access.allow_db_id(db_a);
+    decision = policy.check_websocket_message(context);
     require_true(decision.allowed,
                  "matching WebSocket node identity was rejected");
 
@@ -312,7 +316,7 @@ void test_websocket_authenticated_node_policy_rejects_invalid_body() {
     mdbxc::sync::WebSocketSyncRequestContext context;
     context.has_authenticated_node = true;
     context.authenticated_node = node;
-    context.allowed_dbs.insert(db_id);
+    context.db_access.allow_db_id(db_id);
 
     const std::uint8_t malformed_byte_1 = 0x01;
     const std::uint8_t malformed_byte_2 = 0x02;


### PR DESCRIPTION
## Summary
- add explicit `SyncDbAccess` for transport DB authorization
- replace WebSocket session `allowed_dbs` with explicit `db_access`
- keep HTTP token bindings in explicit allow-any mode until restricted by `allow_db_id_for_token()`
- document default/restricted DB access semantics

## Validation
- `cmake --build tmp/pr113-cpp17 --target test_transport_middleware test_websocket_transport header_sync_umbrella_test`
- `ctest --test-dir tmp/pr113-cpp17 -R test_transport_middleware|test_websocket_transport|header_sync_umbrella_test --output-on-failure`
- `cmake --build tmp/pr113-cpp11 --target test_transport_middleware test_websocket_transport header_sync_umbrella_test`
- `ctest --test-dir tmp/pr113-cpp11 -R test_transport_middleware|test_websocket_transport|header_sync_umbrella_test --output-on-failure`
- `cmake --build tmp/pr113-ws-cpp17 --target sync_17_websocket_simple_web_server`
- `tmp/pr113-ws-cpp17/bin/examples/sync_17_websocket_simple_web_server.exe`
- `cmake --build tmp/pr113-ws-cpp11 --target sync_17_websocket_simple_web_server`
- `tmp/pr113-ws-cpp11/bin/examples/sync_17_websocket_simple_web_server.exe`