### PR TITLE
docs(sync): add v0.1 readiness checklist

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -102,7 +102,9 @@
   готовых transport targets.
   См. [sync transport production notes](guides/sync-transport-production.md)
   про TLS/WSS, ротацию токенов, graceful shutdown, structured logging и
-  offline dependency builds.
+  offline dependency builds. См.
+  [sync v0.1 readiness checklist](guides/sync-v0.1-readiness.md) про текущую
+  матрицу поддержки и отложенные задачи.
   Socket-backed примеры используют эти bindings вместо повторной реализации
   транспорта в каждом файле. Wire-format для специализированных таблиц отложен.
   HTTP auth,

--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@
   transport targets.
   See [sync transport production notes](guides/sync-transport-production.md)
   for TLS/WSS, token rotation, graceful shutdown, structured logging, and
-  offline dependency guidance.
+  offline dependency guidance. See the
+  [sync v0.1 readiness checklist](guides/sync-v0.1-readiness.md) for the
+  current support matrix and deferred work.
   Socket-backed examples use those bindings instead of reimplementing the
   transport in each file. Specialized table wire formats remain deferred.
   HTTP auth, remote-address checks, and rate-limit headers live in

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -1,0 +1,96 @@
+# Sync v0.1 Readiness Checklist
+
+This checklist records the current sync surface after the transport, worker,
+and example hardening pass. It is a release-readiness map, not a stability
+promise: sync remains experimental and opt-in through `MDBXC_SYNC_ENABLED=1`.
+
+## Ready For v0.1 Use
+
+- Supported table capture paths are explicit: `KeyValueTable`, `KeyTable`,
+  `ValueTable`, and `SequenceTable` writes are captured when a
+  `ThreadLocalChangeAccumulator` is attached to the writing `Connection`.
+- `VectorStore` is covered indirectly through its internal `SequenceTable` and
+  `KeyValueTable` members.
+- Standalone writes become standalone sync batches; an explicit transaction
+  spanning multiple supported tables becomes one local atomic batch.
+- Reads, scans, vector search, and other non-mutating APIs are not captured.
+- Remote apply uses `SyncEngine::handle_push()` and commits one pulled page per
+  local transaction.
+- `SyncWorker` owns the background pull loop, pagination, cancellation tokens,
+  observer callbacks, retry backoff, and optional `Retry-After` backoff hints.
+- HTTP and WebSocket framework-neutral seams use `TransportMessageCodec`; DTOs
+  do not carry bearer tokens, cookies, remote addresses, request ids, or trace
+  ids.
+- Ready-made optional backends exist for Simple-Web HTTP, Simple-WebSocket, and
+  Kurlyk/libcurl HTTP through feature-gated provider targets.
+- Installed-package smoke tests cover exported transport provider targets and
+  provider argument validation.
+- Negative wire/transport tests cover malformed DTOs, oversized payloads,
+  response/request mixups, auth/policy rejection, retry classification, and
+  selected cancellation paths.
+
+## Operational Contracts To Preserve
+
+- `SyncWorker`, `SyncEngine`, `ISyncPeer`, and table objects are caller-owned;
+  they must outlive callbacks and in-flight transport calls that can reference
+  them.
+- `SyncWorker` lifecycle methods `start()`, `stop()`, `join()`, and
+  `run_once()` are caller-serialized. State and diagnostics readers are
+  thread-safe.
+- Transport cancellation is best-effort. `request_stop()` cancels the active
+  token and calls `ISyncPeer::request_cancel()`, but shutdown can still wait
+  for a transport that ignores cancellation.
+- `SyncTransportRetryHint` is advisory. `available=false` means the peer did
+  not classify the failure. `available=true, retryable=false` means the peer
+  classified the current transport failure as permanent.
+- Authentication, DB allow-list decisions, request ids, trace ids, rate-limit
+  headers, HTTP status, and WebSocket close codes remain adapter-local
+  metadata.
+- `PullRequest::requester` and `PushRequest::sender` still need to match the
+  authenticated transport identity before a production endpoint dispatches to
+  `SyncEngine`.
+
+## Deferred Table Work
+
+These table families intentionally emit no `ChangeOp` in v0.1:
+
+- `AnyValueTable`, until a wire-level type tag and compatibility policy is
+  specified.
+- `KeyMultiValueTable`, until DUPSORT duplicate framing and multiplicity
+  semantics are specified.
+- `HashedKeyValueStore`, until the relationship between logical key bytes,
+  physical storage keys, and hash-index entries is specified.
+
+Do not add `record_op()` calls to these tables until their wire format and
+round-trip tests exist. A partial capture path is worse than no capture because
+it can make replication appear successful while logical state diverges.
+
+## Suggested Next PRs
+
+- Add a thread-safe `SyncWorker` status snapshot for UI/logging code that does
+  not want to reconstruct state from observer callbacks.
+- Add explicit worker retry policy options for callers that want permanent
+  transport hints to stop the background loop instead of remaining advisory.
+- Add small ergonomics helpers around capture attachment and common worker
+  setup if examples continue to repeat the same lifecycle boilerplate.
+- Start specialized table sync design with `KeyMultiValueTable`, then evaluate
+  whether the same framing ideas carry over to `AnyValueTable` and
+  `HashedKeyValueStore`.
+
+## Validation Baseline
+
+Before declaring a sync-facing change ready, run the narrow affected tests in
+both C++11 and C++17. For shared sync headers and transport contracts, include:
+
+```text
+header_sync_umbrella_test
+header_sync_transport_umbrella_test
+test_transport_middleware
+test_http_transport
+test_websocket_transport
+test_sync_worker
+test_sync_replication
+```
+
+For benchmark or backend-provider changes, also run the dedicated benchmark,
+installed-package, and backend smoke jobs or their local equivalents.


### PR DESCRIPTION
## Summary
- add a sync v0.1 readiness checklist covering supported capture paths, operational contracts, deferred table work, and validation baseline
- link the checklist from English and Russian README sync sections

## Validation
- documentation-only change; reviewed markdown diff