### PR TITLE
build(sync): split transport backend options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
             -DMDBXC_DEPS_MODE=BUNDLED \
             -DMDBXC_BUILD_TESTS=ON \
             -DMDBXC_BUILD_EXAMPLES=ON \
+            -DMDBXC_SIMPLE_WEB_HTTP_TRANSPORT=ON \
             -DMDBXC_HTTP_SYNC_EXAMPLE=ON \
             -Wno-dev \
           2>&1 | tee build-http-fleet/configure.log
@@ -350,6 +351,7 @@ jobs:
             -DMDBXC_DEPS_MODE=BUNDLED \
             -DMDBXC_BUILD_TESTS=ON \
             -DMDBXC_BUILD_EXAMPLES=ON \
+            -DMDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT=ON \
             -DMDBXC_WEBSOCKET_SYNC_EXAMPLE=ON \
             -DMDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK=ON \
             -Wno-dev \
@@ -449,6 +451,7 @@ jobs:
             -DMDBXC_DEPS_MODE=BUNDLED \
             -DMDBXC_BUILD_TESTS=ON \
             -DMDBXC_BUILD_EXAMPLES=ON \
+            -DMDBXC_KURLYK_HTTP_TRANSPORT=ON \
             -DMDBXC_KURLYK_HTTP_SYNC_EXAMPLE=ON \
             -DMDBXC_KURLYK_HTTP_SYNC_MINGW_CURL_FALLBACK=ON \
             -Wno-dev \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,17 +20,52 @@ option(MDBXC_BUILD_BENCHMARKS   "Build benchmark executables"                   
 option(MDBXC_ENABLE_STRESS_TESTS "Register long stress tests with CTest"           OFF)
 option(MDBXC_USE_ASAN "Enable AddressSanitizer for tests/examples (not for libmdbx)" ON)
 
-# Optional transport-binding examples that pull third-party HTTP/process
-# backends (Simple-Web-Server and tiny-process-library). Off by default to keep
-# the default build free of network-stack dependencies. See
-# examples/README-sync.md for usage.
-option(MDBXC_HTTP_SYNC_EXAMPLE "Build the Simple-Web-Server HTTP sync examples" OFF)
-option(MDBXC_WEBSOCKET_SYNC_EXAMPLE "Build the Simple-WebSocket-Server sync binding example" OFF)
-option(MDBXC_KURLYK_HTTP_SYNC_EXAMPLE "Build the Kurlyk/libcurl HTTP sync client example" OFF)
+# Optional transport backends. Off by default to keep the default build free of
+# network-stack dependencies. The *_SYNC_EXAMPLE options below preserve the
+# older example-oriented entry points and enable the matching backend when used.
+option(MDBXC_SIMPLE_WEB_HTTP_TRANSPORT
+    "Enable the optional Simple-Web-Server HTTP sync transport backend" OFF)
+option(MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT
+    "Enable the optional Simple-WebSocket-Server sync transport backend" OFF)
+option(MDBXC_KURLYK_HTTP_TRANSPORT
+    "Enable the optional Kurlyk/libcurl HTTP sync client transport backend" OFF)
+option(MDBXC_HTTP_SYNC_EXAMPLE
+    "Build the Simple-Web-Server HTTP sync examples" OFF)
+option(MDBXC_WEBSOCKET_SYNC_EXAMPLE
+    "Build the Simple-WebSocket-Server sync binding example" OFF)
+option(MDBXC_KURLYK_HTTP_SYNC_EXAMPLE
+    "Build the Kurlyk/libcurl HTTP sync client example" OFF)
 option(MDBXC_KURLYK_HTTP_SYNC_MINGW_CURL_FALLBACK
-    "Fetch a ready-made Win64 libcurl package for the MinGW Kurlyk HTTP example if system libcurl is unavailable" ON)
+    "Fetch a ready-made Win64 libcurl package for the MinGW Kurlyk HTTP transport if system libcurl is unavailable"
+    ON)
 option(MDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK
-    "Fetch a ready-made Win64 OpenSSL Crypto package for the MinGW WebSocket example if system OpenSSL is unavailable" ON)
+    "Fetch a ready-made Win64 OpenSSL Crypto package for the MinGW WebSocket transport if system OpenSSL is unavailable"
+    ON)
+
+if(MDBXC_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES AND
+        NOT MDBXC_SIMPLE_WEB_HTTP_TRANSPORT)
+    set(MDBXC_SIMPLE_WEB_HTTP_TRANSPORT ON CACHE BOOL
+        "Enable the optional Simple-Web-Server HTTP sync transport backend" FORCE)
+    message(STATUS
+        "MDBXC_HTTP_SYNC_EXAMPLE enables MDBXC_SIMPLE_WEB_HTTP_TRANSPORT")
+endif()
+if(MDBXC_WEBSOCKET_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES AND
+        NOT MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT)
+    set(MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT ON CACHE BOOL
+        "Enable the optional Simple-WebSocket-Server sync transport backend"
+        FORCE)
+    message(STATUS
+        "MDBXC_WEBSOCKET_SYNC_EXAMPLE enables "
+        "MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT")
+endif()
+if(MDBXC_KURLYK_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES AND
+        NOT MDBXC_KURLYK_HTTP_TRANSPORT)
+    set(MDBXC_KURLYK_HTTP_TRANSPORT ON CACHE BOOL
+        "Enable the optional Kurlyk/libcurl HTTP sync client transport backend"
+        FORCE)
+    message(STATUS
+        "MDBXC_KURLYK_HTTP_SYNC_EXAMPLE enables MDBXC_KURLYK_HTTP_TRANSPORT")
+endif()
 
 # Three-mode dependency policy for MDBX: AUTO | SYSTEM | BUNDLED
 set(MDBXC_DEPS_MODE "AUTO" CACHE STRING "Dependency mode for MDBX: AUTO|SYSTEM|BUNDLED")
@@ -41,6 +76,12 @@ message(STATUS "MDBXC_BUILD_EXAMPLES    = ${MDBXC_BUILD_EXAMPLES}")
 message(STATUS "MDBXC_BUILD_TESTS       = ${MDBXC_BUILD_TESTS}")
 message(STATUS "MDBXC_BUILD_BENCHMARKS  = ${MDBXC_BUILD_BENCHMARKS}")
 message(STATUS "MDBXC_ENABLE_STRESS_TESTS = ${MDBXC_ENABLE_STRESS_TESTS}")
+message(STATUS
+    "MDBXC_SIMPLE_WEB_HTTP_TRANSPORT = ${MDBXC_SIMPLE_WEB_HTTP_TRANSPORT}")
+message(STATUS
+    "MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT = "
+    "${MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT}")
+message(STATUS "MDBXC_KURLYK_HTTP_TRANSPORT = ${MDBXC_KURLYK_HTTP_TRANSPORT}")
 message(STATUS "MDBXC_HTTP_SYNC_EXAMPLE = ${MDBXC_HTTP_SYNC_EXAMPLE}")
 message(STATUS "MDBXC_WEBSOCKET_SYNC_EXAMPLE = ${MDBXC_WEBSOCKET_SYNC_EXAMPLE}")
 message(STATUS "MDBXC_KURLYK_HTTP_SYNC_EXAMPLE = ${MDBXC_KURLYK_HTTP_SYNC_EXAMPLE}")
@@ -173,52 +214,55 @@ if(MDBXC_BUILD_EXAMPLES)
 endif()
 
 # ---------------------------------------
-# Optional HTTP transport binding example
+# Optional Simple-Web HTTP transport binding
 # ---------------------------------------
-# Pulls Simple-Web-Server through FetchContent and adds examples that use the
-# ready Simple-Web HTTP binding around HttpSyncServer and HttpSyncPeer. The
-# default build does not touch this section; these examples are built only when
-# MDBXC_HTTP_SYNC_EXAMPLE is ON.
-if(MDBXC_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
+# Pulls Simple-Web-Server through FetchContent and exposes the ready
+# Simple-Web HTTP binding around HttpSyncServer and HttpSyncPeer. Tests may use
+# the backend without building examples.
+if(MDBXC_SIMPLE_WEB_HTTP_TRANSPORT)
     list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/deps)
     include(cmake/deps/simple-web-server.cmake)
-    include(cmake/deps/tiny-process-library.cmake)
 
     simple_web_server_provide(OUT_TARGET _MDBXC_SWS_TARGET)
-    tiny_process_library_provide()
 
-    add_executable(sync_13_http_simple_web_server
-        examples/sync_13_http_simple_web_server.cpp)
-    set_target_properties(sync_13_http_simple_web_server PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples
-    )
-    target_compile_features(sync_13_http_simple_web_server PRIVATE cxx_std_11)
-    target_compile_definitions(sync_13_http_simple_web_server PRIVATE
-        MDBXC_SYNC_ENABLED=1
-        ASIO_STANDALONE=1
-        USE_STANDALONE_ASIO=1)
-    target_link_libraries(sync_13_http_simple_web_server PRIVATE
-        ${_PKG_TARGET}
-        ${_MDBXC_SWS_TARGET})
-    message(STATUS "HTTP binding example sync_13_http_simple_web_server -> "
-        "${_MDBXC_SWS_TARGET}")
+    if(MDBXC_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
+        include(cmake/deps/tiny-process-library.cmake)
+        tiny_process_library_provide()
 
-    add_executable(sync_18_http_node_fleet
-        examples/sync_18_http_node_fleet.cpp)
-    set_target_properties(sync_18_http_node_fleet PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples
-    )
-    target_compile_features(sync_18_http_node_fleet PRIVATE cxx_std_11)
-    target_compile_definitions(sync_18_http_node_fleet PRIVATE
-        MDBXC_SYNC_ENABLED=1
-        ASIO_STANDALONE=1
-        USE_STANDALONE_ASIO=1)
-    target_link_libraries(sync_18_http_node_fleet PRIVATE
-        ${_PKG_TARGET}
-        ${_MDBXC_SWS_TARGET}
-        tiny-process-library::tiny-process-library)
-    message(STATUS "HTTP node fleet example sync_18_http_node_fleet -> "
-        "${_MDBXC_SWS_TARGET};tiny-process-library")
+        add_executable(sync_13_http_simple_web_server
+            examples/sync_13_http_simple_web_server.cpp)
+        set_target_properties(sync_13_http_simple_web_server PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples
+        )
+        target_compile_features(sync_13_http_simple_web_server PRIVATE cxx_std_11)
+        target_compile_definitions(sync_13_http_simple_web_server PRIVATE
+            MDBXC_SYNC_ENABLED=1
+            ASIO_STANDALONE=1
+            USE_STANDALONE_ASIO=1)
+        target_link_libraries(sync_13_http_simple_web_server PRIVATE
+            ${_PKG_TARGET}
+            ${_MDBXC_SWS_TARGET})
+        message(STATUS
+            "HTTP binding example sync_13_http_simple_web_server -> "
+            "${_MDBXC_SWS_TARGET}")
+
+        add_executable(sync_18_http_node_fleet
+            examples/sync_18_http_node_fleet.cpp)
+        set_target_properties(sync_18_http_node_fleet PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples
+        )
+        target_compile_features(sync_18_http_node_fleet PRIVATE cxx_std_11)
+        target_compile_definitions(sync_18_http_node_fleet PRIVATE
+            MDBXC_SYNC_ENABLED=1
+            ASIO_STANDALONE=1
+            USE_STANDALONE_ASIO=1)
+        target_link_libraries(sync_18_http_node_fleet PRIVATE
+            ${_PKG_TARGET}
+            ${_MDBXC_SWS_TARGET}
+            tiny-process-library::tiny-process-library)
+        message(STATUS "HTTP node fleet example sync_18_http_node_fleet -> "
+            "${_MDBXC_SWS_TARGET};tiny-process-library")
+    endif()
 
     if(MDBXC_BUILD_TESTS)
         include(CTest)
@@ -246,46 +290,49 @@ if(MDBXC_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
 endif()
 
 # ---------------------------------------
-# Optional Kurlyk HTTP transport client example
+# Optional Kurlyk HTTP transport client binding
 # ---------------------------------------
 # Pulls Kurlyk through FetchContent and uses its libcurl-backed HTTP client
-# around HttpSyncPeer. The server side intentionally reuses the ready
-# Simple-Web listener so this example demonstrates backend interchange at the
-# framework-neutral IHttpSyncClient seam.
-if(MDBXC_KURLYK_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
+# around HttpSyncPeer. Tests may use the client backend without building the
+# example, whose server side intentionally reuses the Simple-Web listener.
+if(MDBXC_KURLYK_HTTP_TRANSPORT)
     list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/deps)
-    include(cmake/deps/simple-web-server.cmake)
     include(cmake/deps/kurlyk.cmake)
 
-    simple_web_server_provide(OUT_TARGET _MDBXC_SWS_TARGET)
     kurlyk_http_client_provide(OUT_TARGET _MDBXC_KURLYK_HTTP_TARGET)
 
-    add_executable(sync_19_kurlyk_http_client
-        examples/sync_19_kurlyk_http_client.cpp)
-    set_target_properties(sync_19_kurlyk_http_client PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples
-    )
-    target_compile_features(sync_19_kurlyk_http_client PRIVATE cxx_std_17)
-    target_compile_definitions(sync_19_kurlyk_http_client PRIVATE
-        MDBXC_SYNC_ENABLED=1
-        ASIO_STANDALONE=1
-        USE_STANDALONE_ASIO=1)
-    target_link_libraries(sync_19_kurlyk_http_client PRIVATE
-        ${_PKG_TARGET}
-        ${_MDBXC_SWS_TARGET}
-        ${_MDBXC_KURLYK_HTTP_TARGET})
-    get_property(_MDBXC_CURL_RUNTIME_DLLS GLOBAL PROPERTY
-        MDBXC_MINGW_CURL_RUNTIME_DLLS)
-    foreach(_MDBXC_CURL_RUNTIME_DLL IN LISTS _MDBXC_CURL_RUNTIME_DLLS)
-        add_custom_command(TARGET sync_19_kurlyk_http_client
-            POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                "${_MDBXC_CURL_RUNTIME_DLL}"
-                "$<TARGET_FILE_DIR:sync_19_kurlyk_http_client>"
-            VERBATIM)
-    endforeach()
-    message(STATUS "Kurlyk HTTP client example sync_19_kurlyk_http_client -> "
-        "${_MDBXC_SWS_TARGET};${_MDBXC_KURLYK_HTTP_TARGET}")
+    if(MDBXC_KURLYK_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
+        include(cmake/deps/simple-web-server.cmake)
+        simple_web_server_provide(OUT_TARGET _MDBXC_SWS_TARGET)
+
+        add_executable(sync_19_kurlyk_http_client
+            examples/sync_19_kurlyk_http_client.cpp)
+        set_target_properties(sync_19_kurlyk_http_client PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples
+        )
+        target_compile_features(sync_19_kurlyk_http_client PRIVATE cxx_std_17)
+        target_compile_definitions(sync_19_kurlyk_http_client PRIVATE
+            MDBXC_SYNC_ENABLED=1
+            ASIO_STANDALONE=1
+            USE_STANDALONE_ASIO=1)
+        target_link_libraries(sync_19_kurlyk_http_client PRIVATE
+            ${_PKG_TARGET}
+            ${_MDBXC_SWS_TARGET}
+            ${_MDBXC_KURLYK_HTTP_TARGET})
+        get_property(_MDBXC_CURL_RUNTIME_DLLS GLOBAL PROPERTY
+            MDBXC_MINGW_CURL_RUNTIME_DLLS)
+        foreach(_MDBXC_CURL_RUNTIME_DLL IN LISTS _MDBXC_CURL_RUNTIME_DLLS)
+            add_custom_command(TARGET sync_19_kurlyk_http_client
+                POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    "${_MDBXC_CURL_RUNTIME_DLL}"
+                    "$<TARGET_FILE_DIR:sync_19_kurlyk_http_client>"
+                VERBATIM)
+        endforeach()
+        message(STATUS
+            "Kurlyk HTTP client example sync_19_kurlyk_http_client -> "
+            "${_MDBXC_SWS_TARGET};${_MDBXC_KURLYK_HTTP_TARGET}")
+    endif()
 
     if(MDBXC_BUILD_TESTS)
         include(CTest)
@@ -322,42 +369,44 @@ if(MDBXC_KURLYK_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
 endif()
 
 # ---------------------------------------
-# Optional WebSocket transport binding example
+# Optional Simple-WebSocket transport binding
 # ---------------------------------------
-# Pulls Simple-WebSocket-Server through FetchContent and adds one example that
-# shows a real loopback WebSocket server + client wiring around
-# WebSocketSyncServer and WebSocketSyncPeer.
-if(MDBXC_WEBSOCKET_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
+# Pulls Simple-WebSocket-Server through FetchContent and exposes the concrete
+# WebSocket binding. Tests may use the backend without building examples.
+if(MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT)
     list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/deps)
     include(cmake/deps/simple-web-server.cmake)
 
     simple_websocket_server_provide(OUT_TARGET _MDBXC_SWS_WS_TARGET)
-
-    add_executable(sync_17_websocket_simple_web_server
-        examples/sync_17_websocket_simple_web_server.cpp)
-    set_target_properties(sync_17_websocket_simple_web_server PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples
-    )
-    target_compile_features(sync_17_websocket_simple_web_server PRIVATE cxx_std_11)
-    target_compile_definitions(sync_17_websocket_simple_web_server PRIVATE
-        MDBXC_SYNC_ENABLED=1
-        ASIO_STANDALONE=1
-        USE_STANDALONE_ASIO=1)
-    target_link_libraries(sync_17_websocket_simple_web_server PRIVATE
-        ${_PKG_TARGET}
-        ${_MDBXC_SWS_WS_TARGET})
     get_property(_MDBXC_OPENSSL_RUNTIME_DLLS GLOBAL PROPERTY
         MDBXC_MINGW_OPENSSL_RUNTIME_DLLS)
-    foreach(_MDBXC_OPENSSL_RUNTIME_DLL IN LISTS _MDBXC_OPENSSL_RUNTIME_DLLS)
-        add_custom_command(TARGET sync_17_websocket_simple_web_server
-            POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                "${_MDBXC_OPENSSL_RUNTIME_DLL}"
-                "$<TARGET_FILE_DIR:sync_17_websocket_simple_web_server>"
-            VERBATIM)
-    endforeach()
-    message(STATUS "WebSocket binding example "
-        "sync_17_websocket_simple_web_server -> ${_MDBXC_SWS_WS_TARGET}")
+
+    if(MDBXC_WEBSOCKET_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
+        add_executable(sync_17_websocket_simple_web_server
+            examples/sync_17_websocket_simple_web_server.cpp)
+        set_target_properties(sync_17_websocket_simple_web_server PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples
+        )
+        target_compile_features(sync_17_websocket_simple_web_server PRIVATE
+            cxx_std_11)
+        target_compile_definitions(sync_17_websocket_simple_web_server PRIVATE
+            MDBXC_SYNC_ENABLED=1
+            ASIO_STANDALONE=1
+            USE_STANDALONE_ASIO=1)
+        target_link_libraries(sync_17_websocket_simple_web_server PRIVATE
+            ${_PKG_TARGET}
+            ${_MDBXC_SWS_WS_TARGET})
+        foreach(_MDBXC_OPENSSL_RUNTIME_DLL IN LISTS _MDBXC_OPENSSL_RUNTIME_DLLS)
+            add_custom_command(TARGET sync_17_websocket_simple_web_server
+                POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    "${_MDBXC_OPENSSL_RUNTIME_DLL}"
+                    "$<TARGET_FILE_DIR:sync_17_websocket_simple_web_server>"
+                VERBATIM)
+        endforeach()
+        message(STATUS "WebSocket binding example "
+            "sync_17_websocket_simple_web_server -> ${_MDBXC_SWS_WS_TARGET}")
+    endif()
 
     if(MDBXC_BUILD_TESTS)
         include(CTest)

--- a/README-RU.md
+++ b/README-RU.md
@@ -92,7 +92,10 @@
   Опциональные готовые Simple-Web HTTP/WebSocket binding headers находятся в
   `mdbx_containers/sync/transports/simple_web/`, а опциональный Kurlyk/libcurl
   HTTP client binding находится в `mdbx_containers/sync/transports/kurlyk/`.
-  Concrete backend targets задают `MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`,
+  `MDBXC_SIMPLE_WEB_HTTP_TRANSPORT`,
+  `MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT` и `MDBXC_KURLYK_HTTP_TRANSPORT`
+  включают эти dependency targets. Concrete backend targets задают
+  `MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`,
   `MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT` или
   `MDBXC_HAS_KURLYK_HTTP_TRANSPORT` для условного подключения backend headers.
   Socket-backed примеры используют эти bindings вместо повторной реализации

--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@
   HTTP/WebSocket binding headers live under
   `mdbx_containers/sync/transports/simple_web/`, and the optional Kurlyk/libcurl
   HTTP client binding lives under `mdbx_containers/sync/transports/kurlyk/`.
-  Concrete backend targets define `MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`,
+  `MDBXC_SIMPLE_WEB_HTTP_TRANSPORT`,
+  `MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT`, and `MDBXC_KURLYK_HTTP_TRANSPORT`
+  enable those dependency targets. Concrete backend targets define
+  `MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`,
   `MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT`, or
   `MDBXC_HAS_KURLYK_HTTP_TRANSPORT` for conditional backend includes.
   Socket-backed examples use those bindings instead of reimplementing the

--- a/cmake/deps/kurlyk.cmake
+++ b/cmake/deps/kurlyk.cmake
@@ -47,6 +47,7 @@ function(kurlyk_http_client_provide)
         GIT_REPOSITORY https://github.com/NewYaroslav/kurlyk.git
         GIT_TAG        ${MDBXC_KURLYK_GIT_TAG}
         GIT_SHALLOW    TRUE
+        GIT_SUBMODULES  ""
     )
     FetchContent_GetProperties(mdbxc_kurlyk)
     if(NOT mdbxc_kurlyk_POPULATED)

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -106,7 +106,12 @@ Targets, которым нужны и Simple-Web HTTP, и WebSocket bindings, м
 #endif
 ```
 
-`MDBXC_*_SYNC_EXAMPLE` options только собирают examples из этого repository.
+`MDBXC_SIMPLE_WEB_HTTP_TRANSPORT`,
+`MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT` и `MDBXC_KURLYK_HTTP_TRANSPORT`
+включают optional dependency targets и их backend smoke tests.
+`MDBXC_*_SYNC_EXAMPLE` options только добавляют examples из этого repository
+поверх этих backends; когда examples включены, старые example options всё ещё
+включают соответствующий backend для совместимости со старыми командами.
 Consumer targets получают `MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`,
 `MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT` или
 `MDBXC_HAS_KURLYK_HTTP_TRANSPORT` от concrete dependency target, к которому
@@ -140,7 +145,10 @@ tmp/build-ws-example/bin/examples/sync_17_websocket_simple_web_server \
 Готовый WebSocket binding подключается так:
 
 ```cpp
+#if defined(MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT) && \
+        MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT
 #include <mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp>
+#endif
 ```
 
 Чтобы использовать свой готовый бинарный пакет OpenSSL, укажите CMake корень

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -105,8 +105,13 @@ include the backend umbrella:
 #endif
 ```
 
-The `MDBXC_*_SYNC_EXAMPLE` options only build repository examples. Consumer
-targets get `MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`,
+`MDBXC_SIMPLE_WEB_HTTP_TRANSPORT`,
+`MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT`, and `MDBXC_KURLYK_HTTP_TRANSPORT`
+enable the optional dependency targets and their backend smoke tests. The
+`MDBXC_*_SYNC_EXAMPLE` options only add repository examples on top of those
+backends; when examples are enabled, the old example options still enable the
+matching backend for compatibility with older commands. Consumer targets get
+`MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`,
 `MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT`, or
 `MDBXC_HAS_KURLYK_HTTP_TRANSPORT` from the concrete dependency target they link.
 
@@ -138,7 +143,10 @@ tmp/build-ws-example/bin/examples/sync_17_websocket_simple_web_server \
 The reusable WebSocket binding lives in:
 
 ```cpp
+#if defined(MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT) && \
+        MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT
 #include <mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp>
+#endif
 ```
 
 To use your own ready-made OpenSSL package instead, point CMake at the package

--- a/guides/build-and-test.md
+++ b/guides/build-and-test.md
@@ -18,14 +18,20 @@ All project options use the `MDBXC_` prefix.
 | `MDBXC_BUILD_TESTS` | `ON` | Build tests from `tests/` and register them with CTest. |
 | `MDBXC_BUILD_BENCHMARKS` | `OFF` | Build manual benchmark executables from `benchmarks/`. |
 | `MDBXC_ENABLE_STRESS_TESTS` | `OFF` | Register long stress tests with CTest. Stress executables are still built when tests are enabled. |
-| `MDBXC_HTTP_SYNC_EXAMPLE` | `OFF` | Build the optional Simple-Web-Server HTTP sync example and fetch standalone Asio/Simple-Web-Server headers. |
-| `MDBXC_WEBSOCKET_SYNC_EXAMPLE` | `OFF` | Build the optional Simple-WebSocket-Server sync example and fetch standalone Asio/Simple-WebSocket-Server headers. Requires OpenSSL Crypto because Simple-WebSocket-Server uses it for the WebSocket handshake. |
-| `MDBXC_KURLYK_HTTP_SYNC_EXAMPLE` | `OFF` | Build the optional Kurlyk/libcurl HTTP sync client example and fetch Kurlyk headers. Requires C++17 and a discoverable libcurl package. |
-| `MDBXC_KURLYK_HTTP_SYNC_MINGW_CURL_FALLBACK` | `ON` | Fetch a pinned ready-made Win64 libcurl package for the MinGW Kurlyk HTTP example when system libcurl is unavailable. |
+| `MDBXC_SIMPLE_WEB_HTTP_TRANSPORT` | `OFF` | Enable the optional Simple-Web-Server HTTP transport backend target and backend smoke test. |
+| `MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT` | `OFF` | Enable the optional Simple-WebSocket-Server transport backend target and backend smoke test. Requires OpenSSL Crypto because Simple-WebSocket-Server uses it for the WebSocket handshake. |
+| `MDBXC_KURLYK_HTTP_TRANSPORT` | `OFF` | Enable the optional Kurlyk/libcurl HTTP client transport backend target and backend smoke test. Requires C++17 and a discoverable libcurl package. |
+| `MDBXC_HTTP_SYNC_EXAMPLE` | `OFF` | Build the optional Simple-Web-Server HTTP sync examples. When examples are enabled, this also enables `MDBXC_SIMPLE_WEB_HTTP_TRANSPORT` for compatibility with older commands. |
+| `MDBXC_WEBSOCKET_SYNC_EXAMPLE` | `OFF` | Build the optional Simple-WebSocket-Server sync example. When examples are enabled, this also enables `MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT` for compatibility with older commands. |
+| `MDBXC_KURLYK_HTTP_SYNC_EXAMPLE` | `OFF` | Build the optional Kurlyk/libcurl HTTP sync client example. When examples are enabled, this also enables `MDBXC_KURLYK_HTTP_TRANSPORT` for compatibility with older commands. |
+| `MDBXC_KURLYK_HTTP_SYNC_MINGW_CURL_FALLBACK` | `ON` | Fetch a pinned ready-made Win64 libcurl package for the MinGW Kurlyk HTTP transport when system libcurl is unavailable. |
+| `MDBXC_WEBSOCKET_SYNC_MINGW_OPENSSL_FALLBACK` | `ON` | Fetch a pinned ready-made Win64 OpenSSL Crypto package for the MinGW WebSocket transport when system OpenSSL is unavailable. |
 | `MDBXC_USE_ASAN` | `ON` | Enable AddressSanitizer for tests/examples when supported. |
 
-The optional transport example options are not public feature-detection macros.
-Concrete backend targets define `MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`,
+The optional transport backend options create concrete dependency targets and,
+when tests are enabled, backend smoke tests. The `*_SYNC_EXAMPLE` options only
+add repository example executables on top of those backends. Concrete backend
+targets define `MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`,
 `MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT`, or
 `MDBXC_HAS_KURLYK_HTTP_TRANSPORT` for consumers that link those dependency
 targets. Use those `MDBXC_HAS_*` macros when application code needs conditional

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -628,9 +628,14 @@ middleware. On Windows/MinGW, its optional example can fetch a pinned
 ready-made libcurl package; that fallback is a build-time convenience for the
 example target, not a dependency of the sync core.
 
-The `MDBXC_HTTP_SYNC_EXAMPLE`, `MDBXC_WEBSOCKET_SYNC_EXAMPLE`, and
-`MDBXC_KURLYK_HTTP_SYNC_EXAMPLE` CMake options only decide whether repository
-examples fetch and build optional backends. Application code should use
+The `MDBXC_SIMPLE_WEB_HTTP_TRANSPORT`,
+`MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT`, and `MDBXC_KURLYK_HTTP_TRANSPORT`
+CMake options enable the optional backend dependency targets and their backend
+smoke tests. The `MDBXC_HTTP_SYNC_EXAMPLE`,
+`MDBXC_WEBSOCKET_SYNC_EXAMPLE`, and `MDBXC_KURLYK_HTTP_SYNC_EXAMPLE` options
+only add repository examples on top of those backends; with
+`MDBXC_BUILD_EXAMPLES=ON`, they still enable the matching backend for
+compatibility with older example build commands. Application code should use
 `MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`,
 `MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT`, and
 `MDBXC_HAS_KURLYK_HTTP_TRANSPORT` when it needs conditional includes for


### PR DESCRIPTION
## Summary
- add explicit CMake backend options for Simple-Web HTTP, Simple-WebSocket, and Kurlyk HTTP transports
- keep legacy `*_SYNC_EXAMPLE` options as compatibility entry points that enable the matching backend when examples are built
- register optional backend tests from backend options instead of requiring example builds
- avoid fetching Kurlyk submodules for the HTTP-only backend
- update CI and docs for backend options vs `MDBXC_HAS_*` feature macros

## Validation
- `git diff --check`
- HTTP backend-only C++11 MinGW configure/build/ctest with `MDBXC_BUILD_EXAMPLES=OFF` and `MDBXC_SIMPLE_WEB_HTTP_TRANSPORT=ON`
- legacy HTTP example C++11 MinGW configure/build with `MDBXC_HTTP_SYNC_EXAMPLE=ON`
- WebSocket backend-only C++11 MinGW configure/build/ctest with `MDBXC_BUILD_EXAMPLES=OFF` and `MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT=ON`
- Kurlyk backend-only C++17 MinGW configure/build/ctest with `MDBXC_BUILD_EXAMPLES=OFF` and `MDBXC_KURLYK_HTTP_TRANSPORT=ON`

## Notes
- A first local Kurlyk configure attempt timed out while CMake was cloning unnecessary Kurlyk submodules; this PR adds `GIT_SUBMODULES ""` and the backend-only Kurlyk configure/build/test then passed.
