### PR TITLE
refactor(sync): rename changelog pull helper

### DIFF
--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -302,7 +302,7 @@ namespace sync {
                 return out;
             }
 
-            return pull_full_snapshot(txn, changelog_dbi, request);
+            return pull_changelog_page(txn, changelog_dbi, request);
         }
 
         /// \brief Returns retained changelog batches newer than
@@ -318,7 +318,7 @@ namespace sync {
         /// decoded.
         /// Sets \c has_more=true when the walk stopped because of
         /// \c request.max_batches or \c request.max_bytes.
-        PullResponse pull_full_snapshot(MDBX_txn* txn, MDBX_dbi dbi,
+        PullResponse pull_changelog_page(MDBX_txn* txn, MDBX_dbi dbi,
                                         const PullRequest& request) {
             PullResponse out;
             if (request.request_full_snapshot) {
@@ -326,7 +326,7 @@ namespace sync {
                 out.error = "PullRequest::request_full_snapshot is not implemented";
                 return out;
             }
-            txn = checked_external_txn(txn, "SyncEngine::pull_full_snapshot");
+            txn = checked_external_txn(txn, "SyncEngine::pull_changelog_page");
             out.remote_have = read_applied_cursor(txn, out.remote_have);
             const std::vector<PullOrigin> origins = collect_known_origins(txn, dbi);
             out.remote_tail_known = copy_known_tail(origins, out.remote_tail);
@@ -344,6 +344,14 @@ namespace sync {
             }
             out.has_more = truncated;
             return out;
+        }
+
+        /// \brief Compatibility wrapper for \c pull_changelog_page().
+        /// \deprecated This method never returned a database snapshot; use
+        /// \c pull_changelog_page() for the retained changelog replay API.
+        PullResponse pull_full_snapshot(MDBX_txn* txn, MDBX_dbi dbi,
+                                        const PullRequest& request) {
+            return pull_changelog_page(txn, dbi, request);
         }
 
         /// \brief Handles a push request: applies each batch in order.

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -984,9 +984,9 @@ void test_engine_rejects_full_snapshot_request() {
     cleanup(p);
 }
 
-void test_engine_direct_pull_rejects_full_snapshot_request() {
+void test_engine_changelog_page_rejects_full_snapshot_request() {
     using namespace mdbxc;
-    const std::string p = "test_engine_direct_full_snapshot_request.mdbx";
+    const std::string p = "test_engine_changelog_full_snapshot_request.mdbx";
     cleanup(p);
 
     auto conn = open_env(p);
@@ -1001,18 +1001,18 @@ void test_engine_direct_pull_rejects_full_snapshot_request() {
     {
         auto txn = conn->transaction(TransactionMode::READ_ONLY);
         const sync::PullResponse resp =
-            engine.pull_full_snapshot(txn.handle(), 0, req);
+            engine.pull_changelog_page(txn.handle(), 0, req);
         if (resp.ok) {
             throw std::runtime_error(
-                "direct full snapshot request should be rejected");
+                "changelog page full snapshot request should be rejected");
         }
         if (!resp.batches.empty()) {
             throw std::runtime_error(
-                "direct full snapshot rejection returned batches");
+                "changelog page full snapshot rejection returned batches");
         }
         if (resp.error.find("request_full_snapshot") == std::string::npos) {
             throw std::runtime_error(
-                "direct full snapshot rejection error is not explicit");
+                "changelog page full snapshot rejection error is not explicit");
         }
     }
 
@@ -1413,8 +1413,8 @@ int main() {
         { "test_engine_handle_pull_wrong_db_id",&test_engine_handle_pull_wrong_db_id },
         { "test_engine_rejects_full_snapshot_request",
           &test_engine_rejects_full_snapshot_request },
-        { "test_engine_direct_pull_rejects_full_snapshot_request",
-          &test_engine_direct_pull_rejects_full_snapshot_request },
+        { "test_engine_changelog_page_rejects_full_snapshot_request",
+          &test_engine_changelog_page_rejects_full_snapshot_request },
         { "test_engine_handle_push_wrong_db_id",&test_engine_handle_push_wrong_db_id },
         { "test_engine_rejects_last_writer_wins_policy",
           &test_engine_rejects_last_writer_wins_policy },

--- a/tests/test_transaction_provenance.cpp
+++ b/tests/test_transaction_provenance.cpp
@@ -210,13 +210,13 @@ void test_sync_components_reject_foreign_transactions() {
         expect_invalid_argument("SyncEngine::applied_cursor",
                                 [&engine, raw] { engine.applied_cursor(raw); });
         expect_invalid_argument_containing(
-            "SyncEngine::pull_full_snapshot",
-            "SyncEngine::pull_full_snapshot",
+            "SyncEngine::pull_changelog_page",
+            "SyncEngine::pull_changelog_page",
             [&engine, raw] {
                 PullRequest request;
                 request.max_batches = 10;
                 request.max_bytes = 1024;
-                engine.pull_full_snapshot(raw, 0, request);
+                engine.pull_changelog_page(raw, 0, request);
             });
 
         expect_invalid_argument("MetaStore::get_schema_version",


### PR DESCRIPTION
## Summary
- add SyncEngine::pull_changelog_page() as the accurately named retained changelog replay API
- keep pull_full_snapshot() as a compatibility wrapper with Doxygen deprecation text
- update direct tests and provenance diagnostics to use the new API name

## Validation
- cmake --build tmp/provenance-cpp17 --target test_sync_engine test_transaction_provenance header_sync_umbrella_test header_all_umbrella_test -j 4
- cmake --build tmp/provenance-cpp11 --target test_sync_engine test_transaction_provenance header_sync_umbrella_test header_all_umbrella_test -j 4
- ctest --test-dir tmp/provenance-cpp17 -R ^(test_sync_engine|test_transaction_provenance)$ --output-on-failure
- ctest --test-dir tmp/provenance-cpp11 -R ^(test_sync_engine|test_transaction_provenance)$ --output-on-failure
- git diff --check