### PR TITLE
docs(sync): clarify capture ergonomics

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -79,11 +79,16 @@
   DUPSORT duplicate framing и hash-index identity semantics.
 - Для поддерживаемых таблиц прикладной CRUD-код не нужно оборачивать
   отдельными sync-вызовами на каждый метод. Прикрепите
-  `ThreadLocalChangeAccumulator` к пишущему `Connection`; закоммиченные
-  одиночные записи становятся одиночными sync batches, а явная транзакция,
-  объединяющая несколько поддерживаемых таблиц, становится одним атомарным
-  локальным batch. Read/search-вызовы не захватываются. Отдельный `SyncWorker`
-  плюс транспорт `ISyncPeer` переносят закоммиченные batches между узлами.
+  `ThreadLocalChangeAccumulator` к пишущему `Connection`; используйте
+  `SyncCaptureScope` для ограниченных фаз записи или более низкоуровневую пару
+  `attach_sync_capture()` / `detach_sync_capture()` для намеренно долгоживущего
+  lifecycle захвата на уровне приложения. Вложенные capture scopes должны
+  завершаться строго в обратном порядке; не меняйте capture sink соединения
+  напрямую, пока scope активен. Закоммиченные одиночные записи становятся
+  одиночными sync batches, а явная транзакция, объединяющая несколько
+  поддерживаемых таблиц, становится одним атомарным локальным batch.
+  Read/search-вызовы не захватываются. Отдельный `SyncWorker` плюс транспорт
+  `ISyncPeer` переносят закоммиченные batches между узлами.
 - `SyncEngine` предоставляет pull/push/apply primitives, `DirectSyncPeer`
   используется для in-process синхронизации в тестах и примерах,
   `HttpSyncPeer` задаёт HTTP-shaped adapter seam, `WebSocketSyncPeer` задаёт

--- a/README.md
+++ b/README.md
@@ -57,10 +57,15 @@
   DUPSORT duplicate framing, and hash-index identity semantics are specified.
 - Application CRUD code does not need per-method sync wrappers for supported
   tables. Attach `ThreadLocalChangeAccumulator` to the writing `Connection`;
-  committed standalone writes become standalone sync batches, while an explicit
-  transaction spanning several supported tables becomes one atomic local batch.
-  Read/search calls are not captured. A separate `SyncWorker` plus an
-  `ISyncPeer` transport moves committed batches between nodes.
+  use `SyncCaptureScope` for bounded write phases, or the lower-level
+  `attach_sync_capture()` / `detach_sync_capture()` pair for a deliberately
+  long-lived application capture lifecycle. Nested capture scopes must end in
+  strict LIFO order; do not change the connection capture sink directly while a
+  scope is active. Committed standalone writes become standalone sync batches,
+  while an explicit transaction spanning several supported tables becomes one
+  atomic local batch. Read/search calls are not captured. A separate
+  `SyncWorker` plus an `ISyncPeer` transport moves committed batches between
+  nodes.
 - `SyncEngine` exposes pull/push/apply primitives, `DirectSyncPeer` provides
   in-process sync for tests and examples, `HttpSyncPeer` defines an HTTP-shaped
   adapter seam, `WebSocketSyncPeer` defines a binary message seam, and

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -218,6 +218,16 @@ cmake -S . -B tmp/build-ws-example `
   `SyncCaptureScope` или более низкоуровневую пару `attach_sync_capture()` /
   `detach_sync_capture()`. Scope-вариант автоматически восстанавливает
   предыдущий capture sink после завершения локальной фазы записи.
+- Предпочитайте `SyncCaptureScope`, когда функция владеет ограниченной фазой
+  записи: например, seed-данными, одной локальной бизнес-операцией или
+  временной подменой sink в тестах. Ручные `attach_sync_capture()` /
+  `detach_sync_capture()` лучше оставлять для более широкого lifecycle
+  компонента, например process-local writer service, который прикрепляет
+  capture один раз после старта и отсоединяет его при shutdown.
+- Вложенные `SyncCaptureScope` должны завершаться строго в обратном порядке.
+  Явный out-of-order `detach()` отклоняется, а raw-вызовы
+  `attach_sync_capture()` / `detach_sync_capture()` не должны подменять sink
+  соединения, пока им владеет активный scope.
 - Методы поддерживаемых таблиц сохраняют обычный API. Не нужно оборачивать
   каждый `insert`, `insert_or_assign`, `erase`, `reconcile` или range erase в
   отдельный sync-вызов. Capture sink записывает поддерживаемые write operations

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -216,6 +216,16 @@ cmake -S . -B tmp/build-ws-example `
   `SyncCaptureScope` or the lower-level `attach_sync_capture()` /
   `detach_sync_capture()` pair. The scope form restores the previous capture
   sink automatically when the local write phase ends.
+- Prefer `SyncCaptureScope` when a function owns a bounded write phase:
+  examples include seeding rows, applying one local business operation, or
+  temporarily overriding an existing sink in tests. Prefer manual
+  `attach_sync_capture()` / `detach_sync_capture()` only when capture is part of
+  a wider component lifecycle, such as a process-local writer service that
+  attaches once after startup and detaches during shutdown.
+- Nested `SyncCaptureScope` objects must end in strict LIFO order. An explicit
+  out-of-order `detach()` is rejected, and raw `attach_sync_capture()` /
+  `detach_sync_capture()` calls must not replace the connection sink while a
+  scope still owns it.
 - Supported table methods keep their normal API. You do not wrap each
   `insert`, `insert_or_assign`, `erase`, `reconcile`, or range erase in a sync
   call. The capture sink records supported write operations when their MDBX

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -205,6 +205,14 @@ Operational rules:
 - v0.1 sync captures normal write paths for `KeyValueTable`, `KeyTable`,
   `ValueTable`, and `SequenceTable`. `VectorStore` is sync-covered only because
   it persists through internal `SequenceTable` and `KeyValueTable` members.
+- Use `SyncCaptureScope` for temporary capture attachment around a bounded
+  write phase. Use raw `attach_sync_capture()` / `detach_sync_capture()` only
+  for a deliberate component lifecycle and keep the same lifecycle-only rule as
+  `Connection`: do not change capture attachment concurrently with table
+  operations or active transactions.
+- Nested `SyncCaptureScope` objects are a stack discipline: detach or destroy
+  the innermost scope first. Do not replace the connection capture sink through
+  raw attach/detach while a scope owns it.
 - `HashedKeyValueStore`, `KeyMultiValueTable`, and `AnyValueTable` are
   not replicated in v0.1; their wire format is not defined. Do not add
   `record_op()` paths for them without first extending `DESIGN.md`.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -309,6 +309,14 @@ Application integration contract:
   attachments and restores the previous sink when the scope ends; supported
   write operations are recorded by table code and flushed by the transaction
   pre-commit hook;
+- choose the scope helper for bounded write phases owned by one stack frame;
+  choose explicit attach/detach only for a wider component lifecycle where the
+  caller can prove no concurrent table operation or active transaction races
+  with capture attachment changes;
+- nested `SyncCaptureScope` objects must be detached or destroyed in strict
+  LIFO order. Explicit out-of-order `detach()` is rejected, and raw
+  attach/detach calls must not replace the connection sink while a scope owns
+  it;
 - a standalone write method call that opens its own transaction commits as one
   local change batch;
 - an explicit transaction passed through several supported table calls commits


### PR DESCRIPTION
Replaces closed stacked PR #146 after #145 was squash-merged and its base branch was deleted.\n\nKeeps README.md and README-RU.md synchronized.\n\nValidation: documentation-only; inherited #145 CI is green.