### PR TITLE
fix(sync): reject unimplemented protocol modes

### DIFF
--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -209,9 +209,14 @@ Operational rules:
   method. Calling a method before `open()` throws `std::logic_error` rather
   than silently writing to DBI 0. Do not weaken this guard.
 - `ConflictPolicy::Reject` is the v0.1 default. `LastWriterWins` is declared
-  for future logical-key conflict resolution, but the current raw batch apply
-  path does not use it in a non-test path. `time_unix_ns` is metadata, not a
-  reliable conflict authority. `Custom` is deferred to v0.2.
+  for future logical-key conflict resolution, but `SyncEngine` rejects it until
+  timestamp/version-based apply semantics exist. `time_unix_ns` is metadata,
+  not a reliable conflict authority. `Custom` is deferred to v0.2.
+- `PullRequest::request_full_snapshot=true` is reserved for the future
+  full export/import protocol. v0.1 responders reject it as
+  `PullResponse{ok=false, error=...}`. This is a sync-level protocol rejection,
+  not a transport retry hint; add a structured response error code before
+  treating it as machine-classified retry policy.
 - v0.1 sync captures normal write paths for `KeyValueTable`, `KeyTable`,
   `ValueTable`, and `SequenceTable`. `VectorStore` is sync-covered only because
   it persists through internal `SequenceTable` and `KeyValueTable` members.

--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -35,8 +35,8 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
 
 ### PR #153: Not-implemented public protocol modes
 
-- Make `PullRequest::request_full_snapshot=true` return an explicit
-  permanent/protocol error until full snapshot export/import is implemented.
+- Make `PullRequest::request_full_snapshot=true` return an explicit sync-level
+  protocol rejection until full snapshot export/import is implemented.
 - Reject or otherwise make unavailable `ConflictPolicy::LastWriterWins` until
   timestamp/version-based apply semantics exist.
 - Update docs/tests so public API no longer appears to support these modes.

--- a/include/mdbx_containers/sync/ConflictPolicy.hpp
+++ b/include/mdbx_containers/sync/ConflictPolicy.hpp
@@ -12,8 +12,9 @@ namespace sync {
     enum class ConflictPolicy {
         /// \brief Reject the incoming change; surface an error to the caller.
         Reject,
-        /// \brief Deterministically pick the change with the larger
-        /// \c revision_key (lexicographic), tie-broken by \c origin_node_id.
+        /// \brief Reserved for future timestamp/version based resolution.
+        /// \details v0.1 \c SyncEngine rejects this policy because raw batch
+        /// apply does not yet have a reliable logical-key conflict authority.
         LastWriterWins,
     };
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -78,8 +78,8 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
   `KeyTable`, `SequenceTable` insert/update/delete including empty serialized
   values, and `VectorStore` add/erase/rebuild through its public API.
 - `ConflictPolicy::Reject` is the default. `ConflictPolicy::LastWriterWins`
-  is declared for future logical-key conflict resolution but is not used by
-  the current raw batch apply path.
+  is declared for future logical-key conflict resolution; `SyncEngine`
+  rejects it until a reliable conflict authority exists.
 - `SyncWorker` background pull/apply lifecycle, cooperative cancellation
   tokens, best-effort peer cancellation hook, and focused worker tests.
 - Manual hub-style benchmark (`sync_tick_hub_benchmark`) plus opt-in and
@@ -241,7 +241,7 @@ Required tests before enabling capture:
 - HLC or other production authority for logical-key `LastWriterWins`.
   `time_unix_ns` is metadata only, not a reliable conflict authority. The
   current apply path does not maintain enough identity-index conflict state to
-  use `LastWriterWins` in a non-test path.
+  use `LastWriterWins`, so `SyncEngine` rejects that policy.
 - `Custom` conflict resolver — schema-level callback; deferred until the
   first real consumer needs it.
 - Production-grade deployment wrappers for concrete socket-bound HTTP and
@@ -459,7 +459,7 @@ Cold replica sync currently uses changelog replay:
 ```
 B: empty cursor
     -> pull request, have = empty
-A: handle_pull treats it as a full changelog snapshot across known origins
+A: handle_pull treats it as a full changelog replay across known origins
     -> streams persisted ChangeBatches from seq=1 with pagination limits
 B: applies each page as above
     -> onward sync is incremental pull-from-have
@@ -467,6 +467,10 @@ B: applies each page as above
 
 The reserved `seq=0, BATCH_HAS_MORE` full export/import format remains planned
 for v0.1 and is not the current cold-replica implementation.
+`PullRequest::request_full_snapshot=true` is rejected explicitly until that
+format is implemented. In v0.1 this is a sync-level protocol rejection carried
+as `PullResponse{ok=false, error=...}`; it does not produce a transport retry
+hint because pull responses do not yet carry structured error codes.
 
 ## Background worker lifecycle
 

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -131,7 +131,12 @@ namespace sync {
         /// \param policy Conflict resolution policy (default: \c Reject).
         explicit SyncEngine(std::shared_ptr<Connection> conn,
                             ConflictPolicy policy = ConflictPolicy::Reject)
-            : m_conn(std::move(conn)), m_policy(policy) {}
+            : m_conn(std::move(conn)), m_policy(policy) {
+            if (m_policy == ConflictPolicy::LastWriterWins) {
+                throw std::invalid_argument(
+                    "ConflictPolicy::LastWriterWins is not implemented");
+            }
+        }
 
         /// \brief Initialises the local \c node_id and \c db_uuid.
         /// \details Throws when already initialised with different values.
@@ -255,8 +260,9 @@ namespace sync {
 
         /// \brief Handles a pull request: reads the local changelog
         /// for batches newer than the requester's cursor.
-        /// \details When \c request.have is empty, returns a full snapshot
-        /// (all known origins, batches from seq=1). Non-empty cursors still
+        /// \details When \c request.have is empty, replays all retained
+        /// changelog batches from seq=1 for all known origins. This is not
+        /// a full database snapshot. Non-empty cursors still
         /// consider all known origins so newly discovered origins and
         /// multi-origin pagination are not stranded. Validates
         /// \c request.db_id against the local \c db_uuid; mismatched peers
@@ -269,6 +275,11 @@ namespace sync {
             if (!db_id_matches(request.db_id)) {
                 out.ok = false;
                 out.error = "db_id mismatch";
+                return out;
+            }
+            if (request.request_full_snapshot) {
+                out.ok = false;
+                out.error = "PullRequest::request_full_snapshot is not implemented";
                 return out;
             }
 
@@ -294,20 +305,28 @@ namespace sync {
             return pull_full_snapshot(txn, changelog_dbi, request);
         }
 
-        /// \brief Returns batches newer than \c request.have.
-        /// \details Empty \c request.have returns a full snapshot. Non-empty
-        /// cursors filter each origin independently and still include origins
-        /// missing from the cursor. Origin discovery uses \c _mdbxc_origins
-        /// when available, with a changelog scan fallback for pre-index
-        /// databases. Indexed origin tails skip origins that have no new
-        /// batches; changelog keys are still used for exact \c have_seq+1
-        /// seeks so old values are not decoded.
+        /// \brief Returns retained changelog batches newer than
+        /// \c request.have.
+        /// \details Empty \c request.have replays all retained changelog
+        /// batches from seq=1 for all known origins. This is not a full
+        /// database snapshot. Non-empty cursors filter each origin
+        /// independently and still include origins missing from the cursor.
+        /// Origin discovery uses \c _mdbxc_origins when available, with a
+        /// changelog scan fallback for pre-index databases. Indexed origin
+        /// tails skip origins that have no new batches; changelog keys are
+        /// still used for exact \c have_seq+1 seeks so old values are not
+        /// decoded.
         /// Sets \c has_more=true when the walk stopped because of
         /// \c request.max_batches or \c request.max_bytes.
         PullResponse pull_full_snapshot(MDBX_txn* txn, MDBX_dbi dbi,
                                         const PullRequest& request) {
-            txn = checked_external_txn(txn, "SyncEngine::pull_full_snapshot");
             PullResponse out;
+            if (request.request_full_snapshot) {
+                out.ok = false;
+                out.error = "PullRequest::request_full_snapshot is not implemented";
+                return out;
+            }
+            txn = checked_external_txn(txn, "SyncEngine::pull_full_snapshot");
             out.remote_have = read_applied_cursor(txn, out.remote_have);
             const std::vector<PullOrigin> origins = collect_known_origins(txn, dbi);
             out.remote_tail_known = copy_known_tail(origins, out.remote_tail);

--- a/include/mdbx_containers/sync/protocol.hpp
+++ b/include/mdbx_containers/sync/protocol.hpp
@@ -24,8 +24,9 @@ namespace sync {
         SyncCursor   have;
         std::uint64_t max_batches = 1000;
         std::uint64_t max_bytes   = 4ULL * 1024ULL * 1024ULL;
-        /// \brief When true, the responder should produce a full snapshot
-        /// instead of an incremental delta.
+        /// \brief Requests a full snapshot instead of an incremental delta.
+        /// \details Reserved for a future snapshot protocol. v0.1
+        /// \c SyncEngine responders reject this request explicitly.
         bool         request_full_snapshot = false;
         /// \brief Cooperative cancellation token for this transport call.
         /// \details Optional; default-constructed tokens never cancel.

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -52,6 +52,20 @@ std::shared_ptr<mdbxc::Connection> open_env(const std::string& path) {
     return Connection::create(cfg);
 }
 
+template<class Fn>
+void expect_invalid_argument(const char* name, Fn fn) {
+    bool rejected = false;
+    try {
+        fn();
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error(
+            std::string(name) + " did not throw std::invalid_argument");
+    }
+}
+
 void seed_node_id(std::shared_ptr<mdbxc::Connection> conn,
                   const mdbxc::sync::NodeId& node_id) {
     using namespace mdbxc;
@@ -941,6 +955,71 @@ void test_engine_handle_pull_wrong_db_id() {
     cleanup(p);
 }
 
+void test_engine_rejects_full_snapshot_request() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_full_snapshot_request.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0xA0), make_node(0xD0));
+
+    sync::PullRequest req;
+    req.requester = make_node(0xB0);
+    req.db_id = make_node(0xD0);
+    req.request_full_snapshot = true;
+
+    const sync::PullResponse resp = engine.handle_pull(req);
+    if (resp.ok) {
+        throw std::runtime_error("full snapshot request should be rejected");
+    }
+    if (!resp.batches.empty()) {
+        throw std::runtime_error("full snapshot rejection returned batches");
+    }
+    if (resp.error.find("request_full_snapshot") == std::string::npos) {
+        throw std::runtime_error("full snapshot rejection error is not explicit");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_direct_pull_rejects_full_snapshot_request() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_direct_full_snapshot_request.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0xA1), make_node(0xD1));
+
+    sync::PullRequest req;
+    req.requester = make_node(0xB1);
+    req.db_id = make_node(0xD1);
+    req.request_full_snapshot = true;
+
+    {
+        auto txn = conn->transaction(TransactionMode::READ_ONLY);
+        const sync::PullResponse resp =
+            engine.pull_full_snapshot(txn.handle(), 0, req);
+        if (resp.ok) {
+            throw std::runtime_error(
+                "direct full snapshot request should be rejected");
+        }
+        if (!resp.batches.empty()) {
+            throw std::runtime_error(
+                "direct full snapshot rejection returned batches");
+        }
+        if (resp.error.find("request_full_snapshot") == std::string::npos) {
+            throw std::runtime_error(
+                "direct full snapshot rejection error is not explicit");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 void test_engine_handle_push_wrong_db_id() {
     using namespace mdbxc;
     const std::string p = "test_engine_push_wrong_db.mdbx";
@@ -977,6 +1056,24 @@ void test_engine_handle_push_wrong_db_id() {
             throw std::runtime_error("table must be empty on wrong db_id push");
         }
     }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_rejects_last_writer_wins_policy() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_lww_policy.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    expect_invalid_argument("SyncEngine LastWriterWins policy",
+                            [&conn]() {
+                                sync::SyncEngine engine(
+                                    conn,
+                                    sync::ConflictPolicy::LastWriterWins);
+                                (void)engine;
+                            });
 
     conn->disconnect();
     cleanup(p);
@@ -1314,7 +1411,13 @@ int main() {
         { "test_engine_handle_push_to_remote",  &test_engine_handle_push_to_remote },
         { "test_engine_push_gap_rolls_back",    &test_engine_push_gap_rolls_back },
         { "test_engine_handle_pull_wrong_db_id",&test_engine_handle_pull_wrong_db_id },
+        { "test_engine_rejects_full_snapshot_request",
+          &test_engine_rejects_full_snapshot_request },
+        { "test_engine_direct_pull_rejects_full_snapshot_request",
+          &test_engine_direct_pull_rejects_full_snapshot_request },
         { "test_engine_handle_push_wrong_db_id",&test_engine_handle_push_wrong_db_id },
+        { "test_engine_rejects_last_writer_wins_policy",
+          &test_engine_rejects_last_writer_wins_policy },
         { "test_engine_handle_pull_pagination", &test_engine_handle_pull_pagination_has_more },
         { "test_engine_handle_pull_multi_origin",&test_engine_handle_pull_multi_origin_pagination },
         { "test_engine_handle_pull_legacy_origin_index",&test_engine_handle_pull_legacy_changelog_without_origin_index },


### PR DESCRIPTION
## Summary
- reject `ConflictPolicy::LastWriterWins` in `SyncEngine` until a real conflict authority exists
- reject `PullRequest::request_full_snapshot` explicitly instead of silently serving incremental changelog replay
- update sync protocol/design docs and add regression coverage

Replaces closed stacked PR #153 with a clean branch based on current `main`.

## Validation
- `cmake --build tmp/provenance-cpp17 --target test_sync_engine header_sync_umbrella_test header_all_umbrella_test -j 4`
- `cmake --build tmp/provenance-cpp11 --target test_sync_engine header_sync_umbrella_test header_all_umbrella_test -j 4`
- `ctest --test-dir tmp/provenance-cpp17 -R ^test_sync_engine$ --output-on-failure`
- `ctest --test-dir tmp/provenance-cpp11 -R ^test_sync_engine$ --output-on-failure`
- `git diff --check`