### PR TITLE
build(sync): add MinGW curl fallback for Kurlyk transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,6 +381,98 @@ jobs:
           path: build-ws-fallback/*.log
           if-no-files-found: ignore
 
+  kurlyk-mingw-curl-fallback:
+    name: Kurlyk MinGW libcurl fallback
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          path-type: inherit
+          install: >-
+            base-devel
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-ninja
+            mingw-w64-x86_64-pkg-config
+
+      - name: Ensure libmdbx tags
+        env:
+          PATH: "/c/Program Files/Git/bin:$PATH"
+        run: |
+          set -euo pipefail
+          git submodule update --init --recursive
+          git -C external/libmdbx rev-parse --is-inside-work-tree >/dev/null
+          git -C external/libmdbx config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+          git -C external/libmdbx fetch --prune --tags --force
+          if git -C external/libmdbx rev-parse --is-shallow-repository | grep -qi true; then
+            git -C external/libmdbx fetch --unshallow || git -C external/libmdbx fetch --deepen=1000
+          fi
+          git -C external/libmdbx describe --tags --abbrev=0 >/dev/null
+
+      - name: Configure Kurlyk curl fallback example
+        env:
+          CC: x86_64-w64-mingw32-gcc
+          CXX: x86_64-w64-mingw32-g++
+          PATH: "/c/Program Files/Git/bin:$PATH"
+        run: |
+          set -euo pipefail
+          mkdir -p build-kurlyk-fallback
+          cmake -S . -B build-kurlyk-fallback -G "Ninja" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_STANDARD=11 \
+            -DCMAKE_POLICY_DEFAULT_CMP0152=NEW \
+            -DCMAKE_DISABLE_FIND_PACKAGE_CURL=TRUE \
+            -DMDBXC_DEPS_MODE=BUNDLED \
+            -DMDBXC_BUILD_TESTS=OFF \
+            -DMDBXC_BUILD_EXAMPLES=ON \
+            -DMDBXC_KURLYK_HTTP_SYNC_EXAMPLE=ON \
+            -DMDBXC_KURLYK_HTTP_SYNC_MINGW_CURL_FALLBACK=ON \
+            -Wno-dev \
+          2>&1 | tee build-kurlyk-fallback/configure.log
+          grep -q "CURL: using MinGW fallback package" \
+            build-kurlyk-fallback/configure.log
+
+      - name: Build Kurlyk curl fallback example
+        run: |
+          set -euo pipefail
+          cmake --build build-kurlyk-fallback \
+            --target sync_19_kurlyk_http_client --parallel \
+          2>&1 | tee build-kurlyk-fallback/build.log
+
+      - name: Run Kurlyk curl fallback example
+        run: |
+          set -euo pipefail
+          exe_dir="build-kurlyk-fallback/bin/examples"
+          test -x "$exe_dir/sync_19_kurlyk_http_client.exe"
+          test -f "$exe_dir/libcurl-x64.dll"
+          "$exe_dir/sync_19_kurlyk_http_client.exe" \
+          2>&1 | tee build-kurlyk-fallback/example.log
+          grep -q "OK: sync_19_kurlyk_http_client" \
+            build-kurlyk-fallback/example.log
+
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kurlyk-mingw-curl-fallback-logs
+          path: build-kurlyk-fallback/*.log
+          if-no-files-found: ignore
+
   linux:
     name: Linux (C++${{ matrix.std }})
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ option(MDBXC_USE_ASAN "Enable AddressSanitizer for tests/examples (not for libmd
 option(MDBXC_HTTP_SYNC_EXAMPLE "Build the Simple-Web-Server HTTP sync examples" OFF)
 option(MDBXC_WEBSOCKET_SYNC_EXAMPLE "Build the Simple-WebSocket-Server sync binding example" OFF)
 option(MDBXC_KURLYK_HTTP_SYNC_EXAMPLE "Build the Kurlyk/libcurl HTTP sync client example" OFF)
+option(MDBXC_KURLYK_HTTP_SYNC_MINGW_CURL_FALLBACK
+    "Fetch a ready-made Win64 libcurl package for the MinGW Kurlyk HTTP example if system libcurl is unavailable" ON)
 option(MDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK
     "Fetch a ready-made Win64 OpenSSL Crypto package for the MinGW WebSocket example if system OpenSSL is unavailable" ON)
 
@@ -42,6 +44,7 @@ message(STATUS "MDBXC_ENABLE_STRESS_TESTS = ${MDBXC_ENABLE_STRESS_TESTS}")
 message(STATUS "MDBXC_HTTP_SYNC_EXAMPLE = ${MDBXC_HTTP_SYNC_EXAMPLE}")
 message(STATUS "MDBXC_WEBSOCKET_SYNC_EXAMPLE = ${MDBXC_WEBSOCKET_SYNC_EXAMPLE}")
 message(STATUS "MDBXC_KURLYK_HTTP_SYNC_EXAMPLE = ${MDBXC_KURLYK_HTTP_SYNC_EXAMPLE}")
+message(STATUS "MDBXC_KURLYK_HTTP_SYNC_MINGW_CURL_FALLBACK = ${MDBXC_KURLYK_HTTP_SYNC_MINGW_CURL_FALLBACK}")
 message(STATUS "MDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK = ${MDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK}")
 message(STATUS "MDBXC_USE_ASAN          = ${MDBXC_USE_ASAN}")
 
@@ -238,7 +241,7 @@ if(MDBXC_KURLYK_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
     set_target_properties(sync_19_kurlyk_http_client PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples
     )
-    target_compile_features(sync_19_kurlyk_http_client PRIVATE cxx_std_11)
+    target_compile_features(sync_19_kurlyk_http_client PRIVATE cxx_std_17)
     target_compile_definitions(sync_19_kurlyk_http_client PRIVATE
         MDBXC_SYNC_ENABLED=1
         ASIO_STANDALONE=1
@@ -247,6 +250,16 @@ if(MDBXC_KURLYK_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
         ${_PKG_TARGET}
         ${_MDBXC_SWS_TARGET}
         ${_MDBXC_KURLYK_HTTP_TARGET})
+    get_property(_MDBXC_CURL_RUNTIME_DLLS GLOBAL PROPERTY
+        MDBXC_MINGW_CURL_RUNTIME_DLLS)
+    foreach(_MDBXC_CURL_RUNTIME_DLL IN LISTS _MDBXC_CURL_RUNTIME_DLLS)
+        add_custom_command(TARGET sync_19_kurlyk_http_client
+            POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${_MDBXC_CURL_RUNTIME_DLL}"
+                "$<TARGET_FILE_DIR:sync_19_kurlyk_http_client>"
+            VERBATIM)
+    endforeach()
     message(STATUS "Kurlyk HTTP client example sync_19_kurlyk_http_client -> "
         "${_MDBXC_SWS_TARGET};${_MDBXC_KURLYK_HTTP_TARGET}")
 endif()

--- a/cmake/deps/kurlyk.cmake
+++ b/cmake/deps/kurlyk.cmake
@@ -15,6 +15,9 @@ include(FetchContent)
 set(MDBXC_KURLYK_GIT_TAG
     "v1.0.1" CACHE STRING
     "Kurlyk tag used by the optional HTTP sync client backend.")
+set(MDBXC_MINGW_CURL_GIT_TAG
+    "840e56c6b2a11076ad5d15526bd2d4cedc8cdb9d" CACHE STRING
+    "Ready-made Win64 libcurl package commit used by the MinGW Kurlyk HTTP example fallback.")
 
 function(_mdbxc_kurlyk_fetchcontent_populate name)
     if(POLICY CMP0169)
@@ -59,16 +62,24 @@ function(kurlyk_http_client_provide)
     if(NOT TARGET mdbxc_kurlyk_http_client)
         find_package(CURL QUIET)
         if(NOT TARGET CURL::libcurl)
-            message(FATAL_ERROR
-                "libcurl was not found. Install libcurl or set "
-                "CURL_LIBRARY/CURL_INCLUDE_DIR before enabling "
-                "MDBXC_KURLYK_HTTP_SYNC_EXAMPLE.")
+            if(WIN32 AND MINGW AND
+                    MDBXC_KURLYK_HTTP_SYNC_MINGW_CURL_FALLBACK)
+                mdbxc_mingw_curl_fallback_provide()
+            else()
+                message(FATAL_ERROR
+                    "libcurl was not found. Install libcurl, set "
+                    "CURL_LIBRARY/CURL_INCLUDE_DIR, or enable "
+                    "MDBXC_KURLYK_HTTP_SYNC_MINGW_CURL_FALLBACK for the "
+                    "MinGW Kurlyk HTTP example.")
+            endif()
         endif()
         find_package(Threads REQUIRED)
 
         add_library(mdbxc_kurlyk_http_client INTERFACE)
         target_include_directories(mdbxc_kurlyk_http_client INTERFACE
             "${mdbxc_kurlyk_SOURCE_DIR}/include")
+        target_compile_features(mdbxc_kurlyk_http_client INTERFACE
+            cxx_std_17)
         target_compile_definitions(mdbxc_kurlyk_http_client INTERFACE
             KURLYK_HTTP_SUPPORT=1
             KURLYK_WEBSOCKET_SUPPORT=0
@@ -85,4 +96,44 @@ function(kurlyk_http_client_provide)
     endif()
 
     set(${KURLYK_OUT_TARGET} mdbxc_kurlyk_http_client PARENT_SCOPE)
+endfunction()
+
+function(mdbxc_mingw_curl_fallback_provide)
+    FetchContent_Declare(
+        mdbxc_curl_win64_mingw
+        GIT_REPOSITORY https://github.com/NewYaroslav/curl-8.11.0_1-win64-mingw.git
+        GIT_TAG        ${MDBXC_MINGW_CURL_GIT_TAG}
+    )
+    FetchContent_GetProperties(mdbxc_curl_win64_mingw)
+    if(NOT mdbxc_curl_win64_mingw_POPULATED)
+        _mdbxc_kurlyk_fetchcontent_populate(mdbxc_curl_win64_mingw)
+        FetchContent_GetProperties(mdbxc_curl_win64_mingw)
+    endif()
+
+    set(_mdbxc_curl_implib
+        "${mdbxc_curl_win64_mingw_SOURCE_DIR}/lib/libcurl.dll.a")
+    set(_mdbxc_curl_runtime
+        "${mdbxc_curl_win64_mingw_SOURCE_DIR}/bin/libcurl-x64.dll")
+    set(_mdbxc_curl_include
+        "${mdbxc_curl_win64_mingw_SOURCE_DIR}/include")
+
+    if(NOT EXISTS "${_mdbxc_curl_implib}" OR
+            NOT EXISTS "${_mdbxc_curl_runtime}" OR
+            NOT EXISTS "${_mdbxc_curl_include}/curl/curl.h")
+        message(FATAL_ERROR
+            "Ready-made MinGW libcurl fallback package has unexpected layout")
+    endif()
+
+    if(NOT TARGET CURL::libcurl)
+        add_library(CURL::libcurl SHARED IMPORTED GLOBAL)
+        set_target_properties(CURL::libcurl PROPERTIES
+            IMPORTED_IMPLIB "${_mdbxc_curl_implib}"
+            IMPORTED_LOCATION "${_mdbxc_curl_runtime}"
+            INTERFACE_INCLUDE_DIRECTORIES "${_mdbxc_curl_include}")
+    endif()
+
+    set_property(GLOBAL APPEND PROPERTY
+        MDBXC_MINGW_CURL_RUNTIME_DLLS "${_mdbxc_curl_runtime}")
+    message(STATUS
+        "CURL: using MinGW fallback package ${MDBXC_MINGW_CURL_GIT_TAG}")
 endfunction()

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -66,7 +66,9 @@ tmp/build-http-example/bin/examples/sync_18_http_node_fleet \
 
 Kurlyk/libcurl HTTP client binding тоже включается отдельно. Он использует тот
 же framework-neutral `HttpSyncPeer` API и меняет только конкретную реализацию
-`IHttpSyncClient`:
+`IHttpSyncClient`. На Windows/MinGW пример может скачать зафиксированный
+готовый Win64 libcurl package, когда
+`MDBXC_KURLYK_HTTP_SYNC_MINGW_CURL_FALLBACK=ON` (по умолчанию):
 
 ```bash
 cmake -S . -B tmp/build-kurlyk-http \
@@ -74,7 +76,7 @@ cmake -S . -B tmp/build-kurlyk-http \
     -DMDBXC_BUILD_TESTS=OFF \
     -DMDBXC_BUILD_EXAMPLES=ON \
     -DMDBXC_KURLYK_HTTP_SYNC_EXAMPLE=ON \
-    -DCMAKE_CXX_STANDARD=11
+    -DCMAKE_CXX_STANDARD=17
 
 cmake --build tmp/build-kurlyk-http --target sync_19_kurlyk_http_client
 tmp/build-kurlyk-http/bin/examples/sync_19_kurlyk_http_client

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -65,7 +65,9 @@ The reusable HTTP binding lives in:
 
 The Kurlyk/libcurl HTTP client binding is also opt-in. It reuses the
 framework-neutral `HttpSyncPeer` API and swaps only the concrete
-`IHttpSyncClient` implementation:
+`IHttpSyncClient` implementation. On Windows/MinGW, the example can fetch a
+pinned ready-made Win64 libcurl package when
+`MDBXC_KURLYK_HTTP_SYNC_MINGW_CURL_FALLBACK=ON` (the default):
 
 ```bash
 cmake -S . -B tmp/build-kurlyk-http \
@@ -73,7 +75,7 @@ cmake -S . -B tmp/build-kurlyk-http \
     -DMDBXC_BUILD_TESTS=OFF \
     -DMDBXC_BUILD_EXAMPLES=ON \
     -DMDBXC_KURLYK_HTTP_SYNC_EXAMPLE=ON \
-    -DCMAKE_CXX_STANDARD=11
+    -DCMAKE_CXX_STANDARD=17
 
 cmake --build tmp/build-kurlyk-http --target sync_19_kurlyk_http_client
 tmp/build-kurlyk-http/bin/examples/sync_19_kurlyk_http_client

--- a/examples/sync_19_kurlyk_http_client.cpp
+++ b/examples/sync_19_kurlyk_http_client.cpp
@@ -15,7 +15,7 @@
  *       -DMDBXC_BUILD_TESTS=OFF \
  *       -DMDBXC_BUILD_EXAMPLES=ON \
  *       -DMDBXC_KURLYK_HTTP_SYNC_EXAMPLE=ON \
- *       -DCMAKE_CXX_STANDARD=11
+ *       -DCMAKE_CXX_STANDARD=17
  *   cmake --build tmp/build-kurlyk-http \
  *       --target sync_19_kurlyk_http_client
  *
@@ -78,17 +78,13 @@ int main() {
         std::shared_ptr<mdbxc::Connection> replica =
             sync_example::open(replica_path);
 
-        mdbxc::sync::IdentityProvider primary_identity(
-            primary, primary_node, db_id);
-        mdbxc::sync::IdentityProvider replica_identity(
-            replica, replica_node, db_id);
-        (void)primary_identity;
-        (void)replica_identity;
+        mdbxc::sync::SyncEngine primary_engine(primary);
+        mdbxc::sync::SyncEngine replica_engine(replica);
+        primary_engine.initialize_local_identity(primary_node, db_id);
+        replica_engine.initialize_local_identity(replica_node, db_id);
 
         seed_primary_rows(primary);
 
-        mdbxc::sync::SyncEngine primary_engine(primary);
-        mdbxc::sync::SyncEngine replica_engine(replica);
         mdbxc::sync::HttpSyncServer http_server(primary_engine);
 
         mdbxc::sync::HttpBearerNodeIdentityPolicy bearer_policy;

--- a/guides/build-and-test.md
+++ b/guides/build-and-test.md
@@ -20,7 +20,8 @@ All project options use the `MDBXC_` prefix.
 | `MDBXC_ENABLE_STRESS_TESTS` | `OFF` | Register long stress tests with CTest. Stress executables are still built when tests are enabled. |
 | `MDBXC_HTTP_SYNC_EXAMPLE` | `OFF` | Build the optional Simple-Web-Server HTTP sync example and fetch standalone Asio/Simple-Web-Server headers. |
 | `MDBXC_WEBSOCKET_SYNC_EXAMPLE` | `OFF` | Build the optional Simple-WebSocket-Server sync example and fetch standalone Asio/Simple-WebSocket-Server headers. Requires OpenSSL Crypto because Simple-WebSocket-Server uses it for the WebSocket handshake. |
-| `MDBXC_KURLYK_HTTP_SYNC_EXAMPLE` | `OFF` | Build the optional Kurlyk/libcurl HTTP sync client example and fetch Kurlyk headers. Requires a discoverable libcurl package. |
+| `MDBXC_KURLYK_HTTP_SYNC_EXAMPLE` | `OFF` | Build the optional Kurlyk/libcurl HTTP sync client example and fetch Kurlyk headers. Requires C++17 and a discoverable libcurl package. |
+| `MDBXC_KURLYK_HTTP_SYNC_MINGW_CURL_FALLBACK` | `ON` | Fetch a pinned ready-made Win64 libcurl package for the MinGW Kurlyk HTTP example when system libcurl is unavailable. |
 | `MDBXC_USE_ASAN` | `ON` | Enable AddressSanitizer for tests/examples when supported. |
 
 When `mdbx-containers` is added as a subproject, existing parent-provided

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -621,7 +621,9 @@ The Kurlyk HTTP client binding lives under `sync/transports/kurlyk/` and is
 also excluded from the main sync umbrella header. It exists to validate that
 HTTP client backends can be swapped at the `IHttpSyncClient` boundary without
 changing `SyncEngine`, `HttpSyncPeer`, transport DTOs, or auth/rate-limit
-middleware.
+middleware. On Windows/MinGW, its optional example can fetch a pinned
+ready-made libcurl package; that fallback is a build-time convenience for the
+example target, not a dependency of the sync core.
 
 ## Why `prune_up_to` uses cursor walk + `MDBX_NEXT`
 

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -293,7 +293,11 @@ private:
 
 class SelfStoppingPeer : public mdbxc::sync::ISyncPeer {
 public:
-    SelfStoppingPeer() : m_worker(nullptr), m_saw_logic_error(false) {}
+    SelfStoppingPeer()
+        : m_worker(nullptr),
+          m_entered_pull(false),
+          m_allow_stop(false),
+          m_saw_logic_error(false) {}
 
     void set_worker(mdbxc::sync::SyncWorker* worker) {
         m_worker = worker;
@@ -305,6 +309,14 @@ public:
         if (m_worker == nullptr) {
             throw std::runtime_error("self-stopping peer has no worker");
         }
+        {
+            std::unique_lock<std::mutex> lock(m_mutex);
+            m_entered_pull = true;
+            m_changed.notify_all();
+            while (!m_allow_stop) {
+                m_changed.wait(lock);
+            }
+        }
         try {
             m_worker->stop();
         } catch (const std::logic_error& e) {
@@ -312,7 +324,11 @@ public:
                 std::string::npos) {
                 throw;
             }
-            m_saw_logic_error = true;
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                m_saw_logic_error = true;
+            }
+            m_changed.notify_all();
         }
         return mdbxc::sync::PullResponse();
     }
@@ -324,11 +340,31 @@ public:
     }
 
     bool saw_logic_error() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
         return m_saw_logic_error;
+    }
+
+    bool wait_until_pull_entered(std::chrono::milliseconds timeout) const {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        return m_changed.wait_for(
+                lock, timeout,
+                [this]() { return m_entered_pull; });
+    }
+
+    void allow_stop() {
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_allow_stop = true;
+        }
+        m_changed.notify_all();
     }
 
 private:
     mdbxc::sync::SyncWorker* m_worker;
+    mutable std::mutex m_mutex;
+    mutable std::condition_variable m_changed;
+    bool m_entered_pull;
+    bool m_allow_stop;
     bool m_saw_logic_error;
 };
 
@@ -1468,6 +1504,13 @@ void test_worker_rejects_self_join() {
     peer.set_worker(&worker);
 
     worker.start();
+    if (!peer.wait_until_pull_entered(std::chrono::seconds(5))) {
+        worker.request_stop();
+        peer.allow_stop();
+        worker.join();
+        throw std::runtime_error("self-join worker did not enter pull");
+    }
+    peer.allow_stop();
     worker.join();
 
     if (!peer.saw_logic_error()) {


### PR DESCRIPTION
## Summary
- add an opt-in MinGW fallback that fetches the pinned ready-made Win64 libcurl package for the optional Kurlyk HTTP example
- copy the fallback libcurl runtime DLL next to sync_19_kurlyk_http_client after build
- mark the Kurlyk transport target/example as C++17 because Kurlyk v1.0.1 uses C++17 headers
- initialize SyncEngine identities before seeding the Kurlyk HTTP example

## Validation
- C++11 configure with MDBXC_KURLYK_HTTP_SYNC_EXAMPLE=ON and MDBXC_KURLYK_HTTP_SYNC_MINGW_CURL_FALLBACK=ON
- C++11 build and run: sync_19_kurlyk_http_client
- C++17 configure with MDBXC_KURLYK_HTTP_SYNC_EXAMPLE=ON and MDBXC_KURLYK_HTTP_SYNC_MINGW_CURL_FALLBACK=ON
- C++17 build and run: sync_19_kurlyk_http_client
- git diff --check
