### PR TITLE
build(sync): export transport backend providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,63 @@ jobs:
           set -euo pipefail
           cmake --build "build-parent-${{ matrix.target_case }}" --parallel
 
+  installed-transport-backend:
+    name: Installed transport backend smoke (Linux C++11)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build
+
+      - name: Create fake MDBX package
+        run: |
+          set -euo pipefail
+          fake_dir="$PWD/build-fake-mdbx/lib/cmake/MDBX"
+          mkdir -p "$fake_dir"
+          cat >"$fake_dir/MDBXConfig.cmake" <<EOF
+          add_library(mdbx::mdbx INTERFACE IMPORTED)
+          set_target_properties(mdbx::mdbx PROPERTIES
+              INTERFACE_INCLUDE_DIRECTORIES "$PWD/external/libmdbx")
+          set(MDBX_FOUND TRUE)
+          EOF
+
+      - name: Install mdbx-containers package
+        run: |
+          set -euo pipefail
+          cmake -S . -B build-install -G "Ninja" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_STANDARD=11 \
+            -DMDBXC_DEPS_MODE=SYSTEM \
+            -DCMAKE_PREFIX_PATH="$PWD/build-fake-mdbx" \
+            -DMDBXC_BUILD_TESTS=OFF \
+            -DMDBXC_BUILD_EXAMPLES=OFF \
+            -DCMAKE_INSTALL_PREFIX="$PWD/build-install-prefix" \
+            -Wno-dev
+          cmake --install build-install
+
+      - name: Configure installed transport consumer
+        run: |
+          set -euo pipefail
+          cmake -S tests/cmake/installed_transport_backend \
+            -B build-installed-transport-backend -G "Ninja" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_STANDARD=11 \
+            -DCMAKE_PREFIX_PATH="$PWD/build-install-prefix;$PWD/build-fake-mdbx" \
+            -Wno-dev
+
+      - name: Build installed transport consumer
+        run: |
+          set -euo pipefail
+          cmake --build build-installed-transport-backend --parallel
+
   benchmark-smoke:
     name: Benchmark smoke (Linux C++17)
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,8 @@ target_link_libraries(${_PKG_TARGET} INTERFACE
 # Namespace alias for consumers
 add_library(mdbx_containers::mdbx_containers ALIAS ${_PKG_TARGET})
 
+include(cmake/mdbx_containersTransportBackends.cmake)
+
 # Install a separate export-only target so the build tree can link the bundled
 # MDBX target directly, while installed packages depend on find_dependency(MDBX).
 add_library(${_PKG_EXPORT_TARGET} INTERFACE)
@@ -220,10 +222,8 @@ endif()
 # Simple-Web HTTP binding around HttpSyncServer and HttpSyncPeer. Tests may use
 # the backend without building examples.
 if(MDBXC_SIMPLE_WEB_HTTP_TRANSPORT)
-    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/deps)
-    include(cmake/deps/simple-web-server.cmake)
-
-    simple_web_server_provide(OUT_TARGET _MDBXC_SWS_TARGET)
+    mdbx_containers_simple_web_http_transport_provide(
+        OUT_TARGET _MDBXC_SIMPLE_WEB_HTTP_TARGET)
 
     if(MDBXC_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
         include(cmake/deps/tiny-process-library.cmake)
@@ -235,16 +235,11 @@ if(MDBXC_SIMPLE_WEB_HTTP_TRANSPORT)
             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples
         )
         target_compile_features(sync_13_http_simple_web_server PRIVATE cxx_std_11)
-        target_compile_definitions(sync_13_http_simple_web_server PRIVATE
-            MDBXC_SYNC_ENABLED=1
-            ASIO_STANDALONE=1
-            USE_STANDALONE_ASIO=1)
         target_link_libraries(sync_13_http_simple_web_server PRIVATE
-            ${_PKG_TARGET}
-            ${_MDBXC_SWS_TARGET})
+            ${_MDBXC_SIMPLE_WEB_HTTP_TARGET})
         message(STATUS
             "HTTP binding example sync_13_http_simple_web_server -> "
-            "${_MDBXC_SWS_TARGET}")
+            "${_MDBXC_SIMPLE_WEB_HTTP_TARGET}")
 
         add_executable(sync_18_http_node_fleet
             examples/sync_18_http_node_fleet.cpp)
@@ -252,16 +247,11 @@ if(MDBXC_SIMPLE_WEB_HTTP_TRANSPORT)
             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples
         )
         target_compile_features(sync_18_http_node_fleet PRIVATE cxx_std_11)
-        target_compile_definitions(sync_18_http_node_fleet PRIVATE
-            MDBXC_SYNC_ENABLED=1
-            ASIO_STANDALONE=1
-            USE_STANDALONE_ASIO=1)
         target_link_libraries(sync_18_http_node_fleet PRIVATE
-            ${_PKG_TARGET}
-            ${_MDBXC_SWS_TARGET}
+            ${_MDBXC_SIMPLE_WEB_HTTP_TARGET}
             tiny-process-library::tiny-process-library)
         message(STATUS "HTTP node fleet example sync_18_http_node_fleet -> "
-            "${_MDBXC_SWS_TARGET};tiny-process-library")
+            "${_MDBXC_SIMPLE_WEB_HTTP_TARGET};tiny-process-library")
     endif()
 
     if(MDBXC_BUILD_TESTS)
@@ -274,18 +264,16 @@ if(MDBXC_SIMPLE_WEB_HTTP_TRANSPORT)
         )
         target_compile_features(test_simple_web_http_transport PRIVATE
             cxx_std_11)
-        target_compile_definitions(test_simple_web_http_transport PRIVATE
-            MDBXC_SYNC_ENABLED=1)
         mdbxc_enable_asan(test_simple_web_http_transport)
         target_link_libraries(test_simple_web_http_transport PRIVATE
-            ${_PKG_TARGET}
-            ${_MDBXC_SWS_TARGET})
+            ${_MDBXC_SIMPLE_WEB_HTTP_TARGET})
         add_test(NAME test_simple_web_http_transport
             COMMAND test_simple_web_http_transport)
         set_tests_properties(test_simple_web_http_transport PROPERTIES
             TIMEOUT 30)
         message(STATUS "HTTP binding test "
-            "test_simple_web_http_transport -> ${_MDBXC_SWS_TARGET}")
+            "test_simple_web_http_transport -> "
+            "${_MDBXC_SIMPLE_WEB_HTTP_TARGET}")
     endif()
 endif()
 
@@ -296,14 +284,12 @@ endif()
 # around HttpSyncPeer. Tests may use the client backend without building the
 # example, whose server side intentionally reuses the Simple-Web listener.
 if(MDBXC_KURLYK_HTTP_TRANSPORT)
-    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/deps)
-    include(cmake/deps/kurlyk.cmake)
-
-    kurlyk_http_client_provide(OUT_TARGET _MDBXC_KURLYK_HTTP_TARGET)
+    mdbx_containers_kurlyk_http_transport_provide(
+        OUT_TARGET _MDBXC_KURLYK_HTTP_TARGET)
 
     if(MDBXC_KURLYK_HTTP_SYNC_EXAMPLE AND MDBXC_BUILD_EXAMPLES)
-        include(cmake/deps/simple-web-server.cmake)
-        simple_web_server_provide(OUT_TARGET _MDBXC_SWS_TARGET)
+        mdbx_containers_simple_web_http_transport_provide(
+            OUT_TARGET _MDBXC_SIMPLE_WEB_HTTP_TARGET)
 
         add_executable(sync_19_kurlyk_http_client
             examples/sync_19_kurlyk_http_client.cpp)
@@ -311,13 +297,8 @@ if(MDBXC_KURLYK_HTTP_TRANSPORT)
             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples
         )
         target_compile_features(sync_19_kurlyk_http_client PRIVATE cxx_std_17)
-        target_compile_definitions(sync_19_kurlyk_http_client PRIVATE
-            MDBXC_SYNC_ENABLED=1
-            ASIO_STANDALONE=1
-            USE_STANDALONE_ASIO=1)
         target_link_libraries(sync_19_kurlyk_http_client PRIVATE
-            ${_PKG_TARGET}
-            ${_MDBXC_SWS_TARGET}
+            ${_MDBXC_SIMPLE_WEB_HTTP_TARGET}
             ${_MDBXC_KURLYK_HTTP_TARGET})
         get_property(_MDBXC_CURL_RUNTIME_DLLS GLOBAL PROPERTY
             MDBXC_MINGW_CURL_RUNTIME_DLLS)
@@ -331,7 +312,7 @@ if(MDBXC_KURLYK_HTTP_TRANSPORT)
         endforeach()
         message(STATUS
             "Kurlyk HTTP client example sync_19_kurlyk_http_client -> "
-            "${_MDBXC_SWS_TARGET};${_MDBXC_KURLYK_HTTP_TARGET}")
+            "${_MDBXC_SIMPLE_WEB_HTTP_TARGET};${_MDBXC_KURLYK_HTTP_TARGET}")
     endif()
 
     if(MDBXC_BUILD_TESTS)
@@ -343,11 +324,8 @@ if(MDBXC_KURLYK_HTTP_TRANSPORT)
             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tests
         )
         target_compile_features(test_kurlyk_http_transport PRIVATE cxx_std_17)
-        target_compile_definitions(test_kurlyk_http_transport PRIVATE
-            MDBXC_SYNC_ENABLED=1)
         mdbxc_enable_asan(test_kurlyk_http_transport)
         target_link_libraries(test_kurlyk_http_transport PRIVATE
-            ${_PKG_TARGET}
             ${_MDBXC_KURLYK_HTTP_TARGET})
         get_property(_MDBXC_CURL_RUNTIME_DLLS GLOBAL PROPERTY
             MDBXC_MINGW_CURL_RUNTIME_DLLS)
@@ -374,10 +352,8 @@ endif()
 # Pulls Simple-WebSocket-Server through FetchContent and exposes the concrete
 # WebSocket binding. Tests may use the backend without building examples.
 if(MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT)
-    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/deps)
-    include(cmake/deps/simple-web-server.cmake)
-
-    simple_websocket_server_provide(OUT_TARGET _MDBXC_SWS_WS_TARGET)
+    mdbx_containers_simple_web_websocket_transport_provide(
+        OUT_TARGET _MDBXC_SIMPLE_WEB_WEBSOCKET_TARGET)
     get_property(_MDBXC_OPENSSL_RUNTIME_DLLS GLOBAL PROPERTY
         MDBXC_MINGW_OPENSSL_RUNTIME_DLLS)
 
@@ -389,13 +365,8 @@ if(MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT)
         )
         target_compile_features(sync_17_websocket_simple_web_server PRIVATE
             cxx_std_11)
-        target_compile_definitions(sync_17_websocket_simple_web_server PRIVATE
-            MDBXC_SYNC_ENABLED=1
-            ASIO_STANDALONE=1
-            USE_STANDALONE_ASIO=1)
         target_link_libraries(sync_17_websocket_simple_web_server PRIVATE
-            ${_PKG_TARGET}
-            ${_MDBXC_SWS_WS_TARGET})
+            ${_MDBXC_SIMPLE_WEB_WEBSOCKET_TARGET})
         foreach(_MDBXC_OPENSSL_RUNTIME_DLL IN LISTS _MDBXC_OPENSSL_RUNTIME_DLLS)
             add_custom_command(TARGET sync_17_websocket_simple_web_server
                 POST_BUILD
@@ -405,7 +376,8 @@ if(MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT)
                 VERBATIM)
         endforeach()
         message(STATUS "WebSocket binding example "
-            "sync_17_websocket_simple_web_server -> ${_MDBXC_SWS_WS_TARGET}")
+            "sync_17_websocket_simple_web_server -> "
+            "${_MDBXC_SIMPLE_WEB_WEBSOCKET_TARGET}")
     endif()
 
     if(MDBXC_BUILD_TESTS)
@@ -417,14 +389,9 @@ if(MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT)
             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tests
         )
         target_compile_features(test_simple_websocket_transport PRIVATE cxx_std_11)
-        target_compile_definitions(test_simple_websocket_transport PRIVATE
-            MDBXC_SYNC_ENABLED=1
-            ASIO_STANDALONE=1
-            USE_STANDALONE_ASIO=1)
         mdbxc_enable_asan(test_simple_websocket_transport)
         target_link_libraries(test_simple_websocket_transport PRIVATE
-            ${_PKG_TARGET}
-            ${_MDBXC_SWS_WS_TARGET})
+            ${_MDBXC_SIMPLE_WEB_WEBSOCKET_TARGET})
         foreach(_MDBXC_OPENSSL_RUNTIME_DLL IN LISTS _MDBXC_OPENSSL_RUNTIME_DLLS)
             add_custom_command(TARGET test_simple_websocket_transport
                 POST_BUILD
@@ -438,7 +405,8 @@ if(MDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT)
         set_tests_properties(test_simple_websocket_transport PROPERTIES
             TIMEOUT 30)
         message(STATUS "WebSocket binding test "
-            "test_simple_websocket_transport -> ${_MDBXC_SWS_WS_TARGET}")
+            "test_simple_websocket_transport -> "
+            "${_MDBXC_SIMPLE_WEB_WEBSOCKET_TARGET}")
     endif()
 endif()
 
@@ -584,6 +552,18 @@ install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/mdbx_containersConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/mdbx_containersConfigVersion.cmake
     DESTINATION ${_PKG_CONFIG_INSTALL_DIR}
+)
+
+install(FILES
+    cmake/mdbx_containersTransportBackends.cmake
+    DESTINATION ${_PKG_CONFIG_INSTALL_DIR}
+)
+
+install(FILES
+    cmake/deps/kurlyk.cmake
+    cmake/deps/openssl-mingw.cmake
+    cmake/deps/simple-web-server.cmake
+    DESTINATION ${_PKG_CONFIG_INSTALL_DIR}/deps
 )
 
 # ---------------------------------------

--- a/README-RU.md
+++ b/README-RU.md
@@ -98,6 +98,8 @@
   `MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`,
   `MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT` или
   `MDBXC_HAS_KURLYK_HTTP_TRANSPORT` для условного подключения backend headers.
+  Установленный package также экспортирует CMake provider functions для этих
+  готовых transport targets.
   Socket-backed примеры используют эти bindings вместо повторной реализации
   транспорта в каждом файле. Wire-format для специализированных таблиц отложен.
   HTTP auth,

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@
   `MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`,
   `MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT`, or
   `MDBXC_HAS_KURLYK_HTTP_TRANSPORT` for conditional backend includes.
+  Installed packages also export CMake provider functions for these ready-made
+  transport targets.
   Socket-backed examples use those bindings instead of reimplementing the
   transport in each file. Specialized table wire formats remain deferred.
   HTTP auth, remote-address checks, and rate-limit headers live in

--- a/cmake/mdbx_containersConfig.cmake.in
+++ b/cmake/mdbx_containersConfig.cmake.in
@@ -12,3 +12,4 @@ endif()
 
 # Pull in the exported targets (namespace mdbx_containers::)
 include("${CMAKE_CURRENT_LIST_DIR}/mdbx_containersTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/mdbx_containersTransportBackends.cmake")

--- a/cmake/mdbx_containersTransportBackends.cmake
+++ b/cmake/mdbx_containersTransportBackends.cmake
@@ -1,0 +1,96 @@
+include_guard(GLOBAL)
+
+include(CMakeParseArguments)
+
+function(_mdbxc_transport_backend_parse_out function_name out_var)
+    set(_options)
+    set(_one_value OUT_TARGET)
+    set(_multi_value)
+    cmake_parse_arguments(MDBXC_TRANSPORT "${_options}" "${_one_value}"
+        "${_multi_value}" ${ARGN})
+
+    if(NOT MDBXC_TRANSPORT_OUT_TARGET)
+        message(FATAL_ERROR "${function_name} requires OUT_TARGET <var>")
+    endif()
+
+    set(${out_var} "${MDBXC_TRANSPORT_OUT_TARGET}" PARENT_SCOPE)
+endfunction()
+
+function(mdbx_containers_simple_web_http_transport_provide)
+    _mdbxc_transport_backend_parse_out(
+        "mdbx_containers_simple_web_http_transport_provide"
+        _out_var ${ARGN})
+
+    include("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/deps/simple-web-server.cmake")
+    simple_web_server_provide(OUT_TARGET _mdbxc_sws_target)
+
+    if(NOT TARGET mdbx_containers::simple_web_http_transport)
+        add_library(mdbx_containers_simple_web_http_transport INTERFACE)
+        target_compile_features(mdbx_containers_simple_web_http_transport
+            INTERFACE cxx_std_11)
+        target_compile_definitions(mdbx_containers_simple_web_http_transport
+            INTERFACE MDBXC_SYNC_ENABLED=1)
+        target_link_libraries(mdbx_containers_simple_web_http_transport
+            INTERFACE
+                mdbx_containers::mdbx_containers
+                ${_mdbxc_sws_target})
+        add_library(mdbx_containers::simple_web_http_transport ALIAS
+            mdbx_containers_simple_web_http_transport)
+    endif()
+
+    set(${_out_var} mdbx_containers::simple_web_http_transport PARENT_SCOPE)
+endfunction()
+
+function(mdbx_containers_simple_web_websocket_transport_provide)
+    _mdbxc_transport_backend_parse_out(
+        "mdbx_containers_simple_web_websocket_transport_provide"
+        _out_var ${ARGN})
+
+    include("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/deps/simple-web-server.cmake")
+    simple_websocket_server_provide(OUT_TARGET _mdbxc_sws_ws_target)
+
+    if(NOT TARGET mdbx_containers::simple_web_websocket_transport)
+        add_library(mdbx_containers_simple_web_websocket_transport INTERFACE)
+        target_compile_features(
+            mdbx_containers_simple_web_websocket_transport
+            INTERFACE cxx_std_11)
+        target_compile_definitions(
+            mdbx_containers_simple_web_websocket_transport
+            INTERFACE MDBXC_SYNC_ENABLED=1)
+        target_link_libraries(
+            mdbx_containers_simple_web_websocket_transport
+            INTERFACE
+                mdbx_containers::mdbx_containers
+                ${_mdbxc_sws_ws_target})
+        add_library(mdbx_containers::simple_web_websocket_transport ALIAS
+            mdbx_containers_simple_web_websocket_transport)
+    endif()
+
+    set(${_out_var} mdbx_containers::simple_web_websocket_transport
+        PARENT_SCOPE)
+endfunction()
+
+function(mdbx_containers_kurlyk_http_transport_provide)
+    _mdbxc_transport_backend_parse_out(
+        "mdbx_containers_kurlyk_http_transport_provide"
+        _out_var ${ARGN})
+
+    include("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/deps/kurlyk.cmake")
+    kurlyk_http_client_provide(OUT_TARGET _mdbxc_kurlyk_target)
+
+    if(NOT TARGET mdbx_containers::kurlyk_http_transport)
+        add_library(mdbx_containers_kurlyk_http_transport INTERFACE)
+        target_compile_features(mdbx_containers_kurlyk_http_transport
+            INTERFACE cxx_std_17)
+        target_compile_definitions(mdbx_containers_kurlyk_http_transport
+            INTERFACE MDBXC_SYNC_ENABLED=1)
+        target_link_libraries(mdbx_containers_kurlyk_http_transport
+            INTERFACE
+                mdbx_containers::mdbx_containers
+                ${_mdbxc_kurlyk_target})
+        add_library(mdbx_containers::kurlyk_http_transport ALIAS
+            mdbx_containers_kurlyk_http_transport)
+    endif()
+
+    set(${_out_var} mdbx_containers::kurlyk_http_transport PARENT_SCOPE)
+endfunction()

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -117,6 +117,25 @@ Consumer targets получают `MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT`,
 `MDBXC_HAS_KURLYK_HTTP_TRANSPORT` от concrete dependency target, к которому
 они линкуются.
 
+При использовании установленного package эти targets можно создать через
+экспортированные provider functions:
+
+```cmake
+find_package(mdbx_containers CONFIG REQUIRED)
+
+mdbx_containers_simple_web_http_transport_provide(OUT_TARGET http_target)
+target_link_libraries(my_http_node PRIVATE ${http_target})
+
+mdbx_containers_simple_web_websocket_transport_provide(OUT_TARGET ws_target)
+target_link_libraries(my_ws_node PRIVATE ${ws_target})
+
+mdbx_containers_kurlyk_http_transport_provide(OUT_TARGET kurlyk_target)
+target_link_libraries(my_kurlyk_client PRIVATE ${kurlyk_target})
+```
+
+Возвращаемые targets включают `MDBXC_SYNC_ENABLED`, линкуют core package target
+и распространяют соответствующий `MDBXC_HAS_*_TRANSPORT` macro.
+
 Реальный WebSocket binding example тоже включается отдельно, потому что он
 скачивает headers standalone Asio и Simple-WebSocket-Server.
 Simple-WebSocket-Server использует OpenSSL Crypto для WebSocket handshake,

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -115,6 +115,25 @@ matching backend for compatibility with older commands. Consumer targets get
 `MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT`, or
 `MDBXC_HAS_KURLYK_HTTP_TRANSPORT` from the concrete dependency target they link.
 
+With an installed package, use the exported provider functions to create those
+targets:
+
+```cmake
+find_package(mdbx_containers CONFIG REQUIRED)
+
+mdbx_containers_simple_web_http_transport_provide(OUT_TARGET http_target)
+target_link_libraries(my_http_node PRIVATE ${http_target})
+
+mdbx_containers_simple_web_websocket_transport_provide(OUT_TARGET ws_target)
+target_link_libraries(my_ws_node PRIVATE ${ws_target})
+
+mdbx_containers_kurlyk_http_transport_provide(OUT_TARGET kurlyk_target)
+target_link_libraries(my_kurlyk_client PRIVATE ${kurlyk_target})
+```
+
+The returned targets enable `MDBXC_SYNC_ENABLED`, link the core package target,
+and propagate the matching `MDBXC_HAS_*_TRANSPORT` macro.
+
 The real WebSocket binding example is also opt-in because it fetches standalone
 Asio and Simple-WebSocket-Server headers. Simple-WebSocket-Server uses OpenSSL
 Crypto for the WebSocket handshake, so set `OPENSSL_ROOT_DIR` if CMake cannot

--- a/guides/build-and-test.md
+++ b/guides/build-and-test.md
@@ -39,6 +39,21 @@ includes around optional sync transport backends. Consumers that wire the same
 third-party dependencies manually may define the corresponding `MDBXC_HAS_*`
 macro themselves.
 
+After `find_package(mdbx_containers CONFIG REQUIRED)`, installed-package
+consumers can create the same ready-made transport usage targets with:
+
+```cmake
+mdbx_containers_simple_web_http_transport_provide(OUT_TARGET http_target)
+mdbx_containers_simple_web_websocket_transport_provide(OUT_TARGET ws_target)
+mdbx_containers_kurlyk_http_transport_provide(OUT_TARGET kurlyk_target)
+```
+
+The returned targets are `mdbx_containers::simple_web_http_transport`,
+`mdbx_containers::simple_web_websocket_transport`, and
+`mdbx_containers::kurlyk_http_transport`. They enable `MDBXC_SYNC_ENABLED`,
+link `mdbx_containers::mdbx_containers`, fetch or find the optional backend
+dependencies, and propagate the matching `MDBXC_HAS_*_TRANSPORT` macro.
+
 When `mdbx-containers` is added as a subproject, existing parent-provided
 `mdbx::mdbx`, `mdbx::mdbx-static`, `libmdbx::mdbx`, and
 `libmdbx::mdbx-static` targets are reused before package, submodule, or

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -642,6 +642,24 @@ compatibility with older example build commands. Application code should use
 concrete backend headers. Consumers that wire the same third-party dependencies
 manually may define the corresponding `MDBXC_HAS_*` macro themselves.
 
+Installed packages export provider functions instead of exporting raw
+FetchContent build-tree targets:
+
+```cmake
+mdbx_containers_simple_web_http_transport_provide(OUT_TARGET http_target)
+mdbx_containers_simple_web_websocket_transport_provide(OUT_TARGET ws_target)
+mdbx_containers_kurlyk_http_transport_provide(OUT_TARGET kurlyk_target)
+```
+
+The returned targets are
+`mdbx_containers::simple_web_http_transport`,
+`mdbx_containers::simple_web_websocket_transport`, and
+`mdbx_containers::kurlyk_http_transport`. They link the core package target,
+enable `MDBXC_SYNC_ENABLED`, fetch or find the optional third-party backend,
+and propagate the matching `MDBXC_HAS_*_TRANSPORT` macro. This keeps installed
+packages relocatable while preserving the same target-based usage model as the
+source-tree examples and tests.
+
 ## Why `prune_up_to` uses cursor walk + `MDBX_NEXT`
 
 MDBX has no batch "delete by key range" primitive. The supported pattern

--- a/tests/cmake/installed_transport_backend/CMakeLists.txt
+++ b/tests/cmake/installed_transport_backend/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.18)
+
+project(mdbxc_installed_transport_backend_smoke LANGUAGES CXX)
+
+find_package(mdbx_containers CONFIG REQUIRED)
+
+if(NOT COMMAND mdbx_containers_simple_web_http_transport_provide)
+    message(FATAL_ERROR
+        "mdbx_containers_simple_web_http_transport_provide was not exported")
+endif()
+
+mdbx_containers_simple_web_http_transport_provide(
+    OUT_TARGET MDBXC_SIMPLE_WEB_HTTP_TARGET)
+
+if(NOT TARGET ${MDBXC_SIMPLE_WEB_HTTP_TARGET})
+    message(FATAL_ERROR
+        "Simple-Web HTTP transport target was not created")
+endif()
+
+add_library(installed_transport_backend_smoke OBJECT main.cpp)
+target_compile_features(installed_transport_backend_smoke PRIVATE cxx_std_11)
+target_link_libraries(installed_transport_backend_smoke PRIVATE
+    ${MDBXC_SIMPLE_WEB_HTTP_TARGET})

--- a/tests/cmake/installed_transport_backend/main.cpp
+++ b/tests/cmake/installed_transport_backend/main.cpp
@@ -1,0 +1,15 @@
+#include <mdbx_containers/sync/transports/simple_web/HttpTransport.hpp>
+
+#if !defined(MDBXC_SYNC_ENABLED) || !MDBXC_SYNC_ENABLED
+#error "transport usage target must enable MDBXC_SYNC_ENABLED"
+#endif
+
+#if !defined(MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT) || \
+        !MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT
+#error "transport usage target must expose MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT"
+#endif
+
+int main() {
+    mdbxc::sync::simple_web::HttpSyncListenerConfig config;
+    return config.sync_route_regex.empty() ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- add installed-package CMake provider functions for optional transport backend usage targets
- reuse the provider functions in source-tree examples/tests instead of hand-wiring dependency targets
- install the provider module and backend dependency CMake helpers alongside the package config
- add an installed consumer smoke project and Linux CI job for `find_package()` + transport provider usage
- document provider usage in README, sync examples, build guide, and sync design notes

## Validation

- `ctest --test-dir tmp/pr130-http-backend-cpp11-mingw -R test_simple_web_http_transport --output-on-failure`
- `ctest --test-dir tmp/pr130-ws-backend-cpp11-mingw -R test_simple_websocket_transport --output-on-failure`
- `ctest --test-dir tmp/pr130-kurlyk-backend-cpp17-mingw -R test_kurlyk_http_transport --output-on-failure`
- installed package smoke:
  - configure/install with `MDBXC_DEPS_MODE=SYSTEM` and fake local `MDBXConfig.cmake`
  - configure `tests/cmake/installed_transport_backend` via installed `mdbx_containersConfig.cmake`
  - build `installed_transport_backend_smoke`
- `git diff --cached --check`