### PR TITLE
test(sync): cover WebSocket exchange cancellation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,6 +279,8 @@ if(MDBXC_WEBSOCKET_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
         endforeach()
         add_test(NAME test_simple_websocket_transport
             COMMAND test_simple_websocket_transport)
+        set_tests_properties(test_simple_websocket_transport PROPERTIES
+            TIMEOUT 30)
         message(STATUS "WebSocket binding test "
             "test_simple_websocket_transport -> ${_MDBXC_SWS_WS_TARGET}")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,37 @@ if(MDBXC_WEBSOCKET_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
     endforeach()
     message(STATUS "WebSocket binding example "
         "sync_17_websocket_simple_web_server -> ${_MDBXC_SWS_WS_TARGET}")
+
+    if(MDBXC_BUILD_TESTS)
+        include(CTest)
+        enable_testing()
+        add_executable(test_simple_websocket_transport
+            tests/optional/test_simple_websocket_transport.cpp)
+        set_target_properties(test_simple_websocket_transport PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tests
+        )
+        target_compile_features(test_simple_websocket_transport PRIVATE cxx_std_11)
+        target_compile_definitions(test_simple_websocket_transport PRIVATE
+            MDBXC_SYNC_ENABLED=1
+            ASIO_STANDALONE=1
+            USE_STANDALONE_ASIO=1)
+        mdbxc_enable_asan(test_simple_websocket_transport)
+        target_link_libraries(test_simple_websocket_transport PRIVATE
+            ${_PKG_TARGET}
+            ${_MDBXC_SWS_WS_TARGET})
+        foreach(_MDBXC_OPENSSL_RUNTIME_DLL IN LISTS _MDBXC_OPENSSL_RUNTIME_DLLS)
+            add_custom_command(TARGET test_simple_websocket_transport
+                POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    "${_MDBXC_OPENSSL_RUNTIME_DLL}"
+                    "$<TARGET_FILE_DIR:test_simple_websocket_transport>"
+                VERBATIM)
+        endforeach()
+        add_test(NAME test_simple_websocket_transport
+            COMMAND test_simple_websocket_transport)
+        message(STATUS "WebSocket binding test "
+            "test_simple_websocket_transport -> ${_MDBXC_SWS_WS_TARGET}")
+    endif()
 endif()
 
 # ---------------------------------------

--- a/include/mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp
+++ b/include/mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp
@@ -234,6 +234,11 @@ namespace simple_web {
             }
 
             client.start();
+            if (cancel_token.is_cancellation_requested() ||
+                m_cancel_generation.load(std::memory_order_acquire) !=
+                    call_generation) {
+                throw std::runtime_error("cancelled during WebSocket exchange");
+            }
             return result.get();
         }
 

--- a/include/mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp
+++ b/include/mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp
@@ -209,7 +209,10 @@ namespace simple_web {
                     int status,
                     const std::string& reason) {
                     (void)connection;
-                    if (status != 1000) {
+                    if (status == 1000) {
+                        state->set_exception(
+                            "WebSocket closed before sync response");
+                    } else {
                         state->set_exception(
                             "WebSocket closed with status " +
                             std::to_string(status) + " (" +

--- a/tests/optional/test_simple_websocket_transport.cpp
+++ b/tests/optional/test_simple_websocket_transport.cpp
@@ -1,0 +1,177 @@
+#include <mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+mdbxc::sync::NodeId make_node(std::uint8_t seed) {
+    mdbxc::sync::NodeId node{};
+    for (int i = 0; i < 16; ++i) {
+        node[i] = static_cast<std::uint8_t>(seed + i);
+    }
+    return node;
+}
+
+class SilentWebSocketServer {
+public:
+    SilentWebSocketServer()
+        : m_received(false),
+          m_running(false) {
+        m_server.config.address = "127.0.0.1";
+        m_server.config.port = 0;
+        m_server.config.thread_pool_size = 1;
+
+        Server::Endpoint& endpoint =
+            m_server.endpoint["^/mdbxc/sync/v1/ws/?$"];
+        endpoint.on_message =
+            [this](
+                std::shared_ptr<Server::Connection> connection,
+                std::shared_ptr<Server::InMessage> in_message) {
+                (void)connection;
+                (void)in_message;
+                {
+                    std::lock_guard<std::mutex> lock(m_mutex);
+                    m_received = true;
+                }
+                m_changed.notify_all();
+                // Intentionally keep the connection open and never send a
+                // response. The client-side cancellation path must unblock the
+                // exchange.
+            };
+    }
+
+    ~SilentWebSocketServer() {
+        stop();
+    }
+
+    void start() {
+        if (m_running) {
+            return;
+        }
+
+        std::shared_ptr<std::promise<unsigned short> > started(
+            new std::promise<unsigned short>());
+        std::future<unsigned short> started_future = started->get_future();
+        m_thread = std::thread(
+            [this, started]() {
+                bool callback_called = false;
+                try {
+                    m_server.start(
+                        [started, &callback_called](
+                            unsigned short assigned_port) {
+                            callback_called = true;
+                            started->set_value(assigned_port);
+                        });
+                } catch (...) {
+                    if (!callback_called) {
+                        try {
+                            started->set_exception(std::current_exception());
+                        } catch (...) {}
+                    }
+                }
+            });
+        m_port = started_future.get();
+        m_running = true;
+    }
+
+    void stop() {
+        if (!m_running) {
+            return;
+        }
+        m_server.stop();
+        if (m_thread.joinable()) {
+            m_thread.join();
+        }
+        m_running = false;
+    }
+
+    unsigned short port() const {
+        return m_port;
+    }
+
+    bool wait_for_message(std::chrono::milliseconds timeout) const {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        return m_changed.wait_for(
+            lock, timeout, [this] { return m_received; });
+    }
+
+private:
+    typedef SimpleWeb::SocketServer<SimpleWeb::WS> Server;
+
+    Server m_server;
+    std::thread m_thread;
+    unsigned short m_port = 0;
+    mutable std::mutex m_mutex;
+    mutable std::condition_variable m_changed;
+    bool m_received;
+    bool m_running;
+};
+
+void require_true(bool value, const char* message) {
+    if (!value) {
+        throw std::runtime_error(message);
+    }
+}
+
+void test_websocket_channel_cancel_unblocks_silent_exchange() {
+    SilentWebSocketServer server;
+    server.start();
+
+    mdbxc::sync::simple_web::WebSocketSyncChannelConfig config;
+    config.host = "127.0.0.1";
+    config.port = server.port();
+    mdbxc::sync::simple_web::WebSocketSyncChannel channel(config);
+
+    mdbxc::sync::PullRequest request;
+    request.requester = make_node(0x10);
+    request.db_id = make_node(0xD0);
+    const std::vector<std::uint8_t> message =
+        mdbxc::sync::TransportMessageCodec::encode_pull_request(request);
+
+    std::promise<std::string> result_promise;
+    std::future<std::string> result = result_promise.get_future();
+    mdbxc::sync::CancellationSource cancel;
+    std::thread client(
+        [&channel, &message, &cancel, &result_promise]() {
+            try {
+                (void)channel.exchange_binary(message, cancel.token());
+                result_promise.set_value("completed");
+            } catch (const std::exception& e) {
+                result_promise.set_value(e.what());
+            } catch (...) {
+                result_promise.set_value("unknown");
+            }
+        });
+
+    require_true(server.wait_for_message(std::chrono::seconds(5)),
+                 "WebSocket server did not receive test message");
+    cancel.request_cancel();
+    channel.request_cancel();
+
+    require_true(result.wait_for(std::chrono::seconds(5)) ==
+                     std::future_status::ready,
+                 "WebSocket exchange did not unblock after cancellation");
+    client.join();
+    server.stop();
+
+    require_true(channel.cancel_count() == 1u,
+                 "WebSocket channel did not count request_cancel");
+    require_true(result.get().find("cancelled") != std::string::npos,
+                 "WebSocket cancelled exchange reported wrong result");
+}
+
+} // namespace
+
+int main() {
+    test_websocket_channel_cancel_unblocks_silent_exchange();
+    return 0;
+}

--- a/tests/optional/test_simple_websocket_transport.cpp
+++ b/tests/optional/test_simple_websocket_transport.cpp
@@ -152,16 +152,36 @@ void test_websocket_channel_cancel_unblocks_silent_exchange() {
             }
         });
 
-    require_true(server.wait_for_message(std::chrono::seconds(5)),
+    const bool server_received =
+        server.wait_for_message(std::chrono::seconds(5));
+    if (!server_received) {
+        cancel.request_cancel();
+        channel.request_cancel();
+        if (client.joinable()) {
+            client.join();
+        }
+        server.stop();
+    }
+    require_true(server_received,
                  "WebSocket server did not receive test message");
+
     cancel.request_cancel();
     channel.request_cancel();
 
-    require_true(result.wait_for(std::chrono::seconds(5)) ==
-                     std::future_status::ready,
-                 "WebSocket exchange did not unblock after cancellation");
-    client.join();
+    const bool exchange_ready =
+        result.wait_for(std::chrono::seconds(5)) ==
+        std::future_status::ready;
+    if (!exchange_ready) {
+        cancel.request_cancel();
+        channel.request_cancel();
+    }
+    if (client.joinable()) {
+        client.join();
+    }
     server.stop();
+
+    require_true(exchange_ready,
+                 "WebSocket exchange did not unblock after cancellation");
 
     require_true(channel.cancel_count() == 1u,
                  "WebSocket channel did not count request_cancel");


### PR DESCRIPTION
## Summary
- make `simple_web::WebSocketSyncChannel` re-check cancellation after `client.start()` returns, before waiting on the response future
- add an opt-in Simple-WebSocket regression test with a silent server that never replies
- register the optional test when `MDBXC_WEBSOCKET_SYNC_EXAMPLE=ON` and tests are enabled

## Validation
- `ctest --test-dir tmp\pr123-ws-cpp17 -R ^test_simple_websocket_transport$ --output-on-failure`
- `ctest --test-dir tmp\pr123-ws-cpp11 -R ^test_simple_websocket_transport$ --output-on-failure`

## Stacking
Depends on #122.