### PR TITLE
fix(tables): validate external transaction provenance

### DIFF
--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -27,6 +27,9 @@ is header-only and template-heavy.
 - Do not pass `Transaction`, raw `MDBX_txn*`, or MDBX cursors across threads.
   Commit, roll back, abort, reset, and destroy transaction guards on the owning
   thread.
+- Caller-supplied `Transaction` and raw `MDBX_txn*` handles must also belong to
+  the same MDBX environment as the table wrapper. Public table methods reject
+  handles from another `Connection` before using the DBI handle.
 - Treat `Connection::configure()`, `connect()`, `disconnect()`, `cleanup()`, and
   destruction as lifecycle-only operations. They must not race with table
   operations, active transactions, or MDBX cursors.

--- a/guides/table-api-guide.md
+++ b/guides/table-api-guide.md
@@ -69,6 +69,9 @@ All public table classes follow the same broad shape:
   or use the caller-supplied transaction.
 - A supplied `MDBX_txn*` or `Transaction` must belong to the current thread.
   Do not pass transaction handles or MDBX cursors across threads.
+- A supplied `MDBX_txn*` or `Transaction` must also belong to the same
+  `Connection`/MDBX environment as the table wrapper. Passing a transaction from
+  another environment is rejected before any table data is touched.
 - Table wrapper instances are not synchronization primitives. For concurrent
   workers, prefer separate wrappers per thread over the same shared
   `Connection`, or protect one shared wrapper with an external mutex.

--- a/include/mdbx_containers/AnyValueTable.hpp
+++ b/include/mdbx_containers/AnyValueTable.hpp
@@ -366,7 +366,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();

--- a/include/mdbx_containers/HashedKeyValueStore.hpp
+++ b/include/mdbx_containers/HashedKeyValueStore.hpp
@@ -903,7 +903,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();
@@ -1501,7 +1501,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();

--- a/include/mdbx_containers/KeyMultiValueTable.hpp
+++ b/include/mdbx_containers/KeyMultiValueTable.hpp
@@ -1150,7 +1150,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();

--- a/include/mdbx_containers/KeyTable.hpp
+++ b/include/mdbx_containers/KeyTable.hpp
@@ -801,7 +801,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();

--- a/include/mdbx_containers/KeyValueTable.hpp
+++ b/include/mdbx_containers/KeyValueTable.hpp
@@ -1395,7 +1395,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode = TransactionMode::WRITABLE, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn(); // reuse transaction bound to this thread if any

--- a/include/mdbx_containers/SequenceTable.hpp
+++ b/include/mdbx_containers/SequenceTable.hpp
@@ -490,7 +490,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();

--- a/include/mdbx_containers/ValueTable.hpp
+++ b/include/mdbx_containers/ValueTable.hpp
@@ -326,7 +326,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -12,6 +12,7 @@
 #endif
 
 #include <string>
+#include <stdexcept>
 #include <vector>
 
 namespace mdbxc {
@@ -165,6 +166,22 @@ namespace mdbxc {
         /// \brief Gets the raw DBI handle.
         /// \return DBI handle for the opened table.
         MDBX_dbi handle() const { return m_dbi; }
+
+        /// \brief Validates that an external transaction belongs to this table's environment.
+        /// \details Table DBI handles are environment-local. Passing a transaction
+        /// from another Connection could otherwise address an unrelated DBI with
+        /// the same numeric handle.
+        MDBX_txn* checked_external_txn(MDBX_txn* txn) const {
+            if (txn == nullptr) {
+                return nullptr;
+            }
+            MDBX_env* txn_env = mdbx_txn_env(txn);
+            if (txn_env != m_connection->env_handle()) {
+                throw std::invalid_argument(
+                    "External transaction belongs to a different MDBX environment");
+            }
+            return txn;
+        }
 
         /// \brief Throws when a duplicate value exceeds the configured proactive limit.
         /// \param value Duplicate value that will be written into an MDBX_DUPSORT DBI.

--- a/tests/test_transaction_provenance.cpp
+++ b/tests/test_transaction_provenance.cpp
@@ -1,0 +1,125 @@
+#include <mdbx_containers.hpp>
+
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+void cleanup(const std::string& p) {
+    std::remove(p.c_str());
+}
+
+std::shared_ptr<mdbxc::Connection> open_env(const std::string& path) {
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 32;
+    cfg.no_subdir = true;
+    return mdbxc::Connection::create(cfg);
+}
+
+template<class Fn>
+void expect_invalid_argument(const char* name, Fn fn) {
+    bool rejected = false;
+    try {
+        fn();
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error(
+            std::string(name) + " accepted a transaction from another environment");
+    }
+}
+
+template<class Table, class Key>
+bool contains_key(Table& table, const Key& key) {
+    return table.contains(key);
+}
+
+void test_external_transaction_must_match_table_connection() {
+    using namespace mdbxc;
+    const std::string path_a = "test_txn_provenance_a.mdbx";
+    const std::string path_b = "test_txn_provenance_b.mdbx";
+    cleanup(path_a);
+    cleanup(path_b);
+
+    auto conn_a = open_env(path_a);
+    auto conn_b = open_env(path_b);
+
+    KeyValueTable<int, int> kv(conn_a, "kv");
+    KeyTable<int> keys(conn_a, "keys");
+    ValueTable<int> value(conn_a, "value");
+    SequenceTable<int> seq(conn_a, "seq");
+    AnyValueTable<int> any(conn_a, "any");
+    KeyMultiValueTable<int, std::string> multi(conn_a, "multi");
+    HashedKeyValueStore<std::string, std::string> hashed(conn_a, "hashed");
+
+    auto txn_b = conn_b->transaction(TransactionMode::WRITABLE);
+
+    expect_invalid_argument("KeyValueTable Transaction",
+                            [&kv, &txn_b]() { kv.insert_or_assign(1, 10, txn_b); });
+    expect_invalid_argument("KeyValueTable raw MDBX_txn",
+                            [&kv, &txn_b]() { kv.insert_or_assign(2, 20, txn_b.handle()); });
+    expect_invalid_argument("KeyTable Transaction",
+                            [&keys, &txn_b]() { keys.insert(1, txn_b); });
+    expect_invalid_argument("ValueTable Transaction",
+                            [&value, &txn_b]() { value.set(10, txn_b); });
+    expect_invalid_argument("SequenceTable Transaction",
+                            [&seq, &txn_b]() { seq.insert_or_assign(1, 10, txn_b); });
+    expect_invalid_argument("AnyValueTable Transaction",
+                            [&any, &txn_b]() { any.set(1, std::string("value"), txn_b); });
+    expect_invalid_argument("KeyMultiValueTable Transaction",
+                            [&multi, &txn_b]() { multi.insert(1, std::string("value"), txn_b); });
+    expect_invalid_argument("HashedKeyValueStore Transaction",
+                            [&hashed, &txn_b]() {
+                                hashed.insert_or_assign(std::string("k"),
+                                                        std::string("v"),
+                                                        txn_b);
+                            });
+
+    txn_b.commit();
+
+    if (contains_key(kv, 1) || contains_key(kv, 2)) {
+        throw std::runtime_error("cross-environment KeyValueTable write reached table A");
+    }
+    if (!keys.empty() || value.has_value() || seq.count() != 0u ||
+        any.contains(1) || multi.count() != 0u || hashed.count() != 0u) {
+        throw std::runtime_error("cross-environment write reached a table");
+    }
+
+    conn_a->disconnect();
+    conn_b->disconnect();
+    cleanup(path_a);
+    cleanup(path_b);
+}
+
+} // namespace
+
+int main() {
+    struct Case {
+        const char* name;
+        void (*fn)();
+    };
+
+    const Case cases[] = {
+        { "test_external_transaction_must_match_table_connection",
+          &test_external_transaction_must_match_table_connection }
+    };
+
+    for (std::size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
+        try {
+            cases[i].fn();
+            std::printf("PASS %s\n", cases[i].name);
+        } catch (const std::exception& e) {
+            std::printf("FAIL %s: %s\n", cases[i].name, e.what());
+            return static_cast<int>(i + 1u);
+        } catch (...) {
+            std::printf("FAIL %s: non-std exception\n", cases[i].name);
+            return static_cast<int>(i + 1u);
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- reject caller-supplied transactions from a different MDBX environment before table DBI use
- route all root table wrappers through the shared BaseTable provenance check
- add a regression test covering Transaction and raw MDBX_txn overloads across public table types
- document the same-Connection transaction invariant for users and implementers

## Validation
- `git diff --check`
- `cmake -S . -B tmp/pr148-make-cpp17 -DCMAKE_CXX_STANDARD=17 -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON`
- `cmake -S . -B tmp/pr148-make-cpp11 -DCMAKE_CXX_STANDARD=11 -DMDBXC_DEPS_MODE=BUNDLED -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=ON`
- `cmake --build tmp/pr148-make-cpp17 --target test_transaction_provenance`
- `cmake --build tmp/pr148-make-cpp11 --target test_transaction_provenance`
- `ctest --test-dir tmp/pr148-make-cpp17 -R ^test_transaction_provenance$ --output-on-failure`
- `ctest --test-dir tmp/pr148-make-cpp11 -R ^test_transaction_provenance$ --output-on-failure`
- `cmake --build tmp/pr148-make-cpp17 --target any_value_table_test hashed_key_value_store_test key_multi_value_table_test key_table_test kv_container_all_types_test sequence_table_test transaction_test value_table_test`
- `cmake --build tmp/pr148-make-cpp11 --target any_value_table_test hashed_key_value_store_test key_multi_value_table_test key_table_test kv_container_all_types_test sequence_table_test transaction_test value_table_test`
- `ctest --test-dir tmp/pr148-make-cpp17 -R ^(any_value_table_test|hashed_key_value_store_test|key_multi_value_table_test|key_table_test|kv_container_all_types_test|sequence_table_test|transaction_test|value_table_test|test_transaction_provenance)$ --output-on-failure`
- `ctest --test-dir tmp/pr148-make-cpp11 -R ^(any_value_table_test|hashed_key_value_store_test|key_multi_value_table_test|key_table_test|kv_container_all_types_test|sequence_table_test|transaction_test|value_table_test|test_transaction_provenance)$ --output-on-failure`