### PR TITLE
feat(sync): harden transport adapter metadata

### DIFF
--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -496,12 +496,19 @@ the sync DTOs self-describing while preventing a transport principal from
 claiming another node id inside the binary payload.
 Rejections may carry response headers such as `WWW-Authenticate` or
 `Retry-After`; concrete HTTP bindings must write those headers to the real
-response.
+response. `HttpSyncHeaders::request_id()` and
+`HttpSyncHeaders::trace_id()` define optional adapter-local correlation
+headers. They are copied from request to response by the framework-neutral HTTP
+server/middleware, but they are not serialized inside sync DTOs.
 `FixedBudgetSyncTransportPolicy` is a deterministic fixed-budget limiter useful
 for tests, examples, and simple adapters; production adapters can replace it
 with a time-window or token-bucket policy while keeping the same middleware
 shape. `SyncTransportMetricsObserver` records basic call, rejection, failure,
 cancel, and batch counters without changing transport behavior.
+`TransportMessageSizePolicy` is a pre-decode guard for HTTP bodies and
+WebSocket binary messages. It complements `CodecBounds`: adapters can reject
+oversized transport frames before decoding, while the codec still validates the
+structured payload.
 
 These helpers do not replace server-framework authentication or
 per-remote-client rate limiting before `HttpSyncServer::handle()`. They also
@@ -533,7 +540,11 @@ payload-size, and malformed-body errors (`400`, `401`, `403`, `404`, `405`,
 `413`, `415`) are permanent for the current request unless a higher-level
 adapter refreshes credentials or changes the request. `Retry-After` is advisory
 transport metadata; `SyncWorker` backoff remains the core retry loop for failed
-sync rounds.
+sync rounds. For WebSocket, close code `1000` is success; `1001`, local
+observations `1005`/`1006`, and server/transient codes `1011`, `1012`, `1013`,
+and `1014` are retryable by default. Policy, malformed payload, and oversized
+message codes such as `1007`, `1008`, and `1009` are permanent for the current
+request.
 
 `ChangeBatchCodec` already rejects `BATCH_COMPRESSED_ZSTD` at both
 encode and decode paths. Adding a real `zstd` backend is a codec

--- a/include/mdbx_containers/sync/HttpTransport.hpp
+++ b/include/mdbx_containers/sync/HttpTransport.hpp
@@ -72,6 +72,40 @@ namespace sync {
         headers.push_back(header);
     }
 
+    /// \brief Conventional HTTP header names used by sync adapters.
+    class HttpSyncHeaders {
+    public:
+        static const char* request_id() {
+            return "X-MDBXC-Sync-Request-Id";
+        }
+
+        static const char* trace_id() {
+            return "X-MDBXC-Sync-Trace-Id";
+        }
+    };
+
+    inline void http_copy_header_if_present(
+            const std::vector<HttpSyncHeader>& source,
+            std::vector<HttpSyncHeader>& destination,
+            const std::string& name) {
+        const std::string value = http_header_value(source, name);
+        if (!value.empty()) {
+            http_add_header(destination, name, value);
+        }
+    }
+
+    /// \brief Copies request/trace correlation headers when present.
+    /// \details Header values are adapter-local metadata. They are not part of
+    /// \c TransportMessageCodec and are intentionally optional.
+    inline void http_copy_sync_correlation_headers(
+            const std::vector<HttpSyncHeader>& source,
+            std::vector<HttpSyncHeader>& destination) {
+        http_copy_header_if_present(
+            source, destination, HttpSyncHeaders::request_id());
+        http_copy_header_if_present(
+            source, destination, HttpSyncHeaders::trace_id());
+    }
+
     /// \brief Minimal request shape consumed by \c HttpSyncServer.
     struct HttpSyncRequest {
         std::string method;
@@ -145,19 +179,21 @@ namespace sync {
         /// failures. Sync-level failures such as db_id mismatch are encoded
         /// inside the binary PullResponse/PushResponse with status 200.
         HttpSyncResponse handle(const HttpSyncRequest& request) const {
+            HttpSyncResponse response;
             if (request.method != HttpSyncRoutes::method_post()) {
-                return make_error(405, "method not allowed");
+                response = make_error(405, "method not allowed");
+            } else if (request.content_type != HttpSyncRoutes::content_type()) {
+                response = make_error(415, "unsupported content type");
+            } else if (request.target == HttpSyncRoutes::pull_target()) {
+                response = handle_pull(request.body);
+            } else if (request.target == HttpSyncRoutes::push_target()) {
+                response = handle_push(request.body);
+            } else {
+                response = make_error(404, "unknown sync route");
             }
-            if (request.content_type != HttpSyncRoutes::content_type()) {
-                return make_error(415, "unsupported content type");
-            }
-            if (request.target == HttpSyncRoutes::pull_target()) {
-                return handle_pull(request.body);
-            }
-            if (request.target == HttpSyncRoutes::push_target()) {
-                return handle_push(request.body);
-            }
-            return make_error(404, "unknown sync route");
+            http_copy_sync_correlation_headers(
+                request.headers, response.headers);
+            return response;
         }
 
     private:

--- a/include/mdbx_containers/sync/TransportMiddleware.hpp
+++ b/include/mdbx_containers/sync/TransportMiddleware.hpp
@@ -71,6 +71,41 @@ namespace sync {
                HttpSyncRetryClass::Retryable;
     }
 
+    /// \brief Retry classification for adapter-level WebSocket close codes.
+    enum class WebSocketSyncCloseRetryClass : std::uint8_t {
+        Success,
+        Retryable,
+        Permanent
+    };
+
+    /// \brief Classifies WebSocket close codes for sync retry policy.
+    /// \details Codes 1005 and 1006 are local observations rather than close
+    /// frame status values, but adapters commonly surface them to callers.
+    inline WebSocketSyncCloseRetryClass
+    classify_websocket_sync_close_code(unsigned close_code) {
+        switch (close_code) {
+            case 1000:
+                return WebSocketSyncCloseRetryClass::Success;
+            case 1001:
+            case 1005:
+            case 1006:
+            case 1011:
+            case 1012:
+            case 1013:
+            case 1014:
+                return WebSocketSyncCloseRetryClass::Retryable;
+            default:
+                return WebSocketSyncCloseRetryClass::Permanent;
+        }
+    }
+
+    /// \brief Returns true when a WebSocket close code is retryable.
+    inline bool websocket_sync_close_code_is_retryable(
+            unsigned close_code) {
+        return classify_websocket_sync_close_code(close_code) ==
+               WebSocketSyncCloseRetryClass::Retryable;
+    }
+
     /// \brief Result returned by a transport policy.
     struct SyncTransportDecision {
         bool allowed = true;
@@ -762,6 +797,47 @@ namespace sync {
         std::map<std::string, Bucket> m_buckets;
     };
 
+    /// \brief Rejects HTTP bodies and WebSocket messages above a byte limit.
+    /// \details This is a pre-decode adapter guard. \c CodecBounds still
+    /// validates the binary DTO payload during encode/decode.
+    class TransportMessageSizePolicy : public ISyncTransportPolicy {
+    public:
+        explicit TransportMessageSizePolicy(
+                std::size_t max_transport_message_bytes)
+            : m_max_transport_message_bytes(max_transport_message_bytes) {
+            if (max_transport_message_bytes == 0) {
+                throw std::invalid_argument(
+                    "sync transport message size limit must be positive");
+            }
+        }
+
+        SyncTransportDecision check_http_post(
+                const std::string& target,
+                const std::string& content_type,
+                const std::vector<std::uint8_t>& body) override {
+            (void)target;
+            (void)content_type;
+            if (body.size() > m_max_transport_message_bytes) {
+                return SyncTransportDecision::reject(
+                    "sync HTTP body is too large", 413);
+            }
+            return SyncTransportDecision::allow();
+        }
+
+        SyncTransportDecision check_websocket_message(
+                const WebSocketSyncRequestContext& request) override {
+            if (request.binary_message.size() >
+                m_max_transport_message_bytes) {
+                return SyncTransportDecision::reject(
+                    "sync WebSocket message is too large", 1009);
+            }
+            return SyncTransportDecision::allow();
+        }
+
+    private:
+        std::size_t m_max_transport_message_bytes;
+    };
+
     /// \brief Fixed request-budget policy for deterministic rate-limit tests.
     /// \details Each accepted operation consumes one budget unit. Use
     /// \c unlimited_budget() for dimensions that should not be limited.
@@ -1235,8 +1311,12 @@ namespace sync {
                     detail::notify_transport_rejected(
                         m_observer, SyncTransportOperation::HttpPost,
                         decision.error);
-                    return detail::make_http_error_response(
+                    HttpSyncResponse response =
+                        detail::make_http_error_response(
                         decision, "HTTP sync request rejected");
+                    http_copy_sync_correlation_headers(
+                        request.headers, response.headers);
+                    return response;
                 }
             }
 

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -52,6 +52,13 @@ int main() {
         mdbxc::sync::TransportMessageType::PullRequest);
     MDBXC_TEST_ASSERT(std::string(mdbxc::sync::HttpSyncRoutes::pull_target())
                       == "/mdbxc/sync/v1/pull");
+    MDBXC_TEST_ASSERT(std::string(mdbxc::sync::HttpSyncHeaders::trace_id())
+                      == "X-MDBXC-Sync-Trace-Id");
+    MDBXC_TEST_ASSERT(mdbxc::sync::http_sync_status_is_retryable(503));
+    MDBXC_TEST_ASSERT(
+        mdbxc::sync::websocket_sync_close_code_is_retryable(1013u));
+    mdbxc::sync::TransportMessageSizePolicy size_policy(1024u);
+    (void)size_policy;
     mdbxc::sync::IWebSocketSyncChannel* websocket_channel = nullptr;
     mdbxc::sync::WebSocketSyncServer* websocket_server = nullptr;
     (void)websocket_channel;

--- a/tests/test_http_transport.cpp
+++ b/tests/test_http_transport.cpp
@@ -224,9 +224,25 @@ void test_http_server_status_mapping() {
     request.method = "GET";
     request.target = mdbxc::sync::HttpSyncRoutes::pull_target();
     request.content_type = mdbxc::sync::HttpSyncRoutes::content_type();
+    mdbxc::sync::http_add_header(
+        request.headers, mdbxc::sync::HttpSyncHeaders::request_id(),
+        "request-123");
+    mdbxc::sync::http_add_header(
+        request.headers, mdbxc::sync::HttpSyncHeaders::trace_id(),
+        "trace-abc");
     mdbxc::sync::HttpSyncResponse response = server.handle(request);
     require_true(response.status_code == 405, "GET must be rejected");
     require_true(!response.body.empty(), "GET rejection must carry body text");
+    require_true(mdbxc::sync::http_header_value(
+                     response.headers,
+                     mdbxc::sync::HttpSyncHeaders::request_id()) ==
+                     "request-123",
+                 "HTTP server did not echo request id");
+    require_true(mdbxc::sync::http_header_value(
+                     response.headers,
+                     mdbxc::sync::HttpSyncHeaders::trace_id()) ==
+                     "trace-abc",
+                 "HTTP server did not echo trace id");
 
     request.method = mdbxc::sync::HttpSyncRoutes::method_post();
     request.content_type = "application/octet-stream";

--- a/tests/test_transport_middleware.cpp
+++ b/tests/test_transport_middleware.cpp
@@ -481,6 +481,43 @@ void test_http_retry_status_classification() {
                  "HTTP 413 must be permanent");
 }
 
+void test_websocket_close_code_classification() {
+    require_true(mdbxc::sync::classify_websocket_sync_close_code(1000) ==
+                     mdbxc::sync::WebSocketSyncCloseRetryClass::Success,
+                 "WebSocket 1000 must be success");
+    require_true(mdbxc::sync::websocket_sync_close_code_is_retryable(1006),
+                 "WebSocket 1006 must be retryable");
+    require_true(mdbxc::sync::websocket_sync_close_code_is_retryable(1013),
+                 "WebSocket 1013 must be retryable");
+    require_true(!mdbxc::sync::websocket_sync_close_code_is_retryable(1008),
+                 "WebSocket 1008 must be permanent");
+    require_true(!mdbxc::sync::websocket_sync_close_code_is_retryable(1009),
+                 "WebSocket 1009 must be permanent");
+}
+
+void test_transport_message_size_policy() {
+    mdbxc::sync::TransportMessageSizePolicy policy(3u);
+
+    mdbxc::sync::SyncTransportDecision decision =
+        policy.check_http_post(
+            mdbxc::sync::HttpSyncRoutes::pull_target(),
+            mdbxc::sync::HttpSyncRoutes::content_type(),
+            std::vector<std::uint8_t>(4u, 0x11u));
+    require_true(!decision.allowed && decision.status_code == 413,
+                 "oversized HTTP body was not rejected as 413");
+
+    mdbxc::sync::WebSocketSyncRequestContext context;
+    context.binary_message.assign(4u, 0x22u);
+    decision = policy.check_websocket_message(context);
+    require_true(!decision.allowed && decision.status_code == 1009,
+                 "oversized WebSocket message was not rejected as 1009");
+
+    context.binary_message.assign(3u, 0x33u);
+    decision = policy.check_websocket_message(context);
+    require_true(decision.allowed,
+                 "size policy rejected message at the configured limit");
+}
+
 void test_http_client_middleware_copies_rejection_headers() {
     mdbxc::sync::FixedWindowHttpRateLimitPolicy rate(
         0, std::chrono::seconds(7));
@@ -520,6 +557,12 @@ void test_http_server_middleware_copies_rejection_headers() {
     request.target = mdbxc::sync::HttpSyncRoutes::pull_target();
     request.content_type = mdbxc::sync::HttpSyncRoutes::content_type();
     request.remote_address = "127.0.0.1";
+    mdbxc::sync::http_add_header(
+        request.headers, mdbxc::sync::HttpSyncHeaders::request_id(),
+        "middleware-request");
+    mdbxc::sync::http_add_header(
+        request.headers, mdbxc::sync::HttpSyncHeaders::trace_id(),
+        "middleware-trace");
 
     const mdbxc::sync::HttpSyncResponse response = wrapped.handle(request);
     require_true(response.status_code == 429,
@@ -527,6 +570,16 @@ void test_http_server_middleware_copies_rejection_headers() {
     require_true(mdbxc::sync::http_header_value(
                      response.headers, "Retry-After") != std::string(),
                  "server middleware dropped Retry-After");
+    require_true(mdbxc::sync::http_header_value(
+                     response.headers,
+                     mdbxc::sync::HttpSyncHeaders::request_id()) ==
+                     "middleware-request",
+                 "server middleware dropped request id");
+    require_true(mdbxc::sync::http_header_value(
+                     response.headers,
+                     mdbxc::sync::HttpSyncHeaders::trace_id()) ==
+                     "middleware-trace",
+                 "server middleware dropped trace id");
 
     db->disconnect();
     cleanup(path);
@@ -543,6 +596,8 @@ int main() {
     test_http_bearer_node_identity_policy();
     test_http_bearer_node_identity_policy_rejects_invalid_body();
     test_http_retry_status_classification();
+    test_websocket_close_code_classification();
+    test_transport_message_size_policy();
     test_http_client_middleware_copies_rejection_headers();
     test_http_server_middleware_copies_rejection_headers();
     return 0;


### PR DESCRIPTION
## Summary
- add optional HTTP sync request/trace correlation header helpers and echo them from server/middleware responses
- add `TransportMessageSizePolicy` for pre-decode HTTP body and WebSocket message limits
- add WebSocket close-code retry classification helpers
- document adapter-local metadata, size guards, and retry mapping

## Stacked on
- #114 (`codex/sync-explicit-db-acl`)

## Validation
- `cmake --build tmp/pr113-cpp17 --target test_http_transport test_transport_middleware test_websocket_transport header_sync_umbrella_test`
- `ctest --test-dir tmp/pr113-cpp17 -R test_http_transport|test_transport_middleware|test_websocket_transport|header_sync_umbrella_test --output-on-failure`
- `cmake --build tmp/pr113-cpp11 --target test_http_transport test_transport_middleware test_websocket_transport header_sync_umbrella_test`
- `ctest --test-dir tmp/pr113-cpp11 -R test_http_transport|test_transport_middleware|test_websocket_transport|header_sync_umbrella_test --output-on-failure`