### PR TITLE
feat(sync): add Kurlyk HTTP client transport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(MDBXC_USE_ASAN "Enable AddressSanitizer for tests/examples (not for libmd
 # examples/README-sync.md for usage.
 option(MDBXC_HTTP_SYNC_EXAMPLE "Build the Simple-Web-Server HTTP sync examples" OFF)
 option(MDBXC_WEBSOCKET_SYNC_EXAMPLE "Build the Simple-WebSocket-Server sync binding example" OFF)
+option(MDBXC_KURLYK_HTTP_SYNC_EXAMPLE "Build the Kurlyk/libcurl HTTP sync client example" OFF)
 option(MDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK
     "Fetch a ready-made Win64 OpenSSL Crypto package for the MinGW WebSocket example if system OpenSSL is unavailable" ON)
 
@@ -40,6 +41,7 @@ message(STATUS "MDBXC_BUILD_BENCHMARKS  = ${MDBXC_BUILD_BENCHMARKS}")
 message(STATUS "MDBXC_ENABLE_STRESS_TESTS = ${MDBXC_ENABLE_STRESS_TESTS}")
 message(STATUS "MDBXC_HTTP_SYNC_EXAMPLE = ${MDBXC_HTTP_SYNC_EXAMPLE}")
 message(STATUS "MDBXC_WEBSOCKET_SYNC_EXAMPLE = ${MDBXC_WEBSOCKET_SYNC_EXAMPLE}")
+message(STATUS "MDBXC_KURLYK_HTTP_SYNC_EXAMPLE = ${MDBXC_KURLYK_HTTP_SYNC_EXAMPLE}")
 message(STATUS "MDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK = ${MDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK}")
 message(STATUS "MDBXC_USE_ASAN          = ${MDBXC_USE_ASAN}")
 
@@ -146,6 +148,8 @@ if(MDBXC_BUILD_EXAMPLES)
         "sync_17_websocket_simple_web_server\\.cpp$")
     list(FILTER EXAMPLES EXCLUDE REGEX
         "sync_18_http_node_fleet\\.cpp$")
+    list(FILTER EXAMPLES EXCLUDE REGEX
+        "sync_19_kurlyk_http_client\\.cpp$")
     foreach(example_file IN LISTS EXAMPLES)
         get_filename_component(example_name ${example_file} NAME_WE)
         add_executable(${example_name} ${example_file})
@@ -212,6 +216,39 @@ if(MDBXC_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
         tiny-process-library::tiny-process-library)
     message(STATUS "HTTP node fleet example sync_18_http_node_fleet -> "
         "${_MDBXC_SWS_TARGET};tiny-process-library")
+endif()
+
+# ---------------------------------------
+# Optional Kurlyk HTTP transport client example
+# ---------------------------------------
+# Pulls Kurlyk through FetchContent and uses its libcurl-backed HTTP client
+# around HttpSyncPeer. The server side intentionally reuses the ready
+# Simple-Web listener so this example demonstrates backend interchange at the
+# framework-neutral IHttpSyncClient seam.
+if(MDBXC_KURLYK_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/deps)
+    include(cmake/deps/simple-web-server.cmake)
+    include(cmake/deps/kurlyk.cmake)
+
+    simple_web_server_provide(OUT_TARGET _MDBXC_SWS_TARGET)
+    kurlyk_http_client_provide(OUT_TARGET _MDBXC_KURLYK_HTTP_TARGET)
+
+    add_executable(sync_19_kurlyk_http_client
+        examples/sync_19_kurlyk_http_client.cpp)
+    set_target_properties(sync_19_kurlyk_http_client PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples
+    )
+    target_compile_features(sync_19_kurlyk_http_client PRIVATE cxx_std_11)
+    target_compile_definitions(sync_19_kurlyk_http_client PRIVATE
+        MDBXC_SYNC_ENABLED=1
+        ASIO_STANDALONE=1
+        USE_STANDALONE_ASIO=1)
+    target_link_libraries(sync_19_kurlyk_http_client PRIVATE
+        ${_PKG_TARGET}
+        ${_MDBXC_SWS_TARGET}
+        ${_MDBXC_KURLYK_HTTP_TARGET})
+    message(STATUS "Kurlyk HTTP client example sync_19_kurlyk_http_client -> "
+        "${_MDBXC_SWS_TARGET};${_MDBXC_KURLYK_HTTP_TARGET}")
 endif()
 
 # ---------------------------------------

--- a/README-RU.md
+++ b/README-RU.md
@@ -90,9 +90,11 @@
   binary message seam, а `SyncWorker` запускает фоновой polling.
   `mdbx_containers/sync/transport.hpp` - umbrella header транспортного слоя.
   Опциональные готовые Simple-Web HTTP/WebSocket binding headers находятся в
-  `mdbx_containers/sync/transports/simple_web/`, а socket-backed примеры
-  используют эти bindings вместо повторной реализации транспорта в каждом
-  файле. Wire-format для специализированных таблиц отложен. HTTP auth,
+  `mdbx_containers/sync/transports/simple_web/`, а опциональный Kurlyk/libcurl
+  HTTP client binding находится в `mdbx_containers/sync/transports/kurlyk/`.
+  Socket-backed примеры используют эти bindings вместо повторной реализации
+  транспорта в каждом файле. Wire-format для специализированных таблиц отложен.
+  HTTP auth,
   remote-address checks и rate-limit headers живут в adapter-local policy
   context, а не внутри sync DTO;
   см. `include/mdbx_containers/sync/DESIGN.md`.

--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@
   `SyncWorker` is the background polling driver. `mdbx_containers/sync/transport.hpp`
   is the transport-layer umbrella. Optional ready-made Simple-Web
   HTTP/WebSocket binding headers live under
-  `mdbx_containers/sync/transports/simple_web/`, and the socket-backed
-  examples use those bindings instead of reimplementing the transport in each
-  file. Specialized table wire formats remain deferred.
+  `mdbx_containers/sync/transports/simple_web/`, and the optional Kurlyk/libcurl
+  HTTP client binding lives under `mdbx_containers/sync/transports/kurlyk/`.
+  Socket-backed examples use those bindings instead of reimplementing the
+  transport in each file. Specialized table wire formats remain deferred.
   HTTP auth, remote-address checks, and rate-limit headers live in
   adapter-local policy context, not inside sync DTOs.
   See

--- a/cmake/deps/kurlyk.cmake
+++ b/cmake/deps/kurlyk.cmake
@@ -1,0 +1,88 @@
+# cmake/deps/kurlyk.cmake
+# Provides a header-only Kurlyk HTTP client target for optional sync transport
+# examples. The target intentionally enables only Kurlyk HTTP support; WebSocket,
+# auth helpers, and OAuth helpers stay disabled so this dependency remains a
+# small libcurl-backed client backend.
+#
+# Public API:
+#   kurlyk_http_client_provide(
+#       OUT_TARGET <var>     # returns the INTERFACE target name to link against
+#   )
+
+include(CMakeParseArguments)
+include(FetchContent)
+
+set(MDBXC_KURLYK_GIT_TAG
+    "v1.0.1" CACHE STRING
+    "Kurlyk tag used by the optional HTTP sync client backend.")
+
+function(_mdbxc_kurlyk_fetchcontent_populate name)
+    if(POLICY CMP0169)
+        cmake_policy(PUSH)
+        cmake_policy(SET CMP0169 OLD)
+    endif()
+    FetchContent_Populate(${name})
+    if(POLICY CMP0169)
+        cmake_policy(POP)
+    endif()
+endfunction()
+
+function(kurlyk_http_client_provide)
+    set(_options)
+    set(_one_value OUT_TARGET)
+    set(_multi_value)
+    cmake_parse_arguments(KURLYK "${_options}" "${_one_value}"
+        "${_multi_value}" ${ARGN})
+
+    if(NOT KURLYK_OUT_TARGET)
+        message(FATAL_ERROR
+            "kurlyk_http_client_provide requires OUT_TARGET <var>")
+    endif()
+
+    FetchContent_Declare(
+        mdbxc_kurlyk
+        GIT_REPOSITORY https://github.com/NewYaroslav/kurlyk.git
+        GIT_TAG        ${MDBXC_KURLYK_GIT_TAG}
+        GIT_SHALLOW    TRUE
+    )
+    FetchContent_GetProperties(mdbxc_kurlyk)
+    if(NOT mdbxc_kurlyk_POPULATED)
+        _mdbxc_kurlyk_fetchcontent_populate(mdbxc_kurlyk)
+        FetchContent_GetProperties(mdbxc_kurlyk)
+    endif()
+
+    if(NOT EXISTS "${mdbxc_kurlyk_SOURCE_DIR}/include/kurlyk.hpp")
+        message(FATAL_ERROR
+            "Kurlyk headers were not found after FetchContent")
+    endif()
+
+    if(NOT TARGET mdbxc_kurlyk_http_client)
+        find_package(CURL QUIET)
+        if(NOT TARGET CURL::libcurl)
+            message(FATAL_ERROR
+                "libcurl was not found. Install libcurl or set "
+                "CURL_LIBRARY/CURL_INCLUDE_DIR before enabling "
+                "MDBXC_KURLYK_HTTP_SYNC_EXAMPLE.")
+        endif()
+        find_package(Threads REQUIRED)
+
+        add_library(mdbxc_kurlyk_http_client INTERFACE)
+        target_include_directories(mdbxc_kurlyk_http_client INTERFACE
+            "${mdbxc_kurlyk_SOURCE_DIR}/include")
+        target_compile_definitions(mdbxc_kurlyk_http_client INTERFACE
+            KURLYK_HTTP_SUPPORT=1
+            KURLYK_WEBSOCKET_SUPPORT=0
+            KURLYK_AUTH_SUPPORT=0
+            KURLYK_OAUTH_SUPPORT=0)
+        target_link_libraries(mdbxc_kurlyk_http_client INTERFACE
+            CURL::libcurl
+            Threads::Threads)
+        if(WIN32)
+            target_link_libraries(mdbxc_kurlyk_http_client INTERFACE
+                ws2_32
+                wsock32)
+        endif()
+    endif()
+
+    set(${KURLYK_OUT_TARGET} mdbxc_kurlyk_http_client PARENT_SCOPE)
+endfunction()

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -5,7 +5,9 @@
 небольшой буфер в памяти, чтобы поток протокола был виден без HTTP, WebSocket
 или IPC-кода. Опциональные HTTP- и WebSocket-примеры используют готовые
 Simple-Web binding headers из `mdbx_containers/sync/transports/simple_web/` поверх
-Simple-Web-Server, Simple-WebSocket-Server и standalone Asio.
+Simple-Web-Server, Simple-WebSocket-Server и standalone Asio. Пример Kurlyk
+использует опциональный HTTP client binding из
+`mdbx_containers/sync/transports/kurlyk/` поверх libcurl.
 
 Синхронизация включается явно. Примеры собираются с `MDBXC_SYNC_ENABLED=1`;
 приложениям, которые используют sync, тоже нужно компилировать соответствующий
@@ -60,6 +62,28 @@ tmp/build-http-example/bin/examples/sync_18_http_node_fleet \
 
 ```cpp
 #include <mdbx_containers/sync/transports/simple_web/HttpTransport.hpp>
+```
+
+Kurlyk/libcurl HTTP client binding тоже включается отдельно. Он использует тот
+же framework-neutral `HttpSyncPeer` API и меняет только конкретную реализацию
+`IHttpSyncClient`:
+
+```bash
+cmake -S . -B tmp/build-kurlyk-http \
+    -DMDBXC_DEPS_MODE=BUNDLED \
+    -DMDBXC_BUILD_TESTS=OFF \
+    -DMDBXC_BUILD_EXAMPLES=ON \
+    -DMDBXC_KURLYK_HTTP_SYNC_EXAMPLE=ON \
+    -DCMAKE_CXX_STANDARD=11
+
+cmake --build tmp/build-kurlyk-http --target sync_19_kurlyk_http_client
+tmp/build-kurlyk-http/bin/examples/sync_19_kurlyk_http_client
+```
+
+Готовый Kurlyk HTTP client binding подключается так:
+
+```cpp
+#include <mdbx_containers/sync/transports/kurlyk/HttpTransport.hpp>
 ```
 
 Targets, которым нужны и Simple-Web HTTP, и WebSocket bindings, могут
@@ -135,6 +159,7 @@ cmake -S . -B tmp/build-ws-example `
 | `sync_16_worker_http_transport.cpp` | `SyncWorker` поверх `HttpSyncPeer` и HTTP request-context policy. | Продвинутый |
 | `sync_17_websocket_simple_web_server.cpp` | Готовый Simple-WebSocket binding поверх standalone Asio. | Продвинутый |
 | `sync_18_http_node_fleet.cpp` | Fleet из нескольких процессов поверх готового Simple-Web HTTP binding. | Продвинутый |
+| `sync_19_kurlyk_http_client.cpp` | Готовый Kurlyk/libcurl HTTP client binding против Simple-Web sync listener. | Продвинутый |
 
 ## Общие правила
 
@@ -271,6 +296,12 @@ capture sink и application loop;
 через stdin. Режим `master-replica` показывает одного активного писателя и
 одного пассивного получателя. Режим `mesh` позволяет обеим нодам писать
 локально, пока каждая нода подтягивает изменения другой по HTTP.
+
+`sync_19_kurlyk_http_client.cpp` оставляет серверную сторону на готовом
+Simple-Web HTTP listener и меняет клиентский backend на
+`mdbxc::sync::kurlyk::HttpSyncClient`. Это показывает форму для других HTTP
+клиентов: реализовать `IHttpSyncClient`, передать его в `HttpSyncPeer` и не
+менять `SyncEngine`, DTO encoding, auth policy и локальный apply.
 
 `sync_17_websocket_simple_web_server.cpp` - socket-backed WebSocket-вариант.
 Он использует `mdbxc::sync::simple_web::WebSocketSyncChannel` и

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -5,7 +5,9 @@ Most use `DirectSyncPeer` or a small in-memory buffer so the protocol flow is
 visible without adding HTTP, WebSocket, or IPC code. The optional HTTP and
 WebSocket examples use ready-made Simple-Web binding headers from
 `mdbx_containers/sync/transports/simple_web/` over Simple-Web-Server,
-Simple-WebSocket-Server, and standalone Asio.
+Simple-WebSocket-Server, and standalone Asio. The Kurlyk example uses the
+optional `mdbx_containers/sync/transports/kurlyk/` HTTP client binding over
+libcurl.
 
 Sync is opt-in. The examples are built with `MDBXC_SYNC_ENABLED=1`; applications
 must also compile sync users with that macro enabled.
@@ -59,6 +61,28 @@ The reusable HTTP binding lives in:
 
 ```cpp
 #include <mdbx_containers/sync/transports/simple_web/HttpTransport.hpp>
+```
+
+The Kurlyk/libcurl HTTP client binding is also opt-in. It reuses the
+framework-neutral `HttpSyncPeer` API and swaps only the concrete
+`IHttpSyncClient` implementation:
+
+```bash
+cmake -S . -B tmp/build-kurlyk-http \
+    -DMDBXC_DEPS_MODE=BUNDLED \
+    -DMDBXC_BUILD_TESTS=OFF \
+    -DMDBXC_BUILD_EXAMPLES=ON \
+    -DMDBXC_KURLYK_HTTP_SYNC_EXAMPLE=ON \
+    -DCMAKE_CXX_STANDARD=11
+
+cmake --build tmp/build-kurlyk-http --target sync_19_kurlyk_http_client
+tmp/build-kurlyk-http/bin/examples/sync_19_kurlyk_http_client
+```
+
+The reusable Kurlyk HTTP client binding lives in:
+
+```cpp
+#include <mdbx_containers/sync/transports/kurlyk/HttpTransport.hpp>
 ```
 
 Targets that intentionally use both Simple-Web HTTP and WebSocket bindings can
@@ -134,6 +158,7 @@ cmake -S . -B tmp/build-ws-example `
 | `sync_16_worker_http_transport.cpp` | `SyncWorker` running through `HttpSyncPeer` and HTTP request-context policy. | Advanced |
 | `sync_17_websocket_simple_web_server.cpp` | Ready-made Simple-WebSocket binding over standalone Asio. | Advanced |
 | `sync_18_http_node_fleet.cpp` | Multi-process node fleet using the ready-made Simple-Web HTTP binding. | Advanced |
+| `sync_19_kurlyk_http_client.cpp` | Ready-made Kurlyk/libcurl HTTP client binding against the Simple-Web sync listener. | Advanced |
 
 ## Common Rules
 
@@ -268,6 +293,13 @@ loop; the parent process only starts nodes and sends `pause` / `stop` commands
 through stdin. The `master-replica` mode shows one active writer and one passive
 receiver. The `mesh` mode lets both nodes write locally while each node pulls
 from the other over HTTP.
+
+`sync_19_kurlyk_http_client.cpp` keeps the server side on the ready
+Simple-Web HTTP listener and swaps the client-side backend to
+`mdbxc::sync::kurlyk::HttpSyncClient`. This demonstrates the intended
+adapter shape for additional HTTP clients: implement `IHttpSyncClient`, pass it
+to `HttpSyncPeer`, and leave `SyncEngine`, DTO encoding, auth policy, and local
+apply unchanged.
 
 `sync_17_websocket_simple_web_server.cpp` is the socket-backed WebSocket
 counterpart. It uses `mdbxc::sync::simple_web::WebSocketSyncChannel` and

--- a/examples/sync_19_kurlyk_http_client.cpp
+++ b/examples/sync_19_kurlyk_http_client.cpp
@@ -1,0 +1,185 @@
+/**
+ * \ingroup mdbxc_examples
+ * \brief HTTP sync client backend over Kurlyk/libcurl.
+ *
+ * This example keeps the server side on the ready Simple-Web HTTP listener and
+ * swaps only the client-side socket backend to Kurlyk. The sync API above the
+ * transport stays the same: KurlykHttpSyncClient implements IHttpSyncClient,
+ * HttpSyncPeer turns it into an ISyncPeer, and the local replica applies the
+ * pulled page with SyncEngine::handle_push().
+ *
+ * Build it explicitly:
+ *
+ *   cmake -S . -B tmp/build-kurlyk-http \
+ *       -DMDBXC_DEPS_MODE=BUNDLED \
+ *       -DMDBXC_BUILD_TESTS=OFF \
+ *       -DMDBXC_BUILD_EXAMPLES=ON \
+ *       -DMDBXC_KURLYK_HTTP_SYNC_EXAMPLE=ON \
+ *       -DCMAKE_CXX_STANDARD=11
+ *   cmake --build tmp/build-kurlyk-http \
+ *       --target sync_19_kurlyk_http_client
+ *
+ * Run:
+ *
+ *   ./tmp/build-kurlyk-http/bin/examples/sync_19_kurlyk_http_client
+ *
+ * Expected output:
+ *
+ *   [server] listening on http://127.0.0.1:<port>
+ *   [client] Kurlyk HTTP pull applied 2 batch(es)
+ *   [client] request_cancel forwarded once
+ *   OK: sync_19_kurlyk_http_client
+ */
+
+#include <mdbx_containers/sync/transports/kurlyk/HttpTransport.hpp>
+#include <mdbx_containers/sync/transports/simple_web/HttpTransport.hpp>
+#include <mdbx_containers/tables.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "sync_example_utils.hpp"
+
+namespace {
+
+const std::uint8_t kPrimaryNodeSeed = 0xC1;
+const std::uint8_t kReplicaNodeSeed = 0xC2;
+const std::uint8_t kDatabaseSeed = 0xC3;
+const char* kBearerToken = "kurlyk-demo-token";
+
+void seed_primary_rows(const std::shared_ptr<mdbxc::Connection>& db);
+void require_quote(const std::shared_ptr<mdbxc::Connection>& db,
+                   int key,
+                   const std::string& expected);
+
+} // namespace
+
+int main() {
+    const std::string primary_path = "sync_19_primary.mdbx";
+    const std::string replica_path = "sync_19_replica.mdbx";
+    sync_example::cleanup(primary_path);
+    sync_example::cleanup(replica_path);
+
+    try {
+        const mdbxc::sync::NodeId primary_node =
+            sync_example::make_node(kPrimaryNodeSeed);
+        const mdbxc::sync::NodeId replica_node =
+            sync_example::make_node(kReplicaNodeSeed);
+        const mdbxc::sync::DbId db_id =
+            sync_example::make_node(kDatabaseSeed);
+
+        std::shared_ptr<mdbxc::Connection> primary =
+            sync_example::open(primary_path);
+        std::shared_ptr<mdbxc::Connection> replica =
+            sync_example::open(replica_path);
+
+        mdbxc::sync::IdentityProvider primary_identity(
+            primary, primary_node, db_id);
+        mdbxc::sync::IdentityProvider replica_identity(
+            replica, replica_node, db_id);
+        (void)primary_identity;
+        (void)replica_identity;
+
+        seed_primary_rows(primary);
+
+        mdbxc::sync::SyncEngine primary_engine(primary);
+        mdbxc::sync::SyncEngine replica_engine(replica);
+        mdbxc::sync::HttpSyncServer http_server(primary_engine);
+
+        mdbxc::sync::HttpBearerNodeIdentityPolicy bearer_policy;
+        bearer_policy.allow_token_for_node(kBearerToken, replica_node);
+        bearer_policy.allow_db_id_for_token(kBearerToken, db_id);
+
+        std::mutex server_mutex;
+        mdbxc::sync::simple_web::HttpSyncListenerConfig server_config;
+        server_config.host = "127.0.0.1";
+        server_config.port = 0;
+        server_config.handler_mutex = &server_mutex;
+
+        mdbxc::sync::simple_web::HttpSyncListener listener(
+            http_server, server_config, &bearer_policy);
+        listener.start();
+        std::printf("[server] listening on http://127.0.0.1:%u\n",
+                    static_cast<unsigned>(listener.port()));
+
+        mdbxc::sync::kurlyk::HttpSyncClientConfig client_config;
+        client_config.base_url =
+            std::string("http://127.0.0.1:") +
+            std::to_string(static_cast<unsigned>(listener.port()));
+        client_config.bearer_token = kBearerToken;
+        client_config.wait_poll_interval = std::chrono::milliseconds(5);
+
+        mdbxc::sync::kurlyk::HttpSyncClient raw_client(client_config);
+        mdbxc::sync::HttpSyncPeer peer(raw_client);
+
+        mdbxc::sync::PullRequest pull;
+        pull.requester = replica_node;
+        pull.db_id = db_id;
+        pull.have = replica_engine.applied_cursor();
+        pull.max_batches = 100;
+
+        const mdbxc::sync::PullResponse pulled = peer.pull(pull);
+        sync_example::require(pulled.ok,
+                              "Kurlyk HTTP pull failed: " + pulled.error);
+
+        mdbxc::sync::PushRequest local_apply;
+        local_apply.sender = primary_node;
+        local_apply.db_id = db_id;
+        local_apply.batches = pulled.batches;
+        const mdbxc::sync::PushResponse applied =
+            replica_engine.handle_push(local_apply);
+        sync_example::require(applied.ok,
+                              "replica apply failed: " + applied.error);
+        std::printf("[client] Kurlyk HTTP pull applied %zu batch(es)\n",
+                    pulled.batches.size());
+
+        require_quote(replica, 1, "BTC/USD");
+        require_quote(replica, 2, "ETH/USD");
+
+        peer.request_cancel();
+        sync_example::require(raw_client.cancel_count() == 1u,
+                              "request_cancel was not forwarded");
+        std::printf("[client] request_cancel forwarded once\n");
+
+        listener.stop();
+        sync_example::disconnect_and_cleanup(primary, primary_path);
+        sync_example::disconnect_and_cleanup(replica, replica_path);
+        std::puts("OK: sync_19_kurlyk_http_client");
+        return 0;
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "sync_19_kurlyk_http_client failed: %s\n",
+                     e.what());
+        sync_example::cleanup(primary_path);
+        sync_example::cleanup(replica_path);
+        return 1;
+    }
+}
+
+namespace {
+
+void seed_primary_rows(const std::shared_ptr<mdbxc::Connection>& db) {
+    mdbxc::sync::ThreadLocalChangeAccumulator sink(db);
+    mdbxc::KeyValueTable<int, std::string> quotes(db, "quotes");
+    db->attach_sync_capture(&sink);
+    quotes.insert_or_assign(1, "BTC/USD");
+    quotes.insert_or_assign(2, "ETH/USD");
+    db->detach_sync_capture();
+}
+
+void require_quote(const std::shared_ptr<mdbxc::Connection>& db,
+                   int key,
+                   const std::string& expected) {
+    mdbxc::KeyValueTable<int, std::string> quotes(db, "quotes");
+    const std::string actual =
+        sync_example::kv_or_throw(db, quotes, key, "quotes");
+    sync_example::require(actual == expected,
+                          "quote mismatch for key " +
+                          std::to_string(key));
+}
+
+} // namespace

--- a/guides/build-and-test.md
+++ b/guides/build-and-test.md
@@ -20,6 +20,7 @@ All project options use the `MDBXC_` prefix.
 | `MDBXC_ENABLE_STRESS_TESTS` | `OFF` | Register long stress tests with CTest. Stress executables are still built when tests are enabled. |
 | `MDBXC_HTTP_SYNC_EXAMPLE` | `OFF` | Build the optional Simple-Web-Server HTTP sync example and fetch standalone Asio/Simple-Web-Server headers. |
 | `MDBXC_WEBSOCKET_SYNC_EXAMPLE` | `OFF` | Build the optional Simple-WebSocket-Server sync example and fetch standalone Asio/Simple-WebSocket-Server headers. Requires OpenSSL Crypto because Simple-WebSocket-Server uses it for the WebSocket handshake. |
+| `MDBXC_KURLYK_HTTP_SYNC_EXAMPLE` | `OFF` | Build the optional Kurlyk/libcurl HTTP sync client example and fetch Kurlyk headers. Requires a discoverable libcurl package. |
 | `MDBXC_USE_ASAN` | `ON` | Enable AddressSanitizer for tests/examples when supported. |
 
 When `mdbx-containers` is added as a subproject, existing parent-provided

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -45,6 +45,10 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
   explicit CMake options, not mandatory runtime dependencies. The backend
   umbrella is `sync/transports/simple_web.hpp`; HTTP-only or WebSocket-only
   targets can include the narrower backend-specific header.
+- Optional ready-made Kurlyk/libcurl HTTP client binding under
+  `sync/transports/kurlyk/`. It implements only the client-side
+  `IHttpSyncClient` seam and can be paired with any server binding that exposes
+  the framework-neutral `HttpSyncServer` contract.
 - Transport middleware helpers: `SyncPeerMiddleware`,
   `HttpSyncClientMiddleware`, allow-list policies, fixed-budget rate limiting,
   HTTP request-context bearer/remote-address/fixed-window policies,
@@ -612,6 +616,12 @@ The framework-neutral `HttpSyncPeer` / `HttpSyncServer` and
 server/client bindings remain separate optional integrations; the ready-made
 Simple-Web bindings live under `sync/transports/simple_web/` and are not
 included by the main sync umbrella header.
+
+The Kurlyk HTTP client binding lives under `sync/transports/kurlyk/` and is
+also excluded from the main sync umbrella header. It exists to validate that
+HTTP client backends can be swapped at the `IHttpSyncClient` boundary without
+changing `SyncEngine`, `HttpSyncPeer`, transport DTOs, or auth/rate-limit
+middleware.
 
 ## Why `prune_up_to` uses cursor walk + `MDBX_NEXT`
 

--- a/include/mdbx_containers/sync/transports/kurlyk.hpp
+++ b/include/mdbx_containers/sync/transports/kurlyk.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_TRANSPORTS_KURLYK_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_TRANSPORTS_KURLYK_HPP_INCLUDED
+
+/// \file sync/transports/kurlyk.hpp
+/// \brief Aggregate header for optional Kurlyk sync transport bindings.
+
+#include <mdbx_containers/sync/transports/kurlyk/HttpTransport.hpp>
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_TRANSPORTS_KURLYK_HPP_INCLUDED

--- a/include/mdbx_containers/sync/transports/kurlyk/HttpTransport.hpp
+++ b/include/mdbx_containers/sync/transports/kurlyk/HttpTransport.hpp
@@ -1,0 +1,233 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_TRANSPORTS_KURLYK_HTTP_TRANSPORT_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_TRANSPORTS_KURLYK_HTTP_TRANSPORT_HPP_INCLUDED
+
+/// \file sync/transports/kurlyk/HttpTransport.hpp
+/// \brief Optional Kurlyk/libcurl client binding for HTTP sync transport.
+/// \details
+/// This header is not included by mdbx_containers/sync.hpp. Include it only in
+/// translation units that intentionally use NewYaroslav/kurlyk as the concrete
+/// HTTP client backend.
+
+#ifndef KURLYK_HTTP_SUPPORT
+#define KURLYK_HTTP_SUPPORT 1
+#endif
+#ifndef KURLYK_WEBSOCKET_SUPPORT
+#define KURLYK_WEBSOCKET_SUPPORT 0
+#endif
+#ifndef KURLYK_AUTH_SUPPORT
+#define KURLYK_AUTH_SUPPORT 0
+#endif
+#ifndef KURLYK_OAUTH_SUPPORT
+#define KURLYK_OAUTH_SUPPORT 0
+#endif
+
+#include <kurlyk.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <exception>
+#include <future>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mdbx_containers/sync/transport.hpp>
+
+#if !MDBXC_SYNC_ENABLED
+#error "mdbx_containers/sync/transports/kurlyk/HttpTransport.hpp requires MDBXC_SYNC_ENABLED=1"
+#endif
+
+namespace mdbxc {
+namespace sync {
+namespace kurlyk {
+
+    namespace detail {
+        inline std::vector<std::uint8_t> string_to_bytes(
+                const std::string& text) {
+            return std::vector<std::uint8_t>(text.begin(), text.end());
+        }
+
+        inline std::string bytes_to_string(
+                const std::vector<std::uint8_t>& bytes) {
+            if (bytes.empty()) {
+                return std::string();
+            }
+            return std::string(reinterpret_cast<const char*>(&bytes[0]),
+                               bytes.size());
+        }
+
+        inline void add_headers(::kurlyk::Headers& destination,
+                                const std::vector<HttpSyncHeader>& source) {
+            for (std::size_t i = 0; i < source.size(); ++i) {
+                destination.emplace(source[i].name, source[i].value);
+            }
+        }
+    } // namespace detail
+
+    /// \brief Configuration for \c HttpSyncClient.
+    struct HttpSyncClientConfig {
+        /// \brief Base URL, for example \c http://127.0.0.1:18080.
+        std::string base_url = "http://127.0.0.1:18080";
+        /// \brief Poll interval used while waiting for Kurlyk's future.
+        std::chrono::milliseconds wait_poll_interval =
+            std::chrono::milliseconds(10);
+        /// \brief Optional bearer token added as an Authorization header.
+        std::string bearer_token;
+        /// \brief Extra headers sent with every sync POST request.
+        std::vector<HttpSyncHeader> headers;
+    };
+
+    /// \brief Kurlyk/libcurl HTTP client binding for \c HttpSyncPeer.
+    /// \note One instance is intended for one active \c post() call at a time.
+    /// Use separate client instances for concurrent callers.
+    class HttpSyncClient : public IHttpSyncClient {
+    public:
+        explicit HttpSyncClient(const HttpSyncClientConfig& config)
+            : m_config(config),
+              m_client(config.base_url),
+              m_cancel_count(0) {
+            validate_config(m_config);
+        }
+
+        explicit HttpSyncClient(const std::string& base_url,
+                                const std::string& bearer_token =
+                                    std::string())
+            : m_client(base_url),
+              m_cancel_count(0) {
+            m_config.base_url = base_url;
+            m_config.bearer_token = bearer_token;
+            validate_config(m_config);
+        }
+
+        HttpSyncResponse post(
+                const std::string& target,
+                const std::string& content_type,
+                const std::vector<std::uint8_t>& body,
+                const CancellationToken& cancel_token) override {
+            if (cancel_token.is_cancellation_requested()) {
+                return make_cancelled_response(
+                    "cancelled before HTTP request");
+            }
+
+            ::kurlyk::Headers headers;
+            headers.emplace("Content-Type", content_type);
+            if (!m_config.bearer_token.empty()) {
+                headers.emplace("Authorization",
+                                std::string("Bearer ") +
+                                m_config.bearer_token);
+            }
+            detail::add_headers(headers, m_config.headers);
+
+            std::future< ::kurlyk::HttpResponsePtr > future =
+                m_client.post(target,
+                              ::kurlyk::QueryParams(),
+                              headers,
+                              detail::bytes_to_string(body));
+
+            while (future.wait_for(m_config.wait_poll_interval) !=
+                   std::future_status::ready) {
+                if (cancel_token.is_cancellation_requested()) {
+                    cancel_requests();
+                    return make_cancelled_response(
+                        "cancelled during HTTP request");
+                }
+            }
+
+            try {
+                ::kurlyk::HttpResponsePtr response = future.get();
+                if (!response) {
+                    return make_transport_error_response(
+                        "Kurlyk HTTP client returned empty response");
+                }
+                return convert_response(*response);
+            } catch (const std::exception& e) {
+                if (cancel_token.is_cancellation_requested()) {
+                    return make_cancelled_response(e.what());
+                }
+                throw;
+            }
+        }
+
+        void request_cancel() override {
+            m_cancel_count.fetch_add(1, std::memory_order_acq_rel);
+            cancel_requests();
+        }
+
+        std::size_t cancel_count() const {
+            return m_cancel_count.load(std::memory_order_acquire);
+        }
+
+    private:
+        static HttpSyncResponse make_cancelled_response(
+                const std::string& diagnostic) {
+            HttpSyncResponse out;
+            out.status_code = 503;
+            out.content_type = "text/plain; charset=utf-8";
+            out.error = diagnostic.empty() ? "cancelled" : diagnostic;
+            out.body = detail::string_to_bytes(out.error);
+            return out;
+        }
+
+        static HttpSyncResponse make_transport_error_response(
+                const std::string& diagnostic) {
+            HttpSyncResponse out;
+            out.status_code = 0;
+            out.content_type = "text/plain; charset=utf-8";
+            out.error = diagnostic;
+            out.body = detail::string_to_bytes(out.error);
+            return out;
+        }
+
+        static HttpSyncResponse convert_response(
+                const ::kurlyk::HttpResponse& response) {
+            HttpSyncResponse out;
+            out.status_code = response.status_code < 0
+                ? 0u
+                : static_cast<unsigned>(response.status_code);
+            for (::kurlyk::Headers::const_iterator it =
+                     response.headers.begin();
+                 it != response.headers.end();
+                 ++it) {
+                http_add_header(out.headers, it->first, it->second);
+            }
+            out.content_type =
+                http_header_value(out.headers, "Content-Type");
+            out.body = detail::string_to_bytes(response.content);
+            if (!response.error_message.empty()) {
+                out.error = response.error_message;
+            } else if (response.error_code) {
+                out.error = response.error_code.message();
+            }
+            return out;
+        }
+
+        static void validate_config(const HttpSyncClientConfig& config) {
+            if (config.base_url.empty()) {
+                throw std::invalid_argument(
+                    "Kurlyk HTTP sync base_url must not be empty");
+            }
+            if (config.wait_poll_interval.count() <= 0) {
+                throw std::invalid_argument(
+                    "Kurlyk HTTP sync wait_poll_interval must be positive");
+            }
+        }
+
+        void cancel_requests() {
+            std::lock_guard<std::mutex> lock(m_cancel_mutex);
+            m_client.cancel_requests();
+        }
+
+        HttpSyncClientConfig m_config;
+        ::kurlyk::HttpClient m_client;
+        std::atomic<std::size_t> m_cancel_count;
+        mutable std::mutex m_cancel_mutex;
+    };
+
+} // namespace kurlyk
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_TRANSPORTS_KURLYK_HTTP_TRANSPORT_HPP_INCLUDED


### PR DESCRIPTION
## Summary
- add an optional Kurlyk/libcurl HTTP client binding that implements `IHttpSyncClient`
- add an opt-in Kurlyk HTTP example using the existing Simple-Web listener on the server side
- document the new optional backend and CMake option

## Validation
- `git diff --check`
- `cmake -S . -B tmp\pr124-default-cpp17-mingw -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=OFF -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_USE_ASAN=OFF -DCMAKE_CXX_STANDARD=17`
- `cmake --build tmp\pr124-default-cpp17-mingw --target sync_16_worker_http_transport --parallel 1`
- `cmake -S . -B tmp\pr124-kurlyk-cpp17-mingw-2 -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=OFF -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_KURLYK_HTTP_SYNC_EXAMPLE=ON -DMDBXC_USE_ASAN=OFF -DCMAKE_CXX_STANDARD=17` fails locally with the expected diagnostic because this MinGW environment has no discoverable libcurl; PR #125 will add the pinned curl fallback.
