### PR TITLE
fix(sync): reject unimplemented protocol modes

### DIFF
--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -117,6 +117,12 @@ mdbxc::KeyValueTable<std::string, int> orders(conn, "orders");
 Set `Config::max_dbs` high enough for tests and examples that open several
 tables in one environment.
 
+DBI names starting with `_mdbxc_` are reserved for library-owned metadata and
+sync system stores. Public table wrappers must reject these names, and incoming
+sync `ChangeOp` entries must not target them. Internal store classes open their
+own DBIs directly and are the only code paths allowed to use the reserved
+namespace.
+
 Read-only configuration:
 
 - `Config::read_only` opens the environment with `MDBX_RDONLY`.

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -208,9 +208,9 @@ Operational rules:
   method. Calling a method before `open()` throws `std::logic_error` rather
   than silently writing to DBI 0. Do not weaken this guard.
 - `ConflictPolicy::Reject` is the v0.1 default. `LastWriterWins` is declared
-  for future logical-key conflict resolution, but the current raw batch apply
-  path does not use it in a non-test path. `time_unix_ns` is metadata, not a
-  reliable conflict authority. `Custom` is deferred to v0.2.
+  for future logical-key conflict resolution, but `SyncEngine` rejects it until
+  timestamp/version-based apply semantics exist. `time_unix_ns` is metadata,
+  not a reliable conflict authority. `Custom` is deferred to v0.2.
 - v0.1 sync captures normal write paths for `KeyValueTable`, `KeyTable`,
   `ValueTable`, and `SequenceTable`. `VectorStore` is sync-covered only because
   it persists through internal `SequenceTable` and `KeyValueTable` members.

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -27,6 +27,9 @@ is header-only and template-heavy.
 - Do not pass `Transaction`, raw `MDBX_txn*`, or MDBX cursors across threads.
   Commit, roll back, abort, reset, and destroy transaction guards on the owning
   thread.
+- Caller-supplied `Transaction` and raw `MDBX_txn*` handles must also belong to
+  the same MDBX environment as the table wrapper. Public table methods reject
+  handles from another `Connection` before using the DBI handle.
 - Treat `Connection::configure()`, `connect()`, `disconnect()`, `cleanup()`, and
   destruction as lifecycle-only operations. They must not race with table
   operations, active transactions, or MDBX cursors.

--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -1,0 +1,68 @@
+# Sync Audit Follow-ups
+
+This note records the follow-up order from the repository-wide sync audit at
+`main` commit `60a5b32479f2d69a78ec9f9e404ab717fb59e92c`. Keep the fixes split
+into small PRs so behavior, storage format, and build hygiene remain reviewable.
+
+## Immediate PR Sequence
+
+### PR #150: Reserved DBI hardening
+
+- Add one shared `is_reserved_dbi_name()` check for the `_mdbxc_` namespace.
+- Reject public user table names that use reserved internal DBI prefixes.
+- Reject incoming `ChangeOp` entries targeting reserved DBIs before apply.
+- Keep internal stores able to open their reserved DBIs through an internal
+  bypass path, not through the public table-name path.
+- Add tests for `Put`, `Delete`, and `ClearTable` attempts against reserved
+  DBIs, including full rollback of the rejected push page.
+
+### PR #151: External transaction provenance
+
+- Expose enough `Transaction` identity to verify its owning MDBX environment.
+- Add a central `BaseTable` helper for external transaction validation.
+- Reject `Transaction&` / raw transaction handles that belong to another
+  `Connection` before table code uses the table DBI handle.
+- Cover cross-connection negative cases for the main table families and
+  multi-table helpers such as `VectorStore` / `HashedKeyValueStore`.
+
+### PR #152: SyncWorker stop-before-apply contract
+
+- Re-check stop/cancellation after `PullResponse` is received and after the
+  `ApplyStarted` observer callback.
+- Re-check immediately before `SyncEngine::handle_push()`.
+- Add a deterministic test where the observer calls `request_stop()` from
+  `ApplyStarted` and verifies the pulled page is not applied.
+
+### PR #153: Not-implemented public protocol modes
+
+- Make `PullRequest::request_full_snapshot=true` return an explicit
+  permanent/protocol error until full snapshot export/import is implemented.
+- Reject or otherwise make unavailable `ConflictPolicy::LastWriterWins` until
+  timestamp/version-based apply semantics exist.
+- Update docs/tests so public API no longer appears to support these modes.
+
+## Next Agreement Point
+
+After PR #150-#153 are reviewed, agree on the next batch before implementation:
+
+- PR #154: standalone public header coverage for the full installed include
+  tree, C++11/C++17, sync enabled/disabled, and transport feature macros.
+- PR #155+: signed integral key ordering. Choose the storage-format strategy
+  explicitly: order-preserving signed encoding with migration/versioning,
+  temporary compile-time rejection for ordered signed keys, or documented
+  unsigned physical ordering.
+
+## Later Medium-Risk Follow-ups
+
+- Pruning recovery: track earliest retained sequence and report
+  snapshot-required when a replica is behind retained history.
+- `VectorStore` collection naming: reject invalid names or use a reversible
+  collision-free encoding.
+- Transport body limits before full buffering in concrete HTTP/WebSocket
+  backends.
+- Rate-limit bucket eviction / hard caps.
+- WebSocket connect/response/request deadlines.
+- Installed package fallback for lowercase-only `mdbxConfig.cmake`.
+- Clarify `PullRequest::max_bytes` as a soft page budget and add a separate
+  max single-batch limit.
+- Canonicalize floating-point zero keys and define NaN key semantics.

--- a/guides/table-api-guide.md
+++ b/guides/table-api-guide.md
@@ -50,6 +50,9 @@ All public table classes follow the same broad shape:
 - They provide constructors from `std::shared_ptr<Connection>` and `Config`.
 - Constructor `name` opens a named MDBX DBI; increase `Config::max_dbs` when
   tests/examples open several named tables in one environment.
+- Names starting with `_mdbxc_` are reserved for internal metadata and sync
+  stores. Public table wrappers reject them; choose an application-specific
+  prefix instead.
 - With `Config::read_only = true`, constructors open existing DBIs using a
   read-only transaction. `BaseTable` clears `MDBX_CREATE` automatically, so
   wrapper defaults can stay the same, but the DBI must already exist and write

--- a/guides/table-api-guide.md
+++ b/guides/table-api-guide.md
@@ -69,6 +69,9 @@ All public table classes follow the same broad shape:
   or use the caller-supplied transaction.
 - A supplied `MDBX_txn*` or `Transaction` must belong to the current thread.
   Do not pass transaction handles or MDBX cursors across threads.
+- A supplied `MDBX_txn*` or `Transaction` must also belong to the same
+  `Connection`/MDBX environment as the table wrapper. Passing a transaction from
+  another environment is rejected before any table data is touched.
 - Table wrapper instances are not synchronization primitives. For concurrent
   workers, prefer separate wrappers per thread over the same shared
   `Connection`, or protect one shared wrapper with an external mutex.

--- a/include/mdbx_containers/AnyValueTable.hpp
+++ b/include/mdbx_containers/AnyValueTable.hpp
@@ -366,7 +366,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();

--- a/include/mdbx_containers/HashedKeyValueStore.hpp
+++ b/include/mdbx_containers/HashedKeyValueStore.hpp
@@ -903,7 +903,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();
@@ -1501,7 +1501,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();

--- a/include/mdbx_containers/KeyMultiValueTable.hpp
+++ b/include/mdbx_containers/KeyMultiValueTable.hpp
@@ -1150,7 +1150,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();

--- a/include/mdbx_containers/KeyTable.hpp
+++ b/include/mdbx_containers/KeyTable.hpp
@@ -801,7 +801,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();

--- a/include/mdbx_containers/KeyValueTable.hpp
+++ b/include/mdbx_containers/KeyValueTable.hpp
@@ -1395,7 +1395,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode = TransactionMode::WRITABLE, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn(); // reuse transaction bound to this thread if any

--- a/include/mdbx_containers/SequenceTable.hpp
+++ b/include/mdbx_containers/SequenceTable.hpp
@@ -490,7 +490,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();

--- a/include/mdbx_containers/ValueTable.hpp
+++ b/include/mdbx_containers/ValueTable.hpp
@@ -326,7 +326,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -42,6 +42,10 @@ namespace mdbxc {
                         std::string name,
                         MDBX_db_flags_t flags)
             : m_connection(std::move(connection)), m_name(std::move(name)) {
+            if (is_reserved_dbi_name(m_name)) {
+                throw std::invalid_argument(
+                    "MDBX Containers table name uses reserved internal prefix '_mdbxc_'");
+            }
             bool read_only = m_connection->is_read_only();
             MDBX_db_flags_t open_flags = read_only
                 ? static_cast<MDBX_db_flags_t>(flags & ~MDBX_CREATE)

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -12,6 +12,7 @@
 #endif
 
 #include <string>
+#include <stdexcept>
 #include <vector>
 
 namespace mdbxc {
@@ -165,6 +166,22 @@ namespace mdbxc {
         /// \brief Gets the raw DBI handle.
         /// \return DBI handle for the opened table.
         MDBX_dbi handle() const { return m_dbi; }
+
+        /// \brief Validates that an external transaction belongs to this table's environment.
+        /// \details Table DBI handles are environment-local. Passing a transaction
+        /// from another Connection could otherwise address an unrelated DBI with
+        /// the same numeric handle.
+        MDBX_txn* checked_external_txn(MDBX_txn* txn) const {
+            if (txn == nullptr) {
+                return nullptr;
+            }
+            MDBX_env* txn_env = mdbx_txn_env(txn);
+            if (txn_env != m_connection->env_handle()) {
+                throw std::invalid_argument(
+                    "External transaction belongs to a different MDBX environment");
+            }
+            return txn;
+        }
 
         /// \brief Throws when a duplicate value exceeds the configured proactive limit.
         /// \param value Duplicate value that will be written into an MDBX_DUPSORT DBI.

--- a/include/mdbx_containers/detail/utils.hpp
+++ b/include/mdbx_containers/detail/utils.hpp
@@ -44,6 +44,17 @@ namespace mdbxc {
             throw MdbxException(context + ": (" + std::to_string(rc) + ") " + std::string(mdbx_strerror(rc)), rc);
         }
     }
+
+    /// \brief Returns true when \p name belongs to the internal DBI namespace.
+    /// \details The `_mdbxc_` prefix is reserved for library metadata and
+    /// sync system stores. Public table wrappers and incoming replication
+    /// changes must not use it as an application DBI name.
+    inline bool is_reserved_dbi_name(const std::string& name) {
+        static const char prefix[] = "_mdbxc_";
+        const std::size_t prefix_len = sizeof(prefix) - 1u;
+        return name.size() >= prefix_len &&
+               name.compare(0u, prefix_len, prefix) == 0;
+    }
     
     /// \brief Convert IEEE754 float to monotonic sortable unsigned int key.
     /// \param f Input float value.

--- a/include/mdbx_containers/sync/ConflictPolicy.hpp
+++ b/include/mdbx_containers/sync/ConflictPolicy.hpp
@@ -12,8 +12,9 @@ namespace sync {
     enum class ConflictPolicy {
         /// \brief Reject the incoming change; surface an error to the caller.
         Reject,
-        /// \brief Deterministically pick the change with the larger
-        /// \c revision_key (lexicographic), tie-broken by \c origin_node_id.
+        /// \brief Reserved for future timestamp/version based resolution.
+        /// \details v0.1 \c SyncEngine rejects this policy because raw batch
+        /// apply does not yet have a reliable logical-key conflict authority.
         LastWriterWins,
     };
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -78,8 +78,8 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
   `KeyTable`, `SequenceTable` insert/update/delete including empty serialized
   values, and `VectorStore` add/erase/rebuild through its public API.
 - `ConflictPolicy::Reject` is the default. `ConflictPolicy::LastWriterWins`
-  is declared for future logical-key conflict resolution but is not used by
-  the current raw batch apply path.
+  is declared for future logical-key conflict resolution; `SyncEngine`
+  rejects it until a reliable conflict authority exists.
 - `SyncWorker` background pull/apply lifecycle, cooperative cancellation
   tokens, best-effort peer cancellation hook, and focused worker tests.
 - Manual hub-style benchmark (`sync_tick_hub_benchmark`) plus opt-in and
@@ -241,7 +241,7 @@ Required tests before enabling capture:
 - HLC or other production authority for logical-key `LastWriterWins`.
   `time_unix_ns` is metadata only, not a reliable conflict authority. The
   current apply path does not maintain enough identity-index conflict state to
-  use `LastWriterWins` in a non-test path.
+  use `LastWriterWins`, so `SyncEngine` rejects that policy.
 - `Custom` conflict resolver — schema-level callback; deferred until the
   first real consumer needs it.
 - Production-grade deployment wrappers for concrete socket-bound HTTP and
@@ -457,7 +457,7 @@ Cold replica sync currently uses changelog replay:
 ```
 B: empty cursor
     -> pull request, have = empty
-A: handle_pull treats it as a full changelog snapshot across known origins
+A: handle_pull treats it as a full changelog replay across known origins
     -> streams persisted ChangeBatches from seq=1 with pagination limits
 B: applies each page as above
     -> onward sync is incremental pull-from-have
@@ -465,6 +465,8 @@ B: applies each page as above
 
 The reserved `seq=0, BATCH_HAS_MORE` full export/import format remains planned
 for v0.1 and is not the current cold-replica implementation.
+`PullRequest::request_full_snapshot=true` is rejected explicitly until that
+format is implemented.
 
 ## Background worker lifecycle
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -268,6 +268,11 @@ any new payload integer: little-endian.
 
 ## Stores
 
+The `_mdbxc_` DBI prefix is reserved for library-owned stores. Application
+tables must not use that prefix, and `SyncEngine` rejects incoming `ChangeOp`
+entries whose `dbi_name` targets the reserved namespace before applying any
+operation from the pushed page.
+
 ### `_mdbxc_meta` (MetaStore)
 
 | Tag | Field | Type | Notes |

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -63,6 +63,7 @@ namespace sync {
         SequenceGap,              ///< Batch seq is not last_applied_seq + 1.
         InconsistentBatchDbiFlags,///< One batch carries contradictory flags for one DBI.
         ExistingDbiFlagsMismatch, ///< Existing destination DBI rejects captured flags.
+        ReservedDbiName,          ///< Incoming ChangeOp targets an internal DBI name.
     };
 
     /// \brief Detailed result for callers that need conflict diagnostics.
@@ -245,6 +246,8 @@ namespace sync {
                     return "inconsistent_batch_dbi_flags";
                 case ApplyConflictReason::ExistingDbiFlagsMismatch:
                     return "existing_dbi_flags_mismatch";
+                case ApplyConflictReason::ReservedDbiName:
+                    return "reserved_dbi_name";
             }
             return "unknown";
         }
@@ -475,6 +478,9 @@ namespace sync {
                 }
                 message += ", mdbx_error_code=" +
                            std::to_string(outcome.mdbx_error_code) + ")";
+            } else if (outcome.conflict_reason ==
+                       ApplyConflictReason::ReservedDbiName) {
+                message += " (dbi='" + outcome.dbi_name + "')";
             }
             return message;
         }
@@ -503,6 +509,17 @@ namespace sync {
             dbis.clear();
             std::unordered_map<std::string, std::vector<BatchDbiFlags>::size_type> index_by_name;
             for (const ChangeOp& op : batch.ops) {
+                if (is_reserved_dbi_name(op.dbi_name)) {
+                    if (outcome != nullptr) {
+                        outcome->result = ApplyResult::Conflict;
+                        outcome->conflict_reason =
+                            ApplyConflictReason::ReservedDbiName;
+                        outcome->dbi_name = op.dbi_name;
+                        outcome->incoming_dbi_flags =
+                            persistent_dbi_flags(op.dbi_flags);
+                    }
+                    return false;
+                }
                 const std::uint32_t flags = persistent_dbi_flags(op.dbi_flags);
                 const std::pair<
                     std::unordered_map<std::string, std::vector<BatchDbiFlags>::size_type>::iterator,

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -131,7 +131,12 @@ namespace sync {
         /// \param policy Conflict resolution policy (default: \c Reject).
         explicit SyncEngine(std::shared_ptr<Connection> conn,
                             ConflictPolicy policy = ConflictPolicy::Reject)
-            : m_conn(std::move(conn)), m_policy(policy) {}
+            : m_conn(std::move(conn)), m_policy(policy) {
+            if (m_policy == ConflictPolicy::LastWriterWins) {
+                throw std::invalid_argument(
+                    "ConflictPolicy::LastWriterWins is not implemented");
+            }
+        }
 
         /// \brief Initialises the local \c node_id and \c db_uuid.
         /// \details Throws when already initialised with different values.
@@ -268,6 +273,11 @@ namespace sync {
             if (!db_id_matches(request.db_id)) {
                 out.ok = false;
                 out.error = "db_id mismatch";
+                return out;
+            }
+            if (request.request_full_snapshot) {
+                out.ok = false;
+                out.error = "PullRequest::request_full_snapshot is not implemented";
                 return out;
             }
 

--- a/include/mdbx_containers/sync/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/SyncWorker.hpp
@@ -567,6 +567,10 @@ namespace sync {
                             event.progress = progress;
                             notify_stage_changed(event);
                         }
+                        if (stop_requested()) {
+                            result.has_more = has_more;
+                            return result;
+                        }
                         PushRequest apply;
                         apply.db_id = request.db_id;
                         apply.batches = response.batches;

--- a/include/mdbx_containers/sync/protocol.hpp
+++ b/include/mdbx_containers/sync/protocol.hpp
@@ -24,8 +24,9 @@ namespace sync {
         SyncCursor   have;
         std::uint64_t max_batches = 1000;
         std::uint64_t max_bytes   = 4ULL * 1024ULL * 1024ULL;
-        /// \brief When true, the responder should produce a full snapshot
-        /// instead of an incremental delta.
+        /// \brief Requests a full snapshot instead of an incremental delta.
+        /// \details Reserved for a future snapshot protocol. v0.1
+        /// \c SyncEngine responders reject this request explicitly.
         bool         request_full_snapshot = false;
         /// \brief Cooperative cancellation token for this transport call.
         /// \details Optional; default-constructed tokens never cancel.

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -52,6 +52,20 @@ std::shared_ptr<mdbxc::Connection> open_env(const std::string& path) {
     return Connection::create(cfg);
 }
 
+template<class Fn>
+void expect_invalid_argument(const char* name, Fn fn) {
+    bool rejected = false;
+    try {
+        fn();
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error(
+            std::string(name) + " did not throw std::invalid_argument");
+    }
+}
+
 void seed_node_id(std::shared_ptr<mdbxc::Connection> conn,
                   const mdbxc::sync::NodeId& node_id) {
     using namespace mdbxc;
@@ -878,6 +892,35 @@ void test_engine_handle_pull_wrong_db_id() {
     cleanup(p);
 }
 
+void test_engine_rejects_full_snapshot_request() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_full_snapshot_request.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0xA0), make_node(0xD0));
+
+    sync::PullRequest req;
+    req.requester = make_node(0xB0);
+    req.db_id = make_node(0xD0);
+    req.request_full_snapshot = true;
+
+    const sync::PullResponse resp = engine.handle_pull(req);
+    if (resp.ok) {
+        throw std::runtime_error("full snapshot request should be rejected");
+    }
+    if (!resp.batches.empty()) {
+        throw std::runtime_error("full snapshot rejection returned batches");
+    }
+    if (resp.error.find("request_full_snapshot") == std::string::npos) {
+        throw std::runtime_error("full snapshot rejection error is not explicit");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 void test_engine_handle_push_wrong_db_id() {
     using namespace mdbxc;
     const std::string p = "test_engine_push_wrong_db.mdbx";
@@ -914,6 +957,24 @@ void test_engine_handle_push_wrong_db_id() {
             throw std::runtime_error("table must be empty on wrong db_id push");
         }
     }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_rejects_last_writer_wins_policy() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_lww_policy.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    expect_invalid_argument("SyncEngine LastWriterWins policy",
+                            [&conn]() {
+                                sync::SyncEngine engine(
+                                    conn,
+                                    sync::ConflictPolicy::LastWriterWins);
+                                (void)engine;
+                            });
 
     conn->disconnect();
     cleanup(p);
@@ -1249,7 +1310,11 @@ int main() {
         { "test_engine_handle_push_to_remote",  &test_engine_handle_push_to_remote },
         { "test_engine_push_gap_rolls_back",    &test_engine_push_gap_rolls_back },
         { "test_engine_handle_pull_wrong_db_id",&test_engine_handle_pull_wrong_db_id },
+        { "test_engine_rejects_full_snapshot_request",
+          &test_engine_rejects_full_snapshot_request },
         { "test_engine_handle_push_wrong_db_id",&test_engine_handle_push_wrong_db_id },
+        { "test_engine_rejects_last_writer_wins_policy",
+          &test_engine_rejects_last_writer_wins_policy },
         { "test_engine_handle_pull_pagination", &test_engine_handle_pull_pagination_has_more },
         { "test_engine_handle_pull_multi_origin",&test_engine_handle_pull_multi_origin_pagination },
         { "test_engine_handle_pull_legacy_origin_index",&test_engine_handle_pull_legacy_changelog_without_origin_index },

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -131,6 +131,30 @@ void append_raw_bytes(mdbxc::sync::ChangeLogStore& log,
     log.append(txn, origin, seq, bytes);
 }
 
+const char* op_type_name(mdbxc::sync::ChangeOpType type) {
+    switch (type) {
+        case mdbxc::sync::ChangeOpType::Put:
+            return "Put";
+        case mdbxc::sync::ChangeOpType::Delete:
+            return "Delete";
+        case mdbxc::sync::ChangeOpType::ClearTable:
+            return "ClearTable";
+    }
+    return "unknown";
+}
+
+void assign_int_key(std::vector<std::uint8_t>& out, int key) {
+    mdbxc::SerializeScratch scratch;
+    const MDBX_val serialized = mdbxc::serialize_key<true>(key, scratch);
+    assign_bytes(out, serialized);
+}
+
+void assign_int_value(std::vector<std::uint8_t>& out, int value) {
+    mdbxc::SerializeScratch scratch;
+    const MDBX_val serialized = mdbxc::serialize_value(value, scratch);
+    assign_bytes(out, serialized);
+}
+
 void test_engine_round_trip_kv() {
     using namespace mdbxc;
     const std::string primary_path = "test_engine_primary.mdbx";
@@ -192,6 +216,113 @@ void test_engine_round_trip_kv() {
     replica_conn->disconnect();
     cleanup(primary_path);
     cleanup(replica_path);
+}
+
+void test_public_tables_reject_reserved_dbi_names() {
+    using namespace mdbxc;
+    const std::string p = "test_public_reserved_dbi_names.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    bool rejected = false;
+    try {
+        KeyValueTable<int, int> kv(conn, "_mdbxc_user_table");
+        (void)kv;
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error("public table accepted reserved DBI name");
+    }
+
+    sync::MetaStore meta(conn->env_handle());
+    auto txn = conn->transaction(TransactionMode::WRITABLE);
+    meta.open(txn.handle());
+    meta.set_schema_version(txn.handle(), sync::meta_schema_version());
+    txn.commit();
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_rejects_reserved_dbi_changes_and_rolls_back_page() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_reserved_dbi_changes.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    const sync::NodeId local_node = make_node(0x10);
+    const sync::NodeId db_id = make_node(0x11);
+    const sync::NodeId origin = make_node(0x20);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(local_node, db_id);
+    KeyValueTable<int, int> safe(conn, "safe");
+
+    const sync::ChangeOpType op_types[] = {
+        sync::ChangeOpType::Put,
+        sync::ChangeOpType::Delete,
+        sync::ChangeOpType::ClearTable
+    };
+
+    for (std::size_t i = 0; i < sizeof(op_types) / sizeof(op_types[0]); ++i) {
+        sync::ChangeBatch batch;
+        batch.origin_node_id = origin;
+        batch.seq = 1;
+
+        sync::ChangeOp safe_op;
+        safe_op.op_type = sync::ChangeOpType::Put;
+        safe_op.dbi_name = "safe";
+        safe_op.dbi_flags = static_cast<std::uint32_t>(MDBX_INTEGERKEY);
+        assign_int_key(safe_op.storage_key, static_cast<int>(100 + i));
+        assign_int_value(safe_op.value, static_cast<int>(200 + i));
+        batch.ops.push_back(safe_op);
+
+        sync::ChangeOp reserved_op;
+        reserved_op.op_type = op_types[i];
+        reserved_op.dbi_name = "_mdbxc_meta";
+        assign_int_key(reserved_op.storage_key, 7);
+        if (reserved_op.op_type == sync::ChangeOpType::Put) {
+            assign_int_value(reserved_op.value, 8);
+        }
+        batch.ops.push_back(reserved_op);
+
+        sync::PushRequest request;
+        request.sender = origin;
+        request.db_id = db_id;
+        request.batches.push_back(batch);
+
+        const sync::PushResponse response = engine.handle_push(request);
+        if (response.ok) {
+            throw std::runtime_error(
+                std::string("reserved DBI ") +
+                op_type_name(op_types[i]) + " push unexpectedly succeeded");
+        }
+        if (response.error.find("reserved_dbi_name") == std::string::npos ||
+            response.error.find("_mdbxc_meta") == std::string::npos) {
+            throw std::runtime_error(
+                std::string("reserved DBI ") +
+                op_type_name(op_types[i]) + " returned wrong error: " +
+                response.error);
+        }
+        if (engine.applied_cursor().last_seq_for(origin) != 0u) {
+            throw std::runtime_error(
+                std::string("reserved DBI ") +
+                op_type_name(op_types[i]) + " advanced applied cursor");
+        }
+        if (kv_has(conn, safe, static_cast<int>(100 + i))) {
+            throw std::runtime_error(
+                std::string("reserved DBI ") +
+                op_type_name(op_types[i]) + " did not roll back page");
+        }
+        if (engine.db_uuid() != db_id) {
+            throw std::runtime_error(
+                std::string("reserved DBI ") +
+                op_type_name(op_types[i]) + " changed metadata");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
 }
 
 void test_engine_skips_self_origin() {
@@ -1103,6 +1234,10 @@ int main() {
     struct Case { const char* name; void (*fn)(); };
     const Case cases[] = {
         { "test_engine_round_trip_kv",          &test_engine_round_trip_kv },
+        { "test_public_tables_reject_reserved_dbi_names",
+          &test_public_tables_reject_reserved_dbi_names },
+        { "test_engine_rejects_reserved_dbi_changes",
+          &test_engine_rejects_reserved_dbi_changes_and_rolls_back_page },
         { "test_engine_skips_self_origin",      &test_engine_skips_self_origin },
         { "test_engine_idempotent_replay",      &test_engine_idempotent_replay },
         { "test_engine_legacy_zero_flags",      &test_engine_applies_legacy_zero_flags_to_integer_dbi },

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -98,6 +98,27 @@ private:
     int m_cancel_count;
 };
 
+class FixedPeer : public mdbxc::sync::ISyncPeer {
+public:
+    explicit FixedPeer(const mdbxc::sync::PullResponse& response)
+        : m_response(response) {}
+
+    mdbxc::sync::PullResponse pull(
+            const mdbxc::sync::PullRequest& request) override {
+        (void)request;
+        return m_response;
+    }
+
+    mdbxc::sync::PushResponse push(
+            const mdbxc::sync::PushRequest& request) override {
+        (void)request;
+        return mdbxc::sync::PushResponse();
+    }
+
+private:
+    mdbxc::sync::PullResponse m_response;
+};
+
 class BlockingPeer : public mdbxc::sync::ISyncPeer {
 public:
     explicit BlockingPeer(const mdbxc::sync::PullResponse& response)
@@ -540,6 +561,29 @@ private:
     std::vector<mdbxc::sync::SyncWorkerRoundResult> m_rounds;
     std::vector<BackoffRecord> m_backoffs;
     std::vector<mdbxc::sync::SyncWorkerStageEvent> m_stages;
+};
+
+class StopOnApplyStartedObserver : public RecordingWorkerObserver {
+public:
+    StopOnApplyStartedObserver() : m_worker(nullptr) {}
+
+    void set_worker(mdbxc::sync::SyncWorker* worker) {
+        m_worker = worker;
+    }
+
+    void on_sync_worker_stage_changed(
+            const mdbxc::sync::SyncWorkerStageEvent& event) override {
+        RecordingWorkerObserver::on_sync_worker_stage_changed(event);
+        if (event.stage == mdbxc::sync::SyncWorkerStage::ApplyStarted) {
+            if (m_worker == nullptr) {
+                throw std::runtime_error("stop observer has no worker");
+            }
+            m_worker->request_stop();
+        }
+    }
+
+private:
+    mdbxc::sync::SyncWorker* m_worker;
 };
 
 class ThrowingRoundObserver : public mdbxc::sync::ISyncWorkerObserver {
@@ -1592,6 +1636,52 @@ void test_worker_stop_while_pull_blocked_does_not_apply_returned_page() {
     cleanup(path);
 }
 
+void test_worker_stop_from_apply_started_observer_skips_apply() {
+    using namespace mdbxc;
+    const std::string path = "test_worker_stop_before_apply.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    const sync::NodeId replica_node = make_node(0xB3);
+    const sync::NodeId remote_origin = make_node(0xA3);
+    const sync::NodeId db_id = make_node(0xD3);
+
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
+
+    sync::ChangeBatch batch;
+    batch.origin_node_id = remote_origin;
+    batch.seq = 1;
+
+    sync::PullResponse response;
+    response.batches.push_back(batch);
+
+    FixedPeer peer(response);
+    StopOnApplyStartedObserver observer;
+    sync::SyncWorkerOptions options;
+    options.observer = &observer;
+    sync::SyncWorker guarded_worker(engine, peer, options);
+    observer.set_worker(&guarded_worker);
+
+    const sync::SyncWorkerRoundResult result = guarded_worker.run_once();
+    if (!result.ok || result.pages_pulled != 1u ||
+        result.batches_applied != 0u) {
+        throw std::runtime_error("stop before apply round result mismatch");
+    }
+    if (guarded_worker.state() != sync::SyncWorkerState::Stopped) {
+        throw std::runtime_error("stop-before-apply worker did not stop");
+    }
+    if (engine.applied_cursor().last_seq_for(remote_origin) != 0u) {
+        throw std::runtime_error("worker applied page after ApplyStarted stop");
+    }
+    if (!observer.pages().empty()) {
+        throw std::runtime_error("page-applied observer ran for skipped apply");
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 void test_worker_repeated_stop_cancels_blocking_peer_once() {
     using namespace mdbxc;
     const std::string path = "test_worker_cancel_once.mdbx";
@@ -1804,6 +1894,8 @@ int main() {
           &test_worker_rejects_invalid_options },
         { "test_worker_stop_while_pull_blocked",
           &test_worker_stop_while_pull_blocked_does_not_apply_returned_page },
+        { "test_worker_stop_from_apply_started_observer_skips_apply",
+          &test_worker_stop_from_apply_started_observer_skips_apply },
         { "test_worker_repeated_stop_cancels_blocking_peer_once",
           &test_worker_repeated_stop_cancels_blocking_peer_once },
         { "test_worker_stop_cancels_blocking_peer",

--- a/tests/test_transaction_provenance.cpp
+++ b/tests/test_transaction_provenance.cpp
@@ -1,0 +1,125 @@
+#include <mdbx_containers.hpp>
+
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+void cleanup(const std::string& p) {
+    std::remove(p.c_str());
+}
+
+std::shared_ptr<mdbxc::Connection> open_env(const std::string& path) {
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 32;
+    cfg.no_subdir = true;
+    return mdbxc::Connection::create(cfg);
+}
+
+template<class Fn>
+void expect_invalid_argument(const char* name, Fn fn) {
+    bool rejected = false;
+    try {
+        fn();
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error(
+            std::string(name) + " accepted a transaction from another environment");
+    }
+}
+
+template<class Table, class Key>
+bool contains_key(Table& table, const Key& key) {
+    return table.contains(key);
+}
+
+void test_external_transaction_must_match_table_connection() {
+    using namespace mdbxc;
+    const std::string path_a = "test_txn_provenance_a.mdbx";
+    const std::string path_b = "test_txn_provenance_b.mdbx";
+    cleanup(path_a);
+    cleanup(path_b);
+
+    auto conn_a = open_env(path_a);
+    auto conn_b = open_env(path_b);
+
+    KeyValueTable<int, int> kv(conn_a, "kv");
+    KeyTable<int> keys(conn_a, "keys");
+    ValueTable<int> value(conn_a, "value");
+    SequenceTable<int> seq(conn_a, "seq");
+    AnyValueTable<int> any(conn_a, "any");
+    KeyMultiValueTable<int, std::string> multi(conn_a, "multi");
+    HashedKeyValueStore<std::string, std::string> hashed(conn_a, "hashed");
+
+    auto txn_b = conn_b->transaction(TransactionMode::WRITABLE);
+
+    expect_invalid_argument("KeyValueTable Transaction",
+                            [&kv, &txn_b]() { kv.insert_or_assign(1, 10, txn_b); });
+    expect_invalid_argument("KeyValueTable raw MDBX_txn",
+                            [&kv, &txn_b]() { kv.insert_or_assign(2, 20, txn_b.handle()); });
+    expect_invalid_argument("KeyTable Transaction",
+                            [&keys, &txn_b]() { keys.insert(1, txn_b); });
+    expect_invalid_argument("ValueTable Transaction",
+                            [&value, &txn_b]() { value.set(10, txn_b); });
+    expect_invalid_argument("SequenceTable Transaction",
+                            [&seq, &txn_b]() { seq.insert_or_assign(1, 10, txn_b); });
+    expect_invalid_argument("AnyValueTable Transaction",
+                            [&any, &txn_b]() { any.set(1, std::string("value"), txn_b); });
+    expect_invalid_argument("KeyMultiValueTable Transaction",
+                            [&multi, &txn_b]() { multi.insert(1, std::string("value"), txn_b); });
+    expect_invalid_argument("HashedKeyValueStore Transaction",
+                            [&hashed, &txn_b]() {
+                                hashed.insert_or_assign(std::string("k"),
+                                                        std::string("v"),
+                                                        txn_b);
+                            });
+
+    txn_b.commit();
+
+    if (contains_key(kv, 1) || contains_key(kv, 2)) {
+        throw std::runtime_error("cross-environment KeyValueTable write reached table A");
+    }
+    if (!keys.empty() || value.has_value() || seq.count() != 0u ||
+        any.contains(1) || multi.count() != 0u || hashed.count() != 0u) {
+        throw std::runtime_error("cross-environment write reached a table");
+    }
+
+    conn_a->disconnect();
+    conn_b->disconnect();
+    cleanup(path_a);
+    cleanup(path_b);
+}
+
+} // namespace
+
+int main() {
+    struct Case {
+        const char* name;
+        void (*fn)();
+    };
+
+    const Case cases[] = {
+        { "test_external_transaction_must_match_table_connection",
+          &test_external_transaction_must_match_table_connection }
+    };
+
+    for (std::size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
+        try {
+            cases[i].fn();
+            std::printf("PASS %s\n", cases[i].name);
+        } catch (const std::exception& e) {
+            std::printf("FAIL %s: %s\n", cases[i].name, e.what());
+            return static_cast<int>(i + 1u);
+        } catch (...) {
+            std::printf("FAIL %s: non-std exception\n", cases[i].name);
+            return static_cast<int>(i + 1u);
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- reject `PullRequest::request_full_snapshot=true` in `SyncEngine::handle_pull()` with an explicit not-implemented error
- reject `ConflictPolicy::LastWriterWins` at `SyncEngine` construction until conflict authority semantics exist
- update public header comments and sync docs so these modes no longer look supported in v0.1
- add engine regressions for both public-but-unimplemented modes while keeping transport codec roundtrip behavior intact

## Validation
- `cmake --build tmp/pr148-make-cpp17 --target test_sync_engine`
- `cmake --build tmp/pr148-make-cpp11 --target test_sync_engine`
- `cmake --build tmp/pr148-make-cpp17 --target test_transport_codec`
- `cmake --build tmp/pr148-make-cpp11 --target test_transport_codec`
- `ctest --test-dir tmp/pr148-make-cpp17 -R ^(test_sync_engine|test_transport_codec)$ --output-on-failure`
- `ctest --test-dir tmp/pr148-make-cpp11 -R ^(test_sync_engine|test_transport_codec)$ --output-on-failure`
- `git diff --check`