### PR TITLE
feat(sync): expose transport trace observer hooks

### DIFF
--- a/guides/sync-transport-production.md
+++ b/guides/sync-transport-production.md
@@ -101,10 +101,15 @@ messages. Useful fields are:
 - local node and remote authenticated node;
 - `db_id`;
 - direction: pull or push;
-- request ID or trace ID;
+- request ID or trace ID from `SyncTransportTraceContext`;
 - HTTP status or WebSocket close code;
 - pulled, applied, skipped, and rejected batch counts;
 - worker stage and catch-up progress when available.
+
+HTTP middleware reports incoming request context to observers before policy
+dispatch, so logging can include request/trace ids for accepted and rejected
+requests. WebSocket middleware does the same with `WebSocketSyncRequestContext`
+when the concrete binding fills its adapter-local trace fields.
 
 Avoid logging raw keys, values, bearer tokens, or full serialized sync bodies in
 normal production logs.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -667,6 +667,13 @@ Production deployment details for TLS/WSS, token rotation, graceful shutdown,
 structured logging, and offline dependency management are kept in
 `guides/sync-transport-production.md`.
 
+Request and trace ids are adapter-local metadata. HTTP bindings carry them in
+`X-MDBXC-Sync-Request-Id` and `X-MDBXC-Sync-Trace-Id`; WebSocket bindings may
+copy equivalent handshake or session metadata into
+`WebSocketSyncRequestContext`. `SyncTransportTraceContext` and the
+`*_sync_trace_context()` helpers expose those fields to observers without
+adding them to `TransportMessageCodec` DTOs.
+
 ## Why `prune_up_to` uses cursor walk + `MDBX_NEXT`
 
 MDBX has no batch "delete by key range" primitive. The supported pattern

--- a/include/mdbx_containers/sync/TransportMiddleware.hpp
+++ b/include/mdbx_containers/sync/TransportMiddleware.hpp
@@ -257,7 +257,45 @@ namespace sync {
         NodeId authenticated_node{};
         SyncDbAccess db_access;
         std::vector<std::uint8_t> binary_message;
+        std::string request_id;
+        std::string trace_id;
     };
+
+    /// \brief Adapter-local trace identifiers for logging and metrics.
+    /// \details These fields are never serialized into sync DTOs. HTTP
+    /// adapters usually get them from headers, while WebSocket bindings may
+    /// copy them from handshake metadata or framework session context.
+    struct SyncTransportTraceContext {
+        std::string request_id;
+        std::string trace_id;
+
+        bool empty() const {
+            return request_id.empty() && trace_id.empty();
+        }
+    };
+
+    inline SyncTransportTraceContext http_sync_trace_context(
+            const std::vector<HttpSyncHeader>& headers) {
+        SyncTransportTraceContext out;
+        out.request_id =
+            http_header_value(headers, HttpSyncHeaders::request_id());
+        out.trace_id =
+            http_header_value(headers, HttpSyncHeaders::trace_id());
+        return out;
+    }
+
+    inline SyncTransportTraceContext http_sync_trace_context(
+            const HttpSyncRequest& request) {
+        return http_sync_trace_context(request.headers);
+    }
+
+    inline SyncTransportTraceContext websocket_sync_trace_context(
+            const WebSocketSyncRequestContext& request) {
+        SyncTransportTraceContext out;
+        out.request_id = request.request_id;
+        out.trace_id = request.trace_id;
+        return out;
+    }
 
     /// \brief Policy hook for sync transport requests.
     /// \details Default methods allow every request. Implementations may
@@ -1063,6 +1101,8 @@ namespace sync {
         std::uint64_t rejected_calls = 0;
         std::uint64_t failed_calls = 0;
         std::uint64_t request_cancel_calls = 0;
+        std::uint64_t http_request_calls = 0;
+        std::uint64_t websocket_message_calls = 0;
         std::uint64_t pulled_batches = 0;
         std::uint64_t pushed_batches = 0;
     };
@@ -1095,11 +1135,21 @@ namespace sync {
             (void)response;
         }
 
+        virtual void on_sync_transport_http_request(
+                const HttpSyncRequest& request) {
+            (void)request;
+        }
+
         virtual void on_sync_transport_http_post_result(
                 const std::string& target,
                 const HttpSyncResponse& response) {
             (void)target;
             (void)response;
+        }
+
+        virtual void on_sync_transport_websocket_message(
+                const WebSocketSyncRequestContext& request) {
+            (void)request;
         }
 
         virtual void on_sync_transport_exception(
@@ -1160,6 +1210,13 @@ namespace sync {
             m_snapshot.pushed_batches += request.batches.size();
         }
 
+        void on_sync_transport_http_request(
+                const HttpSyncRequest& request) override {
+            (void)request;
+            std::lock_guard<std::mutex> lock(m_mutex);
+            ++m_snapshot.http_request_calls;
+        }
+
         void on_sync_transport_http_post_result(
                 const std::string& target,
                 const HttpSyncResponse& response) override {
@@ -1169,6 +1226,13 @@ namespace sync {
             if (response.status_code < 200 || response.status_code >= 300) {
                 ++m_snapshot.failed_calls;
             }
+        }
+
+        void on_sync_transport_websocket_message(
+                const WebSocketSyncRequestContext& request) override {
+            (void)request;
+            std::lock_guard<std::mutex> lock(m_mutex);
+            ++m_snapshot.websocket_message_calls;
         }
 
         void on_sync_transport_exception(
@@ -1223,6 +1287,28 @@ namespace sync {
             }
             try {
                 observer->on_sync_transport_cancel_requested();
+            } catch (...) {}
+        }
+
+        inline void notify_transport_http_request(
+                ISyncTransportObserver* observer,
+                const HttpSyncRequest& request) {
+            if (observer == nullptr) {
+                return;
+            }
+            try {
+                observer->on_sync_transport_http_request(request);
+            } catch (...) {}
+        }
+
+        inline void notify_transport_websocket_message(
+                ISyncTransportObserver* observer,
+                const WebSocketSyncRequestContext& request) {
+            if (observer == nullptr) {
+                return;
+            }
+            try {
+                observer->on_sync_transport_websocket_message(request);
             } catch (...) {}
         }
 
@@ -1372,6 +1458,7 @@ namespace sync {
               m_observer(observer) {}
 
         HttpSyncResponse handle(const HttpSyncRequest& request) {
+            detail::notify_transport_http_request(m_observer, request);
             if (m_policy != nullptr) {
                 const SyncTransportDecision decision =
                     m_policy->check_http_request(request);
@@ -1436,6 +1523,7 @@ namespace sync {
 
         std::vector<std::uint8_t> handle_binary_message(
                 const WebSocketSyncRequestContext& request) {
+            detail::notify_transport_websocket_message(m_observer, request);
             if (m_policy != nullptr) {
                 const SyncTransportDecision decision =
                     m_policy->check_websocket_message(request);

--- a/tests/header_sync_transport_umbrella_test.cpp
+++ b/tests/header_sync_transport_umbrella_test.cpp
@@ -54,6 +54,18 @@ int main() {
     websocket_context.db_access = mdbxc::sync::SyncDbAccess::only(node);
     websocket_context.binary_message = encoded;
 
+#if __cplusplus >= 201402L
+    const mdbxc::sync::WebSocketSyncRequestContext legacy_context = {
+        true,
+        node,
+        mdbxc::sync::SyncDbAccess::only(node),
+        encoded
+    };
+    MDBXC_TEST_ASSERT(legacy_context.binary_message == encoded);
+    MDBXC_TEST_ASSERT(legacy_context.request_id.empty());
+    MDBXC_TEST_ASSERT(legacy_context.trace_id.empty());
+#endif
+
     mdbxc::sync::WebSocketAuthenticatedNodeIdentityPolicy websocket_policy;
     MDBXC_TEST_ASSERT(
         websocket_policy.check_websocket_message(websocket_context).allowed);

--- a/tests/test_transport_middleware.cpp
+++ b/tests/test_transport_middleware.cpp
@@ -123,6 +123,12 @@ private:
 
 class ThrowingObserver : public mdbxc::sync::ISyncTransportObserver {
 public:
+    void on_sync_transport_http_request(
+            const mdbxc::sync::HttpSyncRequest& request) override {
+        (void)request;
+        throw std::runtime_error("observer request failure");
+    }
+
     void on_sync_transport_pull_result(
             const mdbxc::sync::PullRequest& request,
             const mdbxc::sync::PullResponse& response) override {
@@ -138,6 +144,42 @@ public:
         (void)error;
         throw std::runtime_error("observer rejection failure");
     }
+};
+
+class RequestContextObserver : public mdbxc::sync::ISyncTransportObserver {
+public:
+    RequestContextObserver()
+        : m_http_requests(0), m_websocket_messages(0) {}
+
+    void on_sync_transport_http_request(
+            const mdbxc::sync::HttpSyncRequest& request) override {
+        ++m_http_requests;
+        m_http_trace = mdbxc::sync::http_sync_trace_context(request);
+    }
+
+    void on_sync_transport_websocket_message(
+            const mdbxc::sync::WebSocketSyncRequestContext& request) override {
+        ++m_websocket_messages;
+        m_websocket_trace =
+            mdbxc::sync::websocket_sync_trace_context(request);
+    }
+
+    std::size_t http_requests() const { return m_http_requests; }
+    std::size_t websocket_messages() const {
+        return m_websocket_messages;
+    }
+    const mdbxc::sync::SyncTransportTraceContext& http_trace() const {
+        return m_http_trace;
+    }
+    const mdbxc::sync::SyncTransportTraceContext& websocket_trace() const {
+        return m_websocket_trace;
+    }
+
+private:
+    std::size_t m_http_requests;
+    std::size_t m_websocket_messages;
+    mdbxc::sync::SyncTransportTraceContext m_http_trace;
+    mdbxc::sync::SyncTransportTraceContext m_websocket_trace;
 };
 
 void test_peer_middleware_allows_limits_and_observes() {
@@ -198,6 +240,109 @@ void test_peer_middleware_allows_limits_and_observes() {
                  "pulled batch metric mismatch");
     require_true(snapshot.pushed_batches == 1u,
                  "pushed batch metric mismatch");
+}
+
+void test_transport_trace_context_helpers() {
+    mdbxc::sync::HttpSyncRequest request;
+    mdbxc::sync::http_add_header(
+        request.headers, mdbxc::sync::HttpSyncHeaders::request_id(),
+        "http-request");
+    mdbxc::sync::http_add_header(
+        request.headers, mdbxc::sync::HttpSyncHeaders::trace_id(),
+        "http-trace");
+
+    mdbxc::sync::SyncTransportTraceContext trace =
+        mdbxc::sync::http_sync_trace_context(request);
+    require_true(!trace.empty(), "HTTP trace context must not be empty");
+    require_true(trace.request_id == "http-request",
+                 "HTTP request id was not extracted");
+    require_true(trace.trace_id == "http-trace",
+                 "HTTP trace id was not extracted");
+
+    mdbxc::sync::WebSocketSyncRequestContext websocket;
+    websocket.request_id = "ws-request";
+    websocket.trace_id = "ws-trace";
+    trace = mdbxc::sync::websocket_sync_trace_context(websocket);
+    require_true(trace.request_id == "ws-request",
+                 "WebSocket request id was not extracted");
+    require_true(trace.trace_id == "ws-trace",
+                 "WebSocket trace id was not extracted");
+}
+
+void test_transport_observer_receives_request_context() {
+    const std::string http_path =
+        "test_transport_middleware_http_trace.mdbx";
+    cleanup(http_path);
+
+    std::shared_ptr<mdbxc::Connection> http_db = open_db(http_path);
+    mdbxc::sync::SyncEngine http_engine(http_db);
+    mdbxc::sync::HttpSyncServer http_server(http_engine);
+    RequestContextObserver observer;
+    mdbxc::sync::HttpSyncServerMiddleware http_middleware(
+        http_server, nullptr, &observer);
+
+    mdbxc::sync::HttpSyncRequest http_request;
+    http_request.method = "GET";
+    http_request.target = mdbxc::sync::HttpSyncRoutes::pull_target();
+    mdbxc::sync::http_add_header(
+        http_request.headers, mdbxc::sync::HttpSyncHeaders::request_id(),
+        "middleware-http-request");
+    mdbxc::sync::http_add_header(
+        http_request.headers, mdbxc::sync::HttpSyncHeaders::trace_id(),
+        "middleware-http-trace");
+
+    const mdbxc::sync::HttpSyncResponse http_response =
+        http_middleware.handle(http_request);
+    require_true(http_response.status_code == 405,
+                 "HTTP middleware trace test expected method rejection");
+    require_true(observer.http_requests() == 1u,
+                 "observer did not see HTTP request context");
+    require_true(observer.http_trace().request_id ==
+                     "middleware-http-request",
+                 "observer did not receive HTTP request id");
+    require_true(observer.http_trace().trace_id ==
+                     "middleware-http-trace",
+                 "observer did not receive HTTP trace id");
+
+    http_db->disconnect();
+    cleanup(http_path);
+
+    const std::string ws_path =
+        "test_transport_middleware_ws_trace.mdbx";
+    cleanup(ws_path);
+
+    std::shared_ptr<mdbxc::Connection> ws_db = open_db(ws_path);
+    mdbxc::sync::SyncEngine ws_engine(ws_db);
+    mdbxc::sync::WebSocketSyncServer ws_server(ws_engine);
+    mdbxc::sync::TransportMessageSizePolicy reject_oversized(1u);
+    mdbxc::sync::WebSocketSyncServerMiddleware ws_middleware(
+        ws_server, &reject_oversized, &observer);
+
+    mdbxc::sync::WebSocketSyncRequestContext ws_request;
+    ws_request.request_id = "middleware-ws-request";
+    ws_request.trace_id = "middleware-ws-trace";
+    ws_request.binary_message.push_back(0x42u);
+    ws_request.binary_message.push_back(0x43u);
+
+    bool rejected = false;
+    try {
+        (void)ws_middleware.handle_binary_message(ws_request);
+    } catch (const mdbxc::sync::WebSocketSyncRejected&) {
+        rejected = true;
+    }
+    require_true(rejected,
+                 "WebSocket middleware trace test expected rejection");
+    require_true(observer.websocket_messages() == 1u,
+                 "observer did not see WebSocket message context");
+    require_true(observer.websocket_trace().request_id ==
+                     "middleware-ws-request",
+                 "observer did not receive WebSocket request id");
+    require_true(observer.websocket_trace().trace_id ==
+                     "middleware-ws-trace",
+                 "observer did not receive WebSocket trace id");
+
+    ws_db->disconnect();
+    cleanup(ws_path);
 }
 
 void test_observer_exceptions_are_swallowed() {
@@ -693,6 +838,8 @@ void test_http_server_middleware_copies_rejection_headers() {
 
 int main() {
     test_peer_middleware_allows_limits_and_observes();
+    test_transport_trace_context_helpers();
+    test_transport_observer_receives_request_context();
     test_observer_exceptions_are_swallowed();
     test_http_client_middleware_route_policy();
     test_http_client_middleware_budget_policy();


### PR DESCRIPTION
## Summary

- add `SyncTransportTraceContext` helpers for HTTP headers and WebSocket request contexts
- let WebSocket request contexts carry adapter-local request/trace ids
- add observer hooks for incoming HTTP requests and WebSocket messages before policy dispatch
- count those hooks in `SyncTransportMetricsObserver`
- document trace metadata as adapter-local logging context

## Validation

- `cmake -S . -B tmp/pr134-cpp11-mingw -G "MinGW Makefiles" -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=OFF -DCMAKE_CXX_STANDARD=11 -Wno-dev`
- `cmake --build tmp/pr134-cpp11-mingw --target test_transport_middleware --parallel`
- `ctest --test-dir tmp/pr134-cpp11-mingw -R test_transport_middleware --output-on-failure`
- `git diff --check`

## Stack

- base PR: #133
