### PR TITLE
feat(sync): define peer retry hint contract

### DIFF
--- a/guides/sync-transport-production.md
+++ b/guides/sync-transport-production.md
@@ -93,6 +93,18 @@ For WebSocket, close codes `1001`, `1005`, `1006`, `1011`, `1012`, `1013`, and
 payload, and size limits, such as `1007`, `1008`, and `1009`, are permanent
 until the request or session changes.
 
+Concrete `ISyncPeer` implementations that can classify transport failures
+should publish the most recent hint through `ISyncPeer::last_retry_hint()`.
+The default hint is unavailable, which means the peer did not provide advice
+and callers should keep using their fallback retry policy. Successful
+operations should clear older hints so a later caller does not mistake stale
+advice for the current failure. When a peer returns `available=true` and
+`retryable=false`, it classified the current transport failure as permanent.
+Successful transport responses should clear back to an unavailable hint because
+there is no failure to classify.
+The hint is intentionally advisory: applications may cap, ignore, or combine it
+with their own retry and circuit-breaker policy.
+
 ## Structured Logging
 
 Log transport and worker events with stable fields instead of parsing free-form

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -586,6 +586,19 @@ message codes such as `1007`, `1008`, and `1009` are permanent for the current
 request. `websocket_sync_retry_hint()` exposes the same retryable flag for
 concrete bindings that report close codes.
 
+Peers that can classify adapter failures expose the last observed advice
+through `ISyncPeer::last_retry_hint()`. The default implementation returns an
+unavailable hint, so existing peers are source-compatible and callers can keep
+using their fallback retry policy. Concrete peers should set
+`SyncTransportRetryHint::available` when a transport failure was actually
+classified, clear stale retry advice after successful operations, and update it
+after transport-level failures. With `available=true`, `retryable=false` means
+the transport classified the failure as permanent for the current request.
+Successful transport responses are not failures and should clear back to an
+unavailable hint. The hint is advisory: callers may still use their own retry
+scheduler, but `SyncWorker` and examples can consume the same transport-neutral
+shape without depending on HTTP or WebSocket headers.
+
 `ChangeBatchCodec` already rejects `BATCH_COMPRESSED_ZSTD` at both
 encode and decode paths. Adding a real `zstd` backend is a codec
 change and belongs in a separate design pass; it is not part of the

--- a/include/mdbx_containers/sync/ISyncPeer.hpp
+++ b/include/mdbx_containers/sync/ISyncPeer.hpp
@@ -5,10 +5,26 @@
 /// \file ISyncPeer.hpp
 /// \brief Abstract transport-level peer used by \c SyncEngine.
 
+#include <cstdint>
+
 #include "protocol.hpp"
 
 namespace mdbxc {
 namespace sync {
+
+    /// \brief Adapter-level retry hint for transport failures.
+    /// \details \c available distinguishes a peer that did not classify the
+    /// last failure from a peer that explicitly classified it as permanent.
+    /// \c retry_after_seconds is present only when a transport supplied a
+    /// supported relative retry delay such as HTTP
+    /// \c Retry-After: <delta-seconds>. Absolute HTTP-date values are
+    /// intentionally left to concrete bindings that own clock policy.
+    struct SyncTransportRetryHint {
+        bool available = false;
+        bool retryable = false;
+        bool has_retry_after = false;
+        std::uint64_t retry_after_seconds = 0;
+    };
 
     /// \brief Abstract peer that exchanges pull and push requests.
     /// \details Concrete implementations (in-process, HTTP, WebSocket) live
@@ -36,6 +52,16 @@ namespace sync {
         /// peers remain valid. Overrides should return quickly and should not
         /// throw.
         virtual void request_cancel() {}
+
+        /// \brief Returns retry advice for the most recent transport failure.
+        /// \details Peers that can classify adapter failures may override this
+        /// method after a failed \c pull() or \c push(). The default returns an
+        /// unavailable hint. Successful operations should normally clear any
+        /// previous retry advice.
+        /// \return Retry hint for the last observed transport failure.
+        virtual SyncTransportRetryHint last_retry_hint() const {
+            return SyncTransportRetryHint();
+        }
     };
 
 } // namespace sync

--- a/include/mdbx_containers/sync/TransportMiddleware.hpp
+++ b/include/mdbx_containers/sync/TransportMiddleware.hpp
@@ -71,17 +71,6 @@ namespace sync {
                HttpSyncRetryClass::Retryable;
     }
 
-    /// \brief Adapter-level retry hint for transport failures.
-    /// \details \c retry_after_seconds is present only when a transport
-    /// supplied a supported relative retry delay such as HTTP
-    /// \c Retry-After: <delta-seconds>. Absolute HTTP-date values are
-    /// intentionally left to concrete HTTP bindings that own clock policy.
-    struct SyncTransportRetryHint {
-        bool retryable = false;
-        bool has_retry_after = false;
-        std::uint64_t retry_after_seconds = 0;
-    };
-
     inline bool parse_http_retry_after_delta_seconds(
             const std::string& value,
             std::uint64_t& seconds) {
@@ -110,12 +99,20 @@ namespace sync {
     }
 
     /// \brief Builds retry advice from an HTTP sync response.
-    /// \details Successful and permanent statuses are never marked retryable.
-    /// Retryable statuses preserve an optional relative \c Retry-After value.
+    /// \details Successful statuses return an unavailable hint because they
+    /// are not transport failures. Permanent and retryable failures return an
+    /// available hint. Retryable statuses preserve an optional relative
+    /// \c Retry-After value.
     inline SyncTransportRetryHint http_sync_retry_hint(
             const HttpSyncResponse& response) {
         SyncTransportRetryHint hint;
-        hint.retryable = http_sync_status_is_retryable(response.status_code);
+        const HttpSyncRetryClass classification =
+            classify_http_sync_status(response.status_code);
+        if (classification == HttpSyncRetryClass::Success) {
+            return hint;
+        }
+        hint.available = true;
+        hint.retryable = classification == HttpSyncRetryClass::Retryable;
         if (!hint.retryable) {
             return hint;
         }
@@ -169,8 +166,14 @@ namespace sync {
     inline SyncTransportRetryHint websocket_sync_retry_hint(
             unsigned close_code) {
         SyncTransportRetryHint hint;
+        const WebSocketSyncCloseRetryClass classification =
+            classify_websocket_sync_close_code(close_code);
+        if (classification == WebSocketSyncCloseRetryClass::Success) {
+            return hint;
+        }
+        hint.available = true;
         hint.retryable =
-            websocket_sync_close_code_is_retryable(close_code);
+            classification == WebSocketSyncCloseRetryClass::Retryable;
         return hint;
     }
 

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -14,6 +14,21 @@
 #error "header_sync_umbrella_test must be compiled with sync enabled"
 #endif
 
+class HeaderSyncPeer : public mdbxc::sync::ISyncPeer {
+public:
+    mdbxc::sync::PullResponse pull(
+            const mdbxc::sync::PullRequest& request) override {
+        (void)request;
+        return mdbxc::sync::PullResponse();
+    }
+
+    mdbxc::sync::PushResponse push(
+            const mdbxc::sync::PushRequest& request) override {
+        (void)request;
+        return mdbxc::sync::PushResponse();
+    }
+};
+
 int main() {
     mdbxc::sync::NodeId node = mdbxc::sync::make_zero_node();
     MDBXC_TEST_ASSERT(node.size() == 16u);
@@ -57,6 +72,12 @@ int main() {
     MDBXC_TEST_ASSERT(mdbxc::sync::http_sync_status_is_retryable(503));
     MDBXC_TEST_ASSERT(
         mdbxc::sync::websocket_sync_close_code_is_retryable(1013u));
+    HeaderSyncPeer header_peer;
+    const mdbxc::sync::SyncTransportRetryHint default_retry_hint =
+        header_peer.last_retry_hint();
+    MDBXC_TEST_ASSERT(!default_retry_hint.available);
+    MDBXC_TEST_ASSERT(!default_retry_hint.retryable);
+    MDBXC_TEST_ASSERT(!default_retry_hint.has_retry_after);
     mdbxc::sync::TransportMessageSizePolicy size_policy(1024u);
     (void)size_policy;
     mdbxc::sync::IWebSocketSyncChannel* websocket_channel = nullptr;

--- a/tests/test_transport_middleware.cpp
+++ b/tests/test_transport_middleware.cpp
@@ -682,6 +682,7 @@ void test_http_retry_hint() {
 
     mdbxc::sync::SyncTransportRetryHint hint =
         mdbxc::sync::http_sync_retry_hint(response);
+    require_true(hint.available, "HTTP 429 hint must be available");
     require_true(hint.retryable, "HTTP 429 hint must be retryable");
     require_true(hint.has_retry_after,
                  "HTTP 429 hint must preserve Retry-After");
@@ -692,6 +693,8 @@ void test_http_retry_hint() {
     mdbxc::sync::http_add_header(
         response.headers, "Retry-After", "soon");
     hint = mdbxc::sync::http_sync_retry_hint(response);
+    require_true(hint.available,
+                 "invalid Retry-After hint must stay available");
     require_true(hint.retryable,
                  "invalid Retry-After must not change retryable status");
     require_true(!hint.has_retry_after,
@@ -702,6 +705,7 @@ void test_http_retry_hint() {
     mdbxc::sync::http_add_header(
         response.headers, "Retry-After", "5");
     hint = mdbxc::sync::http_sync_retry_hint(response);
+    require_true(!hint.available, "HTTP 200 hint must be unavailable");
     require_true(!hint.retryable,
                  "HTTP 200 hint must not be retryable");
     require_true(!hint.has_retry_after,
@@ -709,6 +713,7 @@ void test_http_retry_hint() {
 
     response.status_code = 401;
     hint = mdbxc::sync::http_sync_retry_hint(response);
+    require_true(hint.available, "HTTP 401 hint must be available");
     require_true(!hint.retryable,
                  "HTTP 401 hint must not be retryable");
 
@@ -747,14 +752,24 @@ void test_websocket_close_code_classification() {
 void test_websocket_retry_hint() {
     mdbxc::sync::SyncTransportRetryHint hint =
         mdbxc::sync::websocket_sync_retry_hint(1011);
+    require_true(hint.available,
+                 "WebSocket 1011 hint must be available");
     require_true(hint.retryable,
                  "WebSocket 1011 hint must be retryable");
     require_true(!hint.has_retry_after,
                  "WebSocket hint must not invent Retry-After");
 
     hint = mdbxc::sync::websocket_sync_retry_hint(1008);
+    require_true(hint.available,
+                 "WebSocket 1008 hint must be available");
     require_true(!hint.retryable,
                  "WebSocket 1008 hint must be permanent");
+
+    hint = mdbxc::sync::websocket_sync_retry_hint(1000);
+    require_true(!hint.available,
+                 "WebSocket 1000 hint must be unavailable");
+    require_true(!hint.retryable,
+                 "WebSocket 1000 hint must not be retryable");
 }
 
 void test_transport_message_size_policy() {


### PR DESCRIPTION
## Summary
- move SyncTransportRetryHint to the peer API surface
- add ISyncPeer::last_retry_hint() as a default no-op retry advice hook
- document how transport adapters should publish and clear retry hints
- add a public umbrella smoke for the default peer hint

## Validation
- cmake configure MinGW C++11/C++17
- build header_sync_umbrella_test, header_sync_transport_umbrella_test, test_transport_middleware in C++11/C++17
- ctest header_sync_umbrella_test, header_sync_transport_umbrella_test, test_transport_middleware in C++11/C++17