### PR TITLE
fix(sync): validate transaction provenance

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -56,6 +56,10 @@
   активной транзакции на поток.
 - `Transaction`, raw `MDBX_txn*` и курсоры MDBX нельзя передавать или
   использовать между потоками.
+- Переданный пользователем `Transaction` / raw `MDBX_txn*` также должен
+  принадлежать тому же MDBX environment, что и таблица или sync engine,
+  который его получает. Handles из другого environment отклоняются через
+  `std::invalid_argument` до использования DBI handles.
 - `configure()`, `connect()`, `disconnect()` и уничтожение `Connection` — это
   lifecycle-операции вне параллельной работы с таблицами.
 - Используйте `shutdown()` для согласованной остановки: он запрещает новые

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@
 - Use one shared `Connection` per MDBX environment, with at most one active
   transaction per thread.
 - Do not share `Transaction`, raw `MDBX_txn*`, or MDBX cursors across threads.
+- Caller-supplied `Transaction` / raw `MDBX_txn*` handles must also belong to
+  the same MDBX environment as the table or sync engine that receives them.
+  Foreign-environment handles are rejected with `std::invalid_argument` before
+  the wrapper uses DBI handles.
 - Treat `configure()`, `connect()`, `disconnect()`, and `Connection`
   destruction as lifecycle operations outside concurrent table activity.
 - Use `shutdown()` to request a coordinated stop: it rejects new transactions,

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -27,6 +27,10 @@ is header-only and template-heavy.
 - Do not pass `Transaction`, raw `MDBX_txn*`, or MDBX cursors across threads.
   Commit, roll back, abort, reset, and destroy transaction guards on the owning
   thread.
+- Any caller-supplied `MDBX_txn*` or `Transaction` passed to a table wrapper,
+  `SyncEngine`, sync store, or capture accumulator must belong to the same
+  MDBX environment as that object. Foreign-environment handles are rejected
+  with `std::invalid_argument` before DBI handles are used.
 - Treat `Connection::configure()`, `connect()`, `disconnect()`, `cleanup()`, and
   destruction as lifecycle-only operations. They must not race with table
   operations, active transactions, or MDBX cursors.

--- a/guides/project-overview.md
+++ b/guides/project-overview.md
@@ -50,6 +50,9 @@ primitive. For concurrent workers, prefer one wrapper instance per worker thread
 over the shared connection, or use an external mutex around a shared wrapper.
 
 Do not pass `Transaction`, raw `MDBX_txn*`, or MDBX cursors across threads.
+Caller-supplied transaction handles must also belong to the same MDBX
+environment as the receiving table wrapper, `SyncEngine`, sync store, or
+capture accumulator; foreign-environment handles are rejected before DBI use.
 `configure()`, `connect()`, `disconnect()`, and `Connection` destruction are
 lifecycle operations: call them before starting worker activity or after all
 workers, transactions, and cursors are finished.

--- a/guides/table-api-guide.md
+++ b/guides/table-api-guide.md
@@ -69,6 +69,9 @@ All public table classes follow the same broad shape:
   or use the caller-supplied transaction.
 - A supplied `MDBX_txn*` or `Transaction` must belong to the current thread.
   Do not pass transaction handles or MDBX cursors across threads.
+- A supplied `MDBX_txn*` or `Transaction` must also belong to the same MDBX
+  environment as the receiving table wrapper. Foreign-environment handles are
+  rejected with `std::invalid_argument` before DBI handles are used.
 - Table wrapper instances are not synchronization primitives. For concurrent
   workers, prefer separate wrappers per thread over the same shared
   `Connection`, or protect one shared wrapper with an external mutex.

--- a/include/mdbx_containers/AnyValueTable.hpp
+++ b/include/mdbx_containers/AnyValueTable.hpp
@@ -366,7 +366,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();

--- a/include/mdbx_containers/HashedKeyValueStore.hpp
+++ b/include/mdbx_containers/HashedKeyValueStore.hpp
@@ -903,7 +903,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();
@@ -1501,7 +1501,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();

--- a/include/mdbx_containers/KeyMultiValueTable.hpp
+++ b/include/mdbx_containers/KeyMultiValueTable.hpp
@@ -1150,7 +1150,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();

--- a/include/mdbx_containers/KeyTable.hpp
+++ b/include/mdbx_containers/KeyTable.hpp
@@ -801,7 +801,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();

--- a/include/mdbx_containers/KeyValueTable.hpp
+++ b/include/mdbx_containers/KeyValueTable.hpp
@@ -1395,7 +1395,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode = TransactionMode::WRITABLE, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn(); // reuse transaction bound to this thread if any

--- a/include/mdbx_containers/SequenceTable.hpp
+++ b/include/mdbx_containers/SequenceTable.hpp
@@ -490,7 +490,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();

--- a/include/mdbx_containers/ValueTable.hpp
+++ b/include/mdbx_containers/ValueTable.hpp
@@ -326,7 +326,7 @@ namespace mdbxc {
         template<typename F>
         void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
             if (txn) {
-                action(txn);
+                action(checked_external_txn(txn));
                 return;
             }
             txn = thread_txn();

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -161,6 +161,13 @@ namespace mdbxc {
         MDBX_txn* thread_txn() const {
                 return m_connection->thread_txn();
         }
+
+        /// \brief Validates a caller-supplied transaction for this table env.
+        MDBX_txn* checked_external_txn(MDBX_txn* txn) const {
+            return checked_txn_env(txn,
+                                   m_connection->env_handle(),
+                                   "BaseTable external transaction");
+        }
         
         /// \brief Gets the raw DBI handle.
         /// \return DBI handle for the opened table.

--- a/include/mdbx_containers/detail/utils.hpp
+++ b/include/mdbx_containers/detail/utils.hpp
@@ -55,6 +55,25 @@ namespace mdbxc {
         return name.size() >= prefix_len &&
                name.compare(0u, prefix_len, prefix) == 0;
     }
+
+    /// \brief Validates that a raw MDBX transaction belongs to the expected env.
+    /// \details Public wrappers accept \c MDBX_txn* for integration with
+    /// caller-owned transactions. A transaction from another environment must
+    /// fail before DBI handles or sync stores are used with it.
+    inline MDBX_txn* checked_txn_env(MDBX_txn* txn,
+                                     MDBX_env* expected_env,
+                                     const char* context) {
+        if (txn == nullptr) {
+            throw std::invalid_argument(
+                std::string(context) + ": transaction is null");
+        }
+        if (mdbx_txn_env(txn) != expected_env) {
+            throw std::invalid_argument(
+                std::string(context) +
+                ": transaction belongs to a different MDBX environment");
+        }
+        return txn;
+    }
     
     /// \brief Convert IEEE754 float to monotonic sortable unsigned int key.
     /// \param f Input float value.

--- a/include/mdbx_containers/sync/ChangeAccumulator.hpp
+++ b/include/mdbx_containers/sync/ChangeAccumulator.hpp
@@ -56,6 +56,7 @@ namespace sync {
                            std::uint32_t dbi_flags,
                            const std::vector<std::uint8_t>& storage_key,
                            const std::vector<std::uint8_t>& value) override {
+            txn = checked_txn_env(txn, m_env, "ThreadLocalChangeAccumulator::record_change");
             PendingOp op;
             op.op_type = op_type;
             op.dbi_flags = dbi_flags;
@@ -67,6 +68,7 @@ namespace sync {
         }
 
         void flush_in_txn(MDBX_txn* txn) override {
+            txn = checked_txn_env(txn, m_env, "ThreadLocalChangeAccumulator::flush_in_txn");
             std::vector<PendingOp> ops;
             {
                 std::lock_guard<std::mutex> lk(m_mutex);

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -195,6 +195,7 @@ namespace sync {
         /// sequence gap, an inconsistent batch schema, or a destination DBI
         /// flag mismatch.
         ApplyOutcome apply_batch_ex(MDBX_txn* txn, const ChangeBatch& batch) {
+            txn = checked_external_txn(txn, "SyncEngine::apply_batch_ex");
             ApplyOutcome outcome = make_apply_outcome(ApplyResult::Applied, batch, 0);
             MetaStore meta(m_conn->env_handle());
             AppliedStore applied(m_conn->env_handle());
@@ -305,6 +306,7 @@ namespace sync {
         /// \c request.max_batches or \c request.max_bytes.
         PullResponse pull_full_snapshot(MDBX_txn* txn, MDBX_dbi dbi,
                                         const PullRequest& request) {
+            txn = checked_external_txn(txn, "SyncEngine::pull_full_snapshot");
             PullResponse out;
             out.remote_have = read_applied_cursor(txn, out.remote_have);
             const std::vector<PullOrigin> origins = collect_known_origins(txn, dbi);
@@ -365,6 +367,7 @@ namespace sync {
         /// \details Used inside \c handle_pull to avoid opening a second
         /// sticky-thread transaction on the same thread.
         SyncCursor applied_cursor(MDBX_txn* txn) const {
+            txn = checked_external_txn(txn, "SyncEngine::applied_cursor");
             SyncCursor cur;
             return read_applied_cursor(txn, cur);
         }
@@ -449,6 +452,11 @@ namespace sync {
             outcome.last_applied_seq = last_applied_seq;
             outcome.batch_seq = batch.seq;
             return outcome;
+        }
+
+        MDBX_txn* checked_external_txn(MDBX_txn* txn,
+                                       const char* context) const {
+            return checked_txn_env(txn, m_conn->env_handle(), context);
         }
 
         static std::string apply_conflict_message(const ApplyOutcome& outcome) {

--- a/include/mdbx_containers/sync/stores/AppliedStore.hpp
+++ b/include/mdbx_containers/sync/stores/AppliedStore.hpp
@@ -19,6 +19,7 @@ namespace sync {
             : m_env(env), m_dbi_name(dbi_name), m_dbi(0), m_open(false) {}
 
         void open(MDBX_txn* txn) {
+            txn = checked_txn(txn, "AppliedStore::open");
             if (m_open) return;
             check_mdbx(
                 mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE, &m_dbi),
@@ -40,6 +41,7 @@ namespace sync {
         /// \brief Returns the last contiguous applied \c seq for \p origin.
         /// \details Returns 0 when no record exists.
         std::uint64_t last_applied_seq(MDBX_txn* txn, const NodeId& origin) const {
+            txn = checked_txn(txn, "AppliedStore::last_applied_seq");
             ensure_open();
             MDBX_val k = { const_cast<std::uint8_t*>(origin.data()), 16 };
             MDBX_val v;
@@ -54,6 +56,7 @@ namespace sync {
         /// \p origin.
         void set_last_applied_seq(MDBX_txn* txn, const NodeId& origin,
                                   std::uint64_t seq) {
+            txn = checked_txn(txn, "AppliedStore::set_last_applied_seq");
             ensure_open();
             std::uint8_t buf[8];
             detail::write_u64_le(seq, buf);
@@ -68,6 +71,7 @@ namespace sync {
         /// \brief Removes the record for \p origin if present.
         /// \return true when a record was removed.
         bool clear(MDBX_txn* txn, const NodeId& origin) {
+            txn = checked_txn(txn, "AppliedStore::clear");
             ensure_open();
             MDBX_val k = { const_cast<std::uint8_t*>(origin.data()), 16 };
             const int rc = mdbx_del(txn, m_dbi, &k, nullptr);
@@ -78,6 +82,10 @@ namespace sync {
         }
 
     private:
+        MDBX_txn* checked_txn(MDBX_txn* txn, const char* context) const {
+            return checked_txn_env(txn, m_env, context);
+        }
+
         MDBX_env*     m_env;
         std::string   m_dbi_name;
         MDBX_dbi      m_dbi;

--- a/include/mdbx_containers/sync/stores/ChangeLogStore.hpp
+++ b/include/mdbx_containers/sync/stores/ChangeLogStore.hpp
@@ -31,6 +31,7 @@ namespace sync {
         /// \details Tries \c MDBX_CREATE first; falls back to a plain open
         /// when the transaction is read-only and the DBI already exists.
         void open(MDBX_txn* txn) {
+            txn = checked_txn(txn, "ChangeLogStore::open");
             if (m_open) return;
             int rc = mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE, &m_dbi);
             if (rc == MDBX_EACCESS) {
@@ -65,6 +66,7 @@ namespace sync {
         /// (origin, seq) key surfaces immediately.
         void append(MDBX_txn* txn, const NodeId& origin,
                     std::uint64_t seq, const std::vector<std::uint8_t>& bytes) {
+            txn = checked_txn(txn, "ChangeLogStore::append");
             ensure_open();
             ensure_origin_index_ready(txn);
             std::vector<std::uint8_t> key_buf;
@@ -81,6 +83,7 @@ namespace sync {
 
         /// \brief Returns true when a record exists for (\p origin, \p seq).
         bool contains(MDBX_txn* txn, const NodeId& origin, std::uint64_t seq) const {
+            txn = checked_txn(txn, "ChangeLogStore::contains");
             ensure_open();
             std::vector<std::uint8_t> key_buf;
             encode_key(origin, seq, key_buf);
@@ -97,6 +100,7 @@ namespace sync {
         /// \return true when present, false when absent.
         bool get(MDBX_txn* txn, const NodeId& origin, std::uint64_t seq,
                  std::vector<std::uint8_t>& out) const {
+            txn = checked_txn(txn, "ChangeLogStore::get");
             ensure_open();
             std::vector<std::uint8_t> key_buf;
             encode_key(origin, seq, key_buf);
@@ -115,6 +119,7 @@ namespace sync {
         /// \brief Removes the record at (\p origin, \p seq).
         /// \return true when a record was removed, false when absent.
         bool erase(MDBX_txn* txn, const NodeId& origin, std::uint64_t seq) {
+            txn = checked_txn(txn, "ChangeLogStore::erase");
             ensure_open();
             std::vector<std::uint8_t> key_buf;
             encode_key(origin, seq, key_buf);
@@ -130,6 +135,7 @@ namespace sync {
         /// \return Number of records removed.
         std::size_t prune_up_to(MDBX_txn* txn, const NodeId& origin,
                                 std::uint64_t up_to) {
+            txn = checked_txn(txn, "ChangeLogStore::prune_up_to");
             if (!m_open) {
                 throw std::logic_error("ChangeLogStore is not open");
             }
@@ -177,6 +183,7 @@ namespace sync {
         /// \note Intended for startup diagnostics, manual repair, or rare
         /// integrity checks. Do not call from the normal pull/sync hot path.
         bool origin_index_matches_changelog(MDBX_txn* txn) const {
+            txn = checked_txn(txn, "ChangeLogStore::origin_index_matches_changelog");
             ensure_open();
             const std::vector<OriginTail> expected =
                 collect_changelog_origin_tails(txn);
@@ -210,6 +217,7 @@ namespace sync {
         /// \complexity O(changelog entries + indexed origins).
         /// \note Explicit maintenance operation; ordinary pull does not call it.
         std::size_t rebuild_origin_index(MDBX_txn* txn) {
+            txn = checked_txn(txn, "ChangeLogStore::rebuild_origin_index");
             ensure_open();
             const std::vector<OriginTail> tails =
                 collect_changelog_origin_tails(txn);
@@ -221,6 +229,10 @@ namespace sync {
         }
 
     private:
+        MDBX_txn* checked_txn(MDBX_txn* txn, const char* context) const {
+            return checked_txn_env(txn, m_env, context);
+        }
+
         struct OriginTail {
             NodeId origin;
             std::uint64_t seq;

--- a/include/mdbx_containers/sync/stores/IdentityIndexStore.hpp
+++ b/include/mdbx_containers/sync/stores/IdentityIndexStore.hpp
@@ -43,6 +43,7 @@ namespace sync {
             : m_env(env), m_dbi_name(dbi_name), m_dbi(0), m_open(false) {}
 
         void open(MDBX_txn* txn) {
+            txn = checked_txn(txn, "IdentityIndexStore::open");
             if (m_open) return;
             check_mdbx(
                 mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE, &m_dbi),
@@ -65,6 +66,7 @@ namespace sync {
         void put(MDBX_txn* txn, const std::string& dbi_name,
                  const std::vector<std::uint8_t>& identity_key,
                  const IdentityIndexValue& value) {
+            txn = checked_txn(txn, "IdentityIndexStore::put");
             ensure_open();
             std::vector<std::uint8_t> key_buf;
             encode_key(dbi_name, identity_key, key_buf);
@@ -83,6 +85,7 @@ namespace sync {
         bool get(MDBX_txn* txn, const std::string& dbi_name,
                  const std::vector<std::uint8_t>& identity_key,
                  IdentityIndexValue& out) const {
+            txn = checked_txn(txn, "IdentityIndexStore::get");
             ensure_open();
             std::vector<std::uint8_t> key_buf;
             encode_key(dbi_name, identity_key, key_buf);
@@ -99,6 +102,7 @@ namespace sync {
         void tombstone(MDBX_txn* txn, const std::string& dbi_name,
                        const std::vector<std::uint8_t>& identity_key,
                        const IdentityIndexValue& marker) {
+            txn = checked_txn(txn, "IdentityIndexStore::tombstone");
             ensure_open();
             IdentityIndexValue v = marker;
             v.flags |= static_cast<std::uint32_t>(IDENTITY_TOMBSTONE);
@@ -109,6 +113,7 @@ namespace sync {
         /// \return true when a record was removed.
         bool erase(MDBX_txn* txn, const std::string& dbi_name,
                    const std::vector<std::uint8_t>& identity_key) {
+            txn = checked_txn(txn, "IdentityIndexStore::erase");
             if (!m_open) {
                 throw std::logic_error("IdentityIndexStore is not open");
             }
@@ -123,6 +128,10 @@ namespace sync {
         }
 
     private:
+        MDBX_txn* checked_txn(MDBX_txn* txn, const char* context) const {
+            return checked_txn_env(txn, m_env, context);
+        }
+
         static void encode_key(const std::string& dbi_name,
                                const std::vector<std::uint8_t>& identity_key,
                                std::vector<std::uint8_t>& out) {

--- a/include/mdbx_containers/sync/stores/MetaStore.hpp
+++ b/include/mdbx_containers/sync/stores/MetaStore.hpp
@@ -30,6 +30,7 @@ namespace sync {
         /// Tries \c MDBX_CREATE first; falls back to a plain open when the
         /// transaction is read-only and the DBI already exists.
         void open(MDBX_txn* txn) {
+            txn = checked_txn(txn, "MetaStore::open");
             if (m_open) return;
             int rc = mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE, &m_dbi);
             if (rc == MDBX_EACCESS) {
@@ -143,6 +144,7 @@ namespace sync {
 
         std::size_t read_fixed(MDBX_txn* txn, std::uint8_t key,
                                std::uint8_t* dst, std::size_t n) const {
+            txn = checked_txn(txn, "MetaStore::read");
             ensure_open();
             MDBX_val k = { &key, 1 };
             MDBX_val v;
@@ -156,6 +158,7 @@ namespace sync {
 
         void write_fixed(MDBX_txn* txn, std::uint8_t key,
                          const std::uint8_t* src, std::size_t n) const {
+            txn = checked_txn(txn, "MetaStore::write");
             ensure_open();
             MDBX_val k = { &key, 1 };
             MDBX_val v = { const_cast<std::uint8_t*>(src), n };
@@ -163,6 +166,10 @@ namespace sync {
                 mdbx_put(txn, m_dbi, &k, &v, MDBX_UPSERT),
                 "MetaStore write failed"
             );
+        }
+
+        MDBX_txn* checked_txn(MDBX_txn* txn, const char* context) const {
+            return checked_txn_env(txn, m_env, context);
         }
 
         MDBX_env*     m_env;

--- a/include/mdbx_containers/sync/stores/OriginIndexStore.hpp
+++ b/include/mdbx_containers/sync/stores/OriginIndexStore.hpp
@@ -28,6 +28,7 @@ namespace sync {
 
         /// \brief Opens or creates the DBI inside the supplied transaction.
         void open(MDBX_txn* txn) {
+            txn = checked_txn(txn, "OriginIndexStore::open");
             if (m_open) return;
             int rc = mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE, &m_dbi);
             if (rc == MDBX_EACCESS) {
@@ -41,6 +42,7 @@ namespace sync {
         /// \brief Opens the DBI only if it already exists.
         /// \return \c true when opened, \c false when the DBI is absent.
         bool open_existing(MDBX_txn* txn) {
+            txn = checked_txn(txn, "OriginIndexStore::open_existing");
             if (m_open) return true;
             const int rc = mdbx_dbi_open(txn, m_dbi_name.c_str(),
                                          static_cast<MDBX_db_flags_t>(0), &m_dbi);
@@ -65,6 +67,7 @@ namespace sync {
 
         /// \brief Returns true when the index contains no origins.
         bool empty(MDBX_txn* txn) const {
+            txn = checked_txn(txn, "OriginIndexStore::empty");
             ensure_open();
             MDBX_cursor* raw = nullptr;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, &raw),
@@ -82,6 +85,7 @@ namespace sync {
         /// \return Number of removed origin entries.
         /// \pre Transaction must be writable.
         std::size_t clear(MDBX_txn* txn) {
+            txn = checked_txn(txn, "OriginIndexStore::clear");
             ensure_open();
             MDBX_cursor* raw = nullptr;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, &raw),
@@ -109,6 +113,7 @@ namespace sync {
 
         /// \brief Records \p origin with at least \p seq as its known tail.
         void note_origin(MDBX_txn* txn, const NodeId& origin, std::uint64_t seq) {
+            txn = checked_txn(txn, "OriginIndexStore::note_origin");
             ensure_open();
             std::uint64_t current = 0;
             if (last_seq(txn, origin, current) && current >= seq) {
@@ -126,6 +131,7 @@ namespace sync {
         /// \return true when the origin exists.
         bool last_seq(MDBX_txn* txn, const NodeId& origin,
                       std::uint64_t& out) const {
+            txn = checked_txn(txn, "OriginIndexStore::last_seq");
             ensure_open();
             MDBX_val k = { const_cast<std::uint8_t*>(origin.data()), origin.size() };
             MDBX_val v;
@@ -141,6 +147,7 @@ namespace sync {
 
         /// \brief Returns all indexed origins with their tails in DB key order.
         std::vector<OriginTail> origin_tails(MDBX_txn* txn) const {
+            txn = checked_txn(txn, "OriginIndexStore::origin_tails");
             ensure_open();
             std::vector<OriginTail> out;
             MDBX_cursor* raw = nullptr;
@@ -188,6 +195,10 @@ namespace sync {
         }
 
     private:
+        MDBX_txn* checked_txn(MDBX_txn* txn, const char* context) const {
+            return checked_txn_env(txn, m_env, context);
+        }
+
         MDBX_env*     m_env;
         std::string   m_dbi_name;
         MDBX_dbi      m_dbi;

--- a/tests/test_transaction_provenance.cpp
+++ b/tests/test_transaction_provenance.cpp
@@ -1,0 +1,351 @@
+#include "test_assert.hpp"
+
+#include <mdbx_containers/AnyValueTable.hpp>
+#include <mdbx_containers/HashedKeyValueStore.hpp>
+#include <mdbx_containers/KeyMultiValueTable.hpp>
+#include <mdbx_containers/KeyTable.hpp>
+#include <mdbx_containers/KeyValueTable.hpp>
+#include <mdbx_containers/SequenceTable.hpp>
+#include <mdbx_containers/ValueTable.hpp>
+#include <mdbx_containers/sync.hpp>
+
+#include <cstdio>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+void cleanup(const std::string& path) {
+    std::remove(path.c_str());
+    std::remove((path + "-lck").c_str());
+}
+
+mdbxc::Config config_for(const std::string& path) {
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 64;
+    cfg.no_subdir = true;
+    return cfg;
+}
+
+mdbxc::sync::NodeId make_node(std::uint8_t seed) {
+    mdbxc::sync::NodeId node{};
+    for (std::size_t i = 0; i < node.size(); ++i) {
+        node[i] = static_cast<std::uint8_t>(seed + i);
+    }
+    return node;
+}
+
+template<class Fn>
+void expect_invalid_argument(const char* label, Fn fn) {
+    bool thrown = false;
+    try {
+        fn();
+    } catch (const std::invalid_argument&) {
+        thrown = true;
+    }
+    if (!thrown) {
+        throw std::runtime_error(
+            std::string(label) + ": expected std::invalid_argument");
+    }
+}
+
+template<class Fn>
+void expect_invalid_argument_containing(const char* label,
+                                        const char* needle,
+                                        Fn fn) {
+    try {
+        fn();
+    } catch (const std::invalid_argument& e) {
+        const std::string message = e.what();
+        if (message.find(needle) == std::string::npos) {
+            throw std::runtime_error(
+                std::string(label) + ": unexpected invalid_argument: " +
+                message);
+        }
+        return;
+    }
+    throw std::runtime_error(
+        std::string(label) + ": expected std::invalid_argument");
+}
+
+void test_public_tables_reject_foreign_transactions() {
+    const std::string path_a = "test_transaction_provenance_tables_a.mdbx";
+    const std::string path_b = "test_transaction_provenance_tables_b.mdbx";
+    cleanup(path_a);
+    cleanup(path_b);
+
+    std::shared_ptr<mdbxc::Connection> conn_a =
+        mdbxc::Connection::create(config_for(path_a));
+    std::shared_ptr<mdbxc::Connection> conn_b =
+        mdbxc::Connection::create(config_for(path_b));
+
+    mdbxc::KeyValueTable<int, int> kv(conn_a, "kv");
+    mdbxc::KeyTable<int> keys(conn_a, "keys");
+    mdbxc::ValueTable<int> value(conn_a, "value");
+    mdbxc::SequenceTable<int> sequence(conn_a, "sequence");
+    mdbxc::AnyValueTable<int> any(conn_a, "any");
+    mdbxc::KeyMultiValueTable<int, std::string> multi(conn_a, "multi");
+    mdbxc::HashedKeyValueStore<std::string, std::string> hashed(conn_a, "hashed");
+
+    {
+        mdbxc::Transaction txn = conn_a->transaction(mdbxc::TransactionMode::WRITABLE);
+        kv.insert_or_assign(100, 200, txn.handle());
+        value.set(5, txn.handle());
+        txn.commit();
+    }
+    MDBXC_TEST_ASSERT(kv.contains(100));
+    MDBXC_TEST_ASSERT(value.get() == 5);
+
+    {
+        mdbxc::Transaction foreign =
+            conn_b->transaction(mdbxc::TransactionMode::WRITABLE);
+        MDBX_txn* raw = foreign.handle();
+
+        expect_invalid_argument("KeyValueTable raw txn",
+                                [&kv, raw] { kv.insert_or_assign(1, 10, raw); });
+        expect_invalid_argument("KeyTable raw txn",
+                                [&keys, raw] { keys.insert(1, raw); });
+        expect_invalid_argument("ValueTable raw txn",
+                                [&value, raw] { value.set(10, raw); });
+        expect_invalid_argument("SequenceTable raw txn",
+                                [&sequence, raw] {
+                                    sequence.insert_or_assign(1, 10, raw);
+                                });
+        expect_invalid_argument("AnyValueTable raw txn",
+                                [&any, raw] {
+                                    any.set<std::string>(1, std::string("value"), raw);
+                                });
+        expect_invalid_argument("KeyMultiValueTable raw txn",
+                                [&multi, raw] {
+                                    multi.insert(1, std::string("value"), raw);
+                                });
+        expect_invalid_argument("HashedKeyValueStore raw txn",
+                                [&hashed, raw] {
+                                    hashed.insert_or_assign(std::string("key"),
+                                                            std::string("value"),
+                                                            raw);
+                                });
+        foreign.commit();
+    }
+
+    MDBXC_TEST_ASSERT(kv.count() == 1u);
+    MDBXC_TEST_ASSERT(keys.empty());
+    MDBXC_TEST_ASSERT(value.get() == 5);
+    MDBXC_TEST_ASSERT(sequence.count() == 0u);
+    MDBXC_TEST_ASSERT(!any.contains(1));
+    MDBXC_TEST_ASSERT(multi.count() == 0u);
+    MDBXC_TEST_ASSERT(hashed.count() == 0u);
+
+    conn_a->disconnect();
+    conn_b->disconnect();
+    cleanup(path_a);
+    cleanup(path_b);
+}
+
+void open_sync_stores(mdbxc::Connection& conn,
+                      mdbxc::sync::MetaStore& meta,
+                      mdbxc::sync::AppliedStore& applied,
+                      mdbxc::sync::ChangeLogStore& change_log,
+                      mdbxc::sync::OriginIndexStore& origins,
+                      mdbxc::sync::IdentityIndexStore& identities) {
+    mdbxc::Transaction txn = conn.transaction(mdbxc::TransactionMode::WRITABLE);
+    meta.open(txn.handle());
+    applied.open(txn.handle());
+    change_log.open(txn.handle());
+    origins.open(txn.handle());
+    identities.open(txn.handle());
+    txn.commit();
+}
+
+void test_sync_components_reject_foreign_transactions() {
+    using namespace mdbxc::sync;
+
+    const std::string path_a = "test_transaction_provenance_sync_a.mdbx";
+    const std::string path_b = "test_transaction_provenance_sync_b.mdbx";
+    cleanup(path_a);
+    cleanup(path_b);
+
+    std::shared_ptr<mdbxc::Connection> conn_a =
+        mdbxc::Connection::create(config_for(path_a));
+    std::shared_ptr<mdbxc::Connection> conn_b =
+        mdbxc::Connection::create(config_for(path_b));
+
+    const NodeId local_node = make_node(0x10);
+    const NodeId remote_node = make_node(0x20);
+    const NodeId db_id = make_node(0xD0);
+
+    SyncEngine engine(conn_a);
+    engine.initialize_local_identity(local_node, db_id);
+
+    ChangeBatch batch;
+    batch.version = 1;
+    batch.origin_node_id = remote_node;
+    batch.seq = 1;
+
+    MetaStore meta(conn_a->env_handle());
+    AppliedStore applied(conn_a->env_handle());
+    ChangeLogStore change_log(conn_a->env_handle());
+    OriginIndexStore origins(conn_a->env_handle());
+    IdentityIndexStore identities(conn_a->env_handle());
+    open_sync_stores(*conn_a, meta, applied, change_log, origins, identities);
+
+    ThreadLocalChangeAccumulator accumulator(conn_a);
+
+    {
+        mdbxc::Transaction foreign =
+            conn_b->transaction(mdbxc::TransactionMode::WRITABLE);
+        MDBX_txn* raw = foreign.handle();
+
+        expect_invalid_argument("SyncEngine::apply_batch_ex",
+                                [&engine, raw, &batch] {
+                                    engine.apply_batch_ex(raw, batch);
+                                });
+        expect_invalid_argument("SyncEngine::apply_batch",
+                                [&engine, raw, &batch] {
+                                    engine.apply_batch(raw, batch);
+                                });
+        expect_invalid_argument("SyncEngine::applied_cursor",
+                                [&engine, raw] { engine.applied_cursor(raw); });
+        expect_invalid_argument_containing(
+            "SyncEngine::pull_full_snapshot",
+            "SyncEngine::pull_full_snapshot",
+            [&engine, raw] {
+                PullRequest request;
+                request.max_batches = 10;
+                request.max_bytes = 1024;
+                engine.pull_full_snapshot(raw, 0, request);
+            });
+
+        expect_invalid_argument("MetaStore::get_schema_version",
+                                [&meta, raw] { meta.get_schema_version(raw); });
+        expect_invalid_argument("MetaStore::set_schema_version",
+                                [&meta, raw] { meta.set_schema_version(raw, 1); });
+        expect_invalid_argument("AppliedStore::last_applied_seq",
+                                [&applied, raw, &remote_node] {
+                                    applied.last_applied_seq(raw, remote_node);
+                                });
+        expect_invalid_argument("AppliedStore::set_last_applied_seq",
+                                [&applied, raw, &remote_node] {
+                                    applied.set_last_applied_seq(raw, remote_node, 1);
+                                });
+        expect_invalid_argument("AppliedStore::clear",
+                                [&applied, raw, &remote_node] {
+                                    applied.clear(raw, remote_node);
+                                });
+
+        const std::vector<std::uint8_t> bytes(1u, 0x42u);
+        expect_invalid_argument("ChangeLogStore::append",
+                                [&change_log, raw, &remote_node, &bytes] {
+                                    change_log.append(raw, remote_node, 1, bytes);
+                                });
+        expect_invalid_argument("ChangeLogStore::contains",
+                                [&change_log, raw, &remote_node] {
+                                    change_log.contains(raw, remote_node, 1);
+                                });
+        expect_invalid_argument("ChangeLogStore::get",
+                                [&change_log, raw, &remote_node] {
+                                    std::vector<std::uint8_t> out;
+                                    change_log.get(raw, remote_node, 1, out);
+                                });
+        expect_invalid_argument("ChangeLogStore::erase",
+                                [&change_log, raw, &remote_node] {
+                                    change_log.erase(raw, remote_node, 1);
+                                });
+        expect_invalid_argument("ChangeLogStore::prune_up_to",
+                                [&change_log, raw, &remote_node] {
+                                    change_log.prune_up_to(raw, remote_node, 1);
+                                });
+        expect_invalid_argument("ChangeLogStore::origin_index_matches_changelog",
+                                [&change_log, raw] {
+                                    change_log.origin_index_matches_changelog(raw);
+                                });
+        expect_invalid_argument("ChangeLogStore::rebuild_origin_index",
+                                [&change_log, raw] {
+                                    change_log.rebuild_origin_index(raw);
+                                });
+
+        std::uint64_t seq = 0;
+        expect_invalid_argument("OriginIndexStore::empty",
+                                [&origins, raw] { origins.empty(raw); });
+        expect_invalid_argument("OriginIndexStore::clear",
+                                [&origins, raw] { origins.clear(raw); });
+        expect_invalid_argument("OriginIndexStore::note_origin",
+                                [&origins, raw, &remote_node] {
+                                    origins.note_origin(raw, remote_node, 1);
+                                });
+        expect_invalid_argument("OriginIndexStore::last_seq",
+                                [&origins, raw, &remote_node, &seq] {
+                                    origins.last_seq(raw, remote_node, seq);
+                                });
+        expect_invalid_argument("OriginIndexStore::origin_tails",
+                                [&origins, raw] { origins.origin_tails(raw); });
+        expect_invalid_argument("OriginIndexStore::origins",
+                                [&origins, raw] { origins.origins(raw); });
+
+        IdentityIndexValue identity_value;
+        identity_value.origin_node_id = remote_node;
+        identity_value.seq = 1;
+        const std::vector<std::uint8_t> identity_key(1u, 0x01u);
+        expect_invalid_argument("IdentityIndexStore::put",
+                                [&identities, raw, &identity_key, &identity_value] {
+                                    identities.put(raw, "records",
+                                                   identity_key,
+                                                   identity_value);
+                                });
+        expect_invalid_argument("IdentityIndexStore::get",
+                                [&identities, raw, &identity_key] {
+                                    IdentityIndexValue out;
+                                    identities.get(raw, "records", identity_key, out);
+                                });
+        expect_invalid_argument("IdentityIndexStore::tombstone",
+                                [&identities, raw, &identity_key, &identity_value] {
+                                    identities.tombstone(raw, "records",
+                                                         identity_key,
+                                                         identity_value);
+                                });
+        expect_invalid_argument("IdentityIndexStore::erase",
+                                [&identities, raw, &identity_key] {
+                                    identities.erase(raw, "records", identity_key);
+                                });
+
+        expect_invalid_argument("ThreadLocalChangeAccumulator::record_change",
+                                [&accumulator, raw, &bytes] {
+                                    accumulator.record_change(raw,
+                                                              "records",
+                                                              ChangeOpType::Put,
+                                                              0,
+                                                              bytes,
+                                                              bytes);
+                                });
+        expect_invalid_argument("ThreadLocalChangeAccumulator::flush_in_txn",
+                                [&accumulator, raw] {
+                                    accumulator.flush_in_txn(raw);
+                                });
+
+        foreign.commit();
+    }
+
+    {
+        mdbxc::Transaction txn =
+            conn_a->transaction(mdbxc::TransactionMode::WRITABLE);
+        const ApplyOutcome outcome = engine.apply_batch_ex(txn.handle(), batch);
+        MDBXC_TEST_ASSERT(outcome.result == ApplyResult::Applied);
+        txn.commit();
+    }
+
+    conn_a->disconnect();
+    conn_b->disconnect();
+    cleanup(path_a);
+    cleanup(path_b);
+}
+
+} // namespace
+
+int main() {
+    test_public_tables_reject_foreign_transactions();
+    test_sync_components_reject_foreign_transactions();
+    return 0;
+}


### PR DESCRIPTION
Replacement for the closed/stale #151 branch.

## Summary
- add a shared raw MDBX transaction environment check
- reject foreign-env transactions in public table wrappers
- reject foreign-env transactions in SyncEngine apply/cursor entry points
- reject foreign-env transactions in sync stores and the default capture accumulator
- add regression coverage for public tables, direct sync stores, SyncEngine, and ChangeAccumulator

## Validation
- C++17 MinGW configure/build targeted tests: passed
- C++11 MinGW configure/build targeted tests: passed
- C++17 CTest targeted table/sync provenance suite: passed
- C++11 CTest targeted table/sync provenance suite: passed
- C++17/C++11 standalone public header smoke targets: built
