### PR TITLE
docs(sync): design KeyMultiValueTable replication

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -75,8 +75,13 @@
   `ValueTable` и `SequenceTable`; `VectorStore` реплицируется косвенно через
   внутренние `SequenceTable` и `KeyValueTable`.
 - `AnyValueTable`, `KeyMultiValueTable` и `HashedKeyValueStore` не
-  реплицируются в v0.1. Их wire-format отложен до явного описания type tags,
-  DUPSORT duplicate framing и hash-index identity semantics.
+  реплицируются в v0.1. Для `KeyMultiValueTable` в `sync/DESIGN.md` описан
+  отложенный unordered multiset sync design для single-writer или causally
+  serialized updates; общие concurrent multi-writer conflict semantics и
+  сохраняющие порядок распределённые histories отложены в будущую работу,
+  например `KeyOrderedMultiValueTable<K, V>`. Реализация остаётся выключенной,
+  пока не появятся capture и round-trip tests. Для `AnyValueTable` и
+  `HashedKeyValueStore` ещё нужны дизайны type tags и hash-index identity.
 - Для поддерживаемых таблиц прикладной CRUD-код не нужно оборачивать
   отдельными sync-вызовами на каждый метод. Прикрепите
   `ThreadLocalChangeAccumulator` к пишущему `Connection`; используйте

--- a/README.md
+++ b/README.md
@@ -53,8 +53,13 @@
   `ValueTable`, and `SequenceTable`; `VectorStore` is replicated indirectly
   through its internal `SequenceTable` and `KeyValueTable` members.
 - `AnyValueTable`, `KeyMultiValueTable`, and `HashedKeyValueStore` are not
-  replicated in v0.1. Their wire formats are deferred until type tags,
-  DUPSORT duplicate framing, and hash-index identity semantics are specified.
+  replicated in v0.1. `KeyMultiValueTable` has a deferred unordered multiset
+  sync design for single-writer or causally serialized updates in
+  `sync/DESIGN.md`; general concurrent multi-writer conflict semantics and
+  order-preserving distributed histories are deferred to future work such as
+  `KeyOrderedMultiValueTable<K, V>`. Implementation remains disabled until
+  capture and round-trip tests exist. `AnyValueTable` and `HashedKeyValueStore`
+  still need type-tag and hash-index identity designs.
 - Application CRUD code does not need per-method sync wrappers for supported
   tables. Attach `ThreadLocalChangeAccumulator` to the writing `Connection`;
   use `SyncCaptureScope` for bounded write phases, or the lower-level

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -259,7 +259,12 @@ cmake -S . -B tmp/build-ws-example `
 - Sync v0.1 поддерживает `KeyValueTable`, `KeyTable`, `ValueTable`,
   `SequenceTable` и `VectorStore` через его внутренние поддерживаемые таблицы.
   `AnyValueTable`, `KeyMultiValueTable` и `HashedKeyValueStore` не
-  реплицируются, пока для них не описан формат передачи.
+  реплицируются в v0.1. Для `KeyMultiValueTable` в `sync/DESIGN.md` описан
+  отложенный unordered multiset design для single-writer или causally
+  serialized updates; concurrent multi-writer conflicts и сохраняющие порядок
+  распределённые histories отложены в будущую работу, например
+  `KeyOrderedMultiValueTable<K, V>`. Capture остаётся выключенным до появления
+  реализации и round-trip tests.
 
 ## Граница транспорта
 

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -253,7 +253,11 @@ cmake -S . -B tmp/build-ws-example `
 - Sync v0.1 supports `KeyValueTable`, `KeyTable`, `ValueTable`,
   `SequenceTable`, and `VectorStore` through its internal supported tables.
   `AnyValueTable`, `KeyMultiValueTable`, and `HashedKeyValueStore` are not
-  replicated until their wire formats are defined.
+  replicated in v0.1. `KeyMultiValueTable` has a deferred unordered multiset
+  design for single-writer or causally serialized updates in `sync/DESIGN.md`;
+  concurrent multi-writer conflicts and ordered distributed histories are
+  deferred to future work such as `KeyOrderedMultiValueTable<K, V>`. Capture
+  remains disabled until the implementation and round-trip tests land.
 
 ## Transport Boundary
 

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -214,8 +214,14 @@ Operational rules:
   the innermost scope first. Do not replace the connection capture sink through
   raw attach/detach while a scope owns it.
 - `HashedKeyValueStore`, `KeyMultiValueTable`, and `AnyValueTable` are
-  not replicated in v0.1; their wire format is not defined. Do not add
-  `record_op()` paths for them without first extending `DESIGN.md`.
+  not replicated in v0.1. `KeyMultiValueTable` has a deferred unordered
+  multiset design for single-writer or causally serialized updates in
+  `sync/DESIGN.md`; general concurrent multi-writer conflict semantics and
+  order-preserving distributed histories are deferred to future work such as
+  `KeyOrderedMultiValueTable<K, V>`. `HashedKeyValueStore` and
+  `AnyValueTable` still need their own wire-format designs. Do not add
+  `record_op()` paths for any unsupported table without capture/apply code and
+  round-trip tests in the same change.
 - Unsupported specialized tables must keep emitting no `ChangeOp` while sync
   capture is attached until their wire-format semantics are designed and tested.
 

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -63,8 +63,9 @@ These table families intentionally emit no `ChangeOp` in v0.1:
 
 - `AnyValueTable`, until a wire-level type tag and compatibility policy is
   specified.
-- `KeyMultiValueTable`, until DUPSORT duplicate framing and multiplicity
-  semantics are specified.
+- `KeyMultiValueTable`, until the deferred unordered multiset design for
+  single-writer or causally serialized updates in `sync/DESIGN.md` is
+  implemented and covered by capture and round-trip tests.
 - `HashedKeyValueStore`, until the relationship between logical key bytes,
   physical storage keys, and hash-index entries is specified.
 
@@ -76,9 +77,15 @@ it can make replication appear successful while logical state diverges.
 
 - Add small ergonomics helpers around common worker setup if examples continue
   to repeat the same lifecycle boilerplate.
-- Start specialized table sync design with `KeyMultiValueTable`, then evaluate
-  whether the same framing ideas carry over to `AnyValueTable` and
-  `HashedKeyValueStore`.
+- Prototype `KeyMultiValueTable` capture/apply using the deferred
+  single-writer/serialized unordered multiset design, with repeated-pair
+  round-trip tests before enabling it.
+- Define explicit conflict/CRDT semantics before claiming general concurrent
+  multi-writer convergence for `KeyMultiValueTable`.
+- Design `KeyOrderedMultiValueTable<K, V>` separately if distributed histories
+  need order convergence across multi-writer nodes.
+- Evaluate whether any `KeyMultiValueTable` framing ideas carry over to
+  `AnyValueTable` and `HashedKeyValueStore`.
 
 ## Validation Baseline
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -197,8 +197,12 @@ global-order-key        = origin-node-id || origin-local-sequence || op-index
 ```
 
 The exact fields are deferred, but the important property is that the order key
-is carried on the wire and replayed unchanged by replicas. Its ordering is a
-deterministic total order, not wall-clock insertion time. The ordered table
+is carried on the wire and replayed unchanged by replicas. With the illustrative
+fields above, this is only a deterministic presentation order: lexicographic
+comparison groups operations by `origin-node-id` before the origin-local
+sequence. It is not wall-clock insertion time and does not express causal order
+between nodes. A causally meaningful distributed history would need an explicit
+Lamport/HLC-style component or another causal-ordering model. The ordered table
 will need its own storage format, delete semantics, conflict semantics, and
 round-trip tests; it is not part of `KeyMultiValueTable` v0.1/v0.2 multiset
 sync.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -95,12 +95,127 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
 | `SequenceTable` | Supported | Captures set/append/delete/clear against stable `uint64_t` record ids. `append()` remains a local single-writer helper; external synchronization is still required for concurrent appenders. |
 | `VectorStore` | Supported indirectly | Does not own a separate wire format. Its persistent writes go through `SequenceTable` and `KeyValueTable` member tables. |
 | `AnyValueTable` | Not supported in v0.1 | Deferred until heterogeneous value type tags are part of the sync wire format. |
-| `KeyMultiValueTable` | Not supported in v0.1 | Deferred until DUPSORT duplicate-value multiplicity and per-value payload framing are specified. |
+| `KeyMultiValueTable` | Not supported in v0.1 | Deferred until unordered multiset replication and DUPSORT duplicate-value payload framing are implemented and tested. |
 | `HashedKeyValueStore` | Not supported in v0.1 | Deferred until hash-index and identity-key mapping semantics are specified. |
 
 Do not add `record_op()` paths for unsupported table types without first
 updating this design document and adding round-trip replication tests for the
 new wire-format semantics.
+
+## Deferred `KeyMultiValueTable` sync design
+
+This section documents the intended direction for future
+`KeyMultiValueTable` replication. It is a design contract only:
+`KeyMultiValueTable` still emits no `ChangeOp` in sync v0.1.
+
+`KeyMultiValueTable` cannot safely reuse the v0.1 raw DBI put/delete model as
+an undocumented implementation detail. The table stores one MDBX DUPSORT record
+per logical pair, but the duplicate value is not just the serialized public
+value. It is:
+
+```text
+stored duplicate value = sequence-prefix || serialized-value
+```
+
+The sequence prefix preserves repeated identical `(key, value)` pairs as
+separate physical records and also affects iteration order for values under the
+same key. Public reads strip the prefix. Public `erase(key, value)` removes all
+duplicate records whose stripped payload equals `serialized-value`. Therefore a
+future `KeyMultiValueTable` wire format must choose and test an explicit
+multiset model instead of assuming that a physical key, a stripped value, or a
+locally assigned sequence prefix uniquely identifies one cross-node record.
+
+The first sync design for `KeyMultiValueTable` targets unordered multiset
+preservation under single-writer or causally serialized updates:
+
+```text
+for every serialized key and serialized public value:
+    count(key, value) is preserved after replaying the same ordered operation history
+```
+
+General concurrent multi-writer convergence is not guaranteed by the operation
+set below. Destructive operations are not commutative with concurrent inserts:
+`EraseAllValues`, `EraseKey`, `EraseRange`, and `Clear` can produce different
+final counts when different replicas observe local writes and remote deletes in
+different orders. Supporting that case requires an explicit conflict model,
+such as a single authoritative writer per key/range, a deterministic global
+operation order with history replay, CRDT tagged occurrences with tombstones, or
+an LWW/version policy for destructive operations. That design is deferred.
+
+Order-sensitive APIs such as `find(key)`, `retrieve_all_vector()`, and
+`range_vector()` may expose different value order on different nodes when
+multiple nodes write values for the same key. The order and multiplicity
+converge only when the application uses one authoritative writer for the
+relevant key/logical dataset or otherwise serializes conflicting updates before
+they are replicated. Ordered distributed history belongs to a separate future
+table.
+
+Planned logical operations:
+
+| Operation | Required payload | Apply semantics |
+|-----------|------------------|-----------------|
+| `InsertOne` | serialized key, serialized public value | Add one logical pair. The replica assigns its own local duplicate sequence prefix. |
+| `EraseKey` | serialized key | Remove all values for the key. |
+| `EraseOneValue` | serialized key, serialized public value | Remove one matching repeated value for the key, if one exists. This is needed for `reconcile()` surplus deletes. |
+| `EraseAllValues` | serialized key, serialized public value | Remove all exact matching repeated values for the key, matching current public `erase(key, value)` semantics. |
+| `EraseRange` | serialized inclusive key range | Remove every physical pair whose key is in the range. |
+| `Clear` | no key/value payload | Remove all pairs in the table. |
+
+`append()` can be represented as a sequence of `InsertOne` operations in the
+same local batch. `erase(key, value)` should emit `EraseAllValues`.
+`reconcile()` should emit one `EraseOneValue` per surplus occurrence and one
+`InsertOne` per missing occurrence so that repeated identical pairs preserve
+their final multiplicity. If a future implementation captures lower-level
+physical deletes during `reconcile()` or range erase, it must copy cursor keys
+and duplicate values before `mdbx_cursor_del()` and must still publish logical
+operations whose replay is deterministic on another node.
+
+The wire payload should carry the stripped public value, not the local
+sequence-prefixed duplicate bytes. This keeps replicas free to assign local
+duplicate sequence prefixes while preserving observable multiset state for the
+supported single-writer or causally serialized case:
+
+```text
+count(key), count(key, value), and per-pair multiplicity
+```
+
+Neither order-sensitive iteration nor concurrent destructive-update convergence
+is guaranteed for general multi-writer `KeyMultiValueTable` replication. The
+sequence prefix remains a local storage detail and is not a cross-node identity.
+
+### Future ordered table
+
+If the library needs replicated per-key histories, event timelines, queues, or
+other APIs where cross-node order is part of the contract, add a separate
+`KeyOrderedMultiValueTable<K, V>` instead of overloading
+`KeyMultiValueTable`. That table should store an explicit globally stable order
+identity, for example:
+
+```text
+ordered duplicate value = global-order-key || serialized-value
+global-order-key        = origin-node-id || origin-local-sequence || op-index
+```
+
+The exact fields are deferred, but the important property is that the order key
+is carried on the wire and replayed unchanged by replicas. Its ordering is a
+deterministic total order, not wall-clock insertion time. The ordered table
+will need its own storage format, delete semantics, conflict semantics, and
+round-trip tests; it is not part of `KeyMultiValueTable` v0.1/v0.2 multiset
+sync.
+
+Required tests before enabling capture:
+
+- sink-level tests for `insert()`, `append()`, `erase(key)`,
+  `erase(key, value)`, `erase_range()`, `clear()`, and `reconcile()`;
+- round-trip tests that preserve repeated identical `(key, value)`
+  multiplicity under a single writer and under causally serialized updates;
+- multi-writer same-key tests that prove order-sensitive APIs and destructive
+  update conflicts are not claimed to converge unless the scenario uses one
+  authoritative writer or another explicit conflict policy;
+- pagination and restart tests, including persisted applied cursor behavior;
+- idempotent replay checks for already-applied batches;
+- negative tests proving unsupported `AnyValueTable` and `HashedKeyValueStore`
+  still emit no `ChangeOp` until their own wire formats are defined.
 
 ## Planned before v0.1 release (NOT YET implemented)
 
@@ -110,7 +225,9 @@ new wire-format semantics.
 
 - `HashedKeyValueStore` — internal hash index layout complicates the wire
   format; deferred until an explicit identity-mapping scheme lands.
-- `KeyMultiValueTable` — DUPSORT values need per-value length prefixes.
+- `KeyMultiValueTable` — DUPSORT duplicate values need the unordered multiset
+  model described above before capture can be enabled. Ordered distributed
+  histories are deferred to a future `KeyOrderedMultiValueTable<K, V>`.
 - `AnyValueTable` — heterogeneous values need type-tag propagation on the wire.
 - `IdentityProvider` integration in `BaseTable` — declared in v0.1, no
   write path until HashedKeyValueStore.


### PR DESCRIPTION
## Summary
- document the deferred `KeyMultiValueTable` sync design
- separate logical multiplicity operations from local DUPSORT sequence-prefix storage
- keep v0.1 no-capture behavior explicit until capture/apply and round-trip tests exist
- update EN/RU READMEs and the readiness checklist with the new status

## Validation
- `git diff --check`
