### PR TITLE
feat(sync): add capture scope helper

### DIFF
--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -215,8 +215,9 @@ cmake -S . -B tmp/build-ws-example `
 - `DbId` идентифицирует одну логическую реплицируемую БД. Все узлы,
   реплицирующие эту логическую БД, должны использовать одинаковый `DbId`.
 - Перед локальными записями прикрепите `ThreadLocalChangeAccumulator` через
-  `attach_sync_capture()`. После завершения локальной фазы записи вызовите
-  `detach_sync_capture()`.
+  `SyncCaptureScope` или более низкоуровневую пару `attach_sync_capture()` /
+  `detach_sync_capture()`. Scope-вариант автоматически восстанавливает
+  предыдущий capture sink после завершения локальной фазы записи.
 - Методы поддерживаемых таблиц сохраняют обычный API. Не нужно оборачивать
   каждый `insert`, `insert_or_assign`, `erase`, `reconcile` или range erase в
   отдельный sync-вызов. Capture sink записывает поддерживаемые write operations

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -213,8 +213,9 @@ cmake -S . -B tmp/build-ws-example `
 - `DbId` identifies one logical replicated database. All nodes replicating the
   same logical database must use the same `DbId`.
 - Before local writes, attach `ThreadLocalChangeAccumulator` with
-  `attach_sync_capture()`. After the local write phase, call
-  `detach_sync_capture()`.
+  `SyncCaptureScope` or the lower-level `attach_sync_capture()` /
+  `detach_sync_capture()` pair. The scope form restores the previous capture
+  sink automatically when the local write phase ends.
 - Supported table methods keep their normal API. You do not wrap each
   `insert`, `insert_or_assign`, `erase`, `reconcile`, or range erase in a sync
   call. The capture sink records supported write operations when their MDBX

--- a/examples/sync_01_lifecycle_direct_peer.cpp
+++ b/examples/sync_01_lifecycle_direct_peer.cpp
@@ -56,12 +56,14 @@ int main() {
 
         mdbxc::sync::ThreadLocalChangeAccumulator capture(primary);
         // Capture is opt-in. While attached, committed writes on supported
-        // tables are appended to the primary's _mdbxc_changelog.
-        primary->attach_sync_capture(&capture);
+        // tables are appended to the primary's _mdbxc_changelog. The scope
+        // restores the previous capture sink when the write phase ends.
         mdbxc::KeyValueTable<int, std::string> prices(primary, "prices");
-        prices.insert_or_assign(1, "BTC/USD");
-        prices.insert_or_assign(2, "ETH/USD");
-        primary->detach_sync_capture();
+        {
+            mdbxc::sync::SyncCaptureScope capture_scope(primary, capture);
+            prices.insert_or_assign(1, "BTC/USD");
+            prices.insert_or_assign(2, "ETH/USD");
+        }
 
         // DirectSyncPeer is an in-process stand-in for a transport. It forwards
         // pull() directly to primary_engine.handle_pull(). A real peer would

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -8,7 +8,8 @@ promise: sync remains experimental and opt-in through `MDBXC_SYNC_ENABLED=1`.
 
 - Supported table capture paths are explicit: `KeyValueTable`, `KeyTable`,
   `ValueTable`, and `SequenceTable` writes are captured when a
-  `ThreadLocalChangeAccumulator` is attached to the writing `Connection`.
+  `ThreadLocalChangeAccumulator` is attached to the writing `Connection`;
+  `SyncCaptureScope` provides RAII attach/restore for write phases.
 - `VectorStore` is covered indirectly through its internal `SequenceTable` and
   `KeyValueTable` members.
 - Standalone writes become standalone sync batches; an explicit transaction
@@ -73,8 +74,8 @@ it can make replication appear successful while logical state diverges.
 
 ## Suggested Next PRs
 
-- Add small ergonomics helpers around capture attachment and common worker
-  setup if examples continue to repeat the same lifecycle boilerplate.
+- Add small ergonomics helpers around common worker setup if examples continue
+  to repeat the same lifecycle boilerplate.
 - Start specialized table sync design with `KeyMultiValueTable`, then evaluate
   whether the same framing ideas carry over to `AnyValueTable` and
   `HashedKeyValueStore`.

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -20,6 +20,7 @@
 #include "sync/ChangeBatch.hpp"
 #include "sync/ChangeBatchCodec.hpp"
 #include "sync/ChangeAccumulator.hpp"
+#include "sync/SyncCaptureScope.hpp"
 #include "sync/cancellation.hpp"
 #include "sync/ConflictPolicy.hpp"
 #include "sync/ISyncCaptureSink.hpp"

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -17,7 +17,7 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
   `Common`, `ChangeAccumulator`, `ChangeBatch`, `ChangeOp`, `Cancellation`,
   `CodecBounds`, `CodecFlags`, `ConflictPolicy`, `DirectSyncPeer`,
   `IdentityProvider`, `ISyncCaptureSink`, `ISyncPeer`, `Protocol`,
-  `SyncCursor`, `SyncEngine`, `SyncWorker`.
+  `SyncCaptureScope`, `SyncCursor`, `SyncEngine`, `SyncWorker`.
 - Five system stores under `include/mdbx_containers/sync/stores/`:
   `MetaStore`, `ChangeLogStore`, `OriginIndexStore`, `AppliedStore`,
   `IdentityIndexStore`.
@@ -305,8 +305,10 @@ Application integration contract:
 - callers do not wrap each individual `insert`, `insert_or_assign`, `erase`,
   `reconcile`, or range erase in a sync-specific call;
 - `Connection::attach_sync_capture()` installs the capture sink for commits on
-  that connection; supported write operations are recorded by table code and
-  flushed by the transaction pre-commit hook;
+  that connection; `SyncCaptureScope` is the RAII helper for temporary
+  attachments and restores the previous sink when the scope ends; supported
+  write operations are recorded by table code and flushed by the transaction
+  pre-commit hook;
 - a standalone write method call that opens its own transaction commits as one
   local change batch;
 - an explicit transaction passed through several supported table calls commits

--- a/include/mdbx_containers/sync/SyncCaptureScope.hpp
+++ b/include/mdbx_containers/sync/SyncCaptureScope.hpp
@@ -1,0 +1,95 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_SYNC_CAPTURE_SCOPE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_SYNC_CAPTURE_SCOPE_HPP_INCLUDED
+
+/// \file SyncCaptureScope.hpp
+/// \brief RAII helper for temporarily attaching an \c ISyncCaptureSink.
+
+#include "sync_module.hpp"
+
+#if MDBXC_SYNC_ENABLED
+
+#include "../common.hpp"
+#include "ISyncCaptureSink.hpp"
+
+#include <memory>
+#include <stdexcept>
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Temporarily attaches a sync capture sink to a \c Connection.
+    /// \details The scope stores the previously attached sink, attaches
+    /// \p sink, and restores the previous sink on destruction or \c detach().
+    /// The sink pointer is non-owning and must outlive the scope. This is a
+    /// lifecycle helper; do not create or destroy it concurrently with table
+    /// operations or active transactions on the same connection.
+    class SyncCaptureScope {
+    public:
+        SyncCaptureScope(const std::shared_ptr<Connection>& connection,
+                         ISyncCaptureSink& sink)
+            : m_connection(connection),
+              m_previous(nullptr),
+              m_active(false) {
+            attach(&sink);
+        }
+
+        SyncCaptureScope(const std::shared_ptr<Connection>& connection,
+                         ISyncCaptureSink* sink)
+            : m_connection(connection),
+              m_previous(nullptr),
+              m_active(false) {
+            if (sink == nullptr) {
+                throw std::invalid_argument("SyncCaptureScope sink is null");
+            }
+            attach(sink);
+        }
+
+        ~SyncCaptureScope() {
+            detach();
+        }
+
+        SyncCaptureScope(const SyncCaptureScope&) = delete;
+        SyncCaptureScope& operator=(const SyncCaptureScope&) = delete;
+
+        /// \brief Restores the sink that was attached before this scope.
+        /// \details Safe to call more than once.
+        void detach() {
+            if (!m_active) {
+                return;
+            }
+            if (m_previous != nullptr) {
+                m_connection->attach_sync_capture(m_previous);
+            } else {
+                m_connection->detach_sync_capture();
+            }
+            m_active = false;
+        }
+
+        /// \brief Returns whether this scope still owns the attachment.
+        bool active() const {
+            return m_active;
+        }
+
+    private:
+        void attach(ISyncCaptureSink* sink) {
+            if (!m_connection) {
+                throw std::invalid_argument(
+                    "SyncCaptureScope connection is null");
+            }
+            m_previous = m_connection->sync_capture();
+            m_connection->attach_sync_capture(sink);
+            m_active = true;
+        }
+
+        std::shared_ptr<Connection> m_connection;
+        ISyncCaptureSink* m_previous;
+        bool m_active;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBXC_SYNC_ENABLED
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_SYNC_CAPTURE_SCOPE_HPP_INCLUDED

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -29,6 +29,27 @@ public:
     }
 };
 
+class HeaderSyncSink : public mdbxc::sync::ISyncCaptureSink {
+public:
+    void record_change(MDBX_txn* txn,
+                       const std::string& dbi_name,
+                       mdbxc::sync::ChangeOpType op_type,
+                       std::uint32_t dbi_flags,
+                       const std::vector<std::uint8_t>& storage_key,
+                       const std::vector<std::uint8_t>& value) override {
+        (void)txn;
+        (void)dbi_name;
+        (void)op_type;
+        (void)dbi_flags;
+        (void)storage_key;
+        (void)value;
+    }
+
+    void flush_in_txn(MDBX_txn* txn) override {
+        (void)txn;
+    }
+};
+
 int main() {
     mdbxc::sync::NodeId node = mdbxc::sync::make_zero_node();
     MDBXC_TEST_ASSERT(node.size() == 16u);
@@ -88,6 +109,10 @@ int main() {
     MDBXC_TEST_ASSERT(
         worker_options.permanent_failure_policy ==
         mdbxc::sync::SyncWorkerPermanentFailurePolicy::StopWorker);
+    mdbxc::sync::SyncCaptureScope* capture_scope = nullptr;
+    HeaderSyncSink header_sink;
+    (void)capture_scope;
+    (void)header_sink;
     mdbxc::sync::TransportMessageSizePolicy size_policy(1024u);
     (void)size_policy;
     mdbxc::sync::IWebSocketSyncChannel* websocket_channel = nullptr;

--- a/tests/test_sync_capture.cpp
+++ b/tests/test_sync_capture.cpp
@@ -119,6 +119,53 @@ void test_capture_writes_via_sink() {
     }
 }
 
+void test_capture_scope_restores_previous_sink() {
+    using namespace mdbxc;
+    const std::string p = "test_capture_scope.mdbx";
+    cleanup(p);
+
+    Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = Connection::create(cfg);
+
+    StubSink outer_sink;
+    StubSink inner_sink;
+    conn->attach_sync_capture(&outer_sink);
+    if (conn->sync_capture() != &outer_sink) {
+        throw std::runtime_error("outer sink was not attached");
+    }
+
+    KeyValueTable<int, int> kv(conn, "t");
+    {
+        sync::SyncCaptureScope scope(conn, inner_sink);
+        if (!scope.active() || conn->sync_capture() != &inner_sink) {
+            throw std::runtime_error("capture scope did not attach inner sink");
+        }
+        kv.insert_or_assign(1, 100);
+    }
+
+    if (conn->sync_capture() != &outer_sink) {
+        throw std::runtime_error("capture scope did not restore outer sink");
+    }
+    kv.insert_or_assign(2, 200);
+
+    conn->detach_sync_capture();
+    kv.insert_or_assign(3, 300);
+    conn->disconnect();
+    cleanup(p);
+
+    if (inner_sink.m_recorded.size() != 1u ||
+        inner_sink.m_recorded[0].op_type != sync::ChangeOpType::Put) {
+        throw std::runtime_error("inner sink did not capture scoped write");
+    }
+    if (outer_sink.m_recorded.size() != 1u ||
+        outer_sink.m_recorded[0].op_type != sync::ChangeOpType::Put) {
+        throw std::runtime_error("outer sink did not capture restored write");
+    }
+}
+
 void test_sequence_set_writes_via_sink() {
     using namespace mdbxc;
     const std::string p = "test_capture_sequence_set.mdbx";
@@ -776,114 +823,126 @@ int main() {
         return 2;
     }
     try {
+        test_capture_scope_restores_previous_sink();
+        std::printf("PASS test_capture_scope_restores_previous_sink\n");
+    } catch (const std::exception& e) {
+        std::printf("FAIL test_capture_scope_restores_previous_sink: %s\n",
+                    e.what());
+        return 3;
+    } catch (...) {
+        std::printf(
+            "FAIL test_capture_scope_restores_previous_sink: non-std exception\n");
+        return 3;
+    }
+    try {
         test_sequence_set_writes_via_sink();
         std::printf("PASS test_sequence_set_writes_via_sink\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_sequence_set_writes_via_sink: %s\n", e.what());
-        return 3;
+        return 4;
     } catch (...) {
         std::printf("FAIL test_sequence_set_writes_via_sink: non-std exception\n");
-        return 3;
+        return 4;
     }
     try {
         test_value_table_writes_storage_key_via_sink();
         std::printf("PASS test_value_table_writes_storage_key_via_sink\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_value_table_writes_storage_key_via_sink: %s\n", e.what());
-        return 4;
+        return 5;
     } catch (...) {
         std::printf("FAIL test_value_table_writes_storage_key_via_sink: non-std exception\n");
-        return 4;
+        return 5;
     }
     try {
         test_key_value_bulk_writes_via_sink();
         std::printf("PASS test_key_value_bulk_writes_via_sink\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_key_value_bulk_writes_via_sink: %s\n", e.what());
-        return 5;
+        return 6;
     } catch (...) {
         std::printf("FAIL test_key_value_bulk_writes_via_sink: non-std exception\n");
-        return 5;
+        return 6;
     }
     try {
         test_range_erase_writes_via_sink();
         std::printf("PASS test_range_erase_writes_via_sink\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_range_erase_writes_via_sink: %s\n", e.what());
-        return 6;
+        return 7;
     } catch (...) {
         std::printf("FAIL test_range_erase_writes_via_sink: non-std exception\n");
-        return 6;
+        return 7;
     }
     try {
         test_vector_store_writes_via_sink();
         std::printf("PASS test_vector_store_writes_via_sink\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_vector_store_writes_via_sink: %s\n", e.what());
-        return 7;
+        return 8;
     } catch (...) {
         std::printf("FAIL test_vector_store_writes_via_sink: non-std exception\n");
-        return 7;
+        return 8;
     }
     try {
         test_capture_flush_on_commit();
         std::printf("PASS test_capture_flush_on_commit\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_capture_flush_on_commit: %s\n", e.what());
-        return 8;
+        return 9;
     } catch (...) {
         std::printf("FAIL test_capture_flush_on_commit: non-std exception\n");
-        return 8;
+        return 9;
     }
     try {
         test_specialized_tables_do_not_capture_in_v01();
         std::printf("PASS test_specialized_tables_do_not_capture_in_v01\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_specialized_tables_do_not_capture_in_v01: %s\n", e.what());
-        return 9;
+        return 10;
     } catch (...) {
         std::printf("FAIL test_specialized_tables_do_not_capture_in_v01: non-std exception\n");
-        return 9;
+        return 10;
     }
     try {
         test_changelog_capture_roundtrip();
         std::printf("PASS test_changelog_capture_roundtrip\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_changelog_capture_roundtrip: %s\n", e.what());
-        return 10;
+        return 11;
     } catch (...) {
         std::printf("FAIL test_changelog_capture_roundtrip: non-std exception\n");
-        return 10;
+        return 11;
     }
     try {
         test_zero_node_id_rejected();
         std::printf("PASS test_zero_node_id_rejected\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_zero_node_id_rejected: %s\n", e.what());
-        return 11;
+        return 12;
     } catch (...) {
         std::printf("FAIL test_zero_node_id_rejected: non-std exception\n");
-        return 11;
+        return 12;
     }
     try {
         test_aborted_transaction_does_not_flush();
         std::printf("PASS test_aborted_transaction_does_not_flush\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_aborted_transaction_does_not_flush: %s\n", e.what());
-        return 12;
+        return 13;
     } catch (...) {
         std::printf("FAIL test_aborted_transaction_does_not_flush: non-std exception\n");
-        return 12;
+        return 13;
     }
     try {
         test_explicit_rollback_does_not_flush();
         std::printf("PASS test_explicit_rollback_does_not_flush\n");
     } catch (const std::exception& e) {
         std::printf("FAIL test_explicit_rollback_does_not_flush: %s\n", e.what());
-        return 13;
+        return 14;
     } catch (...) {
         std::printf("FAIL test_explicit_rollback_does_not_flush: non-std exception\n");
-        return 13;
+        return 14;
     }
 
     return 0;


### PR DESCRIPTION
## Summary
- add `SyncCaptureScope`, an RAII helper for temporary sync capture attachment
- restore the previously attached sink when the scope ends, including nested scopes
- cover the helper in sync umbrella smoke and capture regression tests
- update the first lifecycle example and sync docs to show the scoped capture form

## Validation
- `cmake -S . -B tmp/pr144-cpp11-mingw -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=11 -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_SIMPLE_WEB_HTTP_TRANSPORT=OFF -DMDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT=OFF -DMDBXC_KURLYK_HTTP_TRANSPORT=OFF`
- `cmake --build tmp/pr144-cpp11-mingw --target test_sync_capture`
- `cmake --build tmp/pr144-cpp11-mingw --target header_sync_umbrella_test`
- `cmake --build tmp/pr144-cpp11-mingw --target sync_01_lifecycle_direct_peer`
- `ctest --test-dir tmp/pr144-cpp11-mingw -R "^(header_sync_umbrella_test|test_sync_capture)$" --output-on-failure`
- `tmp\\pr144-cpp11-mingw\\bin\\examples\\sync_01_lifecycle_direct_peer.exe`
- `cmake -S . -B tmp/pr144-cpp17-mingw -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=17 -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_SIMPLE_WEB_HTTP_TRANSPORT=OFF -DMDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT=OFF -DMDBXC_KURLYK_HTTP_TRANSPORT=OFF`
- `cmake --build tmp/pr144-cpp17-mingw --target test_sync_capture`
- `cmake --build tmp/pr144-cpp17-mingw --target header_sync_umbrella_test`
- `cmake --build tmp/pr144-cpp17-mingw --target sync_01_lifecycle_direct_peer`
- `ctest --test-dir tmp/pr144-cpp17-mingw -R "^(header_sync_umbrella_test|test_sync_capture)$" --output-on-failure`
- `tmp\\pr144-cpp17-mingw\\bin\\examples\\sync_01_lifecycle_direct_peer.exe`
