### PR TITLE
fix(sync): stop worker before applying cancelled page

### DIFF
--- a/include/mdbx_containers/sync/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/SyncWorker.hpp
@@ -307,7 +307,8 @@ namespace sync {
         /// \c ISyncPeer::request_cancel() outside the worker mutex at most
         /// once for each observed in-flight peer call.
         /// Cancellation is best-effort; the worker exits before applying a
-        /// page returned after stop was requested.
+        /// page returned after stop was requested unless that page has already
+        /// passed the final apply gate immediately before \c handle_push().
         void request_stop() {
             bool cancel_peer = false;
             {
@@ -558,7 +559,14 @@ namespace sync {
                     }
 
                     if (!response.batches.empty()) {
-                        set_state(SyncWorkerState::Applying);
+                        PushRequest apply;
+                        apply.db_id = request.db_id;
+                        apply.batches = response.batches;
+
+                        if (!begin_apply_stage()) {
+                            result.has_more = has_more;
+                            return result;
+                        }
                         {
                             SyncWorkerStageEvent event = make_stage_event(
                                 SyncWorkerStage::ApplyStarted, result);
@@ -567,10 +575,12 @@ namespace sync {
                             event.progress = progress;
                             notify_stage_changed(event);
                         }
-                        PushRequest apply;
-                        apply.db_id = request.db_id;
-                        apply.batches = response.batches;
-                        const PushResponse applied = m_engine.handle_push(apply);
+                        PushResponse applied;
+                        if (!enter_apply_gate()) {
+                            result.has_more = has_more;
+                            return result;
+                        }
+                        applied = m_engine.handle_push(apply);
                         SyncCursor after_apply = request.have;
                         if (applied.ok) {
                             after_apply = m_engine.applied_cursor();
@@ -888,6 +898,25 @@ namespace sync {
             std::lock_guard<std::mutex> lock(m_mutex);
             m_peer_call_active = false;
             m_peer_cancel_requested = false;
+        }
+
+        bool begin_apply_stage() const {
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                if (m_stop_requested) {
+                    return false;
+                }
+                m_state = SyncWorkerState::Applying;
+                m_status.state = m_state;
+                m_status.backoff_active = false;
+            }
+            m_state_changed.notify_all();
+            return true;
+        }
+
+        bool enter_apply_gate() const {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            return !m_stop_requested;
         }
 
         void request_peer_cancel() const {

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -98,6 +98,27 @@ private:
     int m_cancel_count;
 };
 
+class FixedPeer : public mdbxc::sync::ISyncPeer {
+public:
+    explicit FixedPeer(const mdbxc::sync::PullResponse& response)
+        : m_response(response) {}
+
+    mdbxc::sync::PullResponse pull(
+            const mdbxc::sync::PullRequest& request) override {
+        (void)request;
+        return m_response;
+    }
+
+    mdbxc::sync::PushResponse push(
+            const mdbxc::sync::PushRequest& request) override {
+        (void)request;
+        return mdbxc::sync::PushResponse();
+    }
+
+private:
+    mdbxc::sync::PullResponse m_response;
+};
+
 class BlockingPeer : public mdbxc::sync::ISyncPeer {
 public:
     explicit BlockingPeer(const mdbxc::sync::PullResponse& response)
@@ -540,6 +561,54 @@ private:
     std::vector<mdbxc::sync::SyncWorkerRoundResult> m_rounds;
     std::vector<BackoffRecord> m_backoffs;
     std::vector<mdbxc::sync::SyncWorkerStageEvent> m_stages;
+};
+
+class StopOnApplyStartedObserver : public RecordingWorkerObserver {
+public:
+    StopOnApplyStartedObserver() : m_worker(nullptr) {}
+
+    void set_worker(mdbxc::sync::SyncWorker* worker) {
+        m_worker = worker;
+    }
+
+    void on_sync_worker_stage_changed(
+            const mdbxc::sync::SyncWorkerStageEvent& event) override {
+        RecordingWorkerObserver::on_sync_worker_stage_changed(event);
+        if (event.stage == mdbxc::sync::SyncWorkerStage::ApplyStarted) {
+            if (m_worker == nullptr) {
+                throw std::runtime_error("stop observer has no worker");
+            }
+            m_worker->request_stop();
+        }
+    }
+
+private:
+    mdbxc::sync::SyncWorker* m_worker;
+};
+
+class ThreadedStopOnApplyStartedObserver : public RecordingWorkerObserver {
+public:
+    ThreadedStopOnApplyStartedObserver() : m_worker(nullptr) {}
+
+    void set_worker(mdbxc::sync::SyncWorker* worker) {
+        m_worker = worker;
+    }
+
+    void on_sync_worker_stage_changed(
+            const mdbxc::sync::SyncWorkerStageEvent& event) override {
+        RecordingWorkerObserver::on_sync_worker_stage_changed(event);
+        if (event.stage == mdbxc::sync::SyncWorkerStage::ApplyStarted) {
+            if (m_worker == nullptr) {
+                throw std::runtime_error("threaded stop observer has no worker");
+            }
+            std::thread stopper(
+                &mdbxc::sync::SyncWorker::request_stop, m_worker);
+            stopper.join();
+        }
+    }
+
+private:
+    mdbxc::sync::SyncWorker* m_worker;
 };
 
 class ThrowingRoundObserver : public mdbxc::sync::ISyncWorkerObserver {
@@ -1592,6 +1661,102 @@ void test_worker_stop_while_pull_blocked_does_not_apply_returned_page() {
     cleanup(path);
 }
 
+void test_worker_stop_from_apply_started_observer_skips_apply() {
+    using namespace mdbxc;
+    const std::string path = "test_worker_stop_before_apply.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    const sync::NodeId replica_node = make_node(0xB3);
+    const sync::NodeId remote_origin = make_node(0xA3);
+    const sync::NodeId db_id = make_node(0xD3);
+
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
+
+    sync::ChangeBatch batch;
+    batch.origin_node_id = remote_origin;
+    batch.seq = 1;
+
+    sync::PullResponse response;
+    response.batches.push_back(batch);
+
+    FixedPeer peer(response);
+    StopOnApplyStartedObserver observer;
+    sync::SyncWorkerOptions options;
+    options.observer = &observer;
+    sync::SyncWorker guarded_worker(engine, peer, options);
+    observer.set_worker(&guarded_worker);
+
+    const sync::SyncWorkerRoundResult result = guarded_worker.run_once();
+    if (!result.ok || result.pages_pulled != 1u ||
+        result.batches_applied != 0u) {
+        throw std::runtime_error("stop before apply round result mismatch");
+    }
+    if (guarded_worker.state() != sync::SyncWorkerState::Stopped) {
+        throw std::runtime_error("stop-before-apply worker did not stop");
+    }
+    if (engine.applied_cursor().last_seq_for(remote_origin) != 0u) {
+        throw std::runtime_error("worker applied page after ApplyStarted stop");
+    }
+    if (!observer.pages().empty()) {
+        throw std::runtime_error("page-applied observer ran for skipped apply");
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_worker_threaded_stop_from_apply_started_observer_skips_apply() {
+    using namespace mdbxc;
+    const std::string path = "test_worker_threaded_stop_before_apply.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    const sync::NodeId replica_node = make_node(0xB4);
+    const sync::NodeId remote_origin = make_node(0xA4);
+    const sync::NodeId db_id = make_node(0xD4);
+
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
+
+    sync::ChangeBatch batch;
+    batch.origin_node_id = remote_origin;
+    batch.seq = 1;
+
+    sync::PullResponse response;
+    response.batches.push_back(batch);
+
+    FixedPeer peer(response);
+    ThreadedStopOnApplyStartedObserver observer;
+    sync::SyncWorkerOptions options;
+    options.observer = &observer;
+    sync::SyncWorker guarded_worker(engine, peer, options);
+    observer.set_worker(&guarded_worker);
+
+    const sync::SyncWorkerRoundResult result = guarded_worker.run_once();
+    if (!result.ok || result.pages_pulled != 1u ||
+        result.batches_applied != 0u) {
+        throw std::runtime_error(
+            "threaded stop before apply round result mismatch");
+    }
+    if (guarded_worker.state() != sync::SyncWorkerState::Stopped) {
+        throw std::runtime_error(
+            "threaded stop-before-apply worker did not stop");
+    }
+    if (engine.applied_cursor().last_seq_for(remote_origin) != 0u) {
+        throw std::runtime_error(
+            "worker applied page after threaded ApplyStarted stop");
+    }
+    if (!observer.pages().empty()) {
+        throw std::runtime_error(
+            "page-applied observer ran for threaded skipped apply");
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 void test_worker_repeated_stop_cancels_blocking_peer_once() {
     using namespace mdbxc;
     const std::string path = "test_worker_cancel_once.mdbx";
@@ -1804,6 +1969,10 @@ int main() {
           &test_worker_rejects_invalid_options },
         { "test_worker_stop_while_pull_blocked",
           &test_worker_stop_while_pull_blocked_does_not_apply_returned_page },
+        { "test_worker_stop_from_apply_started_observer_skips_apply",
+          &test_worker_stop_from_apply_started_observer_skips_apply },
+        { "test_worker_threaded_stop_from_apply_started_observer_skips_apply",
+          &test_worker_threaded_stop_from_apply_started_observer_skips_apply },
         { "test_worker_repeated_stop_cancels_blocking_peer_once",
           &test_worker_repeated_stop_cancels_blocking_peer_once },
         { "test_worker_stop_cancels_blocking_peer",


### PR DESCRIPTION
## Summary
- add a second stop checkpoint after `ApplyStarted` observer callbacks and before `SyncEngine::handle_push()`
- cover the race where an observer requests stop after a page is pulled but before it is applied
- verify skipped pages do not advance the applied cursor and do not emit page-applied callbacks

## Validation
- `cmake --build tmp/pr148-make-cpp17 --target test_sync_worker`
- `cmake --build tmp/pr148-make-cpp11 --target test_sync_worker`
- `ctest --test-dir tmp/pr148-make-cpp17 -R ^test_sync_worker$ --output-on-failure`
- `ctest --test-dir tmp/pr148-make-cpp11 -R ^test_sync_worker$ --output-on-failure`
- `git diff --check`