### PR TITLE
feat(sync): expose transport retry hints

### DIFF
--- a/guides/sync-transport-production.md
+++ b/guides/sync-transport-production.md
@@ -66,6 +66,33 @@ destructor may still wait until a transport that ignores or cannot complete
 cancellation returns. Concrete transport clients should use finite timeouts or
 their own socket-level cancellation mechanism.
 
+## Retry Policy
+
+HTTP and WebSocket adapters expose retry classification helpers, but they do
+not own a global retry scheduler. The core worker backoff loop remains the
+portable fallback for failed rounds.
+
+For HTTP, transport status and sync DTO status are separate:
+
+- HTTP `2xx` means the transport request succeeded;
+- the decoded `PullResponse::ok` or `PushResponse::ok` still reports sync-level
+  success or conflict;
+- HTTP `408`, `425`, `429`, `500`, `502`, `503`, and `504` are retryable by
+  default;
+- HTTP policy/framing failures such as `400`, `401`, `403`, `413`, and `415`
+  are permanent until the caller changes credentials, DB access, route, or
+  payload size.
+
+Use `http_sync_retry_hint()` when an adapter needs one object containing the
+retryable flag plus an optional relative `Retry-After` delay. The helper parses
+only `Retry-After: <delta-seconds>`; concrete HTTP bindings should handle
+absolute HTTP-date values if they need clock-aware behavior.
+
+For WebSocket, close codes `1001`, `1005`, `1006`, `1011`, `1012`, `1013`, and
+`1014` are retryable by default. Close codes produced by policy, malformed
+payload, and size limits, such as `1007`, `1008`, and `1009`, are permanent
+until the request or session changes.
+
 ## Structured Logging
 
 Log transport and worker events with stable fields instead of parsing free-form

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -576,12 +576,15 @@ transport statuses by default. Auth, authorization, routing, content-type,
 payload-size, and malformed-body errors (`400`, `401`, `403`, `404`, `405`,
 `413`, `415`) are permanent for the current request unless a higher-level
 adapter refreshes credentials or changes the request. `Retry-After` is advisory
-transport metadata; `SyncWorker` backoff remains the core retry loop for failed
+transport metadata; `http_sync_retry_hint()` exposes relative
+`Retry-After: <delta-seconds>` values without parsing HTTP-date clock policy.
+`SyncWorker` backoff remains the core retry loop for failed
 sync rounds. For WebSocket, close code `1000` is success; `1001`, local
 observations `1005`/`1006`, and server/transient codes `1011`, `1012`, `1013`,
 and `1014` are retryable by default. Policy, malformed payload, and oversized
 message codes such as `1007`, `1008`, and `1009` are permanent for the current
-request.
+request. `websocket_sync_retry_hint()` exposes the same retryable flag for
+concrete bindings that report close codes.
 
 `ChangeBatchCodec` already rejects `BATCH_COMPRESSED_ZSTD` at both
 encode and decode paths. Adding a real `zstd` backend is a codec

--- a/include/mdbx_containers/sync/TransportMiddleware.hpp
+++ b/include/mdbx_containers/sync/TransportMiddleware.hpp
@@ -71,6 +71,65 @@ namespace sync {
                HttpSyncRetryClass::Retryable;
     }
 
+    /// \brief Adapter-level retry hint for transport failures.
+    /// \details \c retry_after_seconds is present only when a transport
+    /// supplied a supported relative retry delay such as HTTP
+    /// \c Retry-After: <delta-seconds>. Absolute HTTP-date values are
+    /// intentionally left to concrete HTTP bindings that own clock policy.
+    struct SyncTransportRetryHint {
+        bool retryable = false;
+        bool has_retry_after = false;
+        std::uint64_t retry_after_seconds = 0;
+    };
+
+    inline bool parse_http_retry_after_delta_seconds(
+            const std::string& value,
+            std::uint64_t& seconds) {
+        if (value.empty()) {
+            return false;
+        }
+
+        std::uint64_t out = 0;
+        for (std::size_t i = 0; i < value.size(); ++i) {
+            const char ch = value[i];
+            if (ch < '0' || ch > '9') {
+                return false;
+            }
+            const std::uint64_t digit =
+                static_cast<std::uint64_t>(ch - '0');
+            if (out >
+                    (std::numeric_limits<std::uint64_t>::max() - digit) /
+                        10u) {
+                return false;
+            }
+            out = out * 10u + digit;
+        }
+
+        seconds = out;
+        return true;
+    }
+
+    /// \brief Builds retry advice from an HTTP sync response.
+    /// \details Successful and permanent statuses are never marked retryable.
+    /// Retryable statuses preserve an optional relative \c Retry-After value.
+    inline SyncTransportRetryHint http_sync_retry_hint(
+            const HttpSyncResponse& response) {
+        SyncTransportRetryHint hint;
+        hint.retryable = http_sync_status_is_retryable(response.status_code);
+        if (!hint.retryable) {
+            return hint;
+        }
+
+        const std::string retry_after =
+            http_header_value(response.headers, "Retry-After");
+        std::uint64_t seconds = 0;
+        if (parse_http_retry_after_delta_seconds(retry_after, seconds)) {
+            hint.has_retry_after = true;
+            hint.retry_after_seconds = seconds;
+        }
+        return hint;
+    }
+
     /// \brief Retry classification for adapter-level WebSocket close codes.
     enum class WebSocketSyncCloseRetryClass : std::uint8_t {
         Success,
@@ -104,6 +163,15 @@ namespace sync {
             unsigned close_code) {
         return classify_websocket_sync_close_code(close_code) ==
                WebSocketSyncCloseRetryClass::Retryable;
+    }
+
+    /// \brief Builds retry advice from a WebSocket close code.
+    inline SyncTransportRetryHint websocket_sync_retry_hint(
+            unsigned close_code) {
+        SyncTransportRetryHint hint;
+        hint.retryable =
+            websocket_sync_close_code_is_retryable(close_code);
+        return hint;
     }
 
     /// \brief Result returned by a transport policy.

--- a/tests/test_transport_middleware.cpp
+++ b/tests/test_transport_middleware.cpp
@@ -529,6 +529,45 @@ void test_http_retry_status_classification() {
                  "HTTP 413 must be permanent");
 }
 
+void test_http_retry_hint() {
+    mdbxc::sync::HttpSyncResponse response;
+    response.status_code = 429;
+    mdbxc::sync::http_add_header(
+        response.headers, "Retry-After", "17");
+
+    mdbxc::sync::SyncTransportRetryHint hint =
+        mdbxc::sync::http_sync_retry_hint(response);
+    require_true(hint.retryable, "HTTP 429 hint must be retryable");
+    require_true(hint.has_retry_after,
+                 "HTTP 429 hint must preserve Retry-After");
+    require_true(hint.retry_after_seconds == 17u,
+                 "HTTP Retry-After seconds parsed incorrectly");
+
+    response.headers.clear();
+    mdbxc::sync::http_add_header(
+        response.headers, "Retry-After", "soon");
+    hint = mdbxc::sync::http_sync_retry_hint(response);
+    require_true(hint.retryable,
+                 "invalid Retry-After must not change retryable status");
+    require_true(!hint.has_retry_after,
+                 "invalid Retry-After must be ignored");
+
+    response.status_code = 200;
+    response.headers.clear();
+    mdbxc::sync::http_add_header(
+        response.headers, "Retry-After", "5");
+    hint = mdbxc::sync::http_sync_retry_hint(response);
+    require_true(!hint.retryable,
+                 "HTTP 200 hint must not be retryable");
+    require_true(!hint.has_retry_after,
+                 "HTTP 200 hint must ignore Retry-After");
+
+    response.status_code = 401;
+    hint = mdbxc::sync::http_sync_retry_hint(response);
+    require_true(!hint.retryable,
+                 "HTTP 401 hint must not be retryable");
+}
+
 void test_websocket_close_code_classification() {
     require_true(mdbxc::sync::classify_websocket_sync_close_code(1000) ==
                      mdbxc::sync::WebSocketSyncCloseRetryClass::Success,
@@ -545,6 +584,19 @@ void test_websocket_close_code_classification() {
                  "WebSocket 1008 must be permanent");
     require_true(!mdbxc::sync::websocket_sync_close_code_is_retryable(1009),
                  "WebSocket 1009 must be permanent");
+}
+
+void test_websocket_retry_hint() {
+    mdbxc::sync::SyncTransportRetryHint hint =
+        mdbxc::sync::websocket_sync_retry_hint(1011);
+    require_true(hint.retryable,
+                 "WebSocket 1011 hint must be retryable");
+    require_true(!hint.has_retry_after,
+                 "WebSocket hint must not invent Retry-After");
+
+    hint = mdbxc::sync::websocket_sync_retry_hint(1008);
+    require_true(!hint.retryable,
+                 "WebSocket 1008 hint must be permanent");
 }
 
 void test_transport_message_size_policy() {
@@ -649,7 +701,9 @@ int main() {
     test_http_bearer_node_identity_policy();
     test_http_bearer_node_identity_policy_rejects_invalid_body();
     test_http_retry_status_classification();
+    test_http_retry_hint();
     test_websocket_close_code_classification();
+    test_websocket_retry_hint();
     test_transport_message_size_policy();
     test_http_client_middleware_copies_rejection_headers();
     test_http_server_middleware_copies_rejection_headers();


### PR DESCRIPTION
## Summary

- add `SyncTransportRetryHint` for adapter-level retry advice
- expose HTTP retry hints with relative `Retry-After: <delta-seconds>` parsing
- expose WebSocket retry hints from close code classification
- document retry policy in DESIGN and production notes
- add regression coverage for retryable/permanent HTTP and WebSocket cases

## Validation

- `cmake -S . -B tmp/pr133-cpp11-mingw -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=OFF -DCMAKE_CXX_STANDARD=11 -Wno-dev`
- `cmake --build tmp/pr133-cpp11-mingw --target test_transport_middleware --parallel`
- `ctest --test-dir tmp/pr133-cpp11-mingw -R test_transport_middleware --output-on-failure`
- `git diff --check`

## Stack

- base PR: #132
