### PR TITLE
build(examples): add MinGW OpenSSL Crypto fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,99 @@ jobs:
           path: build/*.log
           if-no-files-found: ignore
 
+  websocket-mingw-openssl-fallback:
+    name: WebSocket MinGW OpenSSL Crypto fallback
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          path-type: inherit
+          install: >-
+            base-devel
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-ninja
+            mingw-w64-x86_64-pkg-config
+
+      - name: Ensure libmdbx tags
+        env:
+          PATH: "/c/Program Files/Git/bin:$PATH"
+        run: |
+          set -euo pipefail
+          git submodule update --init --recursive
+          git -C external/libmdbx rev-parse --is-inside-work-tree >/dev/null
+          git -C external/libmdbx config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+          git -C external/libmdbx fetch --prune --tags --force
+          if git -C external/libmdbx rev-parse --is-shallow-repository | grep -qi true; then
+            git -C external/libmdbx fetch --unshallow || git -C external/libmdbx fetch --deepen=1000
+          fi
+          git -C external/libmdbx describe --tags --abbrev=0 >/dev/null
+
+      - name: Configure WebSocket fallback example
+        env:
+          CC: x86_64-w64-mingw32-gcc
+          CXX: x86_64-w64-mingw32-g++
+          PATH: "/c/Program Files/Git/bin:$PATH"
+        run: |
+          set -euo pipefail
+          mkdir -p build-ws-fallback
+          cmake -S . -B build-ws-fallback -G "Ninja" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_POLICY_DEFAULT_CMP0152=NEW \
+            -DCMAKE_DISABLE_FIND_PACKAGE_OpenSSL=TRUE \
+            -DMDBXC_DEPS_MODE=BUNDLED \
+            -DMDBXC_BUILD_TESTS=OFF \
+            -DMDBXC_BUILD_EXAMPLES=ON \
+            -DMDBXC_WEBSOCKET_SYNC_EXAMPLE=ON \
+            -DMDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK=ON \
+            -Wno-dev \
+          2>&1 | tee build-ws-fallback/configure.log
+          grep -q "OpenSSL Crypto: using MinGW fallback" \
+            build-ws-fallback/configure.log
+
+      - name: Build WebSocket fallback example
+        run: |
+          set -euo pipefail
+          cmake --build build-ws-fallback \
+            --target sync_17_websocket_simple_web_server --parallel \
+          2>&1 | tee build-ws-fallback/build.log
+
+      - name: Run WebSocket fallback example
+        run: |
+          set -euo pipefail
+          exe_dir="build-ws-fallback/bin/examples"
+          test -x "$exe_dir/sync_17_websocket_simple_web_server.exe"
+          test -f "$exe_dir/libcrypto-3-x64.dll"
+          test ! -f "$exe_dir/libssl-3-x64.dll"
+          "$exe_dir/sync_17_websocket_simple_web_server.exe" 127.0.0.1 18194 \
+          2>&1 | tee build-ws-fallback/example.log
+          grep -q "OK: sync_17_websocket_simple_web_server" \
+            build-ws-fallback/example.log
+
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: websocket-mingw-openssl-fallback-logs
+          path: build-ws-fallback/*.log
+          if-no-files-found: ignore
+
   linux:
     name: Linux (C++${{ matrix.std }})
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ option(MDBXC_USE_ASAN "Enable AddressSanitizer for tests/examples (not for libmd
 # network-stack dependencies. See examples/README-sync.md for usage.
 option(MDBXC_HTTP_SYNC_EXAMPLE "Build the Simple-Web-Server HTTP binding example" OFF)
 option(MDBXC_WEBSOCKET_SYNC_EXAMPLE "Build the Simple-WebSocket-Server sync binding example" OFF)
+option(MDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK
+    "Fetch a ready-made Win64 OpenSSL Crypto package for the MinGW WebSocket example if system OpenSSL is unavailable" ON)
 
 # Three-mode dependency policy for MDBX: AUTO | SYSTEM | BUNDLED
 set(MDBXC_DEPS_MODE "AUTO" CACHE STRING "Dependency mode for MDBX: AUTO|SYSTEM|BUNDLED")
@@ -37,6 +39,7 @@ message(STATUS "MDBXC_BUILD_BENCHMARKS  = ${MDBXC_BUILD_BENCHMARKS}")
 message(STATUS "MDBXC_ENABLE_STRESS_TESTS = ${MDBXC_ENABLE_STRESS_TESTS}")
 message(STATUS "MDBXC_HTTP_SYNC_EXAMPLE = ${MDBXC_HTTP_SYNC_EXAMPLE}")
 message(STATUS "MDBXC_WEBSOCKET_SYNC_EXAMPLE = ${MDBXC_WEBSOCKET_SYNC_EXAMPLE}")
+message(STATUS "MDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK = ${MDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK}")
 message(STATUS "MDBXC_USE_ASAN          = ${MDBXC_USE_ASAN}")
 
 set(MDBXC_HAS_ASAN OFF CACHE BOOL "Compiler+linker support -fsanitize=address")
@@ -214,6 +217,16 @@ if(MDBXC_WEBSOCKET_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
     target_link_libraries(sync_17_websocket_simple_web_server PRIVATE
         ${_PKG_TARGET}
         ${_MDBXC_SWS_WS_TARGET})
+    get_property(_MDBXC_OPENSSL_RUNTIME_DLLS GLOBAL PROPERTY
+        MDBXC_MINGW_OPENSSL_RUNTIME_DLLS)
+    foreach(_MDBXC_OPENSSL_RUNTIME_DLL IN LISTS _MDBXC_OPENSSL_RUNTIME_DLLS)
+        add_custom_command(TARGET sync_17_websocket_simple_web_server
+            POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${_MDBXC_OPENSSL_RUNTIME_DLL}"
+                "$<TARGET_FILE_DIR:sync_17_websocket_simple_web_server>"
+            VERBATIM)
+    endforeach()
     message(STATUS "WebSocket binding example "
         "sync_17_websocket_simple_web_server -> ${_MDBXC_SWS_WS_TARGET}")
 endif()

--- a/cmake/deps/openssl-mingw.cmake
+++ b/cmake/deps/openssl-mingw.cmake
@@ -1,0 +1,68 @@
+# cmake/deps/openssl-mingw.cmake
+# Provides OpenSSL::Crypto from a ready-made Win64 package for the optional
+# WebSocket example when MinGW cannot find a system OpenSSL package.
+
+include(FetchContent)
+
+set(MDBXC_OPENSSL_WIN64_GIT_TAG
+    "635bbfe81230fcf4c3579f9e9f13fdeff71e8d70" CACHE STRING
+    "OpenSSL Win64 package commit used by the optional WebSocket example.")
+
+function(mdbxc_mingw_openssl_fallback_provide)
+    if(NOT WIN32 OR NOT MINGW)
+        message(FATAL_ERROR
+            "mdbxc_mingw_openssl_fallback_provide is only for MinGW on Windows")
+    endif()
+
+    if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+        message(FATAL_ERROR
+            "The bundled OpenSSL fallback is Win64-only")
+    endif()
+
+    FetchContent_Declare(
+        mdbxc_openssl_win64
+        GIT_REPOSITORY https://github.com/NewYaroslav/openssl-win64-v3.4.0.git
+        GIT_TAG        ${MDBXC_OPENSSL_WIN64_GIT_TAG}
+    )
+    FetchContent_GetProperties(mdbxc_openssl_win64)
+    if(NOT mdbxc_openssl_win64_POPULATED)
+        if(COMMAND _mdbxc_fetchcontent_populate)
+            _mdbxc_fetchcontent_populate(mdbxc_openssl_win64)
+        else()
+            FetchContent_Populate(mdbxc_openssl_win64)
+        endif()
+        FetchContent_GetProperties(mdbxc_openssl_win64)
+    endif()
+
+    set(_openssl_include
+        "${mdbxc_openssl_win64_SOURCE_DIR}/include")
+    set(_openssl_lib_dir
+        "${mdbxc_openssl_win64_SOURCE_DIR}/lib/VC/x64/MD")
+    set(_openssl_bin_dir
+        "${mdbxc_openssl_win64_SOURCE_DIR}/bin")
+    set(_openssl_crypto_lib "${_openssl_lib_dir}/libcrypto.lib")
+    set(_openssl_crypto_dll "${_openssl_bin_dir}/libcrypto-3-x64.dll")
+
+    foreach(_required_path IN ITEMS
+            "${_openssl_include}/openssl/crypto.h"
+            "${_openssl_crypto_lib}"
+            "${_openssl_crypto_dll}")
+        if(NOT EXISTS "${_required_path}")
+            message(FATAL_ERROR
+                "OpenSSL Win64 fallback is missing ${_required_path}")
+        endif()
+    endforeach()
+
+    if(NOT TARGET OpenSSL::Crypto)
+        add_library(OpenSSL::Crypto SHARED IMPORTED GLOBAL)
+        set_target_properties(OpenSSL::Crypto PROPERTIES
+            IMPORTED_IMPLIB "${_openssl_crypto_lib}"
+            IMPORTED_LOCATION "${_openssl_crypto_dll}"
+            INTERFACE_INCLUDE_DIRECTORIES "${_openssl_include}")
+    endif()
+
+    set_property(GLOBAL PROPERTY MDBXC_MINGW_OPENSSL_RUNTIME_DLLS
+        "${_openssl_crypto_dll}")
+    message(STATUS
+        "OpenSSL Crypto: using MinGW fallback from openssl-win64-v3.4.0")
+endfunction()

--- a/cmake/deps/simple-web-server.cmake
+++ b/cmake/deps/simple-web-server.cmake
@@ -15,6 +15,8 @@
 include(CMakeParseArguments)
 include(FetchContent)
 
+set(_MDBXC_SIMPLE_WEB_SERVER_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
 set(MDBXC_ASIO_GIT_TAG
     "12e0ce9e0500bf0f247dbd1ae894272656456079" CACHE STRING
     "Asio commit used by the optional HTTP example; corresponds to asio-1-30-2.")
@@ -151,7 +153,22 @@ function(simple_websocket_server_provide)
     endif()
 
     if(NOT TARGET mdbxc_simple_websocket_server)
-        find_package(OpenSSL REQUIRED)
+        if(NOT TARGET OpenSSL::Crypto)
+            find_package(OpenSSL QUIET)
+        endif()
+        if(NOT TARGET OpenSSL::Crypto)
+            if(WIN32 AND MINGW AND
+                    MDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK)
+                include("${_MDBXC_SIMPLE_WEB_SERVER_CMAKE_DIR}/openssl-mingw.cmake")
+                mdbxc_mingw_openssl_fallback_provide()
+            else()
+                message(FATAL_ERROR
+                    "OpenSSL Crypto was not found. Set OPENSSL_ROOT_DIR, "
+                    "install OpenSSL, or enable "
+                    "MDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK for the "
+                    "MinGW WebSocket example.")
+            endif()
+        endif()
 
         add_library(mdbxc_simple_websocket_server INTERFACE)
         target_include_directories(mdbxc_simple_websocket_server INTERFACE

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -52,7 +52,14 @@ tmp/build-http-example/bin/examples/sync_13_http_simple_web_server \
 Реальный WebSocket binding example тоже включается отдельно, потому что он
 скачивает headers standalone Asio и Simple-WebSocket-Server.
 Simple-WebSocket-Server использует OpenSSL Crypto для WebSocket handshake,
-поэтому задайте `OPENSSL_ROOT_DIR`, если CMake не найдёт OpenSSL автоматически:
+поэтому задайте `OPENSSL_ROOT_DIR`, если CMake не найдёт OpenSSL автоматически.
+На Windows/MinGW пример может скачать зафиксированный готовый Win64 OpenSSL
+package, когда `MDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK=ON` (по умолчанию):
+
+Зафиксированный fallback package предоставляет `lib/VC/x64/MD/libcrypto.lib`;
+такой layout import library проверен с MinGW-w64 toolchain, который используется
+в CI проекта. Пример использует обычный `ws://`, а не WSS/TLS, поэтому рядом с
+исполняемым файлом копируется только `libcrypto-3-x64.dll`.
 
 ```bash
 cmake -S . -B tmp/build-ws-example \
@@ -66,7 +73,7 @@ cmake --build tmp/build-ws-example --target sync_17_websocket_simple_web_server
 tmp/build-ws-example/bin/examples/sync_17_websocket_simple_web_server
 ```
 
-На Windows/MinGW с готовым бинарным пакетом OpenSSL укажите CMake корень
+Чтобы использовать свой готовый бинарный пакет OpenSSL, укажите CMake корень
 пакета, в котором лежат `include`, `lib` и `bin`, например:
 
 ```powershell

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -50,7 +50,14 @@ tmp/build-http-example/bin/examples/sync_13_http_simple_web_server \
 The real WebSocket binding example is also opt-in because it fetches standalone
 Asio and Simple-WebSocket-Server headers. Simple-WebSocket-Server uses OpenSSL
 Crypto for the WebSocket handshake, so set `OPENSSL_ROOT_DIR` if CMake cannot
-find OpenSSL automatically:
+find OpenSSL automatically. On Windows/MinGW, the example can fetch a pinned
+ready-made Win64 OpenSSL package when
+`MDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK=ON` (the default):
+
+The pinned fallback package exposes `lib/VC/x64/MD/libcrypto.lib`; this import
+library layout has been validated with the MinGW-w64 toolchain used by the
+project CI. The example uses plain `ws://`, not WSS/TLS, so only
+`libcrypto-3-x64.dll` is copied next to the executable.
 
 ```bash
 cmake -S . -B tmp/build-ws-example \
@@ -64,7 +71,7 @@ cmake --build tmp/build-ws-example --target sync_17_websocket_simple_web_server
 tmp/build-ws-example/bin/examples/sync_17_websocket_simple_web_server
 ```
 
-On Windows/MinGW with a ready-made OpenSSL package, point CMake at the package
+To use your own ready-made OpenSSL package instead, point CMake at the package
 root that contains `include`, `lib`, and `bin`, for example:
 
 ```powershell


### PR DESCRIPTION
## Summary
- add a MinGW-only OpenSSL Crypto fallback for the optional Simple-WebSocket-Server example
- fetch the pinned NewYaroslav/openssl-win64-v3.4.0 package only when system OpenSSL Crypto is unavailable
- pin the dependency by commit SHA without shallow clone, matching the CMake FetchContent contract
- create an OpenSSL::Crypto imported target and copy only the fallback Crypto DLL next to the example executable
- add a dedicated Windows/MinGW CI smoke that disables system OpenSSL discovery and verifies the fallback path
- document that plain ws:// uses OpenSSL Crypto for the WebSocket handshake, while TLS/WSS is not part of this example

## Validation
- `cmake -S . -B tmp/pr119-ws-fallback-clean-cpp17 -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DCMAKE_DISABLE_FIND_PACKAGE_OpenSSL=TRUE -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=OFF -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_WEBSOCKET_SYNC_EXAMPLE=ON -DMDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK=ON`
- `cmake --build tmp/pr119-ws-fallback-clean-cpp17 --target sync_17_websocket_simple_web_server`
- `tmp/pr119-ws-fallback-clean-cpp17/bin/examples/sync_17_websocket_simple_web_server.exe 127.0.0.1 18195`
- `tmp/pr119-ws-fallback-clean-cpp17/bin/examples` contains `libcrypto-3-x64.dll` and does not copy `libssl-3-x64.dll`
- `git diff --check`
