### PR TITLE
feat(sync): add Simple-Web transport bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,89 @@ jobs:
           rows="$(printf '%s\n' "$output" | wc -l | tr -d ' ')"
           test "$rows" = "4"
 
+  http-node-fleet-smoke:
+    name: HTTP node fleet smoke (Linux C++17)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build
+
+      - name: Ensure libmdbx tags
+        run: |
+          set -euo pipefail
+          git submodule update --init --recursive
+          git -C external/libmdbx rev-parse --is-inside-work-tree >/dev/null
+          git -C external/libmdbx config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+          git -C external/libmdbx fetch --prune --tags --force
+          if git -C external/libmdbx rev-parse --is-shallow-repository | grep -qi true; then
+            git -C external/libmdbx fetch --unshallow || git -C external/libmdbx fetch --deepen=1000
+          fi
+          git -C external/libmdbx describe --tags --abbrev=0 >/dev/null
+
+      - name: Configure HTTP node fleet
+        run: |
+          set -euo pipefail
+          mkdir -p build-http-fleet
+          cmake -S . -B build-http-fleet -G "Ninja" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_STANDARD=17 \
+            -DMDBXC_DEPS_MODE=BUNDLED \
+            -DMDBXC_BUILD_TESTS=OFF \
+            -DMDBXC_BUILD_EXAMPLES=ON \
+            -DMDBXC_HTTP_SYNC_EXAMPLE=ON \
+            -Wno-dev \
+          2>&1 | tee build-http-fleet/configure.log
+
+      - name: Build Simple-Web HTTP sync examples
+        run: |
+          set -euo pipefail
+          cmake --build build-http-fleet \
+            --target sync_13_http_simple_web_server \
+                     sync_18_http_node_fleet --parallel \
+          2>&1 | tee build-http-fleet/build.log
+
+      - name: Run Simple-Web HTTP sync smoke
+        run: |
+          set -euo pipefail
+          build-http-fleet/bin/examples/sync_13_http_simple_web_server \
+            demo 127.0.0.1 18080 \
+          2>&1 | tee build-http-fleet/http-demo.log
+          grep -q "OK: sync_13_http_simple_web_server" \
+            build-http-fleet/http-demo.log
+          build-http-fleet/bin/examples/sync_13_http_simple_web_server \
+            worker-demo 127.0.0.1 18081 \
+          2>&1 | tee build-http-fleet/http-worker-demo.log
+          grep -q "OK: sync_13_http_simple_web_server (worker-demo)" \
+            build-http-fleet/http-worker-demo.log
+          build-http-fleet/bin/examples/sync_18_http_node_fleet \
+            master-replica 2 \
+          2>&1 | tee build-http-fleet/master-replica.log
+          grep -q "OK: sync_18_http_node_fleet (master-replica)" \
+            build-http-fleet/master-replica.log
+          build-http-fleet/bin/examples/sync_18_http_node_fleet \
+            mesh 2 \
+          2>&1 | tee build-http-fleet/mesh.log
+          grep -q "OK: sync_18_http_node_fleet (mesh)" \
+            build-http-fleet/mesh.log
+
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: http-node-fleet-smoke-logs
+          path: build-http-fleet/*.log
+          if-no-files-found: ignore
+
   windows:
     name: Windows MinGW64 (C++${{ matrix.std }})
     runs-on: windows-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,11 @@ option(MDBXC_BUILD_BENCHMARKS   "Build benchmark executables"                   
 option(MDBXC_ENABLE_STRESS_TESTS "Register long stress tests with CTest"           OFF)
 option(MDBXC_USE_ASAN "Enable AddressSanitizer for tests/examples (not for libmdbx)" ON)
 
-# Optional transport-binding example that pulls a third-party HTTP backend
-# (Simple-Web-Server). Off by default to keep the default build free of
-# network-stack dependencies. See examples/README-sync.md for usage.
-option(MDBXC_HTTP_SYNC_EXAMPLE "Build the Simple-Web-Server HTTP binding example" OFF)
+# Optional transport-binding examples that pull third-party HTTP/process
+# backends (Simple-Web-Server and tiny-process-library). Off by default to keep
+# the default build free of network-stack dependencies. See
+# examples/README-sync.md for usage.
+option(MDBXC_HTTP_SYNC_EXAMPLE "Build the Simple-Web-Server HTTP sync examples" OFF)
 option(MDBXC_WEBSOCKET_SYNC_EXAMPLE "Build the Simple-WebSocket-Server sync binding example" OFF)
 option(MDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK
     "Fetch a ready-made Win64 OpenSSL Crypto package for the MinGW WebSocket example if system OpenSSL is unavailable" ON)
@@ -143,6 +144,8 @@ if(MDBXC_BUILD_EXAMPLES)
         "sync_13_http_simple_web_server\\.cpp$")
     list(FILTER EXAMPLES EXCLUDE REGEX
         "sync_17_websocket_simple_web_server\\.cpp$")
+    list(FILTER EXAMPLES EXCLUDE REGEX
+        "sync_18_http_node_fleet\\.cpp$")
     foreach(example_file IN LISTS EXAMPLES)
         get_filename_component(example_name ${example_file} NAME_WE)
         add_executable(${example_name} ${example_file})
@@ -165,15 +168,17 @@ endif()
 # ---------------------------------------
 # Optional HTTP transport binding example
 # ---------------------------------------
-# Pulls Simple-Web-Server through FetchContent and adds one example that
-# shows a real loopback HTTP server + client wiring around HttpSyncServer
-# and HttpSyncPeer. The default build does not touch this section; the
-# example is built only when MDBXC_HTTP_SYNC_EXAMPLE is ON.
+# Pulls Simple-Web-Server through FetchContent and adds examples that use the
+# ready Simple-Web HTTP binding around HttpSyncServer and HttpSyncPeer. The
+# default build does not touch this section; these examples are built only when
+# MDBXC_HTTP_SYNC_EXAMPLE is ON.
 if(MDBXC_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
     list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/deps)
     include(cmake/deps/simple-web-server.cmake)
+    include(cmake/deps/tiny-process-library.cmake)
 
     simple_web_server_provide(OUT_TARGET _MDBXC_SWS_TARGET)
+    tiny_process_library_provide()
 
     add_executable(sync_13_http_simple_web_server
         examples/sync_13_http_simple_web_server.cpp)
@@ -190,6 +195,23 @@ if(MDBXC_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
         ${_MDBXC_SWS_TARGET})
     message(STATUS "HTTP binding example sync_13_http_simple_web_server -> "
         "${_MDBXC_SWS_TARGET}")
+
+    add_executable(sync_18_http_node_fleet
+        examples/sync_18_http_node_fleet.cpp)
+    set_target_properties(sync_18_http_node_fleet PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples
+    )
+    target_compile_features(sync_18_http_node_fleet PRIVATE cxx_std_11)
+    target_compile_definitions(sync_18_http_node_fleet PRIVATE
+        MDBXC_SYNC_ENABLED=1
+        ASIO_STANDALONE=1
+        USE_STANDALONE_ASIO=1)
+    target_link_libraries(sync_18_http_node_fleet PRIVATE
+        ${_PKG_TARGET}
+        ${_MDBXC_SWS_TARGET}
+        tiny-process-library::tiny-process-library)
+    message(STATUS "HTTP node fleet example sync_18_http_node_fleet -> "
+        "${_MDBXC_SWS_TARGET};tiny-process-library")
 endif()
 
 # ---------------------------------------

--- a/README-RU.md
+++ b/README-RU.md
@@ -77,14 +77,24 @@
 - `AnyValueTable`, `KeyMultiValueTable` и `HashedKeyValueStore` не
   реплицируются в v0.1. Их wire-format отложен до явного описания type tags,
   DUPSORT duplicate framing и hash-index identity semantics.
+- Для поддерживаемых таблиц прикладной CRUD-код не нужно оборачивать
+  отдельными sync-вызовами на каждый метод. Прикрепите
+  `ThreadLocalChangeAccumulator` к пишущему `Connection`; закоммиченные
+  одиночные записи становятся одиночными sync batches, а явная транзакция,
+  объединяющая несколько поддерживаемых таблиц, становится одним атомарным
+  локальным batch. Read/search-вызовы не захватываются. Отдельный `SyncWorker`
+  плюс транспорт `ISyncPeer` переносят закоммиченные batches между узлами.
 - `SyncEngine` предоставляет pull/push/apply primitives, `DirectSyncPeer`
   используется для in-process синхронизации в тестах и примерах,
   `HttpSyncPeer` задаёт HTTP-shaped adapter seam, `WebSocketSyncPeer` задаёт
-  binary message seam, а `SyncWorker` запускает фоновой polling. Пример HTTP
-  на Simple-Web-Server и WebSocket-пример на Simple-WebSocket-Server собираются
-  опционально; wire-format для специализированных таблиц отложен.
-  HTTP auth, remote-address checks и rate-limit headers живут в adapter-local
-  policy context, а не внутри sync DTO;
+  binary message seam, а `SyncWorker` запускает фоновой polling.
+  `mdbx_containers/sync/transport.hpp` - umbrella header транспортного слоя.
+  Опциональные готовые Simple-Web HTTP/WebSocket binding headers находятся в
+  `mdbx_containers/sync/transports/simple_web/`, а socket-backed примеры
+  используют эти bindings вместо повторной реализации транспорта в каждом
+  файле. Wire-format для специализированных таблиц отложен. HTTP auth,
+  remote-address checks и rate-limit headers живут в adapter-local policy
+  context, а не внутри sync DTO;
   см. `include/mdbx_containers/sync/DESIGN.md`.
 
 ### 🗄️ Структура и конфигурация

--- a/README.md
+++ b/README.md
@@ -55,13 +55,23 @@
 - `AnyValueTable`, `KeyMultiValueTable`, and `HashedKeyValueStore` are not
   replicated in v0.1. Their wire formats are deferred until type tags,
   DUPSORT duplicate framing, and hash-index identity semantics are specified.
+- Application CRUD code does not need per-method sync wrappers for supported
+  tables. Attach `ThreadLocalChangeAccumulator` to the writing `Connection`;
+  committed standalone writes become standalone sync batches, while an explicit
+  transaction spanning several supported tables becomes one atomic local batch.
+  Read/search calls are not captured. A separate `SyncWorker` plus an
+  `ISyncPeer` transport moves committed batches between nodes.
 - `SyncEngine` exposes pull/push/apply primitives, `DirectSyncPeer` provides
   in-process sync for tests and examples, `HttpSyncPeer` defines an HTTP-shaped
   adapter seam, `WebSocketSyncPeer` defines a binary message seam, and
-  `SyncWorker` is the background polling driver. Simple-Web-Server HTTP and
-  Simple-WebSocket-Server WebSocket examples are optional; specialized
-  table wire formats remain deferred. HTTP auth, remote-address checks, and
-  rate-limit headers live in adapter-local policy context, not inside sync DTOs.
+  `SyncWorker` is the background polling driver. `mdbx_containers/sync/transport.hpp`
+  is the transport-layer umbrella. Optional ready-made Simple-Web
+  HTTP/WebSocket binding headers live under
+  `mdbx_containers/sync/transports/simple_web/`, and the socket-backed
+  examples use those bindings instead of reimplementing the transport in each
+  file. Specialized table wire formats remain deferred.
+  HTTP auth, remote-address checks, and rate-limit headers live in
+  adapter-local policy context, not inside sync DTOs.
   See
   `include/mdbx_containers/sync/DESIGN.md`.
 

--- a/cmake/deps/tiny-process-library.cmake
+++ b/cmake/deps/tiny-process-library.cmake
@@ -1,0 +1,34 @@
+# cmake/deps/tiny-process-library.cmake
+# Provides tiny-process-library for optional multi-process examples.
+
+include(FetchContent)
+
+set(MDBXC_TINY_PROCESS_LIBRARY_GIT_TAG
+    "8bbb5a211c5c9df8ee69301da9d22fb977b27dc1" CACHE STRING
+    "tiny-process-library commit used by optional process-spawning examples.")
+
+function(tiny_process_library_provide)
+    if(TARGET tiny-process-library::tiny-process-library)
+        return()
+    endif()
+
+    FetchContent_Declare(
+        mdbxc_tiny_process_library
+        GIT_REPOSITORY https://gitlab.com/eidheim/tiny-process-library.git
+        GIT_TAG        ${MDBXC_TINY_PROCESS_LIBRARY_GIT_TAG}
+    )
+    FetchContent_GetProperties(mdbxc_tiny_process_library)
+    if(NOT mdbxc_tiny_process_library_POPULATED)
+        if(COMMAND _mdbxc_fetchcontent_populate)
+            _mdbxc_fetchcontent_populate(mdbxc_tiny_process_library)
+        else()
+            FetchContent_Populate(mdbxc_tiny_process_library)
+        endif()
+        FetchContent_GetProperties(mdbxc_tiny_process_library)
+    endif()
+
+    add_subdirectory(
+        "${mdbxc_tiny_process_library_SOURCE_DIR}"
+        "${mdbxc_tiny_process_library_BINARY_DIR}"
+        EXCLUDE_FROM_ALL)
+endfunction()

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -3,9 +3,9 @@
 Эти примеры показывают API sync v0.1 как набор блоков, не привязанных к
 конкретному транспорту. Большинство примеров используют `DirectSyncPeer` или
 небольшой буфер в памяти, чтобы поток протокола был виден без HTTP, WebSocket
-или IPC-кода. Опциональные HTTP- и WebSocket-примеры связывают границы
-транспортных адаптеров с Simple-Web-Server, Simple-WebSocket-Server и
-standalone Asio.
+или IPC-кода. Опциональные HTTP- и WebSocket-примеры используют готовые
+Simple-Web binding headers из `mdbx_containers/sync/transports/simple_web/` поверх
+Simple-Web-Server, Simple-WebSocket-Server и standalone Asio.
 
 Синхронизация включается явно. Примеры собираются с `MDBXC_SYNC_ENABLED=1`;
 приложениям, которые используют sync, тоже нужно компилировать соответствующий
@@ -31,8 +31,9 @@ tmp/build-examples/bin/examples/sync_01_lifecycle_direct_peer
 .\tmp\build-examples\bin\examples\sync_01_lifecycle_direct_peer.exe
 ```
 
-Реальный HTTP binding example включается отдельно, потому что он скачивает
-headers standalone Asio и Simple-Web-Server:
+Реальные HTTP binding examples включаются отдельно, потому что они скачивают
+headers standalone Asio, Simple-Web-Server и, для process-supervised demo,
+tiny-process-library:
 
 ```bash
 cmake -S . -B tmp/build-http-example \
@@ -47,6 +48,25 @@ tmp/build-http-example/bin/examples/sync_13_http_simple_web_server \
     demo 127.0.0.1 18080
 tmp/build-http-example/bin/examples/sync_13_http_simple_web_server \
     worker-demo 127.0.0.1 18080
+
+cmake --build tmp/build-http-example --target sync_18_http_node_fleet
+tmp/build-http-example/bin/examples/sync_18_http_node_fleet \
+    master-replica 3
+tmp/build-http-example/bin/examples/sync_18_http_node_fleet \
+    mesh 3
+```
+
+Готовый HTTP binding подключается так:
+
+```cpp
+#include <mdbx_containers/sync/transports/simple_web/HttpTransport.hpp>
+```
+
+Targets, которым нужны и Simple-Web HTTP, и WebSocket bindings, могут
+подключать backend umbrella:
+
+```cpp
+#include <mdbx_containers/sync/transports/simple_web.hpp>
 ```
 
 Реальный WebSocket binding example тоже включается отдельно, потому что он
@@ -70,7 +90,14 @@ cmake -S . -B tmp/build-ws-example \
     -DCMAKE_CXX_STANDARD=11
 
 cmake --build tmp/build-ws-example --target sync_17_websocket_simple_web_server
-tmp/build-ws-example/bin/examples/sync_17_websocket_simple_web_server
+tmp/build-ws-example/bin/examples/sync_17_websocket_simple_web_server \
+    127.0.0.1 18194
+```
+
+Готовый WebSocket binding подключается так:
+
+```cpp
+#include <mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp>
 ```
 
 Чтобы использовать свой готовый бинарный пакет OpenSSL, укажите CMake корень
@@ -102,11 +129,12 @@ cmake -S . -B tmp/build-ws-example `
 | `sync_10_custom_transport.cpp` | Минимальный кастомный `ISyncPeer` поверх закодированных byte buffers. | Продвинутый |
 | `sync_11_http_adapter.cpp` | Фреймворк-независимый HTTP-адаптер поверх `TransportMessageCodec`. | Продвинутый |
 | `sync_12_transport_middleware.cpp` | Allow-list, fixed-budget rate limit и metrics middleware вокруг транспортных адаптеров. | Продвинутый |
-| `sync_13_http_simple_web_server.cpp` | Опциональный настоящий HTTP binding через Simple-Web-Server и standalone Asio, включая worker-demo через реальные loopback HTTP sockets. | Продвинутый |
+| `sync_13_http_simple_web_server.cpp` | Готовый Simple-Web HTTP binding, прямой pull/push и worker-demo через реальные loopback HTTP sockets. | Продвинутый |
 | `sync_14_websocket_adapter.cpp` | Framework-neutral WebSocket binary-message seam поверх `TransportMessageCodec`. | Продвинутый |
 | `sync_15_http_policy_context.cpp` | Bearer-token, remote-address и `Retry-After` HTTP policy context. | Продвинутый |
 | `sync_16_worker_http_transport.cpp` | `SyncWorker` поверх `HttpSyncPeer` и HTTP request-context policy. | Продвинутый |
-| `sync_17_websocket_simple_web_server.cpp` | Опциональный настоящий WebSocket binding через Simple-WebSocket-Server и standalone Asio. | Продвинутый |
+| `sync_17_websocket_simple_web_server.cpp` | Готовый Simple-WebSocket binding поверх standalone Asio. | Продвинутый |
+| `sync_18_http_node_fleet.cpp` | Fleet из нескольких процессов поверх готового Simple-Web HTTP binding. | Продвинутый |
 
 ## Общие правила
 
@@ -117,6 +145,17 @@ cmake -S . -B tmp/build-ws-example `
 - Перед локальными записями прикрепите `ThreadLocalChangeAccumulator` через
   `attach_sync_capture()`. После завершения локальной фазы записи вызовите
   `detach_sync_capture()`.
+- Методы поддерживаемых таблиц сохраняют обычный API. Не нужно оборачивать
+  каждый `insert`, `insert_or_assign`, `erase`, `reconcile` или range erase в
+  отдельный sync-вызов. Capture sink записывает поддерживаемые write operations
+  при commit MDBX-транзакции. Если вы передаёте явную транзакцию через
+  несколько вызовов поддерживаемых таблиц, эти записи коммитятся и
+  реплицируются как один локальный batch. Независимые вызовы без явной
+  транзакции остаются независимыми локальными транзакциями и независимыми sync
+  batches.
+- Чтение, поиск и range scans не запускают sync. Локальный commit также не
+  обращается к другой ноде; `SyncWorker` или явный pull/push-код позже
+  отправляет уже закоммиченные batches через `ISyncPeer`.
 - `PullRequest`, `PullResponse`, `PushRequest` и `PushResponse` - структуры
   данных протокола. Именно эти значения нужно сериализовать и передавать через
   транспорт приложения.
@@ -166,9 +205,9 @@ replica формирует PullRequest
 `sync_08_transport_boundary.cpp` фиксирует контракт, которому должен следовать
 транспортный адаптер, реализующий `ISyncPeer`. Пример показывает, где
 наблюдается `CancellationToken` из `PullRequest` и где
-`ISyncPeer::request_cancel()` закрывает выполняющийся вызов. Реальные
-адаптеры HTTP и WebSocket используют ту же схему, заменяя очереди в памяти
-на сокеты.
+`ISyncPeer::request_cancel()` закрывает выполняющийся вызов. Готовые
+Simple-Web HTTP/WebSocket bindings используют ту же схему, заменяя очереди в
+памяти на сокеты.
 
 `sync_09_transport_codec.cpp` показывает следующий слой: `PullRequest`,
 `PullResponse`, `PushRequest` и `PushResponse` кодируются в byte buffer через
@@ -184,15 +223,16 @@ replica формирует PullRequest
 `sync_11_http_adapter.cpp` показывает границу HTTP-адаптера. `HttpSyncPeer`
 реализует `ISyncPeer` поверх абстрактного `IHttpSyncClient`, а
 `HttpSyncServer` передаёт уже разобранные HTTP method/target/content-type/body
-значения в `SyncEngine`. Реальная HTTP-библиотека добавляет сетевой слой вокруг
-этой границы.
+значения в `SyncEngine`. `mdbxc::sync::simple_web::HttpSyncClient` и
+`mdbxc::sync::simple_web::HttpSyncListener` - готовая опциональная реализация
+этой границы на Simple-Web-Server.
 
 `sync_14_websocket_adapter.cpp` показывает границу WebSocket-адаптера.
 `WebSocketSyncPeer` реализует `ISyncPeer` поверх абстрактного
 `IWebSocketSyncChannel`, а `WebSocketSyncServer` передаёт полные бинарные
-сообщения в `SyncEngine`. Реальная WebSocket-библиотека добавляет вокруг этой
-границы подключение, сборку фрагментов, ping/pong, backpressure и mapping
-close/error.
+сообщения в `SyncEngine`. `mdbxc::sync::simple_web::WebSocketSyncChannel` и
+`mdbxc::sync::simple_web::WebSocketSyncListener` - готовая опциональная
+реализация этой границы на Simple-WebSocket-Server.
 
 `sync_12_transport_middleware.cpp` показывает adapter-local policy wrappers.
 `SyncPeerMiddleware` может проверять декодированные `NodeId` / `DbId` перед
@@ -218,11 +258,22 @@ replica перед тем, как `HttpSyncServer` передаст запрос
 `sync_13_http_simple_web_server.cpp worker-demo` запускает тот же worker path
 через настоящие loopback HTTP sockets. Он использует bearer identity,
 message-size guard, страничные pull-запросы и callbacks observer-а worker-а
-поверх Simple-Web-Server binding.
+поверх `mdbxc::sync::simple_web::HttpSyncClient` и
+`mdbxc::sync::simple_web::HttpSyncListener`.
+
+`sync_18_http_node_fleet.cpp` запускает несколько копий одного исполняемого
+файла через tiny-process-library. Каждый дочерний процесс владеет собственным
+MDBX environment, готовым Simple-Web HTTP listener/client, sync engine,
+capture sink и application loop;
+родительский процесс только стартует ноды и отправляет команды `pause` / `stop`
+через stdin. Режим `master-replica` показывает одного активного писателя и
+одного пассивного получателя. Режим `mesh` позволяет обеим нодам писать
+локально, пока каждая нода подтягивает изменения другой по HTTP.
 
 `sync_17_websocket_simple_web_server.cpp` - socket-backed WebSocket-вариант.
-Он связывает `WebSocketSyncPeer` / `WebSocketSyncServer` с
-Simple-WebSocket-Server, отправляет binary frames, проверяет bearer token во
+Он использует `mdbxc::sync::simple_web::WebSocketSyncChannel` и
+`mdbxc::sync::simple_web::WebSocketSyncListener`, отправляет binary frames,
+проверяет bearer token во
 время WebSocket handshake, передаёт аутентифицированный `NodeId` replica вместе
 с явным `SyncDbAccess` в `WebSocketSyncServerMiddleware`, отклоняет слишком
 большие сообщения до decode и классифицирует close codes для диагностики

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -3,7 +3,8 @@
 These examples show the sync v0.1 API as transport-agnostic building blocks.
 Most use `DirectSyncPeer` or a small in-memory buffer so the protocol flow is
 visible without adding HTTP, WebSocket, or IPC code. The optional HTTP and
-WebSocket examples bind the transport seams to Simple-Web-Server,
+WebSocket examples use ready-made Simple-Web binding headers from
+`mdbx_containers/sync/transports/simple_web/` over Simple-Web-Server,
 Simple-WebSocket-Server, and standalone Asio.
 
 Sync is opt-in. The examples are built with `MDBXC_SYNC_ENABLED=1`; applications
@@ -29,8 +30,9 @@ executable has the `.exe` suffix, for example:
 .\tmp\build-examples\bin\examples\sync_01_lifecycle_direct_peer.exe
 ```
 
-The real HTTP binding example is opt-in because it fetches standalone Asio and
-Simple-Web-Server headers:
+The real HTTP binding examples are opt-in because they fetch standalone Asio,
+Simple-Web-Server headers, and, for the process-supervised demo,
+tiny-process-library:
 
 ```bash
 cmake -S . -B tmp/build-http-example \
@@ -45,6 +47,25 @@ tmp/build-http-example/bin/examples/sync_13_http_simple_web_server \
     demo 127.0.0.1 18080
 tmp/build-http-example/bin/examples/sync_13_http_simple_web_server \
     worker-demo 127.0.0.1 18080
+
+cmake --build tmp/build-http-example --target sync_18_http_node_fleet
+tmp/build-http-example/bin/examples/sync_18_http_node_fleet \
+    master-replica 3
+tmp/build-http-example/bin/examples/sync_18_http_node_fleet \
+    mesh 3
+```
+
+The reusable HTTP binding lives in:
+
+```cpp
+#include <mdbx_containers/sync/transports/simple_web/HttpTransport.hpp>
+```
+
+Targets that intentionally use both Simple-Web HTTP and WebSocket bindings can
+include the backend umbrella:
+
+```cpp
+#include <mdbx_containers/sync/transports/simple_web.hpp>
 ```
 
 The real WebSocket binding example is also opt-in because it fetches standalone
@@ -68,7 +89,14 @@ cmake -S . -B tmp/build-ws-example \
     -DCMAKE_CXX_STANDARD=11
 
 cmake --build tmp/build-ws-example --target sync_17_websocket_simple_web_server
-tmp/build-ws-example/bin/examples/sync_17_websocket_simple_web_server
+tmp/build-ws-example/bin/examples/sync_17_websocket_simple_web_server \
+    127.0.0.1 18194
+```
+
+The reusable WebSocket binding lives in:
+
+```cpp
+#include <mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp>
 ```
 
 To use your own ready-made OpenSSL package instead, point CMake at the package
@@ -100,11 +128,12 @@ cmake -S . -B tmp/build-ws-example `
 | `sync_10_custom_transport.cpp` | Minimal custom `ISyncPeer` over encoded byte buffers. | Advanced |
 | `sync_11_http_adapter.cpp` | Framework-neutral HTTP-shaped adapter over `TransportMessageCodec`. | Advanced |
 | `sync_12_transport_middleware.cpp` | Allow-list, fixed-budget, and metrics middleware around transport adapters. | Advanced |
-| `sync_13_http_simple_web_server.cpp` | Optional real HTTP binding over Simple-Web-Server and standalone Asio, including a socket-backed worker demo. | Advanced |
+| `sync_13_http_simple_web_server.cpp` | Ready-made Simple-Web HTTP binding, direct pull/push, and socket-backed worker demo. | Advanced |
 | `sync_14_websocket_adapter.cpp` | Framework-neutral WebSocket binary-message seam over `TransportMessageCodec`. | Advanced |
 | `sync_15_http_policy_context.cpp` | Bearer-token, remote-address, and `Retry-After` HTTP policy context. | Advanced |
 | `sync_16_worker_http_transport.cpp` | `SyncWorker` running through `HttpSyncPeer` and HTTP request-context policy. | Advanced |
-| `sync_17_websocket_simple_web_server.cpp` | Optional real WebSocket binding over Simple-WebSocket-Server and standalone Asio. | Advanced |
+| `sync_17_websocket_simple_web_server.cpp` | Ready-made Simple-WebSocket binding over standalone Asio. | Advanced |
+| `sync_18_http_node_fleet.cpp` | Multi-process node fleet using the ready-made Simple-Web HTTP binding. | Advanced |
 
 ## Common Rules
 
@@ -115,6 +144,16 @@ cmake -S . -B tmp/build-ws-example `
 - Before local writes, attach `ThreadLocalChangeAccumulator` with
   `attach_sync_capture()`. After the local write phase, call
   `detach_sync_capture()`.
+- Supported table methods keep their normal API. You do not wrap each
+  `insert`, `insert_or_assign`, `erase`, `reconcile`, or range erase in a sync
+  call. The capture sink records supported write operations when their MDBX
+  transaction commits. If you pass an explicit transaction through several
+  supported table calls, those writes commit and replicate as one local batch.
+  Independent calls without an explicit transaction remain independent local
+  transactions and independent sync batches.
+- Sync is not triggered by reads, searches, or range scans. It also does not
+  contact another node during the local commit; a `SyncWorker` or explicit
+  pull/push code sends already committed batches later through an `ISyncPeer`.
 - `PullRequest`, `PullResponse`, `PushRequest`, and `PushResponse` are
   transport payload structs. Serialize and deliver these values through the
   transport used by your application.
@@ -161,8 +200,8 @@ notifies foreground code when pages are applied or rounds finish.
 adapter over `ISyncPeer` must respect. It implements a tiny in-memory
 adapter that owns no MDBX handles and demonstrates where the
 `CancellationToken` from `PullRequest` is observed and where
-`ISyncPeer::request_cancel()` closes the in-flight call. Real HTTP and
-WebSocket adapters will use the same pattern, swapping the in-memory
+`ISyncPeer::request_cancel()` closes the in-flight call. The ready-made
+Simple-Web HTTP/WebSocket bindings use the same pattern, swapping the in-memory
 queues for sockets.
 
 `sync_09_transport_codec.cpp` shows the next layer down: `PullRequest`,
@@ -180,14 +219,18 @@ channel's own interruption primitive.
 implements `ISyncPeer` over an abstract `IHttpSyncClient`, and
 `HttpSyncServer` dispatches already-parsed HTTP method/target/content-type/body
 values to `SyncEngine`. A real HTTP library supplies the socket layer around
-that seam.
+that seam; `mdbxc::sync::simple_web::HttpSyncClient` and
+`mdbxc::sync::simple_web::HttpSyncListener` are the optional Simple-Web
+implementation shipped with these examples.
 
 `sync_14_websocket_adapter.cpp` shows the WebSocket-shaped adapter seam.
 `WebSocketSyncPeer` implements `ISyncPeer` over an abstract
 `IWebSocketSyncChannel`, and `WebSocketSyncServer` dispatches complete binary
 messages to `SyncEngine`. A real WebSocket library supplies connection setup,
 fragment reassembly, ping/pong, backpressure, and close/error mapping around
-that seam.
+that seam; `mdbxc::sync::simple_web::WebSocketSyncChannel` and
+`mdbxc::sync::simple_web::WebSocketSyncListener` are the optional
+Simple-WebSocket implementation shipped with these examples.
 
 `sync_12_transport_middleware.cpp` shows adapter-local policy wrappers.
 `SyncPeerMiddleware` can inspect decoded `NodeId` / `DbId` values before a peer
@@ -212,12 +255,22 @@ the replica `NodeId` before `HttpSyncServer` dispatches the request.
 
 `sync_13_http_simple_web_server.cpp worker-demo` runs the same worker shape
 through real loopback HTTP sockets. It uses bearer identity, a message-size
-guard, paginated pulls, and worker observer callbacks over the Simple-Web-Server
-binding.
+guard, paginated pulls, and worker observer callbacks over
+`mdbxc::sync::simple_web::HttpSyncClient` and
+`mdbxc::sync::simple_web::HttpSyncListener`.
+
+`sync_18_http_node_fleet.cpp` runs several copies of the same executable through
+tiny-process-library. Each child process owns its own MDBX environment, ready
+Simple-Web HTTP listener/client, sync engine, capture sink, and application
+loop; the parent process only starts nodes and sends `pause` / `stop` commands
+through stdin. The `master-replica` mode shows one active writer and one passive
+receiver. The `mesh` mode lets both nodes write locally while each node pulls
+from the other over HTTP.
 
 `sync_17_websocket_simple_web_server.cpp` is the socket-backed WebSocket
-counterpart. It binds `WebSocketSyncPeer` / `WebSocketSyncServer` to
-Simple-WebSocket-Server, sends binary frames, checks the bearer token during
-the WebSocket handshake, passes the authenticated replica `NodeId` plus
-explicit `SyncDbAccess` to `WebSocketSyncServerMiddleware`, rejects oversized
-messages before decode, and classifies close codes for client diagnostics.
+counterpart. It uses `mdbxc::sync::simple_web::WebSocketSyncChannel` and
+`mdbxc::sync::simple_web::WebSocketSyncListener`, sends binary frames, checks
+the bearer token during the WebSocket handshake, passes the authenticated
+replica `NodeId` plus explicit `SyncDbAccess` to
+`WebSocketSyncServerMiddleware`, rejects oversized messages before decode, and
+classifies close codes for client diagnostics.

--- a/examples/sync_13_http_simple_web_server.cpp
+++ b/examples/sync_13_http_simple_web_server.cpp
@@ -44,14 +44,14 @@
  *   OK: sync_13_http_simple_web_server (worker-demo)
  */
 
-#include <atomic>
+#include <mdbx_containers/sync/transports/simple_web/HttpTransport.hpp>
+
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <exception>
-#include <future>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -60,349 +60,15 @@
 #include <thread>
 #include <vector>
 
-#ifndef ASIO_STANDALONE
-#define ASIO_STANDALONE 1
-#endif
-#ifndef USE_STANDALONE_ASIO
-#define USE_STANDALONE_ASIO 1
-#endif
-#include <client_http.hpp>
-#include <server_http.hpp>
-
 #include "sync_example_utils.hpp"
 
 namespace {
-
-using HttpClient = SimpleWeb::Client<SimpleWeb::HTTP>;
-using HttpServer = SimpleWeb::Server<SimpleWeb::HTTP>;
 
 // Demo-only seeds. They have no protocol meaning; they just make the two node
 // ids and one db id deterministic and visibly distinct.
 const std::uint8_t kServerNodeSeed = 0xA0;
 const std::uint8_t kClientNodeSeed = 0xB0;
 const std::uint8_t kDatabaseSeed = 0xA1;
-
-std::string endpoint(const std::string& host, std::uint16_t port) {
-    return host + ":" + std::to_string(static_cast<unsigned>(port));
-}
-
-std::string bytes_to_string(const std::vector<std::uint8_t>& bytes) {
-    if (bytes.empty()) {
-        return std::string();
-    }
-    return std::string(reinterpret_cast<const char*>(&bytes[0]),
-                       bytes.size());
-}
-
-std::vector<std::uint8_t> string_to_bytes(const std::string& text) {
-    return std::vector<std::uint8_t>(text.begin(), text.end());
-}
-
-std::string header_value(const SimpleWeb::CaseInsensitiveMultimap& headers,
-                         const std::string& name) {
-    const auto it = headers.find(name);
-    return it == headers.end() ? std::string() : it->second;
-}
-
-SimpleWeb::StatusCode to_simple_status(unsigned status) {
-    return SimpleWeb::status_code(std::to_string(status));
-}
-
-void write_http_response(
-        const std::shared_ptr<HttpServer::Response>& response,
-        const mdbxc::sync::HttpSyncResponse& out) {
-    SimpleWeb::CaseInsensitiveMultimap headers;
-    headers.emplace("Content-Type",
-                    out.content_type.empty()
-                        ? "text/plain; charset=utf-8"
-                        : out.content_type);
-    for (std::size_t i = 0; i < out.headers.size(); ++i) {
-        headers.emplace(out.headers[i].name, out.headers[i].value);
-    }
-    response->write(to_simple_status(out.status_code),
-                    bytes_to_string(out.body),
-                    headers);
-}
-
-mdbxc::sync::HttpSyncResponse make_cancelled_response(
-        const std::string& diagnostic) {
-    mdbxc::sync::HttpSyncResponse out;
-    out.status_code = 503;
-    out.content_type = "text/plain; charset=utf-8";
-    out.error = diagnostic.empty() ? "cancelled" : diagnostic;
-    out.body = string_to_bytes(out.error);
-    return out;
-}
-
-class SimpleWebHttpSyncClient : public mdbxc::sync::IHttpSyncClient {
-public:
-    SimpleWebHttpSyncClient(const std::string& host,
-                            std::uint16_t port,
-                            std::chrono::seconds timeout,
-                            const std::string& bearer_token = std::string())
-        : m_endpoint(endpoint(host, port)),
-          m_timeout(timeout),
-          m_bearer_token(bearer_token),
-          m_cancel_generation(0),
-          m_active_client(nullptr),
-          m_cancel_count(0) {}
-
-    mdbxc::sync::HttpSyncResponse post(
-            const std::string& target,
-            const std::string& content_type,
-            const std::vector<std::uint8_t>& body,
-            const mdbxc::sync::CancellationToken& cancel_token) override {
-        if (cancel_token.is_cancellation_requested()) {
-            return make_cancelled_response("cancelled before HTTP request");
-        }
-
-        const std::uint64_t call_generation =
-            m_cancel_generation.load(std::memory_order_acquire);
-
-        HttpClient client(m_endpoint);
-        client.config.timeout = static_cast<long>(m_timeout.count());
-        client.config.timeout_connect = static_cast<long>(m_timeout.count());
-        ActiveClientGuard active(*this, client);
-
-        if (cancel_token.is_cancellation_requested() ||
-            m_cancel_generation.load(std::memory_order_acquire) !=
-                call_generation) {
-            return make_cancelled_response("cancelled before HTTP request");
-        }
-
-        try {
-            SimpleWeb::CaseInsensitiveMultimap headers;
-            headers.emplace("Content-Type", content_type);
-            if (!m_bearer_token.empty()) {
-                headers.emplace("Authorization",
-                                std::string("Bearer ") + m_bearer_token);
-            }
-
-            const std::shared_ptr<HttpClient::Response> received =
-                client.request("POST", target, bytes_to_string(body), headers);
-
-            mdbxc::sync::HttpSyncResponse out;
-            out.status_code =
-                static_cast<unsigned>(std::atoi(
-                    received->status_code.c_str()));
-            out.content_type = header_value(received->header, "Content-Type");
-            for (SimpleWeb::CaseInsensitiveMultimap::const_iterator it =
-                     received->header.begin();
-                 it != received->header.end();
-                 ++it) {
-                mdbxc::sync::http_add_header(
-                    out.headers, it->first, it->second);
-            }
-            out.body = string_to_bytes(received->content.string());
-            return out;
-        } catch (const SimpleWeb::system_error& e) {
-            if (m_cancel_generation.load(std::memory_order_acquire) !=
-                    call_generation ||
-                cancel_token.is_cancellation_requested()) {
-                return make_cancelled_response(e.what());
-            }
-            throw;
-        }
-    }
-
-    void request_cancel() override {
-        m_cancel_generation.fetch_add(1, std::memory_order_acq_rel);
-        m_cancel_count.fetch_add(1, std::memory_order_acq_rel);
-
-        std::lock_guard<std::mutex> lock(m_mutex);
-        if (m_active_client != nullptr) {
-            m_active_client->stop();
-        }
-    }
-
-    std::size_t cancel_count() const {
-        return m_cancel_count.load(std::memory_order_acquire);
-    }
-
-private:
-    class ActiveClientGuard {
-    public:
-        ActiveClientGuard(SimpleWebHttpSyncClient& owner,
-                          HttpClient& client)
-            : m_owner(owner), m_client(&client) {
-            m_owner.set_active_client(m_client);
-        }
-
-        ~ActiveClientGuard() {
-            m_owner.clear_active_client(m_client);
-        }
-
-        ActiveClientGuard(const ActiveClientGuard&) = delete;
-        ActiveClientGuard& operator=(const ActiveClientGuard&) = delete;
-
-    private:
-        SimpleWebHttpSyncClient& m_owner;
-        HttpClient* m_client;
-    };
-
-    void set_active_client(HttpClient* client) {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        m_active_client = client;
-    }
-
-    void clear_active_client(HttpClient* client) {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        if (m_active_client == client) {
-            m_active_client = nullptr;
-        }
-    }
-
-    std::string m_endpoint;
-    std::chrono::seconds m_timeout;
-    std::string m_bearer_token;
-    std::atomic<std::uint64_t> m_cancel_generation;
-    mutable std::mutex m_mutex;
-    HttpClient* m_active_client;
-    std::atomic<std::size_t> m_cancel_count;
-};
-
-class SimpleWebHttpSyncServer {
-public:
-    SimpleWebHttpSyncServer(mdbxc::sync::HttpSyncServer& handler,
-                            mdbxc::sync::ISyncTransportPolicy& policy,
-                            const std::string& host,
-                            std::uint16_t port)
-        : m_handler(handler),
-          m_policy(policy),
-          m_host(host),
-          m_port(port),
-          m_running(false) {
-        m_server.config.address = host;
-        m_server.config.port = port;
-        m_server.config.thread_pool_size = 1;
-
-        m_server.resource["^/mdbxc/sync/v1/(pull|push)$"]["POST"] =
-            [this](std::shared_ptr<HttpServer::Response> response,
-                   std::shared_ptr<HttpServer::Request> request) {
-                handle_post(response, request);
-            };
-
-        m_server.default_resource["POST"] =
-            [](std::shared_ptr<HttpServer::Response> response,
-               std::shared_ptr<HttpServer::Request> request) {
-                (void)request;
-                mdbxc::sync::HttpSyncResponse out;
-                out.status_code = 404;
-                out.content_type = "text/plain; charset=utf-8";
-                out.error = "unknown sync route";
-                out.body = string_to_bytes(out.error);
-                write_http_response(response, out);
-            };
-    }
-
-    ~SimpleWebHttpSyncServer() {
-        stop();
-    }
-
-    void start() {
-        if (m_running) {
-            return;
-        }
-
-        std::shared_ptr<std::promise<unsigned short> > started(
-            new std::promise<unsigned short>());
-        std::future<unsigned short> started_future = started->get_future();
-        m_thread = std::thread(
-            [this, started]() {
-                bool started_callback_called = false;
-                try {
-                    m_server.start(
-                        [started, &started_callback_called](
-                            unsigned short assigned_port) {
-                            started_callback_called = true;
-                            started->set_value(assigned_port);
-                        });
-                } catch (...) {
-                    if (!started_callback_called) {
-                        try {
-                            started->set_exception(std::current_exception());
-                        } catch (...) {}
-                    }
-                }
-            });
-        try {
-            m_port = started_future.get();
-        } catch (...) {
-            if (m_thread.joinable()) {
-                m_thread.join();
-            }
-            throw;
-        }
-        m_running = true;
-        std::printf("[server] listening on %s:%u\n",
-                    m_host.c_str(),
-                    static_cast<unsigned>(m_port));
-    }
-
-    void stop() {
-        if (!m_running) {
-            return;
-        }
-        m_server.stop();
-        if (m_thread.joinable()) {
-            m_thread.join();
-        }
-        m_running = false;
-    }
-
-private:
-    void handle_post(
-            const std::shared_ptr<HttpServer::Response>& response,
-            const std::shared_ptr<HttpServer::Request>& request) {
-        const std::string content_type =
-            header_value(request->header, "Content-Type");
-        const std::string content = request->content.string();
-
-        mdbxc::sync::HttpSyncRequest in;
-        in.method = request->method;
-        in.target = request->path;
-        in.content_type = content_type;
-        in.body = string_to_bytes(content);
-        for (SimpleWeb::CaseInsensitiveMultimap::const_iterator it =
-                 request->header.begin();
-             it != request->header.end();
-             ++it) {
-            mdbxc::sync::http_add_header(in.headers, it->first, it->second);
-        }
-        try {
-            in.remote_address =
-                request->remote_endpoint().address().to_string();
-        } catch (...) {
-            in.remote_address.clear();
-        }
-
-        const mdbxc::sync::SyncTransportDecision decision =
-            m_policy.check_http_request(in);
-        if (!decision.allowed) {
-            mdbxc::sync::HttpSyncResponse out;
-            out.status_code =
-                decision.status_code == 0 ? 403 : decision.status_code;
-            out.content_type = "text/plain; charset=utf-8";
-            out.headers = decision.response_headers;
-            mdbxc::sync::http_copy_sync_correlation_headers(
-                in.headers, out.headers);
-            out.error = decision.error.empty() ? "rejected" : decision.error;
-            out.body = string_to_bytes(out.error);
-            write_http_response(response, out);
-            return;
-        }
-
-        write_http_response(response, m_handler.handle(in));
-    }
-
-    mdbxc::sync::HttpSyncServer& m_handler;
-    mdbxc::sync::ISyncTransportPolicy& m_policy;
-    std::string m_host;
-    std::uint16_t m_port;
-    HttpServer m_server;
-    std::thread m_thread;
-    bool m_running;
-};
 
 void seed_server_rows(const std::shared_ptr<mdbxc::Connection>& db) {
     mdbxc::sync::ThreadLocalChangeAccumulator sink(db);
@@ -475,7 +141,7 @@ void run_client_session(const std::shared_ptr<mdbxc::Connection>& db,
                         mdbxc::sync::SyncEngine& engine,
                         const std::string& host,
                         std::uint16_t port) {
-    SimpleWebHttpSyncClient raw_client(
+    mdbxc::sync::simple_web::HttpSyncClient raw_client(
         host, port, std::chrono::seconds(2));
 
     mdbxc::sync::HttpRouteAllowListPolicy routes;
@@ -584,8 +250,15 @@ int run_demo(const std::string& host, std::uint16_t port) {
     route_policy.allow_target(mdbxc::sync::HttpSyncRoutes::pull_target());
     route_policy.allow_target(mdbxc::sync::HttpSyncRoutes::push_target());
 
-    SimpleWebHttpSyncServer listener(handler, route_policy, host, port);
+    mdbxc::sync::simple_web::HttpSyncListenerConfig listener_config;
+    listener_config.host = host;
+    listener_config.port = port;
+    mdbxc::sync::simple_web::HttpSyncListener listener(
+        handler, listener_config, &route_policy);
     listener.start();
+    std::printf("[server] listening on %s:%u\n",
+                host.c_str(),
+                static_cast<unsigned>(listener.port()));
 
     run_client_session(client_db, client_engine, host, port);
     require_quote(server_db, 3, "SOL/USD");
@@ -645,10 +318,14 @@ int run_worker_demo(const std::string& host, std::uint16_t port) {
     server_policy.add(size_policy);
     server_policy.add(identity_policy);
 
-    SimpleWebHttpSyncServer listener(handler, server_policy, host, port);
+    mdbxc::sync::simple_web::HttpSyncListenerConfig listener_config;
+    listener_config.host = host;
+    listener_config.port = port;
+    mdbxc::sync::simple_web::HttpSyncListener listener(
+        handler, listener_config, &server_policy);
     listener.start();
 
-    SimpleWebHttpSyncClient raw_client(
+    mdbxc::sync::simple_web::HttpSyncClient raw_client(
         host, port, std::chrono::seconds(2), "replica-token");
     mdbxc::sync::SyncTransportMetricsObserver metrics;
     mdbxc::sync::HttpSyncClientMiddleware http_client(
@@ -706,8 +383,15 @@ int run_server(const std::string& host, std::uint16_t port) {
     route_policy.allow_target(mdbxc::sync::HttpSyncRoutes::pull_target());
     route_policy.allow_target(mdbxc::sync::HttpSyncRoutes::push_target());
 
-    SimpleWebHttpSyncServer listener(handler, route_policy, host, port);
+    mdbxc::sync::simple_web::HttpSyncListenerConfig listener_config;
+    listener_config.host = host;
+    listener_config.port = port;
+    mdbxc::sync::simple_web::HttpSyncListener listener(
+        handler, listener_config, &route_policy);
     listener.start();
+    std::printf("[server] listening on %s:%u\n",
+                host.c_str(),
+                static_cast<unsigned>(listener.port()));
 
     std::printf("[server] press Enter to stop\n");
     std::string line;

--- a/examples/sync_17_websocket_simple_web_server.cpp
+++ b/examples/sync_17_websocket_simple_web_server.cpp
@@ -23,22 +23,25 @@
  * Run the self-contained demo:
  *
  *   ./tmp/build-ws-example/bin/examples/sync_17_websocket_simple_web_server
+ *   ./tmp/build-ws-example/bin/examples/sync_17_websocket_simple_web_server \
+ *       127.0.0.1 18194
  *
  * Expected output:
  *
- *   [websocket server] listening on 127.0.0.1:18081
+ *   [websocket server] listening on 127.0.0.1:<port>
  *   [websocket client] pull applied 2 batch(es)
  *   [websocket client] push sent 1 batch(es)
  *   [websocket client] request_cancel forwarded once
  *   OK: sync_17_websocket_simple_web_server
  */
 
-#include <atomic>
+#include <mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp>
+
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <exception>
-#include <future>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -46,360 +49,14 @@
 #include <thread>
 #include <vector>
 
-#ifndef ASIO_STANDALONE
-#define ASIO_STANDALONE 1
-#endif
-#ifndef USE_STANDALONE_ASIO
-#define USE_STANDALONE_ASIO 1
-#endif
-#include <client_ws.hpp>
-#include <server_ws.hpp>
-
 #include "sync_example_utils.hpp"
 
 namespace {
 
-using WsClient = SimpleWeb::SocketClient<SimpleWeb::WS>;
-using WsServer = SimpleWeb::SocketServer<SimpleWeb::WS>;
-
 const std::uint8_t kPrimaryNodeSeed = 0xC8;
 const std::uint8_t kReplicaNodeSeed = 0xC9;
 const std::uint8_t kDatabaseSeed = 0xCA;
-const unsigned char kBinaryFrameOpcode = 130;
 const std::size_t kMaxWebSocketMessageBytes = 1024u * 1024u;
-
-const char* websocket_path() {
-    return "/mdbxc/sync/v1/ws";
-}
-
-std::string bytes_to_string(const std::vector<std::uint8_t>& bytes) {
-    if (bytes.empty()) {
-        return std::string();
-    }
-    return std::string(reinterpret_cast<const char*>(&bytes[0]),
-                       bytes.size());
-}
-
-std::vector<std::uint8_t> string_to_bytes(const std::string& text) {
-    return std::vector<std::uint8_t>(text.begin(), text.end());
-}
-
-std::string endpoint(const std::string& host, std::uint16_t port) {
-    return host + ":" + std::to_string(static_cast<unsigned>(port));
-}
-
-const char* close_retry_label(unsigned close_code) {
-    return mdbxc::sync::websocket_sync_close_code_is_retryable(close_code)
-        ? "retryable"
-        : "permanent";
-}
-
-class ExchangeState {
-public:
-    void set_value(const std::vector<std::uint8_t>& bytes) {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        if (!m_completed) {
-            m_completed = true;
-            m_promise.set_value(bytes);
-        }
-    }
-
-    void set_exception(const std::string& message) {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        if (!m_completed) {
-            m_completed = true;
-            m_promise.set_exception(std::make_exception_ptr(
-                std::runtime_error(message)));
-        }
-    }
-
-    std::future<std::vector<std::uint8_t> > future() {
-        return m_promise.get_future();
-    }
-
-private:
-    std::mutex m_mutex;
-    bool m_completed = false;
-    std::promise<std::vector<std::uint8_t> > m_promise;
-};
-
-class SimpleWebSocketSyncChannel
-    : public mdbxc::sync::IWebSocketSyncChannel {
-public:
-    SimpleWebSocketSyncChannel(const std::string& host,
-                               std::uint16_t port,
-                               const std::string& bearer_token)
-        : m_endpoint(endpoint(host, port) + websocket_path()),
-          m_bearer_token(bearer_token),
-          m_cancel_generation(0),
-          m_active_client(nullptr),
-          m_cancel_count(0) {}
-
-    std::vector<std::uint8_t> exchange_binary(
-            const std::vector<std::uint8_t>& binary_message,
-            const mdbxc::sync::CancellationToken& cancel_token) override {
-        if (cancel_token.is_cancellation_requested()) {
-            throw std::runtime_error("cancelled before WebSocket exchange");
-        }
-
-        const std::uint64_t call_generation =
-            m_cancel_generation.load(std::memory_order_acquire);
-
-        WsClient client(m_endpoint);
-        client.config.header.emplace(
-            "Authorization", std::string("Bearer ") + m_bearer_token);
-        ActiveClientGuard active(*this, client);
-
-        std::shared_ptr<ExchangeState> state(new ExchangeState());
-        std::future<std::vector<std::uint8_t> > result = state->future();
-        const std::string outbound = bytes_to_string(binary_message);
-
-        client.on_open =
-            [state, outbound](
-                std::shared_ptr<WsClient::Connection> connection) {
-                try {
-                    connection->send(outbound, nullptr, kBinaryFrameOpcode);
-                } catch (const std::exception& e) {
-                    state->set_exception(e.what());
-                    connection->send_close(1011);
-                }
-            };
-
-        client.on_message =
-            [state](
-                std::shared_ptr<WsClient::Connection> connection,
-                std::shared_ptr<WsClient::InMessage> in_message) {
-                state->set_value(string_to_bytes(in_message->string()));
-                connection->send_close(1000);
-            };
-
-        client.on_close =
-            [state](
-                std::shared_ptr<WsClient::Connection> connection,
-                int status,
-                const std::string& reason) {
-                (void)connection;
-                if (status != 1000) {
-                    state->set_exception(
-                        "WebSocket closed with status " +
-                        std::to_string(status) + " (" +
-                        close_retry_label(static_cast<unsigned>(status)) +
-                        "): " + reason);
-                }
-            };
-
-        client.on_error =
-            [state](
-                std::shared_ptr<WsClient::Connection> connection,
-                const SimpleWeb::error_code& ec) {
-                (void)connection;
-                state->set_exception(ec.message());
-            };
-
-        if (cancel_token.is_cancellation_requested() ||
-            m_cancel_generation.load(std::memory_order_acquire) !=
-                call_generation) {
-            throw std::runtime_error("cancelled before WebSocket start");
-        }
-
-        client.start();
-        return result.get();
-    }
-
-    void request_cancel() override {
-        m_cancel_generation.fetch_add(1, std::memory_order_acq_rel);
-        m_cancel_count.fetch_add(1, std::memory_order_acq_rel);
-
-        std::lock_guard<std::mutex> lock(m_mutex);
-        if (m_active_client != nullptr) {
-            m_active_client->stop();
-        }
-    }
-
-    std::size_t cancel_count() const {
-        return m_cancel_count.load(std::memory_order_acquire);
-    }
-
-private:
-    class ActiveClientGuard {
-    public:
-        ActiveClientGuard(SimpleWebSocketSyncChannel& owner,
-                          WsClient& client)
-            : m_owner(owner), m_client(&client) {
-            m_owner.set_active_client(m_client);
-        }
-
-        ~ActiveClientGuard() {
-            m_owner.clear_active_client(m_client);
-        }
-
-        ActiveClientGuard(const ActiveClientGuard&) = delete;
-        ActiveClientGuard& operator=(const ActiveClientGuard&) = delete;
-
-    private:
-        SimpleWebSocketSyncChannel& m_owner;
-        WsClient* m_client;
-    };
-
-    void set_active_client(WsClient* client) {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        m_active_client = client;
-    }
-
-    void clear_active_client(WsClient* client) {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        if (m_active_client == client) {
-            m_active_client = nullptr;
-        }
-    }
-
-    std::string m_endpoint;
-    std::string m_bearer_token;
-    std::atomic<std::uint64_t> m_cancel_generation;
-    mutable std::mutex m_mutex;
-    WsClient* m_active_client;
-    std::atomic<std::size_t> m_cancel_count;
-};
-
-class SimpleWebSocketSyncListener {
-public:
-    SimpleWebSocketSyncListener(
-            mdbxc::sync::WebSocketSyncServerMiddleware& server,
-            const std::string& bearer_token,
-            const mdbxc::sync::NodeId& authenticated_node,
-            const mdbxc::sync::SyncDbAccess& db_access,
-            const std::string& host,
-            std::uint16_t port)
-        : m_server(server),
-          m_bearer_token(bearer_token),
-          m_authenticated_node(authenticated_node),
-          m_db_access(db_access),
-          m_host(host),
-          m_port(port),
-          m_running(false) {
-        m_ws.config.address = host;
-        m_ws.config.port = port;
-        m_ws.config.thread_pool_size = 1;
-
-        WsServer::Endpoint& endpoint =
-            m_ws.endpoint["^/mdbxc/sync/v1/ws/?$"];
-
-        endpoint.on_handshake =
-            [this](
-                std::shared_ptr<WsServer::Connection> connection,
-                SimpleWeb::CaseInsensitiveMultimap& response_header) {
-                (void)response_header;
-                const SimpleWeb::CaseInsensitiveMultimap::const_iterator it =
-                    connection->header.find("Authorization");
-                if (it == connection->header.end() ||
-                    it->second !=
-                        std::string("Bearer ") + m_bearer_token) {
-                    return SimpleWeb::StatusCode::client_error_unauthorized;
-                }
-                return SimpleWeb::StatusCode::information_switching_protocols;
-            };
-
-        endpoint.on_message =
-            [this](
-                std::shared_ptr<WsServer::Connection> connection,
-                std::shared_ptr<WsServer::InMessage> in_message) {
-                try {
-                    mdbxc::sync::WebSocketSyncRequestContext context;
-                    context.has_authenticated_node = true;
-                    context.authenticated_node = m_authenticated_node;
-                    context.db_access = m_db_access;
-                    context.binary_message =
-                        string_to_bytes(in_message->string());
-                    const std::vector<std::uint8_t> response =
-                        m_server.handle_binary_message(context);
-                    connection->send(bytes_to_string(response),
-                                     nullptr,
-                                     kBinaryFrameOpcode);
-                } catch (const mdbxc::sync::WebSocketSyncRejected& e) {
-                    connection->send_close(
-                        static_cast<int>(e.close_code()), e.what());
-                } catch (const std::exception& e) {
-                    connection->send_close(1011, e.what());
-                }
-            };
-
-        endpoint.on_error =
-            [](
-                std::shared_ptr<WsServer::Connection> connection,
-                const SimpleWeb::error_code& ec) {
-                (void)connection;
-                (void)ec;
-            };
-    }
-
-    ~SimpleWebSocketSyncListener() {
-        stop();
-    }
-
-    void start() {
-        if (m_running) {
-            return;
-        }
-
-        std::shared_ptr<std::promise<unsigned short> > started(
-            new std::promise<unsigned short>());
-        std::future<unsigned short> started_future = started->get_future();
-
-        m_thread = std::thread(
-            [this, started]() {
-                bool started_callback_called = false;
-                try {
-                    m_ws.start(
-                        [started, &started_callback_called](
-                            unsigned short assigned_port) {
-                            started_callback_called = true;
-                            started->set_value(assigned_port);
-                        });
-                } catch (...) {
-                    if (!started_callback_called) {
-                        try {
-                            started->set_exception(std::current_exception());
-                        } catch (...) {}
-                    }
-                }
-            });
-
-        try {
-            m_port = started_future.get();
-        } catch (...) {
-            if (m_thread.joinable()) {
-                m_thread.join();
-            }
-            throw;
-        }
-        m_running = true;
-        std::printf("[websocket server] listening on %s:%u\n",
-                    m_host.c_str(),
-                    static_cast<unsigned>(m_port));
-    }
-
-    void stop() {
-        if (!m_running) {
-            return;
-        }
-        m_ws.stop();
-        if (m_thread.joinable()) {
-            m_thread.join();
-        }
-        m_running = false;
-    }
-
-private:
-    mdbxc::sync::WebSocketSyncServerMiddleware& m_server;
-    std::string m_bearer_token;
-    mdbxc::sync::NodeId m_authenticated_node;
-    mdbxc::sync::SyncDbAccess m_db_access;
-    std::string m_host;
-    std::uint16_t m_port;
-    WsServer m_ws;
-    std::thread m_thread;
-    bool m_running;
-};
 
 void seed_primary_rows(const std::shared_ptr<mdbxc::Connection>& db) {
     mdbxc::sync::ThreadLocalChangeAccumulator sink(db);
@@ -429,17 +86,29 @@ void require_quote(const std::shared_ptr<mdbxc::Connection>& db,
                           std::to_string(key));
 }
 
+std::uint16_t parse_port(const char* text) {
+    const int value = std::atoi(text);
+    if (value <= 0 || value > 65535) {
+        throw std::invalid_argument("port must be in 1..65535");
+    }
+    return static_cast<std::uint16_t>(value);
+}
+
 } // namespace
 
-int main() {
+int main(int argc, char** argv) {
+    if (argc != 1 && argc != 3) {
+        std::fprintf(stderr, "usage: %s [host port]\n", argv[0]);
+        return 2;
+    }
+
+    const std::string host = argc == 3 ? argv[1] : "127.0.0.1";
+    const std::uint16_t port = argc == 3 ? parse_port(argv[2]) : 18081;
+    const std::string bearer_token = "replica-token";
     const std::string primary_path = "sync_17_primary.mdbx";
     const std::string replica_path = "sync_17_replica.mdbx";
     sync_example::cleanup(primary_path);
     sync_example::cleanup(replica_path);
-
-    const std::string host = "127.0.0.1";
-    const std::uint16_t port = 18081;
-    const std::string bearer_token = "replica-token";
 
     try {
         std::shared_ptr<mdbxc::Connection> primary =
@@ -473,16 +142,23 @@ int main() {
         ws_policy.add(ws_identity);
         mdbxc::sync::WebSocketSyncServerMiddleware ws_middleware(
             ws_server, &ws_policy);
-        SimpleWebSocketSyncListener listener(
-            ws_middleware,
-            bearer_token,
-            replica_node,
-            mdbxc::sync::SyncDbAccess::only(db_id),
-            host,
-            port);
+        mdbxc::sync::simple_web::WebSocketSyncListenerConfig
+            listener_config;
+        listener_config.host = host;
+        listener_config.port = port;
+        listener_config.bearer_token = bearer_token;
+        listener_config.has_authenticated_node = true;
+        listener_config.authenticated_node = replica_node;
+        listener_config.db_access = mdbxc::sync::SyncDbAccess::only(db_id);
+        mdbxc::sync::simple_web::WebSocketSyncListener listener(
+            ws_middleware, listener_config);
         listener.start();
+        std::printf("[websocket server] listening on %s:%u\n",
+                    host.c_str(),
+                    static_cast<unsigned>(listener.port()));
 
-        SimpleWebSocketSyncChannel channel(host, port, bearer_token);
+        mdbxc::sync::simple_web::WebSocketSyncChannel channel(
+            host, port, bearer_token);
         mdbxc::sync::WebSocketSyncPeer peer(channel, bounds);
 
         mdbxc::sync::PullRequest pull;

--- a/examples/sync_18_http_node_fleet.cpp
+++ b/examples/sync_18_http_node_fleet.cpp
@@ -1,0 +1,488 @@
+/**
+ * \ingroup mdbxc_examples
+ * \brief Multi-process HTTP sync node fleet demo.
+ *
+ * This example starts several copies of itself through tiny-process-library.
+ * Every child process owns its own MDBX environment, HTTP server, sync engine,
+ * capture sink, and application loop. The only thing crossing process
+ * boundaries is HTTP sync DTO traffic.
+ *
+ * Default run:
+ *
+ *   ./sync_18_http_node_fleet
+ *
+ * It executes two short scenarios:
+ *   - master-replica: node A writes, node B only pulls from A;
+ *   - mesh: nodes A and B both write and pull from each other.
+ *
+ * Manual node mode:
+ *
+ *   ./sync_18_http_node_fleet node A 127.0.0.1 18220 a.mdbx \
+ *       16 208 127.0.0.1 18221 32 1 1
+ *
+ * Type "stop" on stdin to shut the node down.
+ */
+
+#include <mdbx_containers/sync/transports/simple_web/HttpTransport.hpp>
+#include <mdbx_containers/tables.hpp>
+
+#include "sync_example_utils.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <process.hpp>
+
+namespace {
+
+const std::uint8_t kDbSeed = 0xD0;
+const std::uint16_t kMasterBasePort = 18220;
+const std::uint16_t kMeshBasePort = 18230;
+
+int parse_int(const char* text, const char* label) {
+    char* end = nullptr;
+    const long value = std::strtol(text, &end, 10);
+    if (end == text || *end != '\0') {
+        throw std::invalid_argument(std::string("invalid ") + label);
+    }
+    return static_cast<int>(value);
+}
+
+std::uint8_t parse_byte_seed(const char* text, const char* label) {
+    const int value = parse_int(text, label);
+    if (value < 0 || value > 255) {
+        throw std::invalid_argument(std::string("invalid ") + label);
+    }
+    return static_cast<std::uint8_t>(value);
+}
+
+std::uint16_t parse_port(const char* text, const char* label) {
+    const int value = parse_int(text, label);
+    if (value <= 0 || value > 65535) {
+        throw std::invalid_argument(std::string("invalid ") + label);
+    }
+    return static_cast<std::uint16_t>(value);
+}
+
+struct NodeOptions {
+    std::string name;
+    std::string host;
+    std::uint16_t port;
+    std::string db_path;
+    std::uint8_t node_seed;
+    std::uint8_t db_seed;
+    std::string peer_host;
+    std::uint16_t peer_port;
+    std::uint8_t peer_node_seed;
+    bool active_writer;
+    bool fresh_db;
+};
+
+void write_activity(const NodeOptions& options,
+                    const std::shared_ptr<mdbxc::Connection>& conn,
+                    mdbxc::KeyValueTable<int, std::string>& events,
+                    mdbxc::KeyTable<int>& live_ids,
+                    mdbxc::ValueTable<std::string>& status,
+                    int tick) {
+    mdbxc::Transaction txn =
+        conn->transaction(mdbxc::TransactionMode::WRITABLE);
+    const int key = static_cast<int>(options.node_seed) * 1000 + tick;
+    const int old_key = key - 3;
+
+    std::ostringstream text;
+    text << options.name << " tick " << tick;
+    events.insert_or_assign(key, text.str(), txn);
+    live_ids.insert(key, txn);
+
+    std::ostringstream state;
+    state << options.name << " local tick " << tick;
+    status.set(state.str(), txn);
+
+    if (tick % 4 == 0) {
+        events.erase(old_key, txn);
+        live_ids.erase(old_key, txn);
+    }
+
+    txn.commit();
+    std::printf("[%s] local write tick=%d key=%d\n",
+                options.name.c_str(),
+                tick,
+                key);
+}
+
+std::size_t pull_once(const NodeOptions& options,
+                      mdbxc::sync::SyncEngine& local_engine,
+                      mdbxc::sync::HttpSyncPeer& peer,
+                      std::mutex& db_mutex) {
+    mdbxc::sync::PullRequest pull;
+    pull.requester = sync_example::make_node(options.node_seed);
+    pull.db_id = sync_example::make_node(options.db_seed);
+    pull.max_batches = 8;
+    pull.max_bytes = 1024 * 1024;
+    {
+        std::lock_guard<std::mutex> lock(db_mutex);
+        pull.have = local_engine.applied_cursor();
+    }
+
+    const mdbxc::sync::PullResponse response = peer.pull(pull);
+    if (!response.ok) {
+        throw std::runtime_error("pull failed: " + response.error);
+    }
+    if (response.batches.empty()) {
+        return 0;
+    }
+
+    mdbxc::sync::PushRequest push;
+    push.sender = sync_example::make_node(options.peer_node_seed);
+    push.db_id = pull.db_id;
+    push.batches = response.batches;
+
+    mdbxc::sync::PushResponse applied;
+    {
+        std::lock_guard<std::mutex> lock(db_mutex);
+        applied = local_engine.handle_push(push);
+    }
+    if (!applied.ok) {
+        throw std::runtime_error("apply failed: " + applied.error);
+    }
+    return response.batches.size();
+}
+
+void print_snapshot(const NodeOptions& options,
+                    mdbxc::KeyValueTable<int, std::string>& events,
+                    mdbxc::KeyTable<int>& live_ids,
+                    mdbxc::ValueTable<std::string>& status,
+                    std::mutex& db_mutex) {
+    std::lock_guard<std::mutex> lock(db_mutex);
+    const std::map<int, std::string> event_rows =
+        events.retrieve_all<std::map>();
+    const std::set<int> live_rows = live_ids.retrieve_all<std::set>();
+    std::string status_text;
+    const bool has_status = status.try_get(status_text);
+
+    std::printf("[%s] snapshot events=%u live_ids=%u status=%s\n",
+                options.name.c_str(),
+                static_cast<unsigned>(event_rows.size()),
+                static_cast<unsigned>(live_rows.size()),
+                has_status ? status_text.c_str() : "<empty>");
+}
+
+int run_node(const NodeOptions& options) {
+    if (options.fresh_db) {
+        sync_example::cleanup(options.db_path);
+    }
+
+    std::shared_ptr<mdbxc::Connection> conn =
+        sync_example::open(options.db_path);
+    std::mutex db_mutex;
+
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(
+        sync_example::make_node(options.node_seed),
+        sync_example::make_node(options.db_seed));
+
+    mdbxc::sync::ThreadLocalChangeAccumulator capture(conn);
+    conn->attach_sync_capture(&capture);
+
+    mdbxc::KeyValueTable<int, std::string> events(conn, "fleet_events");
+    mdbxc::KeyTable<int> live_ids(conn, "fleet_live_ids");
+    mdbxc::ValueTable<std::string> status(conn, "fleet_status");
+
+    mdbxc::sync::HttpSyncServer http_handler(engine);
+    mdbxc::sync::simple_web::HttpSyncListenerConfig listener_config;
+    listener_config.host = options.host;
+    listener_config.port = options.port;
+    listener_config.handler_mutex = &db_mutex;
+    mdbxc::sync::simple_web::HttpSyncListener http_server(
+        http_handler, listener_config);
+    http_server.start();
+    std::printf("[%s] listening on %s:%u\n",
+                options.name.c_str(),
+                options.host.c_str(),
+                static_cast<unsigned>(http_server.port()));
+
+    mdbxc::sync::simple_web::HttpSyncClientConfig client_config;
+    client_config.host = options.peer_host;
+    client_config.port = options.peer_port;
+    client_config.timeout = std::chrono::seconds(2);
+    mdbxc::sync::simple_web::HttpSyncClient http_client(client_config);
+    mdbxc::sync::HttpSyncPeer peer(http_client);
+
+    std::atomic<bool> pause_writes(false);
+    std::atomic<bool> stop_requested(false);
+    std::thread stdin_thread(
+        [&pause_writes, &stop_requested, &options]() {
+            std::string line;
+            while (std::getline(std::cin, line)) {
+                if (line == "pause") {
+                    pause_writes.store(true, std::memory_order_release);
+                    std::printf("[%s] pause command received\n",
+                                options.name.c_str());
+                    continue;
+                }
+                if (line == "stop" || line == "quit" || line == "exit") {
+                    stop_requested.store(true, std::memory_order_release);
+                    std::printf("[%s] stop command received\n",
+                                options.name.c_str());
+                    return;
+                }
+            }
+            stop_requested.store(true, std::memory_order_release);
+        });
+
+    int tick = 0;
+    while (!stop_requested.load(std::memory_order_acquire)) {
+        ++tick;
+        try {
+            if (options.active_writer &&
+                !pause_writes.load(std::memory_order_acquire)) {
+                std::lock_guard<std::mutex> lock(db_mutex);
+                write_activity(options, conn, events, live_ids, status, tick);
+            }
+
+            const std::size_t pulled =
+                pull_once(options, engine, peer, db_mutex);
+            if (pulled != 0) {
+                std::printf("[%s] pulled %u batch(es) from peer\n",
+                            options.name.c_str(),
+                            static_cast<unsigned>(pulled));
+            }
+        } catch (const std::exception& e) {
+            std::printf("[%s] loop warning: %s\n",
+                        options.name.c_str(),
+                        e.what());
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(350));
+    }
+
+    if (stdin_thread.joinable()) {
+        stdin_thread.join();
+    }
+    print_snapshot(options, events, live_ids, status, db_mutex);
+
+    http_server.stop();
+    conn->detach_sync_capture();
+    sync_example::disconnect_and_cleanup(conn, options.db_path);
+    std::printf("[%s] stopped\n", options.name.c_str());
+    return 0;
+}
+
+NodeOptions parse_node_options(int argc, char** argv) {
+    if (argc != 13) {
+        throw std::invalid_argument(
+            "node mode expects: node <name> <host> <port> <db_path> "
+            "<node_seed> <db_seed> <peer_host> <peer_port> "
+            "<peer_node_seed> <active_writer> <fresh_db>");
+    }
+
+    NodeOptions options;
+    options.name = argv[2];
+    options.host = argv[3];
+    options.port = parse_port(argv[4], "port");
+    options.db_path = argv[5];
+    options.node_seed = parse_byte_seed(argv[6], "node_seed");
+    options.db_seed = parse_byte_seed(argv[7], "db_seed");
+    options.peer_host = argv[8];
+    options.peer_port = parse_port(argv[9], "peer_port");
+    options.peer_node_seed = parse_byte_seed(argv[10], "peer_node_seed");
+    options.active_writer = parse_int(argv[11], "active_writer") != 0;
+    options.fresh_db = parse_int(argv[12], "fresh_db") != 0;
+    return options;
+}
+
+std::vector<std::string> node_command(const std::string& executable,
+                                      const std::string& name,
+                                      std::uint16_t port,
+                                      const std::string& db_path,
+                                      std::uint8_t node_seed,
+                                      std::uint16_t peer_port,
+                                      std::uint8_t peer_seed,
+                                      bool active_writer) {
+    std::vector<std::string> args;
+    args.push_back(executable);
+    args.push_back("node");
+    args.push_back(name);
+    args.push_back("127.0.0.1");
+    args.push_back(std::to_string(static_cast<unsigned>(port)));
+    args.push_back(db_path);
+    args.push_back(std::to_string(static_cast<unsigned>(node_seed)));
+    args.push_back(std::to_string(static_cast<unsigned>(kDbSeed)));
+    args.push_back("127.0.0.1");
+    args.push_back(std::to_string(static_cast<unsigned>(peer_port)));
+    args.push_back(std::to_string(static_cast<unsigned>(peer_seed)));
+    args.push_back(active_writer ? "1" : "0");
+    args.push_back("1");
+    return args;
+}
+
+class ChildNode {
+public:
+    ChildNode(const std::string& name,
+              const std::vector<std::string>& command)
+        : m_name(name),
+          m_process(
+              command,
+              std::string(),
+              [this](const char* bytes, std::size_t n) {
+                  print_child_output(bytes, n, false);
+              },
+              [this](const char* bytes, std::size_t n) {
+                  print_child_output(bytes, n, true);
+              },
+              true) {}
+
+    void stop() {
+        m_process.write("stop\n");
+        m_process.close_stdin();
+    }
+
+    void pause() {
+        m_process.write("pause\n");
+    }
+
+    int wait() {
+        return m_process.get_exit_status();
+    }
+
+private:
+    void print_child_output(const char* bytes,
+                            std::size_t n,
+                            bool is_error) {
+        std::lock_guard<std::mutex> lock(output_mutex());
+        std::printf("[%s %s] %s",
+                    m_name.c_str(),
+                    is_error ? "stderr" : "stdout",
+                    std::string(bytes, n).c_str());
+    }
+
+    static std::mutex& output_mutex() {
+        static std::mutex mutex;
+        return mutex;
+    }
+
+    std::string m_name;
+    TinyProcessLib::Process m_process;
+};
+
+int run_supervisor_scenario(const std::string& executable,
+                            const std::string& scenario,
+                            unsigned seconds) {
+    const bool mesh = scenario == "mesh";
+    const std::uint16_t base_port =
+        mesh ? kMeshBasePort : kMasterBasePort;
+    const std::string prefix =
+        mesh ? "sync_18_mesh_" : "sync_18_master_";
+
+    sync_example::cleanup(prefix + "A.mdbx");
+    sync_example::cleanup(prefix + "B.mdbx");
+
+    std::printf("[supervisor] starting %s scenario for %u second(s)\n",
+                scenario.c_str(),
+                seconds);
+
+    ChildNode node_a(
+        "A",
+        node_command(executable,
+                     "A",
+                     base_port,
+                     prefix + "A.mdbx",
+                     0x10,
+                     static_cast<std::uint16_t>(base_port + 1),
+                     0x20,
+                     true));
+    ChildNode node_b(
+        "B",
+        node_command(executable,
+                     "B",
+                     static_cast<std::uint16_t>(base_port + 1),
+                     prefix + "B.mdbx",
+                     0x20,
+                     base_port,
+                     0x10,
+                     mesh));
+
+    std::this_thread::sleep_for(std::chrono::seconds(seconds));
+    node_a.pause();
+    node_b.pause();
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    node_a.stop();
+    node_b.stop();
+
+    const int a_status = node_a.wait();
+    const int b_status = node_b.wait();
+    std::printf("[supervisor] %s exits: A=%d B=%d\n",
+                scenario.c_str(),
+                a_status,
+                b_status);
+    return a_status == 0 && b_status == 0 ? 0 : 1;
+}
+
+void print_usage(const char* executable) {
+    std::printf("Usage:\n");
+    std::printf("  %s\n", executable);
+    std::printf("  %s master-replica [seconds]\n", executable);
+    std::printf("  %s mesh [seconds]\n", executable);
+    std::printf("  %s node <name> <host> <port> <db_path> "
+                "<node_seed> <db_seed> <peer_host> <peer_port> "
+                "<peer_node_seed> <active_writer> <fresh_db>\n",
+                executable);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        if (argc >= 2 && std::string(argv[1]) == "node") {
+            return run_node(parse_node_options(argc, argv));
+        }
+
+        const unsigned seconds =
+            argc >= 3
+                ? static_cast<unsigned>(parse_int(argv[2], "seconds"))
+                : 5u;
+
+        if (argc == 1) {
+            const int one_way =
+                run_supervisor_scenario(argv[0], "master-replica", seconds);
+            const int mesh =
+                run_supervisor_scenario(argv[0], "mesh", seconds);
+            if (one_way == 0 && mesh == 0) {
+                std::printf("OK: sync_18_http_node_fleet\n");
+                return 0;
+            }
+            return 1;
+        }
+
+        const std::string scenario = argv[1];
+        if (scenario == "master-replica" || scenario == "mesh") {
+            const int rc = run_supervisor_scenario(
+                argv[0], scenario, seconds);
+            if (rc == 0) {
+                std::printf("OK: sync_18_http_node_fleet (%s)\n",
+                            scenario.c_str());
+            }
+            return rc;
+        }
+
+        print_usage(argv[0]);
+        return 2;
+    } catch (const std::exception& e) {
+        std::printf("FAIL: %s\n", e.what());
+        print_usage(argv[0]);
+        return 1;
+    }
+}

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -36,10 +36,15 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
   `IWebSocketSyncChannel`, and `WebSocketSyncServer`. It defines a complete
   binary-message request/response contract over `TransportMessageCodec` but
   does not open sockets, own sessions, or depend on a WebSocket framework.
-- Optional socket-backed HTTP and WebSocket examples over
-  Simple-Web-Server / Simple-WebSocket-Server plus standalone Asio. These are
-  example bindings behind explicit CMake options, not mandatory runtime
-  dependencies.
+- `sync/transport.hpp` umbrella for framework-neutral transport seams and
+  middleware.
+- Optional ready-made Simple-Web HTTP/WebSocket bindings under
+  `sync/transports/simple_web/` plus socket-backed examples over Simple-Web-Server /
+  Simple-WebSocket-Server, standalone Asio, and a process-supervised HTTP
+  node-fleet example over tiny-process-library. These integrations are behind
+  explicit CMake options, not mandatory runtime dependencies. The backend
+  umbrella is `sync/transports/simple_web.hpp`; HTTP-only or WebSocket-only
+  targets can include the narrower backend-specific header.
 - Transport middleware helpers: `SyncPeerMiddleware`,
   `HttpSyncClientMiddleware`, allow-list policies, fixed-budget rate limiting,
   HTTP request-context bearer/remote-address/fixed-window policies,
@@ -111,11 +116,12 @@ new wire-format semantics.
   use `LastWriterWins` in a non-test path.
 - `Custom` conflict resolver — schema-level callback; deferred until the
   first real consumer needs it.
-- Production-grade concrete socket-bound HTTP and WebSocket transports
-  (`Boost.Beast`, libcurl, or another framework) with deployment-specific
-  lifecycle, TLS, reconnect, and observability policy. The optional
-  Simple-Web-Server examples demonstrate the binding shape but are not a
-  production transport layer.
+- Production-grade deployment wrappers for concrete socket-bound HTTP and
+  WebSocket transports (`Boost.Beast`, libcurl, Simple-Web-Server, or another
+  framework) with deployment-specific lifecycle, TLS, reconnect, and
+  observability policy. The optional Simple-Web bindings are convenience and
+  reference integrations; production services may still wrap or replace them
+  for their own operations model.
 - `zstd` compression — reserved flag, encoder throws, decoder rejects.
 
 ## Endianness policy (do not change)
@@ -282,6 +288,23 @@ receiver B
                 mark_applied(origin, seq)
             -> commit
 ```
+
+Application integration contract:
+
+- supported table write methods keep the same public API with or without sync;
+- callers do not wrap each individual `insert`, `insert_or_assign`, `erase`,
+  `reconcile`, or range erase in a sync-specific call;
+- `Connection::attach_sync_capture()` installs the capture sink for commits on
+  that connection; supported write operations are recorded by table code and
+  flushed by the transaction pre-commit hook;
+- a standalone write method call that opens its own transaction commits as one
+  local change batch;
+- an explicit transaction passed through several supported table calls commits
+  those writes atomically and flushes one local change batch;
+- reads, searches, range scans, and failed/rolled-back transactions emit no
+  change batch;
+- local commit never contacts a remote node. Pull/push delivery is performed
+  later by explicit protocol code or by `SyncWorker` through an `ISyncPeer`.
 
 Cold replica sync currently uses changelog replay:
 
@@ -579,7 +602,9 @@ A concrete socket-bound transport adapter ships as a separate pair of headers
 
 The framework-neutral `HttpSyncPeer` / `HttpSyncServer` and
 `WebSocketSyncPeer` / `WebSocketSyncServer` seams are part of v0.1. Concrete
-server/client bindings remain separate optional integrations.
+server/client bindings remain separate optional integrations; the ready-made
+Simple-Web bindings live under `sync/transports/simple_web/` and are not
+included by the main sync umbrella header.
 
 ## Why `prune_up_to` uses cursor walk + `MDBX_NEXT`
 

--- a/include/mdbx_containers/sync/transport.hpp
+++ b/include/mdbx_containers/sync/transport.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_TRANSPORT_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_TRANSPORT_HPP_INCLUDED
+
+/// \file sync/transport.hpp
+/// \brief Aggregate header for framework-neutral sync transport adapters.
+/// \details
+/// This header pulls in the sync core plus the HTTP/WebSocket transport seams
+/// and adapter-local middleware. It can be included directly by concrete
+/// transport backends. It does not include concrete socket backend
+/// integrations such as Simple-Web-Server.
+
+#include <mdbx_containers/sync.hpp>
+
+#if MDBXC_SYNC_ENABLED
+#include <mdbx_containers/sync/HttpTransport.hpp>
+#include <mdbx_containers/sync/WebSocketTransport.hpp>
+#include <mdbx_containers/sync/TransportMiddleware.hpp>
+#endif
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_TRANSPORT_HPP_INCLUDED

--- a/include/mdbx_containers/sync/transports/simple_web.hpp
+++ b/include/mdbx_containers/sync/transports/simple_web.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_TRANSPORTS_SIMPLE_WEB_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_TRANSPORTS_SIMPLE_WEB_HPP_INCLUDED
+
+/// \file sync/transports/simple_web.hpp
+/// \brief Aggregate header for optional Simple-Web sync transport bindings.
+/// \details
+/// Include this header only in translation units that intentionally use both
+/// the HTTP and WebSocket Simple-Web bindings. To avoid pulling WebSocket
+/// handshake dependencies into an HTTP-only target, include the backend-specific
+/// header from \c sync/transports/simple_web/ instead.
+
+#include <mdbx_containers/sync/transports/simple_web/HttpTransport.hpp>
+#include <mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp>
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_TRANSPORTS_SIMPLE_WEB_HPP_INCLUDED

--- a/include/mdbx_containers/sync/transports/simple_web/HttpTransport.hpp
+++ b/include/mdbx_containers/sync/transports/simple_web/HttpTransport.hpp
@@ -1,0 +1,466 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_TRANSPORTS_SIMPLE_WEB_HTTP_TRANSPORT_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_TRANSPORTS_SIMPLE_WEB_HTTP_TRANSPORT_HPP_INCLUDED
+
+/// \file sync/transports/simple_web/HttpTransport.hpp
+/// \brief Optional Simple-Web-Server binding for HTTP sync transport.
+/// \details
+/// This header is not included by mdbx_containers/sync.hpp. Include it only in
+/// translation units that intentionally use eidheim/Simple-Web-Server and
+/// standalone Asio.
+
+#ifndef ASIO_STANDALONE
+#define ASIO_STANDALONE 1
+#endif
+#ifndef USE_STANDALONE_ASIO
+#define USE_STANDALONE_ASIO 1
+#endif
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#endif
+
+#include <client_http.hpp>
+#include <server_http.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <mdbx_containers/sync/transport.hpp>
+
+#if !MDBXC_SYNC_ENABLED
+#error "mdbx_containers/sync/transports/simple_web/HttpTransport.hpp requires MDBXC_SYNC_ENABLED=1"
+#endif
+
+namespace mdbxc {
+namespace sync {
+namespace simple_web {
+
+    namespace detail {
+        inline std::string endpoint(const std::string& host,
+                                    std::uint16_t port) {
+            return host + ":" + std::to_string(static_cast<unsigned>(port));
+        }
+
+        inline std::vector<std::uint8_t> string_to_bytes(
+                const std::string& text) {
+            return std::vector<std::uint8_t>(text.begin(), text.end());
+        }
+
+        inline std::string bytes_to_string(
+                const std::vector<std::uint8_t>& bytes) {
+            if (bytes.empty()) {
+                return std::string();
+            }
+            return std::string(reinterpret_cast<const char*>(&bytes[0]),
+                               bytes.size());
+        }
+
+        inline std::string header_value(
+                const SimpleWeb::CaseInsensitiveMultimap& headers,
+                const std::string& name) {
+            const SimpleWeb::CaseInsensitiveMultimap::const_iterator it =
+                headers.find(name);
+            return it == headers.end() ? std::string() : it->second;
+        }
+
+        inline SimpleWeb::StatusCode to_simple_status(unsigned status) {
+            return SimpleWeb::status_code(
+                std::to_string(static_cast<unsigned>(status)));
+        }
+    } // namespace detail
+
+    /// \brief Configuration for \c HttpSyncClient.
+    struct HttpSyncClientConfig {
+        /// \brief Remote HTTP server host name or address.
+        std::string host = "127.0.0.1";
+        /// \brief Remote HTTP server port.
+        std::uint16_t port = 0;
+        /// \brief Simple-Web-Server connect and request timeout.
+        std::chrono::seconds timeout = std::chrono::seconds(2);
+        /// \brief Optional bearer token added as an Authorization header.
+        std::string bearer_token;
+        /// \brief Extra headers sent with every sync POST request.
+        std::vector<HttpSyncHeader> headers;
+    };
+
+    /// \brief Simple-Web-Server HTTP client binding for \c HttpSyncPeer.
+    /// \note One instance is intended for one active \c post() call at a time.
+    /// This matches \c SyncWorker, which performs transport operations
+    /// sequentially. Use separate client instances for concurrent callers.
+    class HttpSyncClient : public IHttpSyncClient {
+    public:
+        explicit HttpSyncClient(const HttpSyncClientConfig& config)
+            : m_config(config),
+              m_cancel_generation(0),
+              m_active_client(nullptr),
+              m_cancel_count(0) {}
+
+        HttpSyncClient(const std::string& host,
+                       std::uint16_t port,
+                       std::chrono::seconds timeout,
+                       const std::string& bearer_token = std::string())
+            : m_cancel_generation(0),
+              m_active_client(nullptr),
+              m_cancel_count(0) {
+            m_config.host = host;
+            m_config.port = port;
+            m_config.timeout = timeout;
+            m_config.bearer_token = bearer_token;
+        }
+
+        HttpSyncResponse post(
+                const std::string& target,
+                const std::string& content_type,
+                const std::vector<std::uint8_t>& body,
+                const CancellationToken& cancel_token) override {
+            if (cancel_token.is_cancellation_requested()) {
+                return make_cancelled_response(
+                    "cancelled before HTTP request");
+            }
+
+            const std::uint64_t call_generation =
+                m_cancel_generation.load(std::memory_order_acquire);
+            Client client(detail::endpoint(m_config.host, m_config.port));
+            client.config.timeout =
+                static_cast<long>(m_config.timeout.count());
+            client.config.timeout_connect =
+                static_cast<long>(m_config.timeout.count());
+            ActiveClientGuard active(*this, client);
+
+            if (cancel_token.is_cancellation_requested() ||
+                m_cancel_generation.load(std::memory_order_acquire) !=
+                    call_generation) {
+                return make_cancelled_response(
+                    "cancelled before HTTP request");
+            }
+
+            try {
+                SimpleWeb::CaseInsensitiveMultimap headers;
+                headers.emplace("Content-Type", content_type);
+                if (!m_config.bearer_token.empty()) {
+                    headers.emplace(
+                        "Authorization",
+                        std::string("Bearer ") + m_config.bearer_token);
+                }
+                for (std::size_t i = 0; i < m_config.headers.size(); ++i) {
+                    headers.emplace(m_config.headers[i].name,
+                                    m_config.headers[i].value);
+                }
+
+                const std::shared_ptr<Client::Response> received =
+                    client.request("POST",
+                                   target,
+                                   detail::bytes_to_string(body),
+                                   headers);
+
+                HttpSyncResponse out;
+                out.status_code =
+                    static_cast<unsigned>(
+                        std::atoi(received->status_code.c_str()));
+                out.content_type =
+                    detail::header_value(received->header, "Content-Type");
+                for (SimpleWeb::CaseInsensitiveMultimap::const_iterator it =
+                         received->header.begin();
+                     it != received->header.end();
+                     ++it) {
+                    http_add_header(out.headers, it->first, it->second);
+                }
+                out.body = detail::string_to_bytes(
+                    received->content.string());
+                return out;
+            } catch (const SimpleWeb::system_error& e) {
+                if (m_cancel_generation.load(std::memory_order_acquire) !=
+                        call_generation ||
+                    cancel_token.is_cancellation_requested()) {
+                    return make_cancelled_response(e.what());
+                }
+                throw;
+            }
+        }
+
+        void request_cancel() override {
+            m_cancel_generation.fetch_add(1, std::memory_order_acq_rel);
+            m_cancel_count.fetch_add(1, std::memory_order_acq_rel);
+
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (m_active_client != nullptr) {
+                m_active_client->stop();
+            }
+        }
+
+        std::size_t cancel_count() const {
+            return m_cancel_count.load(std::memory_order_acquire);
+        }
+
+    private:
+        typedef SimpleWeb::Client<SimpleWeb::HTTP> Client;
+
+        class ActiveClientGuard {
+        public:
+            ActiveClientGuard(HttpSyncClient& owner, Client& client)
+                : m_owner(owner), m_client(&client) {
+                m_owner.set_active_client(m_client);
+            }
+
+            ~ActiveClientGuard() {
+                m_owner.clear_active_client(m_client);
+            }
+
+            ActiveClientGuard(const ActiveClientGuard&) = delete;
+            ActiveClientGuard& operator=(const ActiveClientGuard&) = delete;
+
+        private:
+            HttpSyncClient& m_owner;
+            Client* m_client;
+        };
+
+        static HttpSyncResponse make_cancelled_response(
+                const std::string& diagnostic) {
+            HttpSyncResponse out;
+            out.status_code = 503;
+            out.content_type = "text/plain; charset=utf-8";
+            out.error = diagnostic.empty() ? "cancelled" : diagnostic;
+            out.body = detail::string_to_bytes(out.error);
+            return out;
+        }
+
+        void set_active_client(Client* client) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_active_client = client;
+        }
+
+        void clear_active_client(Client* client) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (m_active_client == client) {
+                m_active_client = nullptr;
+            }
+        }
+
+        HttpSyncClientConfig m_config;
+        std::atomic<std::uint64_t> m_cancel_generation;
+        mutable std::mutex m_mutex;
+        Client* m_active_client;
+        std::atomic<std::size_t> m_cancel_count;
+    };
+
+    /// \brief Configuration for \c HttpSyncListener.
+    struct HttpSyncListenerConfig {
+        /// \brief Local bind host name or address.
+        std::string host = "127.0.0.1";
+        /// \brief Local bind port. Use 0 to let the OS assign a free port.
+        std::uint16_t port = 0;
+        /// \brief Simple-Web-Server worker thread count.
+        std::size_t thread_pool_size = 1;
+        /// \brief Regex route accepting /pull and /push sync requests.
+        std::string sync_route_regex = "^/mdbxc/sync/v1/(pull|push)$";
+        /// \brief Install a default POST handler returning 404.
+        bool install_default_post_handler = true;
+        /// \brief Optional external lock around \c HttpSyncServer::handle().
+        /// \details
+        /// Use this when the same MDBX-backed \c SyncEngine is also touched
+        /// by application code while the HTTP listener is running.
+        std::mutex* handler_mutex = nullptr;
+    };
+
+    /// \brief Simple-Web-Server listener binding for \c HttpSyncServer.
+    class HttpSyncListener {
+    public:
+        HttpSyncListener(HttpSyncServer& handler,
+                         const HttpSyncListenerConfig& config,
+                         ISyncTransportPolicy* policy = nullptr)
+            : m_handler(handler),
+              m_policy(policy),
+              m_config(config),
+              m_running(false) {
+            m_server.config.address = config.host;
+            m_server.config.port = config.port;
+            m_server.config.thread_pool_size = config.thread_pool_size;
+
+            m_server.resource[config.sync_route_regex]["POST"] =
+                [this](std::shared_ptr<Server::Response> response,
+                       std::shared_ptr<Server::Request> request) {
+                    handle_post(response, request);
+                };
+
+            if (config.install_default_post_handler) {
+                m_server.default_resource["POST"] =
+                    [](std::shared_ptr<Server::Response> response,
+                       std::shared_ptr<Server::Request> request) {
+                        (void)request;
+                        HttpSyncResponse out;
+                        out.status_code = 404;
+                        out.content_type = "text/plain; charset=utf-8";
+                        out.error = "unknown sync route";
+                        out.body = detail::string_to_bytes(out.error);
+                        write_response(response, out);
+                    };
+            }
+        }
+
+        ~HttpSyncListener() {
+            stop();
+        }
+
+        void start() {
+            if (m_running) {
+                return;
+            }
+
+            std::shared_ptr<std::promise<unsigned short> > started(
+                new std::promise<unsigned short>());
+            std::future<unsigned short> started_future =
+                started->get_future();
+
+            m_thread = std::thread(
+                [this, started]() {
+                    bool started_callback_called = false;
+                    try {
+                        m_server.start(
+                            [started, &started_callback_called](
+                                unsigned short assigned_port) {
+                                started_callback_called = true;
+                                started->set_value(assigned_port);
+                            });
+                    } catch (...) {
+                        if (!started_callback_called) {
+                            try {
+                                started->set_exception(
+                                    std::current_exception());
+                            } catch (...) {}
+                        }
+                    }
+                });
+
+            try {
+                m_config.port = started_future.get();
+            } catch (...) {
+                if (m_thread.joinable()) {
+                    m_thread.join();
+                }
+                throw;
+            }
+            m_running = true;
+        }
+
+        void stop() {
+            if (!m_running) {
+                return;
+            }
+            m_server.stop();
+            if (m_thread.joinable()) {
+                m_thread.join();
+            }
+            m_running = false;
+        }
+
+        std::uint16_t port() const {
+            return m_config.port;
+        }
+
+    private:
+        typedef SimpleWeb::Server<SimpleWeb::HTTP> Server;
+
+        static void write_response(
+                const std::shared_ptr<Server::Response>& response,
+                const HttpSyncResponse& out) {
+            SimpleWeb::CaseInsensitiveMultimap headers;
+            headers.emplace("Content-Type",
+                            out.content_type.empty()
+                                ? "text/plain; charset=utf-8"
+                                : out.content_type);
+            for (std::size_t i = 0; i < out.headers.size(); ++i) {
+                headers.emplace(out.headers[i].name, out.headers[i].value);
+            }
+            response->write(detail::to_simple_status(out.status_code),
+                            detail::bytes_to_string(out.body),
+                            headers);
+        }
+
+        HttpSyncRequest make_request(
+                const std::shared_ptr<Server::Request>& request) const {
+            HttpSyncRequest in;
+            in.method = request->method;
+            in.target = request->path;
+            in.content_type =
+                detail::header_value(request->header, "Content-Type");
+            in.body = detail::string_to_bytes(request->content.string());
+            for (SimpleWeb::CaseInsensitiveMultimap::const_iterator it =
+                     request->header.begin();
+                 it != request->header.end();
+                 ++it) {
+                http_add_header(in.headers, it->first, it->second);
+            }
+            try {
+                in.remote_address =
+                    request->remote_endpoint().address().to_string();
+            } catch (...) {
+                in.remote_address.clear();
+            }
+            return in;
+        }
+
+        static HttpSyncResponse make_rejected_response(
+                const HttpSyncRequest& in,
+                const SyncTransportDecision& decision) {
+            HttpSyncResponse out;
+            out.status_code =
+                decision.status_code == 0 ? 403 : decision.status_code;
+            out.content_type = "text/plain; charset=utf-8";
+            out.headers = decision.response_headers;
+            http_copy_sync_correlation_headers(in.headers, out.headers);
+            out.error = decision.error.empty() ? "rejected" : decision.error;
+            out.body = detail::string_to_bytes(out.error);
+            return out;
+        }
+
+        void handle_post(
+                const std::shared_ptr<Server::Response>& response,
+                const std::shared_ptr<Server::Request>& request) {
+            const HttpSyncRequest in = make_request(request);
+            if (m_policy != nullptr) {
+                const SyncTransportDecision decision =
+                    m_policy->check_http_request(in);
+                if (!decision.allowed) {
+                    write_response(
+                        response, make_rejected_response(in, decision));
+                    return;
+                }
+            }
+
+            HttpSyncResponse out;
+            if (m_config.handler_mutex != nullptr) {
+                std::lock_guard<std::mutex> lock(*m_config.handler_mutex);
+                out = m_handler.handle(in);
+            } else {
+                out = m_handler.handle(in);
+            }
+            write_response(response, out);
+        }
+
+        HttpSyncServer& m_handler;
+        ISyncTransportPolicy* m_policy;
+        HttpSyncListenerConfig m_config;
+        Server m_server;
+        std::thread m_thread;
+        bool m_running;
+    };
+
+} // namespace simple_web
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_TRANSPORTS_SIMPLE_WEB_HTTP_TRANSPORT_HPP_INCLUDED

--- a/include/mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp
+++ b/include/mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp
@@ -1,0 +1,479 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_TRANSPORTS_SIMPLE_WEB_WEB_SOCKET_TRANSPORT_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_TRANSPORTS_SIMPLE_WEB_WEB_SOCKET_TRANSPORT_HPP_INCLUDED
+
+/// \file sync/transports/simple_web/WebSocketTransport.hpp
+/// \brief Optional Simple-WebSocket-Server binding for WebSocket sync transport.
+/// \details
+/// This header is not included by mdbx_containers/sync.hpp. Include it only in
+/// translation units that intentionally use eidheim/Simple-WebSocket-Server and
+/// standalone Asio.
+
+#ifndef ASIO_STANDALONE
+#define ASIO_STANDALONE 1
+#endif
+#ifndef USE_STANDALONE_ASIO
+#define USE_STANDALONE_ASIO 1
+#endif
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#endif
+
+#include <client_ws.hpp>
+#include <server_ws.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <exception>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <mdbx_containers/sync/transport.hpp>
+
+#if !MDBXC_SYNC_ENABLED
+#error "mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp requires MDBXC_SYNC_ENABLED=1"
+#endif
+
+namespace mdbxc {
+namespace sync {
+namespace simple_web {
+
+    namespace detail {
+        inline std::string ws_endpoint(const std::string& host,
+                                       std::uint16_t port,
+                                       const std::string& path) {
+            return host + ":" + std::to_string(static_cast<unsigned>(port)) +
+                   path;
+        }
+
+        inline std::vector<std::uint8_t> ws_string_to_bytes(
+                const std::string& text) {
+            return std::vector<std::uint8_t>(text.begin(), text.end());
+        }
+
+        inline std::string ws_bytes_to_string(
+                const std::vector<std::uint8_t>& bytes) {
+            if (bytes.empty()) {
+                return std::string();
+            }
+            return std::string(reinterpret_cast<const char*>(&bytes[0]),
+                               bytes.size());
+        }
+
+        inline const char* ws_close_retry_label(unsigned close_code) {
+            return websocket_sync_close_code_is_retryable(close_code)
+                ? "retryable"
+                : "permanent";
+        }
+    } // namespace detail
+
+    /// \brief Default binary frame opcode used by Simple-WebSocket-Server.
+    inline unsigned char websocket_binary_frame_opcode() {
+        return 130;
+    }
+
+    /// \brief Default sync WebSocket path.
+    inline const char* websocket_sync_path() {
+        return "/mdbxc/sync/v1/ws";
+    }
+
+    /// \brief Configuration for \c WebSocketSyncChannel.
+    struct WebSocketSyncChannelConfig {
+        /// \brief Remote WebSocket server host name or address.
+        std::string host = "127.0.0.1";
+        /// \brief Remote WebSocket server port.
+        std::uint16_t port = 0;
+        /// \brief WebSocket endpoint path.
+        std::string path = websocket_sync_path();
+        /// \brief Optional bearer token sent during the WebSocket handshake.
+        std::string bearer_token;
+        /// \brief Simple-WebSocket-Server opcode for binary frames.
+        unsigned char binary_frame_opcode = 130;
+    };
+
+    class WebSocketExchangeState {
+    public:
+        void set_value(const std::vector<std::uint8_t>& bytes) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (!m_completed) {
+                m_completed = true;
+                m_promise.set_value(bytes);
+            }
+        }
+
+        void set_exception(const std::string& message) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (!m_completed) {
+                m_completed = true;
+                m_promise.set_exception(std::make_exception_ptr(
+                    std::runtime_error(message)));
+            }
+        }
+
+        std::future<std::vector<std::uint8_t> > future() {
+            return m_promise.get_future();
+        }
+
+    private:
+        std::mutex m_mutex;
+        bool m_completed = false;
+        std::promise<std::vector<std::uint8_t> > m_promise;
+    };
+
+    /// \brief Simple-WebSocket-Server channel binding for
+    /// \c WebSocketSyncPeer.
+    /// \note One instance is intended for one active \c exchange_binary() call
+    /// at a time. This matches \c SyncWorker, which performs transport
+    /// operations sequentially. Use separate channel instances for concurrent
+    /// callers.
+    class WebSocketSyncChannel : public IWebSocketSyncChannel {
+    public:
+        explicit WebSocketSyncChannel(
+                const WebSocketSyncChannelConfig& config)
+            : m_config(config),
+              m_cancel_generation(0),
+              m_active_client(nullptr),
+              m_cancel_count(0) {}
+
+        WebSocketSyncChannel(const std::string& host,
+                             std::uint16_t port,
+                             const std::string& bearer_token = std::string())
+            : m_cancel_generation(0),
+              m_active_client(nullptr),
+              m_cancel_count(0) {
+            m_config.host = host;
+            m_config.port = port;
+            m_config.bearer_token = bearer_token;
+        }
+
+        std::vector<std::uint8_t> exchange_binary(
+                const std::vector<std::uint8_t>& binary_message,
+                const CancellationToken& cancel_token) override {
+            if (cancel_token.is_cancellation_requested()) {
+                throw std::runtime_error(
+                    "cancelled before WebSocket exchange");
+            }
+
+            const std::uint64_t call_generation =
+                m_cancel_generation.load(std::memory_order_acquire);
+            Client client(detail::ws_endpoint(
+                m_config.host, m_config.port, m_config.path));
+            if (!m_config.bearer_token.empty()) {
+                client.config.header.emplace(
+                    "Authorization",
+                    std::string("Bearer ") + m_config.bearer_token);
+            }
+            ActiveClientGuard active(*this, client);
+
+            std::shared_ptr<WebSocketExchangeState> state(
+                new WebSocketExchangeState());
+            std::future<std::vector<std::uint8_t> > result =
+                state->future();
+            const std::string outbound =
+                detail::ws_bytes_to_string(binary_message);
+            const unsigned char opcode = m_config.binary_frame_opcode;
+
+            client.on_open =
+                [state, outbound, opcode](
+                    std::shared_ptr<Client::Connection> connection) {
+                    try {
+                        connection->send(outbound, nullptr, opcode);
+                    } catch (const std::exception& e) {
+                        state->set_exception(e.what());
+                        connection->send_close(1011);
+                    }
+                };
+
+            client.on_message =
+                [state](
+                    std::shared_ptr<Client::Connection> connection,
+                    std::shared_ptr<Client::InMessage> in_message) {
+                    state->set_value(
+                        detail::ws_string_to_bytes(in_message->string()));
+                    connection->send_close(1000);
+                };
+
+            client.on_close =
+                [state](
+                    std::shared_ptr<Client::Connection> connection,
+                    int status,
+                    const std::string& reason) {
+                    (void)connection;
+                    if (status != 1000) {
+                        state->set_exception(
+                            "WebSocket closed with status " +
+                            std::to_string(status) + " (" +
+                            detail::ws_close_retry_label(
+                                static_cast<unsigned>(status)) +
+                            "): " + reason);
+                    }
+                };
+
+            client.on_error =
+                [state](
+                    std::shared_ptr<Client::Connection> connection,
+                    const SimpleWeb::error_code& ec) {
+                    (void)connection;
+                    state->set_exception(ec.message());
+                };
+
+            if (cancel_token.is_cancellation_requested() ||
+                m_cancel_generation.load(std::memory_order_acquire) !=
+                    call_generation) {
+                throw std::runtime_error("cancelled before WebSocket start");
+            }
+
+            client.start();
+            return result.get();
+        }
+
+        void request_cancel() override {
+            m_cancel_generation.fetch_add(1, std::memory_order_acq_rel);
+            m_cancel_count.fetch_add(1, std::memory_order_acq_rel);
+
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (m_active_client != nullptr) {
+                m_active_client->stop();
+            }
+        }
+
+        std::size_t cancel_count() const {
+            return m_cancel_count.load(std::memory_order_acquire);
+        }
+
+    private:
+        typedef SimpleWeb::SocketClient<SimpleWeb::WS> Client;
+
+        class ActiveClientGuard {
+        public:
+            ActiveClientGuard(WebSocketSyncChannel& owner, Client& client)
+                : m_owner(owner), m_client(&client) {
+                m_owner.set_active_client(m_client);
+            }
+
+            ~ActiveClientGuard() {
+                m_owner.clear_active_client(m_client);
+            }
+
+            ActiveClientGuard(const ActiveClientGuard&) = delete;
+            ActiveClientGuard& operator=(const ActiveClientGuard&) = delete;
+
+        private:
+            WebSocketSyncChannel& m_owner;
+            Client* m_client;
+        };
+
+        void set_active_client(Client* client) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_active_client = client;
+        }
+
+        void clear_active_client(Client* client) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (m_active_client == client) {
+                m_active_client = nullptr;
+            }
+        }
+
+        WebSocketSyncChannelConfig m_config;
+        std::atomic<std::uint64_t> m_cancel_generation;
+        mutable std::mutex m_mutex;
+        Client* m_active_client;
+        std::atomic<std::size_t> m_cancel_count;
+    };
+
+    /// \brief Configuration for \c WebSocketSyncListener.
+    struct WebSocketSyncListenerConfig {
+        /// \brief Local bind host name or address.
+        std::string host = "127.0.0.1";
+        /// \brief Local bind port. Use 0 to let the OS assign a free port.
+        std::uint16_t port = 0;
+        /// \brief Simple-WebSocket-Server worker thread count.
+        std::size_t thread_pool_size = 1;
+        /// \brief Regex endpoint accepting sync WebSocket connections.
+        std::string endpoint_regex = "^/mdbxc/sync/v1/ws/?$";
+        /// \brief Optional bearer token required during the handshake.
+        std::string bearer_token;
+        /// \brief Whether the binding should pass an authenticated node.
+        bool has_authenticated_node = false;
+        /// \brief Authenticated session node passed to middleware.
+        NodeId authenticated_node{};
+        /// \brief Explicit DB allow-list for this listener/session.
+        SyncDbAccess db_access;
+        /// \brief Simple-WebSocket-Server opcode for binary frames.
+        unsigned char binary_frame_opcode = 130;
+        /// \brief Optional external lock around middleware server handling.
+        /// \details
+        /// Use this when the same MDBX-backed \c SyncEngine is also touched
+        /// by application code while the WebSocket listener is running.
+        std::mutex* handler_mutex = nullptr;
+    };
+
+    /// \brief Simple-WebSocket-Server listener binding for
+    /// \c WebSocketSyncServerMiddleware.
+    class WebSocketSyncListener {
+    public:
+        WebSocketSyncListener(WebSocketSyncServerMiddleware& server,
+                              const WebSocketSyncListenerConfig& config)
+            : m_server(server),
+              m_config(config),
+              m_running(false) {
+            m_ws.config.address = config.host;
+            m_ws.config.port = config.port;
+            m_ws.config.thread_pool_size = config.thread_pool_size;
+
+            Server::Endpoint& endpoint =
+                m_ws.endpoint[config.endpoint_regex];
+
+            endpoint.on_handshake =
+                [this](
+                    std::shared_ptr<Server::Connection> connection,
+                    SimpleWeb::CaseInsensitiveMultimap& response_header) {
+                    (void)response_header;
+                    if (m_config.bearer_token.empty()) {
+                        return SimpleWeb::StatusCode::
+                            information_switching_protocols;
+                    }
+                    const SimpleWeb::CaseInsensitiveMultimap::const_iterator
+                        it = connection->header.find("Authorization");
+                    if (it == connection->header.end() ||
+                        it->second !=
+                            std::string("Bearer ") +
+                                m_config.bearer_token) {
+                        return SimpleWeb::StatusCode::
+                            client_error_unauthorized;
+                    }
+                    return SimpleWeb::StatusCode::
+                        information_switching_protocols;
+                };
+
+            endpoint.on_message =
+                [this](
+                    std::shared_ptr<Server::Connection> connection,
+                    std::shared_ptr<Server::InMessage> in_message) {
+                    try {
+                        WebSocketSyncRequestContext context;
+                        context.has_authenticated_node =
+                            m_config.has_authenticated_node;
+                        context.authenticated_node =
+                            m_config.authenticated_node;
+                        context.db_access = m_config.db_access;
+                        context.binary_message =
+                            detail::ws_string_to_bytes(
+                                in_message->string());
+                        std::vector<std::uint8_t> response;
+                        if (m_config.handler_mutex != nullptr) {
+                            std::lock_guard<std::mutex> lock(
+                                *m_config.handler_mutex);
+                            response =
+                                m_server.handle_binary_message(context);
+                        } else {
+                            response =
+                                m_server.handle_binary_message(context);
+                        }
+                        connection->send(
+                            detail::ws_bytes_to_string(response),
+                            nullptr,
+                            m_config.binary_frame_opcode);
+                    } catch (const WebSocketSyncRejected& e) {
+                        connection->send_close(
+                            static_cast<int>(e.close_code()), e.what());
+                    } catch (const std::exception& e) {
+                        connection->send_close(1011, e.what());
+                    }
+                };
+
+            endpoint.on_error =
+                [](
+                    std::shared_ptr<Server::Connection> connection,
+                    const SimpleWeb::error_code& ec) {
+                    (void)connection;
+                    (void)ec;
+                };
+        }
+
+        ~WebSocketSyncListener() {
+            stop();
+        }
+
+        void start() {
+            if (m_running) {
+                return;
+            }
+
+            std::shared_ptr<std::promise<unsigned short> > started(
+                new std::promise<unsigned short>());
+            std::future<unsigned short> started_future =
+                started->get_future();
+
+            m_thread = std::thread(
+                [this, started]() {
+                    bool started_callback_called = false;
+                    try {
+                        m_ws.start(
+                            [started, &started_callback_called](
+                                unsigned short assigned_port) {
+                                started_callback_called = true;
+                                started->set_value(assigned_port);
+                            });
+                    } catch (...) {
+                        if (!started_callback_called) {
+                            try {
+                                started->set_exception(
+                                    std::current_exception());
+                            } catch (...) {}
+                        }
+                    }
+                });
+
+            try {
+                m_config.port = started_future.get();
+            } catch (...) {
+                if (m_thread.joinable()) {
+                    m_thread.join();
+                }
+                throw;
+            }
+            m_running = true;
+        }
+
+        void stop() {
+            if (!m_running) {
+                return;
+            }
+            m_ws.stop();
+            if (m_thread.joinable()) {
+                m_thread.join();
+            }
+            m_running = false;
+        }
+
+        std::uint16_t port() const {
+            return m_config.port;
+        }
+
+    private:
+        typedef SimpleWeb::SocketServer<SimpleWeb::WS> Server;
+
+        WebSocketSyncServerMiddleware& m_server;
+        WebSocketSyncListenerConfig m_config;
+        Server m_ws;
+        std::thread m_thread;
+        bool m_running;
+    };
+
+} // namespace simple_web
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_TRANSPORTS_SIMPLE_WEB_WEB_SOCKET_TRANSPORT_HPP_INCLUDED

--- a/tests/header_sync_transport_umbrella_test.cpp
+++ b/tests/header_sync_transport_umbrella_test.cpp
@@ -1,0 +1,50 @@
+#include <mdbx_containers/sync/transport.hpp>
+
+#include "test_assert.hpp"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#ifndef MDBXC_SYNC_ENABLED
+#error "MDBXC_SYNC_ENABLED must be defined by the test target"
+#endif
+
+#if !MDBXC_SYNC_ENABLED
+#error "header_sync_transport_umbrella_test must be compiled with sync enabled"
+#endif
+
+int main() {
+    mdbxc::sync::NodeId node = mdbxc::sync::make_zero_node();
+    mdbxc::sync::PullRequest pull;
+    pull.requester = node;
+    pull.db_id = node;
+    pull.max_batches = 1;
+
+    const std::vector<std::uint8_t> encoded =
+        mdbxc::sync::TransportMessageCodec::encode_pull_request(pull);
+    MDBXC_TEST_ASSERT(
+        mdbxc::sync::TransportMessageCodec::peek_message_type(encoded) ==
+        mdbxc::sync::TransportMessageType::PullRequest);
+
+    MDBXC_TEST_ASSERT(std::string(mdbxc::sync::HttpSyncRoutes::pull_target())
+                      == "/mdbxc/sync/v1/pull");
+    MDBXC_TEST_ASSERT(mdbxc::sync::http_sync_status_is_retryable(503u));
+    MDBXC_TEST_ASSERT(
+        mdbxc::sync::websocket_sync_close_code_is_retryable(1013u));
+
+    mdbxc::sync::TransportMessageSizePolicy size_policy(1024u);
+    MDBXC_TEST_ASSERT(size_policy.check_pull(pull).allowed);
+
+    mdbxc::sync::WebSocketSyncRequestContext websocket_context;
+    websocket_context.has_authenticated_node = true;
+    websocket_context.authenticated_node = node;
+    websocket_context.db_access = mdbxc::sync::SyncDbAccess::only(node);
+    websocket_context.binary_message = encoded;
+
+    mdbxc::sync::WebSocketAuthenticatedNodeIdentityPolicy websocket_policy;
+    MDBXC_TEST_ASSERT(
+        websocket_policy.check_websocket_message(websocket_context).allowed);
+
+    return 0;
+}


### PR DESCRIPTION
﻿## Summary
- add `mdbx_containers/sync/transport.hpp` as the framework-neutral transport umbrella
- add optional ready-made Simple-Web HTTP/WebSocket binding headers under `mdbx_containers/sync/transports/simple_web/` plus `mdbx_containers/sync/transports/simple_web.hpp` for targets that intentionally use both backends
- refactor the socket-backed HTTP, WebSocket, and node-fleet examples to consume those bindings instead of reimplementing Simple-Web transport glue in each example
- keep the concrete bindings opt-in behind the existing Simple-Web / standalone Asio example CMake options, so the main sync umbrella stays dependency-free
- extend the HTTP CI smoke to build/run both the direct HTTP demo and the process-supervised node-fleet modes
- add a standalone `sync/transport.hpp` umbrella regression test
- update English/Russian docs and sync design notes to describe the transport/backend layout and the remaining production-wrapper boundary

## Validation
- `cmake --build tmp/pr120-http-fleet-cpp11 --target sync_13_http_simple_web_server sync_18_http_node_fleet --parallel`
- `cmake --build tmp/pr120-http-fleet-cpp17 --target sync_13_http_simple_web_server sync_18_http_node_fleet --parallel`
- `cmake --build tmp/pr119-ws-fallback-cpp11 --target sync_17_websocket_simple_web_server --parallel`
- `cmake --build tmp/pr119-ws-fallback-cpp17 --target sync_17_websocket_simple_web_server --parallel`
- `cmake -S . -B tmp/pr120-transport-umbrella-mingw-cpp11 -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=11 -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=OFF -Wno-dev`
- `cmake --build tmp/pr120-transport-umbrella-mingw-cpp11 --target header_sync_transport_umbrella_test --parallel`
- `ctest --test-dir tmp/pr120-transport-umbrella-mingw-cpp11 -R header_sync_transport_umbrella_test --output-on-failure`
- `cmake -S . -B tmp/pr120-transport-umbrella-mingw-cpp17 -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=17 -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=OFF -Wno-dev`
- `cmake --build tmp/pr120-transport-umbrella-mingw-cpp17 --target header_sync_transport_umbrella_test --parallel`
- `ctest --test-dir tmp/pr120-transport-umbrella-mingw-cpp17 -R header_sync_transport_umbrella_test --output-on-failure`
- `tmp/pr120-http-fleet-cpp17/bin/examples/sync_13_http_simple_web_server.exe demo 127.0.0.1 18080`
- `tmp/pr120-http-fleet-cpp17/bin/examples/sync_18_http_node_fleet.exe master-replica 2`
- `tmp/pr119-ws-fallback-cpp17/bin/examples/sync_17_websocket_simple_web_server.exe 127.0.0.1 18194`
- `git diff --check`


## Follow-ups
- Add a regression test for cancelling a blocked WebSocket exchange so `request_cancel()` cannot leave `exchange_binary()` waiting on an unfinished promise.
- Add production-wrapper docs/examples around TLS/WSS termination, token rotation, graceful shutdown, structured logging, connection limits, and deployment-owned retry orchestration.
- When a second backend lands, consider adding `sync/transports/README` or a backend registry section in docs that explains available optional transports and their dependency/CMake options.
- Design sync observability callbacks for status/stage tracking: round started/finished, pull started/finished, page received, page apply started/finished, retry/backoff, cancellation, transport error, and rough progress estimates for initial full clone or large backlog sync.
- Add an optional Kurlyk-based HTTP client/backend (`NewYaroslav/kurlyk`) as another transport implementation, behind its own CMake option and without affecting default builds.
- For Kurlyk/curl-based tests on Windows/MinGW, investigate using a pinned prebuilt curl dependency in the same style as the existing MinGW OpenSSL fallback.
