### PR TITLE
feat(sync): add worker permanent failure policy

### DIFF
--- a/guides/sync-transport-production.md
+++ b/guides/sync-transport-production.md
@@ -158,7 +158,12 @@ The hint is intentionally advisory: applications may cap, ignore, or combine it
 with their own retry and circuit-breaker policy. `SyncWorker` copies the hint
 into failed round and stage events. In background mode, an available retryable
 relative `Retry-After` value replaces the current exponential backoff delay for
-one wait and is capped by `SyncWorkerOptions::max_backoff`.
+one wait and is capped by `SyncWorkerOptions::max_backoff`. Permanent hints
+also stay advisory by default: `SyncWorkerPermanentFailurePolicy::KeepRetrying`
+preserves the normal retry loop. Use
+`SyncWorkerPermanentFailurePolicy::StopWorker` when a classified permanent
+transport failure should move the background worker to `Failed` instead of
+backoff.
 
 ## Structured Logging
 

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -46,6 +46,9 @@ promise: sync remains experimental and opt-in through `MDBXC_SYNC_ENABLED=1`.
 - `SyncTransportRetryHint` is advisory. `available=false` means the peer did
   not classify the failure. `available=true, retryable=false` means the peer
   classified the current transport failure as permanent.
+- `SyncWorker` keeps retrying permanent transport hints by default for backward
+  compatibility. Set `SyncWorkerPermanentFailurePolicy::StopWorker` when a
+  permanent hint should stop the background loop in `Failed`.
 - Authentication, DB allow-list decisions, request ids, trace ids, rate-limit
   headers, HTTP status, and WebSocket close codes remain adapter-local
   metadata.
@@ -70,8 +73,6 @@ it can make replication appear successful while logical state diverges.
 
 ## Suggested Next PRs
 
-- Add explicit worker retry policy options for callers that want permanent
-  transport hints to stop the background loop instead of remaining advisory.
 - Add small ergonomics helpers around capture attachment and common worker
   setup if examples continue to repeat the same lifecycle boilerplate.
 - Start specialized table sync design with `KeyMultiValueTable`, then evaluate

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -603,7 +603,12 @@ thread-safe snapshot for polling UIs, health endpoints, and structured logging
 code that does not want to reconstruct state from observer callbacks. In
 background mode, an available retryable hint with relative `Retry-After`
 overrides the current exponential delay for that backoff wait, capped by
-`SyncWorkerOptions::max_backoff`.
+`SyncWorkerOptions::max_backoff`. Permanent hints remain advisory by default:
+`SyncWorkerPermanentFailurePolicy::KeepRetrying` keeps using the normal
+backoff loop. Applications that want a classified permanent transport failure
+to stop the background loop can set
+`SyncWorkerPermanentFailurePolicy::StopWorker`, which leaves the worker in
+`SyncWorkerState::Failed` instead of entering backoff.
 
 `ChangeBatchCodec` already rejects `BATCH_COMPRESSED_ZSTD` at both
 encode and decode paths. Adding a real `zstd` backend is a codec

--- a/include/mdbx_containers/sync/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/SyncWorker.hpp
@@ -50,6 +50,12 @@ namespace sync {
         BackoffStarted, ///< Background worker entered retry backoff.
     };
 
+    /// \brief Policy for classified permanent transport failures.
+    enum class SyncWorkerPermanentFailurePolicy {
+        KeepRetrying, ///< Keep using normal background retry/backoff.
+        StopWorker    ///< Stop the background loop in \c Failed state.
+    };
+
     /// \brief Timing and pagination settings for \c SyncWorker.
     struct SyncWorkerOptions {
         /// \brief Max batches requested from the peer per pull page.
@@ -72,6 +78,14 @@ namespace sync {
 
         /// \brief Whether one round drains all \c has_more pages immediately.
         bool drain_pages = true;
+
+        /// \brief How the background worker handles permanent transport hints.
+        /// \details The default keeps v0.1 retry hints advisory. Set to
+        /// \c StopWorker when a classified permanent transport failure should
+        /// leave the worker in \c SyncWorkerState::Failed instead of entering
+        /// retry backoff.
+        SyncWorkerPermanentFailurePolicy permanent_failure_policy =
+            SyncWorkerPermanentFailurePolicy::KeepRetrying;
 
         /// \brief Optional observer for stage, page, round, and backoff events.
         /// \details The worker does not own the observer. When set, the
@@ -889,6 +903,7 @@ namespace sync {
 
         void thread_main() {
             std::chrono::milliseconds backoff = m_options.initial_backoff;
+            bool failed = false;
             try {
                 set_state(SyncWorkerState::Idle);
                 while (!stop_requested()) {
@@ -905,6 +920,11 @@ namespace sync {
                         }
                     } else {
                         set_last_error(result.error);
+                        if (should_stop_on_permanent_failure(result)) {
+                            failed = true;
+                            set_state(SyncWorkerState::Failed);
+                            break;
+                        }
                         set_state(SyncWorkerState::Backoff);
                         const std::chrono::milliseconds delay =
                             retry_delay(result, backoff);
@@ -915,7 +935,9 @@ namespace sync {
                         backoff = next_backoff(backoff);
                     }
                 }
-                set_state(SyncWorkerState::Stopped);
+                if (!failed) {
+                    set_state(SyncWorkerState::Stopped);
+                }
             } catch (const std::exception& e) {
                 set_last_error(e.what());
                 set_state(SyncWorkerState::Failed);
@@ -941,6 +963,14 @@ namespace sync {
                 return m_options.max_backoff;
             }
             return current + current;
+        }
+
+        bool should_stop_on_permanent_failure(
+                const SyncWorkerRoundResult& result) const {
+            return m_options.permanent_failure_policy ==
+                SyncWorkerPermanentFailurePolicy::StopWorker &&
+                result.retry_hint.available &&
+                !result.retry_hint.retryable;
         }
 
         bool stop_requested() const {

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -82,6 +82,12 @@ int main() {
     MDBXC_TEST_ASSERT(worker_status.state ==
                       mdbxc::sync::SyncWorkerState::Stopped);
     MDBXC_TEST_ASSERT(!worker_status.last_round_known);
+    mdbxc::sync::SyncWorkerOptions worker_options;
+    worker_options.permanent_failure_policy =
+        mdbxc::sync::SyncWorkerPermanentFailurePolicy::StopWorker;
+    MDBXC_TEST_ASSERT(
+        worker_options.permanent_failure_policy ==
+        mdbxc::sync::SyncWorkerPermanentFailurePolicy::StopWorker);
     mdbxc::sync::TransportMessageSizePolicy size_policy(1024u);
     (void)size_policy;
     mdbxc::sync::IWebSocketSyncChannel* websocket_channel = nullptr;

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -335,6 +335,36 @@ private:
     int m_cancel_count;
 };
 
+class PermanentHintPeer : public mdbxc::sync::ISyncPeer {
+public:
+    PermanentHintPeer() {
+        m_hint.available = true;
+        m_hint.retryable = false;
+    }
+
+    mdbxc::sync::PullResponse pull(
+            const mdbxc::sync::PullRequest& request) override {
+        (void)request;
+        mdbxc::sync::PullResponse response;
+        response.ok = false;
+        response.error = "permanent transport failure";
+        return response;
+    }
+
+    mdbxc::sync::PushResponse push(
+            const mdbxc::sync::PushRequest& request) override {
+        (void)request;
+        return mdbxc::sync::PushResponse();
+    }
+
+    mdbxc::sync::SyncTransportRetryHint last_retry_hint() const override {
+        return m_hint;
+    }
+
+private:
+    mdbxc::sync::SyncTransportRetryHint m_hint;
+};
+
 class SelfStoppingPeer : public mdbxc::sync::ISyncPeer {
 public:
     SelfStoppingPeer()
@@ -1176,6 +1206,98 @@ void test_worker_backoff_uses_retry_after_hint() {
     cleanup(path);
 }
 
+void test_worker_permanent_hint_keeps_retrying_by_default() {
+    using namespace mdbxc;
+    const std::string path = "test_worker_permanent_default.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0xB0), make_node(0xD0));
+
+    PermanentHintPeer peer;
+    RecordingWorkerObserver observer;
+    sync::SyncWorkerOptions options;
+    options.initial_backoff = std::chrono::milliseconds(10000);
+    options.max_backoff = std::chrono::milliseconds(10000);
+    options.observer = &observer;
+    sync::SyncWorker worker(engine, peer, options);
+
+    worker.start();
+    if (!observer.wait_for_backoffs(1u, std::chrono::milliseconds(2000))) {
+        throw std::runtime_error(
+            "permanent hint default worker did not enter backoff");
+    }
+    const sync::SyncWorkerStatus status = worker.status();
+    if (status.state != sync::SyncWorkerState::Backoff ||
+        !status.backoff_active ||
+        status.last_backoff_delay != std::chrono::milliseconds(10000) ||
+        !status.last_round_known ||
+        status.last_round.ok ||
+        !status.last_round.retry_hint.available ||
+        status.last_round.retry_hint.retryable ||
+        status.rounds_failed != 1u) {
+        throw std::runtime_error(
+            "permanent hint default status snapshot mismatch");
+    }
+    worker.stop();
+    if (worker.state() != sync::SyncWorkerState::Stopped) {
+        throw std::runtime_error("permanent hint default worker did not stop");
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_worker_permanent_hint_can_stop_worker() {
+    using namespace mdbxc;
+    const std::string path = "test_worker_permanent_stop.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0xB0), make_node(0xD0));
+
+    PermanentHintPeer peer;
+    RecordingWorkerObserver observer;
+    sync::SyncWorkerOptions options;
+    options.initial_backoff = std::chrono::milliseconds(10000);
+    options.max_backoff = std::chrono::milliseconds(10000);
+    options.observer = &observer;
+    options.permanent_failure_policy =
+        sync::SyncWorkerPermanentFailurePolicy::StopWorker;
+    sync::SyncWorker worker(engine, peer, options);
+
+    worker.start();
+    if (!worker.wait_until_state(sync::SyncWorkerState::Failed,
+                                 std::chrono::milliseconds(2000))) {
+        throw std::runtime_error(
+            "permanent hint worker did not enter Failed state");
+    }
+    worker.join();
+
+    const sync::SyncWorkerStatus status = worker.status();
+    if (status.state != sync::SyncWorkerState::Failed ||
+        status.backoff_active ||
+        status.last_backoff_delay != std::chrono::milliseconds(0) ||
+        !status.last_round_known ||
+        status.last_round.ok ||
+        !status.last_round.retry_hint.available ||
+        status.last_round.retry_hint.retryable ||
+        status.rounds_failed != 1u ||
+        status.last_error.find("permanent transport failure") ==
+            std::string::npos) {
+        throw std::runtime_error("permanent hint stop status mismatch");
+    }
+    if (!observer.backoffs().empty()) {
+        throw std::runtime_error(
+            "permanent hint stop worker should not enter backoff");
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 void test_worker_observer_exception_does_not_fail_round() {
     using namespace mdbxc;
     const std::string path = "test_worker_observer_exception.mdbx";
@@ -1664,6 +1786,10 @@ int main() {
         { "test_worker_backoff_on_pull_error", &test_worker_backoff_on_pull_error },
         { "test_worker_backoff_uses_retry_after_hint",
           &test_worker_backoff_uses_retry_after_hint },
+        { "test_worker_permanent_hint_keeps_retrying_by_default",
+          &test_worker_permanent_hint_keeps_retrying_by_default },
+        { "test_worker_permanent_hint_can_stop_worker",
+          &test_worker_permanent_hint_can_stop_worker },
         { "test_worker_observer_exception_does_not_fail_round",
           &test_worker_observer_exception_does_not_fail_round },
         { "test_worker_stage_observer_exception_does_not_fail_round",


### PR DESCRIPTION
## Summary
- add an opt-in `SyncWorkerPermanentFailurePolicy::StopWorker` mode
- keep permanent transport retry hints advisory by default for compatibility
- cover default retry/backoff and explicit Failed-state behavior in worker tests
- document the permanent-hint policy in sync design and production notes

## Validation
- `cmake -S . -B tmp/pr143-cpp11-mingw -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=11 -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=OFF`
- `cmake --build tmp/pr143-cpp11-mingw --target test_sync_worker`
- `cmake --build tmp/pr143-cpp11-mingw --target header_sync_umbrella_test`
- `ctest --test-dir tmp/pr143-cpp11-mingw -R "^(header_sync_umbrella_test|test_sync_worker)$" --output-on-failure`
- `cmake -S . -B tmp/pr143-cpp17-mingw -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=17 -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=OFF`
- `cmake --build tmp/pr143-cpp17-mingw --target test_sync_worker`
- `cmake --build tmp/pr143-cpp17-mingw --target header_sync_umbrella_test`
- `ctest --test-dir tmp/pr143-cpp17-mingw -R "^(header_sync_umbrella_test|test_sync_worker)$" --output-on-failure`
