### PR TITLE
feat(sync): expose worker status snapshot

### DIFF
--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -18,6 +18,9 @@ promise: sync remains experimental and opt-in through `MDBXC_SYNC_ENABLED=1`.
   local transaction.
 - `SyncWorker` owns the background pull loop, pagination, cancellation tokens,
   observer callbacks, retry backoff, and optional `Retry-After` backoff hints.
+- `SyncWorker::status()` exposes a thread-safe snapshot for polling UIs,
+  health endpoints, and structured logging code that do not subscribe to
+  observer callbacks.
 - HTTP and WebSocket framework-neutral seams use `TransportMessageCodec`; DTOs
   do not carry bearer tokens, cookies, remote addresses, request ids, or trace
   ids.
@@ -67,8 +70,6 @@ it can make replication appear successful while logical state diverges.
 
 ## Suggested Next PRs
 
-- Add a thread-safe `SyncWorker` status snapshot for UI/logging code that does
-  not want to reconstruct state from observer callbacks.
 - Add explicit worker retry policy options for callers that want permanent
   transport hints to stop the background loop instead of remaining advisory.
 - Add small ergonomics helpers around capture attachment and common worker

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -598,9 +598,12 @@ Successful transport responses are not failures and should clear back to an
 unavailable hint. The hint is advisory: callers may still use their own retry
 scheduler, but `SyncWorker` and examples consume the same transport-neutral
 shape without depending on HTTP or WebSocket headers. Worker round and stage
-events carry the latest hint for failed pulls. In background mode, an available
-retryable hint with relative `Retry-After` overrides the current exponential
-delay for that backoff wait, capped by `SyncWorkerOptions::max_backoff`.
+events carry the latest hint for failed pulls. `SyncWorker::status()` exposes a
+thread-safe snapshot for polling UIs, health endpoints, and structured logging
+code that does not want to reconstruct state from observer callbacks. In
+background mode, an available retryable hint with relative `Retry-After`
+overrides the current exponential delay for that backoff wait, capped by
+`SyncWorkerOptions::max_backoff`.
 
 `ChangeBatchCodec` already rejects `BATCH_COMPRESSED_ZSTD` at both
 encode and decode paths. Adding a real `zstd` backend is a codec

--- a/include/mdbx_containers/sync/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/SyncWorker.hpp
@@ -120,6 +120,37 @@ namespace sync {
         SyncTransportRetryHint retry_hint; ///< Transport retry advice.
     };
 
+    /// \brief Thread-safe snapshot of the current \c SyncWorker status.
+    /// \details The snapshot is intended for polling UIs, health endpoints,
+    /// and structured logging code that does not want to reconstruct state
+    /// from observer callbacks. Time points use the process-local steady
+    /// clock and are meaningful only for elapsed-time calculations inside the
+    /// current process.
+    struct SyncWorkerStatus {
+        SyncWorkerState state =
+            SyncWorkerState::Stopped; ///< Current lifecycle state.
+        SyncWorkerStage current_stage =
+            SyncWorkerStage::RoundCompleted; ///< Last observed stage.
+        bool last_stage_known = false; ///< Whether \c last_stage is valid.
+        bool last_round_known = false; ///< Whether \c last_round is valid.
+        bool round_active = false; ///< A round has started and not completed.
+        bool backoff_active = false; ///< Worker is currently in backoff wait.
+        std::uint64_t rounds_started = 0; ///< Rounds started in this session.
+        std::uint64_t rounds_completed = 0; ///< Rounds completed in this session.
+        std::uint64_t rounds_succeeded = 0; ///< Successful completed rounds.
+        std::uint64_t rounds_failed = 0; ///< Failed completed rounds.
+        SyncWorkerStageEvent last_stage; ///< Last reported stage event.
+        SyncWorkerRoundResult last_round; ///< Last completed round result.
+        SyncWorkerProgressEstimate last_progress; ///< Last known progress.
+        SyncTransportRetryHint last_retry_hint; ///< Last known retry hint.
+        std::chrono::milliseconds last_backoff_delay =
+            std::chrono::milliseconds::zero(); ///< Last scheduled backoff.
+        std::chrono::steady_clock::time_point last_round_started_at;
+        std::chrono::steady_clock::time_point last_round_finished_at;
+        std::string last_error; ///< Most recent worker failure message.
+        std::string last_observer_error; ///< Most recent observer failure.
+    };
+
     /// \brief Details for a successfully applied page.
     struct SyncWorkerPageEvent {
         std::size_t pages_pulled = 0; ///< 1-based page count in the round.
@@ -239,6 +270,7 @@ namespace sync {
                 m_last_error.clear();
                 m_last_observer_error.clear();
                 m_state = SyncWorkerState::Starting;
+                reset_status_locked();
             }
             m_state_changed.notify_all();
             try {
@@ -319,6 +351,7 @@ namespace sync {
                 m_peer_cancel_requested = false;
                 m_last_error.clear();
                 m_last_observer_error.clear();
+                reset_status_locked();
             }
             const SyncWorkerRoundResult result = run_once_impl();
             notify_round_completed(result);
@@ -359,6 +392,16 @@ namespace sync {
         std::string last_observer_error() const {
             std::lock_guard<std::mutex> lock(m_mutex);
             return m_last_observer_error;
+        }
+
+        /// \brief Returns a thread-safe snapshot of worker status.
+        SyncWorkerStatus status() const {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            SyncWorkerStatus snapshot = m_status;
+            snapshot.state = m_state;
+            snapshot.last_error = m_last_error;
+            snapshot.last_observer_error = m_last_observer_error;
+            return snapshot;
         }
 
         /// \brief Waits until \p desired is observed or \p timeout expires.
@@ -684,6 +727,7 @@ namespace sync {
         }
 
         void notify_stage_changed(const SyncWorkerStageEvent& event) const {
+            record_stage_status(event);
             if (m_options.observer == nullptr) {
                 return;
             }
@@ -711,6 +755,7 @@ namespace sync {
 
         void notify_round_completed(
                 const SyncWorkerRoundResult& result) const {
+            record_round_status(result);
             notify_stage_changed(make_stage_event(
                 SyncWorkerStage::RoundCompleted, result));
             if (m_options.observer == nullptr) {
@@ -727,6 +772,7 @@ namespace sync {
 
         void notify_backoff(const SyncWorkerRoundResult& result,
                             std::chrono::milliseconds delay) const {
+            record_backoff_status(delay);
             SyncWorkerStageEvent event = make_stage_event(
                 SyncWorkerStage::BackoffStarted, result);
             event.state = SyncWorkerState::Backoff;
@@ -753,6 +799,56 @@ namespace sync {
                 error += detail;
             }
             set_last_observer_error(error);
+        }
+
+        void reset_status_locked() const {
+            m_status = SyncWorkerStatus();
+            m_status.state = m_state;
+        }
+
+        void record_stage_status(
+                const SyncWorkerStageEvent& event) const {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_status.state = m_state;
+            m_status.current_stage = event.stage;
+            m_status.last_stage_known = true;
+            m_status.last_stage = event;
+            m_status.last_progress = event.progress;
+            m_status.last_retry_hint = event.retry_hint;
+            if (event.stage == SyncWorkerStage::RoundStarted) {
+                m_status.round_active = true;
+                m_status.backoff_active = false;
+                m_status.last_backoff_delay =
+                    std::chrono::milliseconds::zero();
+                m_status.last_round_started_at =
+                    std::chrono::steady_clock::now();
+                ++m_status.rounds_started;
+            }
+        }
+
+        void record_round_status(
+                const SyncWorkerRoundResult& result) const {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_status.last_round_known = true;
+            m_status.last_round = result;
+            m_status.last_progress = result.progress;
+            m_status.last_retry_hint = result.retry_hint;
+            m_status.round_active = false;
+            m_status.last_round_finished_at =
+                std::chrono::steady_clock::now();
+            ++m_status.rounds_completed;
+            if (result.ok) {
+                ++m_status.rounds_succeeded;
+            } else {
+                ++m_status.rounds_failed;
+            }
+        }
+
+        void record_backoff_status(
+                std::chrono::milliseconds delay) const {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_status.backoff_active = true;
+            m_status.last_backoff_delay = delay;
         }
 
         bool begin_peer_call(CancellationToken& token) const {
@@ -856,6 +952,10 @@ namespace sync {
             {
                 std::lock_guard<std::mutex> lock(m_mutex);
                 m_state = state;
+                m_status.state = state;
+                if (state != SyncWorkerState::Backoff) {
+                    m_status.backoff_active = false;
+                }
             }
             m_state_changed.notify_all();
         }
@@ -883,6 +983,7 @@ namespace sync {
         mutable CancellationSource  m_peer_cancel_source;
         mutable std::string         m_last_error;
         mutable std::string         m_last_observer_error;
+        mutable SyncWorkerStatus    m_status;
     };
 
 } // namespace sync

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -78,6 +78,10 @@ int main() {
     MDBXC_TEST_ASSERT(!default_retry_hint.available);
     MDBXC_TEST_ASSERT(!default_retry_hint.retryable);
     MDBXC_TEST_ASSERT(!default_retry_hint.has_retry_after);
+    mdbxc::sync::SyncWorkerStatus worker_status;
+    MDBXC_TEST_ASSERT(worker_status.state ==
+                      mdbxc::sync::SyncWorkerState::Stopped);
+    MDBXC_TEST_ASSERT(!worker_status.last_round_known);
     mdbxc::sync::TransportMessageSizePolicy size_policy(1024u);
     (void)size_policy;
     mdbxc::sync::IWebSocketSyncChannel* websocket_channel = nullptr;

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -883,6 +883,32 @@ void test_worker_run_once_drains_paginated_pull() {
         rounds[0].progress.batches_total != 5u) {
         throw std::runtime_error("worker observer round progress mismatch");
     }
+    const sync::SyncWorkerStatus status = worker.status();
+    if (status.state != sync::SyncWorkerState::Stopped ||
+        !status.last_stage_known || !status.last_round_known ||
+        status.round_active || status.backoff_active) {
+        throw std::runtime_error("worker status lifecycle mismatch");
+    }
+    if (status.rounds_started != 1u ||
+        status.rounds_completed != 1u ||
+        status.rounds_succeeded != 1u ||
+        status.rounds_failed != 0u) {
+        throw std::runtime_error("worker status counters mismatch");
+    }
+    if (status.current_stage != sync::SyncWorkerStage::RoundCompleted ||
+        status.last_stage.stage != sync::SyncWorkerStage::RoundCompleted ||
+        !status.last_round.ok ||
+        status.last_round.pages_pulled != 3u ||
+        status.last_round.batches_applied != 5u) {
+        throw std::runtime_error("worker status round snapshot mismatch");
+    }
+    if (!status.last_progress.remote_tail_known ||
+        status.last_progress.batches_applied != 5u ||
+        status.last_progress.batches_remaining != 0u ||
+        status.last_backoff_delay != std::chrono::milliseconds::zero() ||
+        status.last_round_finished_at < status.last_round_started_at) {
+        throw std::runtime_error("worker status progress snapshot mismatch");
+    }
 
     KeyValueTable<int, int> replica_kv(replica_conn, "kv");
     for (int i = 1; i <= 5; ++i) {
@@ -1069,6 +1095,16 @@ void test_worker_backoff_on_pull_error() {
     }
     if (!observer.wait_for_backoffs(1u, std::chrono::milliseconds(2000))) {
         throw std::runtime_error("worker observer did not see backoff");
+    }
+    const sync::SyncWorkerStatus status = worker.status();
+    if (status.state != sync::SyncWorkerState::Backoff ||
+        !status.backoff_active ||
+        status.last_backoff_delay != std::chrono::milliseconds(10000) ||
+        status.current_stage != sync::SyncWorkerStage::BackoffStarted ||
+        !status.last_round_known ||
+        status.last_round.ok ||
+        status.rounds_failed != 1u) {
+        throw std::runtime_error("worker backoff status snapshot mismatch");
     }
     const std::vector<sync::SyncWorkerRoundResult> rounds = observer.rounds();
     if (rounds.empty() || rounds[0].ok ||


### PR DESCRIPTION
## Summary
- add SyncWorkerStatus and SyncWorker::status() for polling UI/logging/health checks
- track last stage, last round, progress, retry hint, backoff delay, round counters, and diagnostics
- document the snapshot in sync design/readiness notes and cover it in worker/header tests

## Validation
- cmake --build tmp/pr142-cpp11-mingw --target header_sync_umbrella_test test_sync_worker --parallel
- .\\tmp\\pr142-cpp11-mingw\\bin\\tests\\header_sync_umbrella_test.exe
- .\\tmp\\pr142-cpp11-mingw\\bin\\tests\\test_sync_worker.exe
- cmake --build tmp/pr142-cpp17-mingw --target header_sync_umbrella_test test_sync_worker --parallel
- .\\tmp\\pr142-cpp17-mingw\\bin\\tests\\header_sync_umbrella_test.exe
- .\\tmp\\pr142-cpp17-mingw\\bin\\tests\\test_sync_worker.exe