### PR TITLE
build(sync): expose transport backend feature macros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_STANDARD=17 \
             -DMDBXC_DEPS_MODE=BUNDLED \
-            -DMDBXC_BUILD_TESTS=OFF \
+            -DMDBXC_BUILD_TESTS=ON \
             -DMDBXC_BUILD_EXAMPLES=ON \
             -DMDBXC_HTTP_SYNC_EXAMPLE=ON \
             -Wno-dev \
@@ -166,12 +166,15 @@ jobs:
           set -euo pipefail
           cmake --build build-http-fleet \
             --target sync_13_http_simple_web_server \
-                     sync_18_http_node_fleet --parallel \
+                     sync_18_http_node_fleet \
+                     test_simple_web_http_transport --parallel \
           2>&1 | tee build-http-fleet/build.log
 
       - name: Run Simple-Web HTTP sync smoke
         run: |
           set -euo pipefail
+          build-http-fleet/bin/tests/test_simple_web_http_transport \
+          2>&1 | tee build-http-fleet/http-transport-test.log
           build-http-fleet/bin/examples/sync_13_http_simple_web_server \
             demo 127.0.0.1 18080 \
           2>&1 | tee build-http-fleet/http-demo.log
@@ -345,7 +348,7 @@ jobs:
             -DCMAKE_POLICY_DEFAULT_CMP0152=NEW \
             -DCMAKE_DISABLE_FIND_PACKAGE_OpenSSL=TRUE \
             -DMDBXC_DEPS_MODE=BUNDLED \
-            -DMDBXC_BUILD_TESTS=OFF \
+            -DMDBXC_BUILD_TESTS=ON \
             -DMDBXC_BUILD_EXAMPLES=ON \
             -DMDBXC_WEBSOCKET_SYNC_EXAMPLE=ON \
             -DMDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK=ON \
@@ -358,12 +361,18 @@ jobs:
         run: |
           set -euo pipefail
           cmake --build build-ws-fallback \
-            --target sync_17_websocket_simple_web_server --parallel \
+            --target sync_17_websocket_simple_web_server \
+                     test_simple_websocket_transport --parallel \
           2>&1 | tee build-ws-fallback/build.log
 
       - name: Run WebSocket fallback example
         run: |
           set -euo pipefail
+          test_dir="build-ws-fallback/bin/tests"
+          test -x "$test_dir/test_simple_websocket_transport.exe"
+          test -f "$test_dir/libcrypto-3-x64.dll"
+          "$test_dir/test_simple_websocket_transport.exe" \
+          2>&1 | tee build-ws-fallback/transport-test.log
           exe_dir="build-ws-fallback/bin/examples"
           test -x "$exe_dir/sync_17_websocket_simple_web_server.exe"
           test -f "$exe_dir/libcrypto-3-x64.dll"
@@ -438,7 +447,7 @@ jobs:
             -DCMAKE_POLICY_DEFAULT_CMP0152=NEW \
             -DCMAKE_DISABLE_FIND_PACKAGE_CURL=TRUE \
             -DMDBXC_DEPS_MODE=BUNDLED \
-            -DMDBXC_BUILD_TESTS=OFF \
+            -DMDBXC_BUILD_TESTS=ON \
             -DMDBXC_BUILD_EXAMPLES=ON \
             -DMDBXC_KURLYK_HTTP_SYNC_EXAMPLE=ON \
             -DMDBXC_KURLYK_HTTP_SYNC_MINGW_CURL_FALLBACK=ON \
@@ -451,12 +460,18 @@ jobs:
         run: |
           set -euo pipefail
           cmake --build build-kurlyk-fallback \
-            --target sync_19_kurlyk_http_client --parallel \
+            --target sync_19_kurlyk_http_client \
+                     test_kurlyk_http_transport --parallel \
           2>&1 | tee build-kurlyk-fallback/build.log
 
       - name: Run Kurlyk curl fallback example
         run: |
           set -euo pipefail
+          test_dir="build-kurlyk-fallback/bin/tests"
+          test -x "$test_dir/test_kurlyk_http_transport.exe"
+          test -f "$test_dir/libcurl-x64.dll"
+          "$test_dir/test_kurlyk_http_transport.exe" \
+          2>&1 | tee build-kurlyk-fallback/transport-test.log
           exe_dir="build-kurlyk-fallback/bin/examples"
           test -x "$exe_dir/sync_19_kurlyk_http_client.exe"
           test -f "$exe_dir/libcurl-x64.dll"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,30 @@ if(MDBXC_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
         tiny-process-library::tiny-process-library)
     message(STATUS "HTTP node fleet example sync_18_http_node_fleet -> "
         "${_MDBXC_SWS_TARGET};tiny-process-library")
+
+    if(MDBXC_BUILD_TESTS)
+        include(CTest)
+        enable_testing()
+        add_executable(test_simple_web_http_transport
+            tests/optional/test_simple_web_http_transport.cpp)
+        set_target_properties(test_simple_web_http_transport PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tests
+        )
+        target_compile_features(test_simple_web_http_transport PRIVATE
+            cxx_std_11)
+        target_compile_definitions(test_simple_web_http_transport PRIVATE
+            MDBXC_SYNC_ENABLED=1)
+        mdbxc_enable_asan(test_simple_web_http_transport)
+        target_link_libraries(test_simple_web_http_transport PRIVATE
+            ${_PKG_TARGET}
+            ${_MDBXC_SWS_TARGET})
+        add_test(NAME test_simple_web_http_transport
+            COMMAND test_simple_web_http_transport)
+        set_tests_properties(test_simple_web_http_transport PROPERTIES
+            TIMEOUT 30)
+        message(STATUS "HTTP binding test "
+            "test_simple_web_http_transport -> ${_MDBXC_SWS_TARGET}")
+    endif()
 endif()
 
 # ---------------------------------------
@@ -262,6 +286,39 @@ if(MDBXC_KURLYK_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
     endforeach()
     message(STATUS "Kurlyk HTTP client example sync_19_kurlyk_http_client -> "
         "${_MDBXC_SWS_TARGET};${_MDBXC_KURLYK_HTTP_TARGET}")
+
+    if(MDBXC_BUILD_TESTS)
+        include(CTest)
+        enable_testing()
+        add_executable(test_kurlyk_http_transport
+            tests/optional/test_kurlyk_http_transport.cpp)
+        set_target_properties(test_kurlyk_http_transport PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tests
+        )
+        target_compile_features(test_kurlyk_http_transport PRIVATE cxx_std_17)
+        target_compile_definitions(test_kurlyk_http_transport PRIVATE
+            MDBXC_SYNC_ENABLED=1)
+        mdbxc_enable_asan(test_kurlyk_http_transport)
+        target_link_libraries(test_kurlyk_http_transport PRIVATE
+            ${_PKG_TARGET}
+            ${_MDBXC_KURLYK_HTTP_TARGET})
+        get_property(_MDBXC_CURL_RUNTIME_DLLS GLOBAL PROPERTY
+            MDBXC_MINGW_CURL_RUNTIME_DLLS)
+        foreach(_MDBXC_CURL_RUNTIME_DLL IN LISTS _MDBXC_CURL_RUNTIME_DLLS)
+            add_custom_command(TARGET test_kurlyk_http_transport
+                POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    "${_MDBXC_CURL_RUNTIME_DLL}"
+                    "$<TARGET_FILE_DIR:test_kurlyk_http_transport>"
+                VERBATIM)
+        endforeach()
+        add_test(NAME test_kurlyk_http_transport
+            COMMAND test_kurlyk_http_transport)
+        set_tests_properties(test_kurlyk_http_transport PROPERTIES
+            TIMEOUT 30)
+        message(STATUS "Kurlyk HTTP client test "
+            "test_kurlyk_http_transport -> ${_MDBXC_KURLYK_HTTP_TARGET}")
+    endif()
 endif()
 
 # ---------------------------------------

--- a/README-RU.md
+++ b/README-RU.md
@@ -92,6 +92,9 @@
   Опциональные готовые Simple-Web HTTP/WebSocket binding headers находятся в
   `mdbx_containers/sync/transports/simple_web/`, а опциональный Kurlyk/libcurl
   HTTP client binding находится в `mdbx_containers/sync/transports/kurlyk/`.
+  Concrete backend targets задают `MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`,
+  `MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT` или
+  `MDBXC_HAS_KURLYK_HTTP_TRANSPORT` для условного подключения backend headers.
   Socket-backed примеры используют эти bindings вместо повторной реализации
   транспорта в каждом файле. Wire-format для специализированных таблиц отложен.
   HTTP auth,

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@
   HTTP/WebSocket binding headers live under
   `mdbx_containers/sync/transports/simple_web/`, and the optional Kurlyk/libcurl
   HTTP client binding lives under `mdbx_containers/sync/transports/kurlyk/`.
+  Concrete backend targets define `MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`,
+  `MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT`, or
+  `MDBXC_HAS_KURLYK_HTTP_TRANSPORT` for conditional backend includes.
   Socket-backed examples use those bindings instead of reimplementing the
   transport in each file. Specialized table wire formats remain deferred.
   HTTP auth, remote-address checks, and rate-limit headers live in

--- a/cmake/deps/kurlyk.cmake
+++ b/cmake/deps/kurlyk.cmake
@@ -81,6 +81,7 @@ function(kurlyk_http_client_provide)
         target_compile_features(mdbxc_kurlyk_http_client INTERFACE
             cxx_std_17)
         target_compile_definitions(mdbxc_kurlyk_http_client INTERFACE
+            MDBXC_HAS_KURLYK_HTTP_TRANSPORT=1
             KURLYK_HTTP_SUPPORT=1
             KURLYK_WEBSOCKET_SUPPORT=0
             KURLYK_AUTH_SUPPORT=0

--- a/cmake/deps/simple-web-server.cmake
+++ b/cmake/deps/simple-web-server.cmake
@@ -91,7 +91,8 @@ function(simple_web_server_provide)
             "${mdbxc_asio_SOURCE_DIR}/asio/include")
         target_compile_definitions(mdbxc_simple_web_server INTERFACE
             ASIO_STANDALONE=1
-            USE_STANDALONE_ASIO=1)
+            USE_STANDALONE_ASIO=1
+            MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT=1)
 
         find_package(Threads REQUIRED)
         target_link_libraries(mdbxc_simple_web_server INTERFACE
@@ -176,7 +177,8 @@ function(simple_websocket_server_provide)
             "${mdbxc_asio_SOURCE_DIR}/asio/include")
         target_compile_definitions(mdbxc_simple_websocket_server INTERFACE
             ASIO_STANDALONE=1
-            USE_STANDALONE_ASIO=1)
+            USE_STANDALONE_ASIO=1
+            MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT=1)
 
         find_package(Threads REQUIRED)
         target_link_libraries(mdbxc_simple_websocket_server INTERFACE

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -61,7 +61,10 @@ tmp/build-http-example/bin/examples/sync_18_http_node_fleet \
 Готовый HTTP binding подключается так:
 
 ```cpp
+#if defined(MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT) && \
+        MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT
 #include <mdbx_containers/sync/transports/simple_web/HttpTransport.hpp>
+#endif
 ```
 
 Kurlyk/libcurl HTTP client binding тоже включается отдельно. Он использует тот
@@ -85,15 +88,29 @@ tmp/build-kurlyk-http/bin/examples/sync_19_kurlyk_http_client
 Готовый Kurlyk HTTP client binding подключается так:
 
 ```cpp
+#if defined(MDBXC_HAS_KURLYK_HTTP_TRANSPORT) && \
+        MDBXC_HAS_KURLYK_HTTP_TRANSPORT
 #include <mdbx_containers/sync/transports/kurlyk/HttpTransport.hpp>
+#endif
 ```
 
 Targets, которым нужны и Simple-Web HTTP, и WebSocket bindings, могут
 подключать backend umbrella:
 
 ```cpp
+#if defined(MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT) && \
+        MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT && \
+        defined(MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT) && \
+        MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT
 #include <mdbx_containers/sync/transports/simple_web.hpp>
+#endif
 ```
+
+`MDBXC_*_SYNC_EXAMPLE` options только собирают examples из этого repository.
+Consumer targets получают `MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`,
+`MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT` или
+`MDBXC_HAS_KURLYK_HTTP_TRANSPORT` от concrete dependency target, к которому
+они линкуются.
 
 Реальный WebSocket binding example тоже включается отдельно, потому что он
 скачивает headers standalone Asio и Simple-WebSocket-Server.

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -60,7 +60,10 @@ tmp/build-http-example/bin/examples/sync_18_http_node_fleet \
 The reusable HTTP binding lives in:
 
 ```cpp
+#if defined(MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT) && \
+        MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT
 #include <mdbx_containers/sync/transports/simple_web/HttpTransport.hpp>
+#endif
 ```
 
 The Kurlyk/libcurl HTTP client binding is also opt-in. It reuses the
@@ -84,15 +87,28 @@ tmp/build-kurlyk-http/bin/examples/sync_19_kurlyk_http_client
 The reusable Kurlyk HTTP client binding lives in:
 
 ```cpp
+#if defined(MDBXC_HAS_KURLYK_HTTP_TRANSPORT) && \
+        MDBXC_HAS_KURLYK_HTTP_TRANSPORT
 #include <mdbx_containers/sync/transports/kurlyk/HttpTransport.hpp>
+#endif
 ```
 
 Targets that intentionally use both Simple-Web HTTP and WebSocket bindings can
 include the backend umbrella:
 
 ```cpp
+#if defined(MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT) && \
+        MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT && \
+        defined(MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT) && \
+        MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT
 #include <mdbx_containers/sync/transports/simple_web.hpp>
+#endif
 ```
+
+The `MDBXC_*_SYNC_EXAMPLE` options only build repository examples. Consumer
+targets get `MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`,
+`MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT`, or
+`MDBXC_HAS_KURLYK_HTTP_TRANSPORT` from the concrete dependency target they link.
 
 The real WebSocket binding example is also opt-in because it fetches standalone
 Asio and Simple-WebSocket-Server headers. Simple-WebSocket-Server uses OpenSSL

--- a/guides/build-and-test.md
+++ b/guides/build-and-test.md
@@ -24,6 +24,15 @@ All project options use the `MDBXC_` prefix.
 | `MDBXC_KURLYK_HTTP_SYNC_MINGW_CURL_FALLBACK` | `ON` | Fetch a pinned ready-made Win64 libcurl package for the MinGW Kurlyk HTTP example when system libcurl is unavailable. |
 | `MDBXC_USE_ASAN` | `ON` | Enable AddressSanitizer for tests/examples when supported. |
 
+The optional transport example options are not public feature-detection macros.
+Concrete backend targets define `MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`,
+`MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT`, or
+`MDBXC_HAS_KURLYK_HTTP_TRANSPORT` for consumers that link those dependency
+targets. Use those `MDBXC_HAS_*` macros when application code needs conditional
+includes around optional sync transport backends. Consumers that wire the same
+third-party dependencies manually may define the corresponding `MDBXC_HAS_*`
+macro themselves.
+
 When `mdbx-containers` is added as a subproject, existing parent-provided
 `mdbx::mdbx`, `mdbx::mdbx-static`, `libmdbx::mdbx`, and
 `libmdbx::mdbx-static` targets are reused before package, submodule, or

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -44,11 +44,14 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
   node-fleet example over tiny-process-library. These integrations are behind
   explicit CMake options, not mandatory runtime dependencies. The backend
   umbrella is `sync/transports/simple_web.hpp`; HTTP-only or WebSocket-only
-  targets can include the narrower backend-specific header.
+  targets can include the narrower backend-specific header. Targets that link
+  these dependency backends receive `MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT` and/or
+  `MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT`.
 - Optional ready-made Kurlyk/libcurl HTTP client binding under
   `sync/transports/kurlyk/`. It implements only the client-side
   `IHttpSyncClient` seam and can be paired with any server binding that exposes
-  the framework-neutral `HttpSyncServer` contract.
+  the framework-neutral `HttpSyncServer` contract. Targets that link the
+  backend receive `MDBXC_HAS_KURLYK_HTTP_TRANSPORT`.
 - Transport middleware helpers: `SyncPeerMiddleware`,
   `HttpSyncClientMiddleware`, allow-list policies, fixed-budget rate limiting,
   HTTP request-context bearer/remote-address/fixed-window policies,
@@ -624,6 +627,15 @@ changing `SyncEngine`, `HttpSyncPeer`, transport DTOs, or auth/rate-limit
 middleware. On Windows/MinGW, its optional example can fetch a pinned
 ready-made libcurl package; that fallback is a build-time convenience for the
 example target, not a dependency of the sync core.
+
+The `MDBXC_HTTP_SYNC_EXAMPLE`, `MDBXC_WEBSOCKET_SYNC_EXAMPLE`, and
+`MDBXC_KURLYK_HTTP_SYNC_EXAMPLE` CMake options only decide whether repository
+examples fetch and build optional backends. Application code should use
+`MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`,
+`MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT`, and
+`MDBXC_HAS_KURLYK_HTTP_TRANSPORT` when it needs conditional includes for
+concrete backend headers. Consumers that wire the same third-party dependencies
+manually may define the corresponding `MDBXC_HAS_*` macro themselves.
 
 ## Why `prune_up_to` uses cursor walk + `MDBX_NEXT`
 

--- a/include/mdbx_containers/sync/transports/kurlyk/HttpTransport.hpp
+++ b/include/mdbx_containers/sync/transports/kurlyk/HttpTransport.hpp
@@ -9,6 +9,11 @@
 /// translation units that intentionally use NewYaroslav/kurlyk as the concrete
 /// HTTP client backend.
 
+#if !defined(MDBXC_HAS_KURLYK_HTTP_TRANSPORT) || \
+        !MDBXC_HAS_KURLYK_HTTP_TRANSPORT
+#error "Kurlyk HTTP transport requires MDBXC_HAS_KURLYK_HTTP_TRANSPORT=1"
+#endif
+
 #ifndef KURLYK_HTTP_SUPPORT
 #define KURLYK_HTTP_SUPPORT 1
 #endif

--- a/include/mdbx_containers/sync/transports/simple_web/HttpTransport.hpp
+++ b/include/mdbx_containers/sync/transports/simple_web/HttpTransport.hpp
@@ -9,6 +9,11 @@
 /// translation units that intentionally use eidheim/Simple-Web-Server and
 /// standalone Asio.
 
+#if !defined(MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT) || \
+        !MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT
+#error "Simple-Web HTTP transport requires MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT=1"
+#endif
+
 #ifndef ASIO_STANDALONE
 #define ASIO_STANDALONE 1
 #endif

--- a/include/mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp
+++ b/include/mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp
@@ -9,6 +9,11 @@
 /// translation units that intentionally use eidheim/Simple-WebSocket-Server and
 /// standalone Asio.
 
+#if !defined(MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT) || \
+        !MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT
+#error "Simple-WebSocket transport requires MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT=1"
+#endif
+
 #ifndef ASIO_STANDALONE
 #define ASIO_STANDALONE 1
 #endif

--- a/tests/header_sync_transport_umbrella_test.cpp
+++ b/tests/header_sync_transport_umbrella_test.cpp
@@ -14,6 +14,18 @@
 #error "header_sync_transport_umbrella_test must be compiled with sync enabled"
 #endif
 
+#if defined(MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT)
+#error "framework-neutral sync/transport.hpp must not enable Simple-Web HTTP"
+#endif
+
+#if defined(MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT)
+#error "framework-neutral sync/transport.hpp must not enable Simple-WebSocket"
+#endif
+
+#if defined(MDBXC_HAS_KURLYK_HTTP_TRANSPORT)
+#error "framework-neutral sync/transport.hpp must not enable Kurlyk HTTP"
+#endif
+
 int main() {
     mdbxc::sync::NodeId node = mdbxc::sync::make_zero_node();
     mdbxc::sync::PullRequest pull;

--- a/tests/optional/test_kurlyk_http_transport.cpp
+++ b/tests/optional/test_kurlyk_http_transport.cpp
@@ -1,0 +1,20 @@
+#include <mdbx_containers/sync/transports/kurlyk/HttpTransport.hpp>
+
+#include "../test_assert.hpp"
+
+#if !defined(MDBXC_HAS_KURLYK_HTTP_TRANSPORT)
+#error "Kurlyk HTTP transport target must define its feature macro"
+#endif
+
+#if !MDBXC_HAS_KURLYK_HTTP_TRANSPORT
+#error "Kurlyk HTTP transport feature macro must be non-zero"
+#endif
+
+int main() {
+    mdbxc::sync::kurlyk::HttpSyncClientConfig config;
+    config.base_url = "http://127.0.0.1:18080";
+
+    MDBXC_TEST_ASSERT(config.base_url == "http://127.0.0.1:18080");
+
+    return 0;
+}

--- a/tests/optional/test_simple_web_http_transport.cpp
+++ b/tests/optional/test_simple_web_http_transport.cpp
@@ -1,0 +1,22 @@
+#include <mdbx_containers/sync/transports/simple_web/HttpTransport.hpp>
+
+#include "../test_assert.hpp"
+
+#if !defined(MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT)
+#error "Simple-Web HTTP transport target must define its feature macro"
+#endif
+
+#if !MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT
+#error "Simple-Web HTTP transport feature macro must be non-zero"
+#endif
+
+int main() {
+    mdbxc::sync::simple_web::HttpSyncClientConfig config;
+    config.host = "127.0.0.1";
+    config.port = 18080;
+
+    MDBXC_TEST_ASSERT(config.host == "127.0.0.1");
+    MDBXC_TEST_ASSERT(config.port == 18080u);
+
+    return 0;
+}

--- a/tests/optional/test_simple_websocket_transport.cpp
+++ b/tests/optional/test_simple_websocket_transport.cpp
@@ -1,5 +1,13 @@
 #include <mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp>
 
+#if !defined(MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT)
+#error "Simple-WebSocket transport target must define its feature macro"
+#endif
+
+#if !MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT
+#error "Simple-WebSocket transport feature macro must be non-zero"
+#endif
+
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>


### PR DESCRIPTION
## Summary
- add `MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`, `MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT`, and `MDBXC_HAS_KURLYK_HTTP_TRANSPORT` as backend feature macros from concrete dependency targets
- make concrete optional backend headers fail early with a clear macro contract when included without the matching backend target
- add optional backend smoke tests and wire them into the optional CI jobs
- document the difference between `MDBXC_*_SYNC_EXAMPLE` build options and public `MDBXC_HAS_*` feature macros

## Validation
- `git diff --check`
- `cmake -S . -B tmp\\pr128-feature-macros-cpp11-mingw -G "MinGW Makefiles" -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=OFF -DMDBXC_USE_ASAN=OFF -DCMAKE_CXX_STANDARD=11`
- `cmake --build tmp\\pr128-feature-macros-cpp11-mingw --target header_sync_transport_umbrella_test`
- `ctest --test-dir tmp\\pr128-feature-macros-cpp11-mingw -R header_sync_transport_umbrella_test --output-on-failure`
- `cmake -S . -B tmp\\pr128-feature-macros-cpp17-mingw -G "MinGW Makefiles" -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=OFF -DMDBXC_USE_ASAN=OFF -DCMAKE_CXX_STANDARD=17`
- `cmake --build tmp\\pr128-feature-macros-cpp17-mingw --target header_sync_transport_umbrella_test`
- `ctest --test-dir tmp\\pr128-feature-macros-cpp17-mingw -R header_sync_transport_umbrella_test --output-on-failure`
- `cmake -S . -B tmp\\pr128-simple-web-http -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_HTTP_SYNC_EXAMPLE=ON -DMDBXC_USE_ASAN=OFF -DCMAKE_CXX_STANDARD=11`
- `cmake --build tmp\\pr128-simple-web-http --target test_simple_web_http_transport`
- `tmp\\pr128-simple-web-http\\bin\\tests\\test_simple_web_http_transport.exe`
- `cmake --build tmp\\pr128-simple-web-http --target sync_13_http_simple_web_server`
- `cmake -S . -B tmp\\pr128-kurlyk-fallback -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_KURLYK_HTTP_SYNC_EXAMPLE=ON -DMDBXC_KURLYK_HTTP_SYNC_MINGW_CURL_FALLBACK=ON -DCMAKE_DISABLE_FIND_PACKAGE_CURL=TRUE -DMDBXC_USE_ASAN=OFF -DCMAKE_CXX_STANDARD=17`
- `cmake --build tmp\\pr128-kurlyk-fallback --target test_kurlyk_http_transport`
- `tmp\\pr128-kurlyk-fallback\\bin\\tests\\test_kurlyk_http_transport.exe`
- `cmake --build tmp\\pr128-kurlyk-fallback --target sync_19_kurlyk_http_client`
- `cmake -S . -B tmp\\pr128-ws-fallback -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_WEBSOCKET_SYNC_EXAMPLE=ON -DMDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK=ON -DCMAKE_DISABLE_FIND_PACKAGE_OpenSSL=TRUE -DMDBXC_USE_ASAN=OFF -DCMAKE_CXX_STANDARD=17`
- `cmake --build tmp\\pr128-ws-fallback --target test_simple_websocket_transport`
- `tmp\\pr128-ws-fallback\\bin\\tests\\test_simple_websocket_transport.exe`
- `cmake --build tmp\\pr128-ws-fallback --target sync_17_websocket_simple_web_server`
