### PR TITLE
fix(sync): reject reserved dbi names

### DIFF
--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -117,6 +117,12 @@ mdbxc::KeyValueTable<std::string, int> orders(conn, "orders");
 Set `Config::max_dbs` high enough for tests and examples that open several
 tables in one environment.
 
+DBI names starting with `_mdbxc_` are reserved for library-owned metadata and
+sync system stores. Public table wrappers must reject these names, and incoming
+sync `ChangeOp` entries must not target them. Internal store classes open their
+own DBIs directly and are the only code paths allowed to use the reserved
+namespace.
+
 Read-only configuration:
 
 - `Config::read_only` opens the environment with `MDBX_RDONLY`.

--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -1,0 +1,68 @@
+# Sync Audit Follow-ups
+
+This note records the follow-up order from the repository-wide sync audit at
+`main` commit `60a5b32479f2d69a78ec9f9e404ab717fb59e92c`. Keep the fixes split
+into small PRs so behavior, storage format, and build hygiene remain reviewable.
+
+## Immediate PR Sequence
+
+### PR #150: Reserved DBI hardening
+
+- Add one shared `is_reserved_dbi_name()` check for the `_mdbxc_` namespace.
+- Reject public user table names that use reserved internal DBI prefixes.
+- Reject incoming `ChangeOp` entries targeting reserved DBIs before apply.
+- Keep internal stores able to open their reserved DBIs through an internal
+  bypass path, not through the public table-name path.
+- Add tests for `Put`, `Delete`, and `ClearTable` attempts against reserved
+  DBIs, including full rollback of the rejected push page.
+
+### PR #151: External transaction provenance
+
+- Expose enough `Transaction` identity to verify its owning MDBX environment.
+- Add a central `BaseTable` helper for external transaction validation.
+- Reject `Transaction&` / raw transaction handles that belong to another
+  `Connection` before table code uses the table DBI handle.
+- Cover cross-connection negative cases for the main table families and
+  multi-table helpers such as `VectorStore` / `HashedKeyValueStore`.
+
+### PR #152: SyncWorker stop-before-apply contract
+
+- Re-check stop/cancellation after `PullResponse` is received and after the
+  `ApplyStarted` observer callback.
+- Re-check immediately before `SyncEngine::handle_push()`.
+- Add a deterministic test where the observer calls `request_stop()` from
+  `ApplyStarted` and verifies the pulled page is not applied.
+
+### PR #153: Not-implemented public protocol modes
+
+- Make `PullRequest::request_full_snapshot=true` return an explicit
+  permanent/protocol error until full snapshot export/import is implemented.
+- Reject or otherwise make unavailable `ConflictPolicy::LastWriterWins` until
+  timestamp/version-based apply semantics exist.
+- Update docs/tests so public API no longer appears to support these modes.
+
+## Next Agreement Point
+
+After PR #150-#153 are reviewed, agree on the next batch before implementation:
+
+- PR #154: standalone public header coverage for the full installed include
+  tree, C++11/C++17, sync enabled/disabled, and transport feature macros.
+- PR #155+: signed integral key ordering. Choose the storage-format strategy
+  explicitly: order-preserving signed encoding with migration/versioning,
+  temporary compile-time rejection for ordered signed keys, or documented
+  unsigned physical ordering.
+
+## Later Medium-Risk Follow-ups
+
+- Pruning recovery: track earliest retained sequence and report
+  snapshot-required when a replica is behind retained history.
+- `VectorStore` collection naming: reject invalid names or use a reversible
+  collision-free encoding.
+- Transport body limits before full buffering in concrete HTTP/WebSocket
+  backends.
+- Rate-limit bucket eviction / hard caps.
+- WebSocket connect/response/request deadlines.
+- Installed package fallback for lowercase-only `mdbxConfig.cmake`.
+- Clarify `PullRequest::max_bytes` as a soft page budget and add a separate
+  max single-batch limit.
+- Canonicalize floating-point zero keys and define NaN key semantics.

--- a/guides/table-api-guide.md
+++ b/guides/table-api-guide.md
@@ -50,6 +50,9 @@ All public table classes follow the same broad shape:
 - They provide constructors from `std::shared_ptr<Connection>` and `Config`.
 - Constructor `name` opens a named MDBX DBI; increase `Config::max_dbs` when
   tests/examples open several named tables in one environment.
+- Names starting with `_mdbxc_` are reserved for internal metadata and sync
+  stores. Public table wrappers reject them; choose an application-specific
+  prefix instead.
 - With `Config::read_only = true`, constructors open existing DBIs using a
   read-only transaction. `BaseTable` clears `MDBX_CREATE` automatically, so
   wrapper defaults can stay the same, but the DBI must already exist and write

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -42,6 +42,10 @@ namespace mdbxc {
                         std::string name,
                         MDBX_db_flags_t flags)
             : m_connection(std::move(connection)), m_name(std::move(name)) {
+            if (is_reserved_dbi_name(m_name)) {
+                throw std::invalid_argument(
+                    "MDBX Containers table name uses reserved internal prefix '_mdbxc_'");
+            }
             bool read_only = m_connection->is_read_only();
             MDBX_db_flags_t open_flags = read_only
                 ? static_cast<MDBX_db_flags_t>(flags & ~MDBX_CREATE)

--- a/include/mdbx_containers/detail/utils.hpp
+++ b/include/mdbx_containers/detail/utils.hpp
@@ -44,6 +44,17 @@ namespace mdbxc {
             throw MdbxException(context + ": (" + std::to_string(rc) + ") " + std::string(mdbx_strerror(rc)), rc);
         }
     }
+
+    /// \brief Returns true when \p name belongs to the internal DBI namespace.
+    /// \details The `_mdbxc_` prefix is reserved for library metadata and
+    /// sync system stores. Public table wrappers and incoming replication
+    /// changes must not use it as an application DBI name.
+    inline bool is_reserved_dbi_name(const std::string& name) {
+        static const char prefix[] = "_mdbxc_";
+        const std::size_t prefix_len = sizeof(prefix) - 1u;
+        return name.size() >= prefix_len &&
+               name.compare(0u, prefix_len, prefix) == 0;
+    }
     
     /// \brief Convert IEEE754 float to monotonic sortable unsigned int key.
     /// \param f Input float value.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -268,6 +268,11 @@ any new payload integer: little-endian.
 
 ## Stores
 
+The `_mdbxc_` DBI prefix is reserved for library-owned stores. Application
+tables must not use that prefix, and `SyncEngine` rejects incoming `ChangeOp`
+entries whose `dbi_name` targets the reserved namespace before applying any
+operation from the pushed page.
+
 ### `_mdbxc_meta` (MetaStore)
 
 | Tag | Field | Type | Notes |

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -271,7 +271,9 @@ any new payload integer: little-endian.
 The `_mdbxc_` DBI prefix is reserved for library-owned stores. Application
 tables must not use that prefix, and `SyncEngine` rejects incoming `ChangeOp`
 entries whose `dbi_name` targets the reserved namespace before applying any
-operation from the pushed page.
+operation from the containing batch. A multi-batch `PushRequest` is still
+atomic: earlier batches in the same request are rolled back when a later batch
+is rejected.
 
 ### `_mdbxc_meta` (MetaStore)
 

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -93,7 +93,7 @@ namespace sync {
 
         /// \brief DBI name for DBI-related conflicts.
         /// \details Set for \c InconsistentBatchDbiFlags and
-        /// \c ExistingDbiFlagsMismatch.
+        /// \c ExistingDbiFlagsMismatch, and \c ReservedDbiName.
         std::string          dbi_name;
 
         /// \brief Previously seen flags for \c InconsistentBatchDbiFlags.

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -63,6 +63,7 @@ namespace sync {
         SequenceGap,              ///< Batch seq is not last_applied_seq + 1.
         InconsistentBatchDbiFlags,///< One batch carries contradictory flags for one DBI.
         ExistingDbiFlagsMismatch, ///< Existing destination DBI rejects captured flags.
+        ReservedDbiName,          ///< Incoming ChangeOp targets an internal DBI name.
     };
 
     /// \brief Detailed result for callers that need conflict diagnostics.
@@ -245,6 +246,8 @@ namespace sync {
                     return "inconsistent_batch_dbi_flags";
                 case ApplyConflictReason::ExistingDbiFlagsMismatch:
                     return "existing_dbi_flags_mismatch";
+                case ApplyConflictReason::ReservedDbiName:
+                    return "reserved_dbi_name";
             }
             return "unknown";
         }
@@ -475,6 +478,9 @@ namespace sync {
                 }
                 message += ", mdbx_error_code=" +
                            std::to_string(outcome.mdbx_error_code) + ")";
+            } else if (outcome.conflict_reason ==
+                       ApplyConflictReason::ReservedDbiName) {
+                message += " (dbi='" + outcome.dbi_name + "')";
             }
             return message;
         }
@@ -503,6 +509,17 @@ namespace sync {
             dbis.clear();
             std::unordered_map<std::string, std::vector<BatchDbiFlags>::size_type> index_by_name;
             for (const ChangeOp& op : batch.ops) {
+                if (is_reserved_dbi_name(op.dbi_name)) {
+                    if (outcome != nullptr) {
+                        outcome->result = ApplyResult::Conflict;
+                        outcome->conflict_reason =
+                            ApplyConflictReason::ReservedDbiName;
+                        outcome->dbi_name = op.dbi_name;
+                        outcome->incoming_dbi_flags =
+                            persistent_dbi_flags(op.dbi_flags);
+                    }
+                    return false;
+                }
                 const std::uint32_t flags = persistent_dbi_flags(op.dbi_flags);
                 const std::pair<
                     std::unordered_map<std::string, std::vector<BatchDbiFlags>::size_type>::iterator,

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -131,6 +131,30 @@ void append_raw_bytes(mdbxc::sync::ChangeLogStore& log,
     log.append(txn, origin, seq, bytes);
 }
 
+const char* op_type_name(mdbxc::sync::ChangeOpType type) {
+    switch (type) {
+        case mdbxc::sync::ChangeOpType::Put:
+            return "Put";
+        case mdbxc::sync::ChangeOpType::Delete:
+            return "Delete";
+        case mdbxc::sync::ChangeOpType::ClearTable:
+            return "ClearTable";
+    }
+    return "unknown";
+}
+
+void assign_int_key(std::vector<std::uint8_t>& out, int key) {
+    mdbxc::SerializeScratch scratch;
+    const MDBX_val serialized = mdbxc::serialize_key<true>(key, scratch);
+    assign_bytes(out, serialized);
+}
+
+void assign_int_value(std::vector<std::uint8_t>& out, int value) {
+    mdbxc::SerializeScratch scratch;
+    const MDBX_val serialized = mdbxc::serialize_value(value, scratch);
+    assign_bytes(out, serialized);
+}
+
 void test_engine_round_trip_kv() {
     using namespace mdbxc;
     const std::string primary_path = "test_engine_primary.mdbx";
@@ -192,6 +216,113 @@ void test_engine_round_trip_kv() {
     replica_conn->disconnect();
     cleanup(primary_path);
     cleanup(replica_path);
+}
+
+void test_public_tables_reject_reserved_dbi_names() {
+    using namespace mdbxc;
+    const std::string p = "test_public_reserved_dbi_names.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    bool rejected = false;
+    try {
+        KeyValueTable<int, int> kv(conn, "_mdbxc_user_table");
+        (void)kv;
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error("public table accepted reserved DBI name");
+    }
+
+    sync::MetaStore meta(conn->env_handle());
+    auto txn = conn->transaction(TransactionMode::WRITABLE);
+    meta.open(txn.handle());
+    meta.set_schema_version(txn.handle(), sync::meta_schema_version());
+    txn.commit();
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_rejects_reserved_dbi_changes_and_rolls_back_page() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_reserved_dbi_changes.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    const sync::NodeId local_node = make_node(0x10);
+    const sync::NodeId db_id = make_node(0x11);
+    const sync::NodeId origin = make_node(0x20);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(local_node, db_id);
+    KeyValueTable<int, int> safe(conn, "safe");
+
+    const sync::ChangeOpType op_types[] = {
+        sync::ChangeOpType::Put,
+        sync::ChangeOpType::Delete,
+        sync::ChangeOpType::ClearTable
+    };
+
+    for (std::size_t i = 0; i < sizeof(op_types) / sizeof(op_types[0]); ++i) {
+        sync::ChangeBatch batch;
+        batch.origin_node_id = origin;
+        batch.seq = 1;
+
+        sync::ChangeOp safe_op;
+        safe_op.op_type = sync::ChangeOpType::Put;
+        safe_op.dbi_name = "safe";
+        safe_op.dbi_flags = static_cast<std::uint32_t>(MDBX_INTEGERKEY);
+        assign_int_key(safe_op.storage_key, static_cast<int>(100 + i));
+        assign_int_value(safe_op.value, static_cast<int>(200 + i));
+        batch.ops.push_back(safe_op);
+
+        sync::ChangeOp reserved_op;
+        reserved_op.op_type = op_types[i];
+        reserved_op.dbi_name = "_mdbxc_meta";
+        assign_int_key(reserved_op.storage_key, 7);
+        if (reserved_op.op_type == sync::ChangeOpType::Put) {
+            assign_int_value(reserved_op.value, 8);
+        }
+        batch.ops.push_back(reserved_op);
+
+        sync::PushRequest request;
+        request.sender = origin;
+        request.db_id = db_id;
+        request.batches.push_back(batch);
+
+        const sync::PushResponse response = engine.handle_push(request);
+        if (response.ok) {
+            throw std::runtime_error(
+                std::string("reserved DBI ") +
+                op_type_name(op_types[i]) + " push unexpectedly succeeded");
+        }
+        if (response.error.find("reserved_dbi_name") == std::string::npos ||
+            response.error.find("_mdbxc_meta") == std::string::npos) {
+            throw std::runtime_error(
+                std::string("reserved DBI ") +
+                op_type_name(op_types[i]) + " returned wrong error: " +
+                response.error);
+        }
+        if (engine.applied_cursor().last_seq_for(origin) != 0u) {
+            throw std::runtime_error(
+                std::string("reserved DBI ") +
+                op_type_name(op_types[i]) + " advanced applied cursor");
+        }
+        if (kv_has(conn, safe, static_cast<int>(100 + i))) {
+            throw std::runtime_error(
+                std::string("reserved DBI ") +
+                op_type_name(op_types[i]) + " did not roll back page");
+        }
+        if (engine.db_uuid() != db_id) {
+            throw std::runtime_error(
+                std::string("reserved DBI ") +
+                op_type_name(op_types[i]) + " changed metadata");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
 }
 
 void test_engine_skips_self_origin() {
@@ -1103,6 +1234,10 @@ int main() {
     struct Case { const char* name; void (*fn)(); };
     const Case cases[] = {
         { "test_engine_round_trip_kv",          &test_engine_round_trip_kv },
+        { "test_public_tables_reject_reserved_dbi_names",
+          &test_public_tables_reject_reserved_dbi_names },
+        { "test_engine_rejects_reserved_dbi_changes",
+          &test_engine_rejects_reserved_dbi_changes_and_rolls_back_page },
         { "test_engine_skips_self_origin",      &test_engine_skips_self_origin },
         { "test_engine_idempotent_replay",      &test_engine_idempotent_replay },
         { "test_engine_legacy_zero_flags",      &test_engine_applies_legacy_zero_flags_to_integer_dbi },

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -325,6 +325,69 @@ void test_engine_rejects_reserved_dbi_changes_and_rolls_back_page() {
     cleanup(p);
 }
 
+void test_engine_reserved_dbi_rolls_back_multi_batch_push() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_reserved_dbi_multi_batch.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    const sync::NodeId local_node = make_node(0x12);
+    const sync::NodeId db_id = make_node(0x13);
+    const sync::NodeId origin = make_node(0x22);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(local_node, db_id);
+    KeyValueTable<int, int> safe(conn, "safe");
+
+    sync::ChangeBatch valid_batch;
+    valid_batch.origin_node_id = origin;
+    valid_batch.seq = 1;
+
+    sync::ChangeOp safe_op;
+    safe_op.op_type = sync::ChangeOpType::Put;
+    safe_op.dbi_name = "safe";
+    safe_op.dbi_flags = static_cast<std::uint32_t>(MDBX_INTEGERKEY);
+    assign_int_key(safe_op.storage_key, 501);
+    assign_int_value(safe_op.value, 601);
+    valid_batch.ops.push_back(safe_op);
+
+    sync::ChangeBatch reserved_batch;
+    reserved_batch.origin_node_id = origin;
+    reserved_batch.seq = 2;
+
+    sync::ChangeOp reserved_op;
+    reserved_op.op_type = sync::ChangeOpType::ClearTable;
+    reserved_op.dbi_name = "_mdbxc_meta";
+    reserved_batch.ops.push_back(reserved_op);
+
+    sync::PushRequest request;
+    request.sender = origin;
+    request.db_id = db_id;
+    request.batches.push_back(valid_batch);
+    request.batches.push_back(reserved_batch);
+
+    const sync::PushResponse response = engine.handle_push(request);
+    if (response.ok) {
+        throw std::runtime_error("reserved DBI multi-batch push unexpectedly succeeded");
+    }
+    if (response.error.find("reserved_dbi_name") == std::string::npos ||
+        response.error.find("_mdbxc_meta") == std::string::npos) {
+        throw std::runtime_error("reserved DBI multi-batch push returned wrong error: " +
+                                 response.error);
+    }
+    if (engine.applied_cursor().last_seq_for(origin) != 0u) {
+        throw std::runtime_error("reserved DBI multi-batch push advanced applied cursor");
+    }
+    if (kv_has(conn, safe, 501)) {
+        throw std::runtime_error("reserved DBI multi-batch push committed earlier batch");
+    }
+    if (engine.db_uuid() != db_id) {
+        throw std::runtime_error("reserved DBI multi-batch push changed metadata");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 void test_engine_skips_self_origin() {
     using namespace mdbxc;
     const std::string p = "test_engine_self_origin.mdbx";
@@ -1238,6 +1301,8 @@ int main() {
           &test_public_tables_reject_reserved_dbi_names },
         { "test_engine_rejects_reserved_dbi_changes",
           &test_engine_rejects_reserved_dbi_changes_and_rolls_back_page },
+        { "test_engine_reserved_dbi_rolls_back_multi_batch_push",
+          &test_engine_reserved_dbi_rolls_back_multi_batch_push },
         { "test_engine_skips_self_origin",      &test_engine_skips_self_origin },
         { "test_engine_idempotent_replay",      &test_engine_idempotent_replay },
         { "test_engine_legacy_zero_flags",      &test_engine_applies_legacy_zero_flags_to_integer_dbi },


### PR DESCRIPTION
## Summary
- record the audit follow-up plan for #150-#155+
- reserve the `_mdbxc_` DBI namespace for library stores
- reject public table names and incoming `ChangeOp` DBI names that target reserved stores
- add rollback/metadata regression coverage for reserved DBI push pages

## Validation
- `git diff --check`
- `cmake --build tmp/pr148-make-cpp17 --target test_sync_engine`
- `ctest --test-dir tmp/pr148-make-cpp17 -R ^test_sync_engine$ --output-on-failure`
- `cmake --build tmp/pr148-make-cpp11 --target test_sync_engine`
- `ctest --test-dir tmp/pr148-make-cpp11 -R ^test_sync_engine$ --output-on-failure`