### PR TITLE
docs(sync): add transport production notes

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -100,6 +100,9 @@
   `MDBXC_HAS_KURLYK_HTTP_TRANSPORT` для условного подключения backend headers.
   Установленный package также экспортирует CMake provider functions для этих
   готовых transport targets.
+  См. [sync transport production notes](guides/sync-transport-production.md)
+  про TLS/WSS, ротацию токенов, graceful shutdown, structured logging и
+  offline dependency builds.
   Socket-backed примеры используют эти bindings вместо повторной реализации
   транспорта в каждом файле. Wire-format для специализированных таблиц отложен.
   HTTP auth,

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@
   `MDBXC_HAS_KURLYK_HTTP_TRANSPORT` for conditional backend includes.
   Installed packages also export CMake provider functions for these ready-made
   transport targets.
+  See [sync transport production notes](guides/sync-transport-production.md)
+  for TLS/WSS, token rotation, graceful shutdown, structured logging, and
+  offline dependency guidance.
   Socket-backed examples use those bindings instead of reimplementing the
   transport in each file. Specialized table wire formats remain deferred.
   HTTP auth, remote-address checks, and rate-limit headers live in

--- a/guides/sync-transport-production.md
+++ b/guides/sync-transport-production.md
@@ -59,9 +59,12 @@ For HTTP and WebSocket servers, shutdown should happen in this order:
 4. Join worker and listener threads.
 5. Destroy `SyncEngine`, tables, and `Connection` objects.
 
-`SyncWorker::request_stop()` does not interrupt a blocking transport by itself.
-Concrete transport clients should use finite timeouts or their own cancellation
-mechanism.
+`SyncWorker::request_stop()` requests cancellation through the active
+`CancellationToken` and calls `ISyncPeer::request_cancel()` for the observed
+in-flight peer call. Cancellation is best-effort: `stop()`, `join()`, and the
+destructor may still wait until a transport that ignores or cannot complete
+cancellation returns. Concrete transport clients should use finite timeouts or
+their own socket-level cancellation mechanism.
 
 ## Structured Logging
 
@@ -88,12 +91,18 @@ does not fetch transport dependencies; fetching starts only after calling a
 
 For offline or controlled builds, prefer one of these approaches:
 
-- provide dependency targets before calling the provider function;
 - set `FETCHCONTENT_SOURCE_DIR_<NAME>` cache variables to audited source trees;
-- mirror the dependency repositories and override `GIT_REPOSITORY` variables in
-  the corresponding dependency helper;
-- vendor the dependency in the parent project and expose compatible CMake
-  targets.
+- mirror dependencies through Git URL rewriting configured outside this
+  package;
+- vendor the dependency in the parent project and point the corresponding
+  `FETCHCONTENT_SOURCE_DIR_<NAME>` variable at that source tree;
+- patch or fork the dependency helper when a build system needs different
+  repository URLs.
+
+The current dependency helpers expose cache variables for pinned tags, but not
+for repository URLs. Creating compatible dependency targets ahead of time is
+not sufficient by itself to skip `FetchContent`, because the helpers still
+populate the expected source trees before wiring the final usage targets.
 
 The provider target should remain the only target linked by application code.
 This keeps `MDBXC_SYNC_ENABLED`, backend feature macros, include directories,

--- a/guides/sync-transport-production.md
+++ b/guides/sync-transport-production.md
@@ -1,0 +1,100 @@
+# Sync Transport Production Notes
+
+This guide describes deployment contracts around the optional HTTP and
+WebSocket sync transports. It does not replace the transport API reference; it
+records the operational decisions an application should make before exposing a
+sync endpoint outside a trusted test process.
+
+## Transport Security Boundary
+
+The sync wire format carries sync DTOs only. Transport-local metadata stays in
+the adapter layer:
+
+- bearer tokens, cookies, mTLS principals, and remote addresses;
+- HTTP response headers such as `WWW-Authenticate` and `Retry-After`;
+- WebSocket close codes and handshake metadata;
+- request IDs, trace IDs, and log correlation metadata.
+
+Application code should authenticate the transport session before calling the
+sync server adapter. Then it should bind the authenticated session identity to
+the expected `NodeId` and DB access policy.
+
+## TLS and WSS
+
+The built-in Simple-Web examples use plain HTTP or WS to keep local smoke tests
+simple. Production deployments should put one of these in front of the sync
+endpoint:
+
+- TLS termination in a reverse proxy or service mesh;
+- an HTTPS/WSS-capable framework binding;
+- mTLS at the edge when node identity comes from certificates.
+
+When TLS termination happens outside the process, pass only trusted forwarded
+identity metadata into the adapter policy layer. Do not treat arbitrary
+`X-Forwarded-*` headers from the public network as authenticated facts.
+
+## Token Rotation
+
+Bearer-token policies should support at least two active credentials during a
+rotation window:
+
+1. Register the new token for the same `NodeId` and DB access policy.
+2. Roll clients to the new token.
+3. Remove the old token after the maximum expected client restart or reconnect
+   delay.
+
+Long-lived WebSocket sessions should be closed gracefully when their credential
+is revoked. The current adapter contract supports this at the binding layer:
+the concrete server can reject new handshakes and close existing sessions using
+a policy close code such as `1008`.
+
+## Graceful Shutdown
+
+For HTTP and WebSocket servers, shutdown should happen in this order:
+
+1. Stop accepting new transport requests.
+2. Request sync workers to stop.
+3. Let in-flight `pull()` / `push()` calls return or hit their transport
+   timeout.
+4. Join worker and listener threads.
+5. Destroy `SyncEngine`, tables, and `Connection` objects.
+
+`SyncWorker::request_stop()` does not interrupt a blocking transport by itself.
+Concrete transport clients should use finite timeouts or their own cancellation
+mechanism.
+
+## Structured Logging
+
+Log transport and worker events with stable fields instead of parsing free-form
+messages. Useful fields are:
+
+- local node and remote authenticated node;
+- `db_id`;
+- direction: pull or push;
+- request ID or trace ID;
+- HTTP status or WebSocket close code;
+- pulled, applied, skipped, and rejected batch counts;
+- worker stage and catch-up progress when available.
+
+Avoid logging raw keys, values, bearer tokens, or full serialized sync bodies in
+normal production logs.
+
+## Offline and Corporate Builds
+
+Provider functions may call `FetchContent` when a backend dependency target is
+not already available. `find_package(mdbx_containers CONFIG REQUIRED)` itself
+does not fetch transport dependencies; fetching starts only after calling a
+`*_transport_provide()` function.
+
+For offline or controlled builds, prefer one of these approaches:
+
+- provide dependency targets before calling the provider function;
+- set `FETCHCONTENT_SOURCE_DIR_<NAME>` cache variables to audited source trees;
+- mirror the dependency repositories and override `GIT_REPOSITORY` variables in
+  the corresponding dependency helper;
+- vendor the dependency in the parent project and expose compatible CMake
+  targets.
+
+The provider target should remain the only target linked by application code.
+This keeps `MDBXC_SYNC_ENABLED`, backend feature macros, include directories,
+libraries, and C++ standard requirements in one place.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -660,6 +660,10 @@ and propagate the matching `MDBXC_HAS_*_TRANSPORT` macro. This keeps installed
 packages relocatable while preserving the same target-based usage model as the
 source-tree examples and tests.
 
+Production deployment details for TLS/WSS, token rotation, graceful shutdown,
+structured logging, and offline dependency management are kept in
+`guides/sync-transport-production.md`.
+
 ## Why `prune_up_to` uses cursor walk + `MDBX_NEXT`
 
 MDBX has no batch "delete by key range" primitive. The supported pattern


### PR DESCRIPTION
## Summary

- add production-facing notes for optional sync transports
- document TLS/WSS deployment boundaries, token rotation, graceful shutdown, structured logging, and offline dependency setup
- link the guide from README, README-RU, and sync DESIGN

## Validation

- `git diff --check`

## Stack

- base PR: #131