### PR TITLE
test(sync): harden WebSocket binding example

### DIFF
--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -202,5 +202,7 @@ message-size guard, страничные pull-запросы и callbacks observ
 `sync_17_websocket_simple_web_server.cpp` - socket-backed WebSocket-вариант.
 Он связывает `WebSocketSyncPeer` / `WebSocketSyncServer` с
 Simple-WebSocket-Server, отправляет binary frames, проверяет bearer token во
-время WebSocket handshake и передаёт аутентифицированный `NodeId` replica в
-`WebSocketSyncServerMiddleware` перед dispatch.
+время WebSocket handshake, передаёт аутентифицированный `NodeId` replica вместе
+с явным `SyncDbAccess` в `WebSocketSyncServerMiddleware`, отклоняет слишком
+большие сообщения до decode и классифицирует close codes для диагностики
+клиента.

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -3,8 +3,9 @@
 Эти примеры показывают API sync v0.1 как набор блоков, не привязанных к
 конкретному транспорту. Большинство примеров используют `DirectSyncPeer` или
 небольшой буфер в памяти, чтобы поток протокола был виден без HTTP, WebSocket
-или IPC-кода. Опциональный HTTP-пример связывает HTTP seam с Simple-Web-Server
-и standalone Asio, а WebSocket-пример остаётся framework-neutral.
+или IPC-кода. Опциональные HTTP- и WebSocket-примеры связывают границы
+транспортных адаптеров с Simple-Web-Server, Simple-WebSocket-Server и
+standalone Asio.
 
 Синхронизация включается явно. Примеры собираются с `MDBXC_SYNC_ENABLED=1`;
 приложениям, которые используют sync, тоже нужно компилировать соответствующий
@@ -63,6 +64,19 @@ cmake -S . -B tmp/build-ws-example \
 
 cmake --build tmp/build-ws-example --target sync_17_websocket_simple_web_server
 tmp/build-ws-example/bin/examples/sync_17_websocket_simple_web_server
+```
+
+На Windows/MinGW с готовым бинарным пакетом OpenSSL укажите CMake корень
+пакета, в котором лежат `include`, `lib` и `bin`, например:
+
+```powershell
+cmake -S . -B tmp/build-ws-example `
+    -DMDBXC_DEPS_MODE=BUNDLED `
+    -DMDBXC_BUILD_TESTS=OFF `
+    -DMDBXC_BUILD_EXAMPLES=ON `
+    -DMDBXC_WEBSOCKET_SYNC_EXAMPLE=ON `
+    -DOPENSSL_ROOT_DIR=C:/deps/openssl-win64-v3.4.0 `
+    -DCMAKE_CXX_STANDARD=11
 ```
 
 ## Порядок чтения

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -2,9 +2,9 @@
 
 These examples show the sync v0.1 API as transport-agnostic building blocks.
 Most use `DirectSyncPeer` or a small in-memory buffer so the protocol flow is
-visible without adding HTTP, WebSocket, or IPC code. The optional HTTP example
-binds the HTTP seam to Simple-Web-Server and standalone Asio, while the
-WebSocket example stays framework-neutral.
+visible without adding HTTP, WebSocket, or IPC code. The optional HTTP and
+WebSocket examples bind the transport seams to Simple-Web-Server,
+Simple-WebSocket-Server, and standalone Asio.
 
 Sync is opt-in. The examples are built with `MDBXC_SYNC_ENABLED=1`; applications
 must also compile sync users with that macro enabled.
@@ -62,6 +62,19 @@ cmake -S . -B tmp/build-ws-example \
 
 cmake --build tmp/build-ws-example --target sync_17_websocket_simple_web_server
 tmp/build-ws-example/bin/examples/sync_17_websocket_simple_web_server
+```
+
+On Windows/MinGW with a ready-made OpenSSL package, point CMake at the package
+root that contains `include`, `lib`, and `bin`, for example:
+
+```powershell
+cmake -S . -B tmp/build-ws-example `
+    -DMDBXC_DEPS_MODE=BUNDLED `
+    -DMDBXC_BUILD_TESTS=OFF `
+    -DMDBXC_BUILD_EXAMPLES=ON `
+    -DMDBXC_WEBSOCKET_SYNC_EXAMPLE=ON `
+    -DOPENSSL_ROOT_DIR=C:/deps/openssl-win64-v3.4.0 `
+    -DCMAKE_CXX_STANDARD=11
 ```
 
 ## Reading Order

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -198,5 +198,6 @@ binding.
 `sync_17_websocket_simple_web_server.cpp` is the socket-backed WebSocket
 counterpart. It binds `WebSocketSyncPeer` / `WebSocketSyncServer` to
 Simple-WebSocket-Server, sends binary frames, checks the bearer token during
-the WebSocket handshake, and passes the authenticated replica `NodeId` to
-`WebSocketSyncServerMiddleware` before dispatch.
+the WebSocket handshake, passes the authenticated replica `NodeId` plus
+explicit `SyncDbAccess` to `WebSocketSyncServerMiddleware`, rejects oversized
+messages before decode, and classifies close codes for client diagnostics.

--- a/examples/sync_17_websocket_simple_web_server.cpp
+++ b/examples/sync_17_websocket_simple_web_server.cpp
@@ -5,7 +5,9 @@
  * This example binds the framework-neutral WebSocketSyncServer /
  * WebSocketSyncPeer seam to eidheim/Simple-WebSocket-Server with
  * chriskohlhoff standalone Asio. It sends complete binary WebSocket messages
- * encoded by TransportMessageCodec.
+ * encoded by TransportMessageCodec. The demo includes handshake bearer auth,
+ * explicit session DB access, pre-decode message-size limits, and close-code
+ * retry classification in client diagnostics.
  *
  * Build it explicitly:
  *
@@ -64,6 +66,11 @@ const std::uint8_t kPrimaryNodeSeed = 0xC8;
 const std::uint8_t kReplicaNodeSeed = 0xC9;
 const std::uint8_t kDatabaseSeed = 0xCA;
 const unsigned char kBinaryFrameOpcode = 130;
+const std::size_t kMaxWebSocketMessageBytes = 1024u * 1024u;
+
+const char* websocket_path() {
+    return "/mdbxc/sync/v1/ws";
+}
 
 std::string bytes_to_string(const std::vector<std::uint8_t>& bytes) {
     if (bytes.empty()) {
@@ -79,6 +86,12 @@ std::vector<std::uint8_t> string_to_bytes(const std::string& text) {
 
 std::string endpoint(const std::string& host, std::uint16_t port) {
     return host + ":" + std::to_string(static_cast<unsigned>(port));
+}
+
+const char* close_retry_label(unsigned close_code) {
+    return mdbxc::sync::websocket_sync_close_code_is_retryable(close_code)
+        ? "retryable"
+        : "permanent";
 }
 
 class ExchangeState {
@@ -116,7 +129,7 @@ public:
     SimpleWebSocketSyncChannel(const std::string& host,
                                std::uint16_t port,
                                const std::string& bearer_token)
-        : m_endpoint(endpoint(host, port) + "/mdbxc/sync/v1/ws"),
+        : m_endpoint(endpoint(host, port) + websocket_path()),
           m_bearer_token(bearer_token),
           m_cancel_generation(0),
           m_active_client(nullptr),
@@ -169,7 +182,9 @@ public:
                 if (status != 1000) {
                     state->set_exception(
                         "WebSocket closed with status " +
-                        std::to_string(status) + ": " + reason);
+                        std::to_string(status) + " (" +
+                        close_retry_label(static_cast<unsigned>(status)) +
+                        "): " + reason);
                 }
             };
 
@@ -252,13 +267,13 @@ public:
             mdbxc::sync::WebSocketSyncServerMiddleware& server,
             const std::string& bearer_token,
             const mdbxc::sync::NodeId& authenticated_node,
-            const mdbxc::sync::DbId& allowed_db,
+            const mdbxc::sync::SyncDbAccess& db_access,
             const std::string& host,
             std::uint16_t port)
         : m_server(server),
           m_bearer_token(bearer_token),
           m_authenticated_node(authenticated_node),
-          m_allowed_db(allowed_db),
+          m_db_access(db_access),
           m_host(host),
           m_port(port),
           m_running(false) {
@@ -292,7 +307,7 @@ public:
                     mdbxc::sync::WebSocketSyncRequestContext context;
                     context.has_authenticated_node = true;
                     context.authenticated_node = m_authenticated_node;
-                    context.db_access.allow_db_id(m_allowed_db);
+                    context.db_access = m_db_access;
                     context.binary_message =
                         string_to_bytes(in_message->string());
                     const std::vector<std::uint8_t> response =
@@ -378,7 +393,7 @@ private:
     mdbxc::sync::WebSocketSyncServerMiddleware& m_server;
     std::string m_bearer_token;
     mdbxc::sync::NodeId m_authenticated_node;
-    mdbxc::sync::DbId m_allowed_db;
+    mdbxc::sync::SyncDbAccess m_db_access;
     std::string m_host;
     std::uint16_t m_port;
     WsServer m_ws;
@@ -446,16 +461,29 @@ int main() {
 
         seed_primary_rows(primary);
 
-        mdbxc::sync::WebSocketSyncServer ws_server(primary_engine);
-        mdbxc::sync::WebSocketAuthenticatedNodeIdentityPolicy ws_identity;
+        mdbxc::sync::CodecBounds bounds;
+        bounds.max_transport_message_bytes = kMaxWebSocketMessageBytes;
+        mdbxc::sync::WebSocketSyncServer ws_server(primary_engine, bounds);
+        mdbxc::sync::TransportMessageSizePolicy ws_size(
+            kMaxWebSocketMessageBytes);
+        mdbxc::sync::WebSocketAuthenticatedNodeIdentityPolicy ws_identity(
+            bounds);
+        mdbxc::sync::CompositeSyncTransportPolicy ws_policy;
+        ws_policy.add(ws_size);
+        ws_policy.add(ws_identity);
         mdbxc::sync::WebSocketSyncServerMiddleware ws_middleware(
-            ws_server, &ws_identity);
+            ws_server, &ws_policy);
         SimpleWebSocketSyncListener listener(
-            ws_middleware, bearer_token, replica_node, db_id, host, port);
+            ws_middleware,
+            bearer_token,
+            replica_node,
+            mdbxc::sync::SyncDbAccess::only(db_id),
+            host,
+            port);
         listener.start();
 
         SimpleWebSocketSyncChannel channel(host, port, bearer_token);
-        mdbxc::sync::WebSocketSyncPeer peer(channel);
+        mdbxc::sync::WebSocketSyncPeer peer(channel, bounds);
 
         mdbxc::sync::PullRequest pull;
         pull.requester = replica_node;


### PR DESCRIPTION
﻿## Summary
- harden the Simple-WebSocket-Server sync example with an explicit policy stack
- pass `SyncDbAccess` as session DB authorization context
- add pre-decode WebSocket message-size limits through `TransportMessageSizePolicy`
- use close-code retry classification in client diagnostics
- document the production-ish WebSocket binding behavior

## Stacked on
- #116 (`codex/sync-worker-real-http`)

## Validation
- `cmake --build tmp/pr113-ws-cpp17 --target sync_17_websocket_simple_web_server`
- `tmp/pr113-ws-cpp17/bin/examples/sync_17_websocket_simple_web_server.exe`
- `cmake --build tmp/pr113-ws-cpp11 --target sync_17_websocket_simple_web_server`
- `tmp/pr113-ws-cpp11/bin/examples/sync_17_websocket_simple_web_server.exe`
