### PR TITLE
test(sync): cover installed transport providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install build tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build
+          sudo apt-get install -y cmake ninja-build libcurl4-openssl-dev libssl-dev
 
       - name: Configure parent-target smoke
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install build tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build libcurl4-openssl-dev libssl-dev
+          sudo apt-get install -y cmake ninja-build
 
       - name: Configure parent-target smoke
         run: |
@@ -57,7 +57,7 @@ jobs:
           cmake --build "build-parent-${{ matrix.target_case }}" --parallel
 
   installed-transport-backend:
-    name: Installed transport backend smoke (Linux C++11)
+    name: Installed transport providers smoke
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -70,7 +70,11 @@ jobs:
       - name: Install build tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build
+          sudo apt-get install -y \
+            cmake \
+            ninja-build \
+            libcurl4-openssl-dev \
+            libssl-dev
 
       - name: Create fake MDBX package
         run: |

--- a/tests/cmake/installed_transport_backend/CMakeLists.txt
+++ b/tests/cmake/installed_transport_backend/CMakeLists.txt
@@ -8,16 +8,52 @@ if(NOT COMMAND mdbx_containers_simple_web_http_transport_provide)
     message(FATAL_ERROR
         "mdbx_containers_simple_web_http_transport_provide was not exported")
 endif()
+if(NOT COMMAND mdbx_containers_simple_web_websocket_transport_provide)
+    message(FATAL_ERROR
+        "mdbx_containers_simple_web_websocket_transport_provide was not exported")
+endif()
+if(NOT COMMAND mdbx_containers_kurlyk_http_transport_provide)
+    message(FATAL_ERROR
+        "mdbx_containers_kurlyk_http_transport_provide was not exported")
+endif()
 
 mdbx_containers_simple_web_http_transport_provide(
     OUT_TARGET MDBXC_SIMPLE_WEB_HTTP_TARGET)
+mdbx_containers_simple_web_websocket_transport_provide(
+    OUT_TARGET MDBXC_SIMPLE_WEB_WEBSOCKET_TARGET)
+mdbx_containers_kurlyk_http_transport_provide(
+    OUT_TARGET MDBXC_KURLYK_HTTP_TARGET)
 
 if(NOT TARGET ${MDBXC_SIMPLE_WEB_HTTP_TARGET})
     message(FATAL_ERROR
         "Simple-Web HTTP transport target was not created")
 endif()
+if(NOT TARGET ${MDBXC_SIMPLE_WEB_WEBSOCKET_TARGET})
+    message(FATAL_ERROR
+        "Simple-WebSocket transport target was not created")
+endif()
+if(NOT TARGET ${MDBXC_KURLYK_HTTP_TARGET})
+    message(FATAL_ERROR
+        "Kurlyk HTTP transport target was not created")
+endif()
 
-add_library(installed_transport_backend_smoke OBJECT main.cpp)
-target_compile_features(installed_transport_backend_smoke PRIVATE cxx_std_11)
-target_link_libraries(installed_transport_backend_smoke PRIVATE
+add_library(installed_simple_web_http_transport_smoke OBJECT
+    simple_web_http.cpp)
+target_compile_features(installed_simple_web_http_transport_smoke PRIVATE
+    cxx_std_11)
+target_link_libraries(installed_simple_web_http_transport_smoke PRIVATE
     ${MDBXC_SIMPLE_WEB_HTTP_TARGET})
+
+add_library(installed_simple_web_websocket_transport_smoke OBJECT
+    simple_web_websocket.cpp)
+target_compile_features(installed_simple_web_websocket_transport_smoke
+    PRIVATE cxx_std_11)
+target_link_libraries(installed_simple_web_websocket_transport_smoke PRIVATE
+    ${MDBXC_SIMPLE_WEB_WEBSOCKET_TARGET})
+
+add_library(installed_kurlyk_http_transport_smoke OBJECT
+    kurlyk_http.cpp)
+target_compile_features(installed_kurlyk_http_transport_smoke PRIVATE
+    cxx_std_17)
+target_link_libraries(installed_kurlyk_http_transport_smoke PRIVATE
+    ${MDBXC_KURLYK_HTTP_TARGET})

--- a/tests/cmake/installed_transport_backend/kurlyk_http.cpp
+++ b/tests/cmake/installed_transport_backend/kurlyk_http.cpp
@@ -1,0 +1,15 @@
+#include <mdbx_containers/sync/transports/kurlyk/HttpTransport.hpp>
+
+#if !defined(MDBXC_SYNC_ENABLED) || !MDBXC_SYNC_ENABLED
+#error "transport usage target must enable MDBXC_SYNC_ENABLED"
+#endif
+
+#if !defined(MDBXC_HAS_KURLYK_HTTP_TRANSPORT) || \
+        !MDBXC_HAS_KURLYK_HTTP_TRANSPORT
+#error "Kurlyk HTTP target must expose MDBXC_HAS_KURLYK_HTTP_TRANSPORT"
+#endif
+
+int main() {
+    mdbxc::sync::kurlyk::HttpSyncClientConfig config;
+    return config.base_url.empty() ? 1 : 0;
+}

--- a/tests/cmake/installed_transport_backend/simple_web_http.cpp
+++ b/tests/cmake/installed_transport_backend/simple_web_http.cpp
@@ -6,7 +6,7 @@
 
 #if !defined(MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT) || \
         !MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT
-#error "transport usage target must expose MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT"
+#error "Simple-Web HTTP target must expose MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT"
 #endif
 
 int main() {

--- a/tests/cmake/installed_transport_backend/simple_web_websocket.cpp
+++ b/tests/cmake/installed_transport_backend/simple_web_websocket.cpp
@@ -1,0 +1,15 @@
+#include <mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp>
+
+#if !defined(MDBXC_SYNC_ENABLED) || !MDBXC_SYNC_ENABLED
+#error "transport usage target must enable MDBXC_SYNC_ENABLED"
+#endif
+
+#if !defined(MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT) || \
+        !MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT
+#error "Simple-WebSocket target must expose MDBXC_HAS_SIMPLE_WEB_WEBSOCKET_TRANSPORT"
+#endif
+
+int main() {
+    mdbxc::sync::simple_web::WebSocketSyncListenerConfig config;
+    return config.endpoint_regex.empty() ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- extend the installed-package transport consumer smoke to request all exported backend providers
- compile Simple-Web HTTP, Simple-WebSocket, and Kurlyk HTTP public backend headers through installed provider targets
- verify backend feature macros and sync enablement for each provider target
- install curl/OpenSSL dev packages in the CI smoke because the installed consumer now covers Kurlyk and WebSocket too

## Validation

- installed consumer smoke via installed package config on MinGW:
  - `cmake -S tests/cmake/installed_transport_backend -B tmp/pr131-installed-consumer ...`
  - `cmake --build tmp/pr131-installed-consumer`
- `git diff --check`