### PR TITLE
fix(tables): preserve signed integer key order

### DIFF
--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -193,10 +193,14 @@ Operational rules:
 - Read `DESIGN.md` before changing any sync header, the `ChangeBatchCodec`
   layout, or any store's key encoding. These are wire-format and on-disk
   contracts; changes break data on disk and break other nodes.
-- Endianness policy (LE for payloads, BE only when a key participates in a
-  numeric range scan) is documented in `DESIGN.md`. Do not "fix" the BE
-  seq field in `ChangeLogStore::encode_key` back to LE — the change was
-  intentional and required for correct range scan order.
+- Sync store endianness policy (LE for payloads, BE for composite key fields
+  that participate in bytewise range scans) is documented in `DESIGN.md`. Do
+  not "fix" the BE seq field in `ChangeLogStore::encode_key` back to LE — the
+  change was intentional and required for correct range scan order.
+- Public table signed integral keys use an order-preserving bias before MDBX
+  integer-key comparison. Keep that transform scoped to key serialization; value
+  serialization for signed integers remains the ordinary trivially-copyable byte
+  representation.
 - `IdentityIndexValue` is an opaque structured payload keyed by a
   length-prefixed composite. Variable-size fields inside the value
   (`storage_key`, `revision_key`) are themselves length-prefixed for

--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -47,10 +47,8 @@ After PR #150-#153 are reviewed, agree on the next batch before implementation:
 
 - PR #154: standalone public header coverage for the full installed include
   tree, C++11/C++17, sync enabled/disabled, and transport feature macros.
-- PR #155+: signed integral key ordering. Choose the storage-format strategy
-  explicitly: order-preserving signed encoding with migration/versioning,
-  temporary compile-time rejection for ordered signed keys, or documented
-  unsigned physical ordering.
+- PR #157: signed integral key ordering. Use order-preserving signed key
+  encoding for ordered table keys, while leaving value serialization unchanged.
 
 ## Later Medium-Risk Follow-ups
 

--- a/guides/table-api-guide.md
+++ b/guides/table-api-guide.md
@@ -84,6 +84,11 @@ All public table classes follow the same broad shape:
 - Raw MDBX return codes go through `check_mdbx()`.
 - Serialization uses `SerializeScratch`, `serialize_key()`,
   `serialize_value()`, and `deserialize_value()`.
+- Ordered table keys use storage encodings chosen for MDBX key comparison.
+  Signed integral keys are biased into an unsigned order-preserving
+  representation before MDBX sees them, so ranges such as `-2..1` follow normal
+  signed numeric order. This rule applies to keys only; value serialization keeps
+  the ordinary value byte representation.
 - Keep C++11 support. Guard `std::optional`, `std::filesystem`, structured
   bindings, and other C++17 features.
 
@@ -152,7 +157,8 @@ Restrictions and common mistakes:
 - Retrieval into unique-key containers follows the container's own insertion
   rules.
 - `range()` and `range_values()` scan in MDBX key order before the requested
-  output container applies its own ordering or deduplication rules.
+  output container applies its own ordering or deduplication rules. For signed
+  integral keys, MDBX key order matches signed numeric order.
 
 Use it for:
 
@@ -241,7 +247,8 @@ Restrictions and common mistakes:
 - There is no user value. Do not encode payloads into fake keys unless the data
   is truly a set.
 - `reconcile()` is replacement-oriented and not an incremental set diff.
-- Key order follows MDBX key ordering, not insertion order.
+- Key order follows MDBX key ordering, not insertion order. For signed integral
+  keys, MDBX key order matches signed numeric order.
 - `range()` scans in the same MDBX key ordering before the requested output
   container applies its own ordering or deduplication rules.
 
@@ -414,7 +421,8 @@ Restrictions and common mistakes:
 - `reconcile()` avoids unnecessary writes, but it does not reorder existing
   matching records to match source iteration order.
 - `range()` and `range_values()` follow MDBX key ordering before the requested
-  output container applies its own ordering or deduplication rules.
+  output container applies its own ordering or deduplication rules. For signed
+  integral keys, MDBX key order matches signed numeric order.
 
 Use it for:
 

--- a/include/mdbx_containers/detail/utils.hpp
+++ b/include/mdbx_containers/detail/utils.hpp
@@ -23,6 +23,7 @@
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -92,6 +93,63 @@ namespace mdbxc {
         std::memcpy(&u, &d, sizeof(uint64_t));
         return (u & 0x8000000000000000ull) ? ~u : (u ^ 0x8000000000000000ull);
     }
+
+    template<typename T>
+    struct OrderedIntegerKeyStorage {
+        typedef typename std::conditional<(sizeof(T) <= 4),
+            std::uint32_t,
+            std::uint64_t>::type type;
+    };
+
+    template<typename T, bool Signed>
+    struct OrderedIntegerKeyCodec;
+
+    template<typename T>
+    struct OrderedIntegerKeyCodec<T, false> {
+        typedef typename OrderedIntegerKeyStorage<T>::type StorageT;
+
+        static StorageT encode(T value) {
+            return static_cast<StorageT>(value);
+        }
+
+        static T decode(StorageT stored) {
+            return static_cast<T>(stored);
+        }
+    };
+
+    template<typename T>
+    struct OrderedIntegerKeyCodec<T, true> {
+        typedef typename std::make_unsigned<T>::type UnsignedT;
+        typedef typename OrderedIntegerKeyStorage<T>::type StorageT;
+
+        static StorageT encode(T value) {
+            const UnsignedT sign_bit =
+                static_cast<UnsignedT>(UnsignedT(1) << (sizeof(T) * 8u - 1u));
+            const UnsignedT encoded =
+                static_cast<UnsignedT>(value) ^ sign_bit;
+            return static_cast<StorageT>(encoded);
+        }
+
+        static T decode(StorageT stored) {
+            const UnsignedT sign_bit =
+                static_cast<UnsignedT>(UnsignedT(1) << (sizeof(T) * 8u - 1u));
+            const UnsignedT raw =
+                static_cast<UnsignedT>(stored) ^ sign_bit;
+            T out;
+            std::memcpy(&out, &raw, sizeof(T));
+            return out;
+        }
+    };
+
+    template<typename T>
+    typename OrderedIntegerKeyStorage<T>::type sortable_key_from_integral(T value) {
+        return OrderedIntegerKeyCodec<T, std::is_signed<T>::value>::encode(value);
+    }
+
+    template<typename T>
+    T integral_from_sortable_key(typename OrderedIntegerKeyStorage<T>::type stored) {
+        return OrderedIntegerKeyCodec<T, std::is_signed<T>::value>::decode(stored);
+    }
     
     // --- Traits --- 
 
@@ -150,8 +208,10 @@ namespace mdbxc {
     };
 
     /// \brief Compile-time policy options for table behavior.
-    /// \tparam SafeIntegerKey Copy 32/64-bit integer keys into aligned scratch
-    ///         storage before MDBX calls when true.
+    /// \tparam SafeIntegerKey Copy unsigned 32/64-bit integer keys into aligned
+    ///         scratch storage before MDBX calls when true. Signed integral
+    ///         keys always use scratch storage because they are biased into an
+    ///         unsigned order-preserving MDBX_INTEGERKEY representation.
     template<bool SafeIntegerKey = true>
     struct TableOptions {
         static const bool safe_integer_key = SafeIntegerKey;
@@ -160,10 +220,11 @@ namespace mdbxc {
     /// \brief Default table policy using safe integer key serialization.
     typedef TableOptions<true> DefaultTableOptions;
 
-    /// \brief Table policy using direct views for 32/64-bit integer keys.
+    /// \brief Table policy using direct views for unsigned 32/64-bit integer keys.
     ///
     /// \warning This mode is a lifetime/alignment tradeoff and does not change
-    ///          the database storage format.
+    ///          the database storage format. Signed integral keys still use the
+    ///          order-preserving scratch representation.
     typedef TableOptions<false> FastIntegerKeyOptions;
 
 //-----------------------------------------------------------------------------
@@ -174,11 +235,8 @@ namespace mdbxc {
     template<typename T>
     inline MDBX_db_flags_t get_mdbx_flags() {
         return
-            std::is_same<T, int>::value || std::is_same<T, int32_t>::value ||
-            std::is_same<T, uint32_t>::value || std::is_same<T, int64_t>::value ||
-            std::is_same<T, uint64_t>::value || std::is_same<T, float>::value ||
-            std::is_same<T, double>::value || std::is_same<T, char>::value ||
-            std::is_same<T, unsigned char>::value
+            (std::is_integral<T>::value && !std::is_same<T, bool>::value) ||
+            std::is_same<T, float>::value || std::is_same<T, double>::value
             ? MDBX_INTEGERKEY : static_cast<MDBX_db_flags_t>(0);
     }
     
@@ -354,7 +412,7 @@ namespace mdbxc {
     serialize_key(const T& key, SerializeScratch& sc) {
         (void)SafeIntegerKey;
         static_assert(sizeof(uint32_t) == 4, "Expected 4-byte wrapper");
-        uint32_t temp = static_cast<uint32_t>(key);
+        uint32_t temp = sortable_key_from_integral(key);
         return sc.view_small_copy(&temp, sizeof(uint32_t));
     }
 
@@ -362,13 +420,16 @@ namespace mdbxc {
     /// \tparam T Supported 32-bit type.
     template<bool SafeIntegerKey = true, typename T>
     typename std::enable_if<
-        std::is_same<T, int32_t>::value ||
-        std::is_same<T, uint32_t>::value, MDBX_val>::type
+        std::is_integral<T>::value &&
+        (sizeof(T) > 2) &&
+        (sizeof(T) <= 4), MDBX_val>::type
     serialize_key(const T& key, SerializeScratch& sc) {
         static_assert(sizeof(uint32_t) == 4, "Expected 4-byte integer");
-        return SafeIntegerKey
-            ? sc.view_small_copy(&key, sizeof(uint32_t))
-            : SerializeScratch::view(static_cast<const void*>(&key), sizeof(uint32_t));
+        if (std::is_signed<T>::value || SafeIntegerKey) {
+            uint32_t temp = sortable_key_from_integral(key);
+            return sc.view_small_copy(&temp, sizeof(uint32_t));
+        }
+        return SerializeScratch::view(static_cast<const void*>(&key), sizeof(uint32_t));
     }
     
     /// \brief Serializes a 32-bit float key.
@@ -387,13 +448,16 @@ namespace mdbxc {
     /// \tparam T Supported 64-bit type.
     template<bool SafeIntegerKey = true, typename T>
     typename std::enable_if<
-        std::is_same<T, int64_t>::value ||
-        std::is_same<T, uint64_t>::value, MDBX_val>::type
+        std::is_integral<T>::value &&
+        (sizeof(T) > 4) &&
+        (sizeof(T) <= 8), MDBX_val>::type
     serialize_key(const T& key, SerializeScratch& sc) {
         static_assert(sizeof(uint64_t) == 8, "Expected 8-byte integer");
-        return SafeIntegerKey
-            ? sc.view_small_copy(&key, sizeof(uint64_t))
-            : SerializeScratch::view(static_cast<const void*>(&key), sizeof(uint64_t));
+        if (std::is_signed<T>::value || SafeIntegerKey) {
+            uint64_t temp = sortable_key_from_integral(key);
+            return sc.view_small_copy(&temp, sizeof(uint64_t));
+        }
+        return SerializeScratch::view(static_cast<const void*>(&key), sizeof(uint64_t));
     }
     
     /// \brief Serializes a 64-bit double key.
@@ -415,11 +479,9 @@ namespace mdbxc {
         std::is_trivially_copyable<T>::value &&
         !std::is_same<T, std::string>::value &&
         !(std::is_integral<T>::value && sizeof(T) <= 2) &&
-        !std::is_same<T, int32_t>::value &&
-        !std::is_same<T, uint32_t>::value &&
+        !(std::is_integral<T>::value && (sizeof(T) > 2) && (sizeof(T) <= 4)) &&
         !std::is_same<T, float>::value &&
-        !std::is_same<T, int64_t>::value &&
-        !std::is_same<T, uint64_t>::value &&
+        !(std::is_integral<T>::value && (sizeof(T) > 4) && (sizeof(T) <= 8)) &&
         !std::is_same<T, double>::value, MDBX_val>::type
     serialize_key(const T& key, SerializeScratch& sc) {
         (void)SafeIntegerKey;
@@ -872,17 +934,22 @@ namespace mdbxc {
         }
         uint32_t out;
         std::memcpy(&out, val.iov_base, sizeof(uint32_t));
-        return static_cast<T>(out);
+        return integral_from_sortable_key<T>(out);
     }
 
     template<typename T>
     typename std::enable_if<
-        std::is_same<T, int32_t>::value ||
-        std::is_same<T, uint32_t>::value ||
-        std::is_same<T, int64_t>::value ||
-        std::is_same<T, uint64_t>::value, T>::type
+        std::is_integral<T>::value &&
+        (sizeof(T) > 2) &&
+        (sizeof(T) <= 8), T>::type
     deserialize_key(const MDBX_val& val) {
-        return deserialize_value<T>(val);
+        typedef typename OrderedIntegerKeyStorage<T>::type StorageT;
+        if (val.iov_len != sizeof(StorageT)) {
+            throw std::runtime_error("deserialize_key: size mismatch");
+        }
+        StorageT raw;
+        std::memcpy(&raw, val.iov_base, sizeof(StorageT));
+        return integral_from_sortable_key<T>(raw);
     }
 
     inline float float_from_sortable_key(uint32_t key) {
@@ -942,11 +1009,9 @@ namespace mdbxc {
         std::is_trivially_copyable<T>::value &&
         !std::is_same<T, std::string>::value &&
         !(std::is_integral<T>::value && sizeof(T) <= 2) &&
-        !std::is_same<T, int32_t>::value &&
-        !std::is_same<T, uint32_t>::value &&
+        !(std::is_integral<T>::value && (sizeof(T) > 2) && (sizeof(T) <= 4)) &&
         !std::is_same<T, float>::value &&
-        !std::is_same<T, int64_t>::value &&
-        !std::is_same<T, uint64_t>::value &&
+        !(std::is_integral<T>::value && (sizeof(T) > 4) && (sizeof(T) <= 8)) &&
         !std::is_same<T, double>::value, T>::type
     deserialize_key(const MDBX_val& val) {
         return deserialize_value<T>(val);

--- a/tests/key_multi_value_table_test.cpp
+++ b/tests/key_multi_value_table_test.cpp
@@ -49,14 +49,25 @@ int main() {
         table.insert(7, "created");
         table.insert(7, "sent");
         table.insert(8, "queued");
+        table.insert(-1, "before-zero");
+        table.insert(0, "zero");
 
-        MDBXC_TEST_ASSERT(table.count() == 4);
+        MDBXC_TEST_ASSERT(table.count() == 6);
         MDBXC_TEST_ASSERT(table.count(7) == 3);
         MDBXC_TEST_ASSERT(table.count(7, std::string("created")) == 2);
         MDBXC_TEST_ASSERT(table.count(7, std::string("missing")) == 0);
         MDBXC_TEST_ASSERT(table.contains(7));
         MDBXC_TEST_ASSERT(table.contains(7, std::string("sent")));
         MDBXC_TEST_ASSERT(!table.contains(9));
+
+        std::vector<std::pair<int, std::string> > signed_range_pairs;
+        signed_range_pairs.push_back(std::make_pair(-1, std::string("before-zero")));
+        signed_range_pairs.push_back(std::make_pair(0, std::string("zero")));
+        signed_range_pairs.push_back(std::make_pair(7, std::string("created")));
+        signed_range_pairs.push_back(std::make_pair(7, std::string("created")));
+        signed_range_pairs.push_back(std::make_pair(7, std::string("sent")));
+        signed_range_pairs.push_back(std::make_pair(8, std::string("queued")));
+        assert_vector_equal(table.range_vector(-1, 8), signed_range_pairs);
 
         assert_vector_equal(table.find(7), std::vector<std::string>{"created", "created", "sent"});
         std::vector<std::pair<int, std::string> > range_pairs;
@@ -84,22 +95,26 @@ int main() {
 
         std::multimap<int, std::string> as_multimap;
         table.load(as_multimap);
-        MDBXC_TEST_ASSERT(as_multimap.size() == 4);
+        MDBXC_TEST_ASSERT(as_multimap.size() == 6);
+        MDBXC_TEST_ASSERT(as_multimap.count(-1) == 1);
+        MDBXC_TEST_ASSERT(as_multimap.count(0) == 1);
         MDBXC_TEST_ASSERT(as_multimap.count(7) == 3);
 
         std::vector<std::pair<int, std::string> > as_vector;
         table.load(as_vector);
-        MDBXC_TEST_ASSERT(as_vector.size() == 4);
-        MDBXC_TEST_ASSERT(as_vector[0] == std::make_pair(7, std::string("created")));
-        MDBXC_TEST_ASSERT(as_vector[1] == std::make_pair(7, std::string("created")));
-        MDBXC_TEST_ASSERT(as_vector[2] == std::make_pair(7, std::string("sent")));
-        MDBXC_TEST_ASSERT(as_vector[3] == std::make_pair(8, std::string("queued")));
+        MDBXC_TEST_ASSERT(as_vector.size() == 6);
+        MDBXC_TEST_ASSERT(as_vector[0] == std::make_pair(-1, std::string("before-zero")));
+        MDBXC_TEST_ASSERT(as_vector[1] == std::make_pair(0, std::string("zero")));
+        MDBXC_TEST_ASSERT(as_vector[2] == std::make_pair(7, std::string("created")));
+        MDBXC_TEST_ASSERT(as_vector[3] == std::make_pair(7, std::string("created")));
+        MDBXC_TEST_ASSERT(as_vector[4] == std::make_pair(7, std::string("sent")));
+        MDBXC_TEST_ASSERT(as_vector[5] == std::make_pair(8, std::string("queued")));
 
         MDBXC_TEST_ASSERT(table.erase(7, std::string("created")) == 2);
         assert_vector_equal(table.find(7), std::vector<std::string>{"sent"});
         MDBXC_TEST_ASSERT(table.erase(7));
         MDBXC_TEST_ASSERT(!table.contains(7));
-        MDBXC_TEST_ASSERT(table.count() == 1);
+        MDBXC_TEST_ASSERT(table.count() == 3);
 
         std::vector<std::pair<int, std::string> > replacement;
         replacement.push_back(std::make_pair(3, std::string("a")));

--- a/tests/key_table_test.cpp
+++ b/tests/key_table_test.cpp
@@ -82,11 +82,13 @@ int main() {
         mdbxc::KeyTable<int> safe_table(conn, "key_options");
         mdbxc::KeyTable<int, mdbxc::FastIntegerKeyOptions> fast_table(conn, "key_options");
         safe_table.clear();
+        MDBXC_TEST_ASSERT(safe_table.insert(-1));
+        MDBXC_TEST_ASSERT(fast_table.contains(-1));
         MDBXC_TEST_ASSERT(safe_table.insert(11));
         MDBXC_TEST_ASSERT(fast_table.contains(11));
         MDBXC_TEST_ASSERT(fast_table.insert(12));
         MDBXC_TEST_ASSERT(safe_table.contains(12));
-        MDBXC_TEST_ASSERT(safe_table.range(10, 12) == (std::set<int>{11, 12}));
+        MDBXC_TEST_ASSERT(safe_table.range(-1, 12) == (std::set<int>{-1, 11, 12}));
         MDBXC_TEST_ASSERT(fast_table.range(12, 12) == (std::set<int>{12}));
     }
 
@@ -94,11 +96,19 @@ int main() {
     {
         mdbxc::KeyTable<int> table(conn, "range_api_keys");
         table.clear();
+        table.insert(-2);
+        table.insert(-1);
+        table.insert(0);
         table.insert(1);
         table.insert(2);
         table.insert(3);
         table.insert(4);
         table.insert(5);
+
+        MDBXC_TEST_ASSERT(table.range(-2, 1) ==
+               (std::set<int>{-2, -1, 0, 1}));
+        MDBXC_TEST_ASSERT(table.range<std::vector>(-2, 1) ==
+               (std::vector<int>{-2, -1, 0, 1}));
 
         // for_each_range full scan
         std::vector<int> collected;
@@ -143,7 +153,10 @@ int main() {
 
         std::size_t erased = table.erase_range(2, 4);
         MDBXC_TEST_ASSERT(erased == 3);
-        MDBXC_TEST_ASSERT(table.count() == 2);
+        MDBXC_TEST_ASSERT(table.count() == 5);
+        MDBXC_TEST_ASSERT(table.contains(-2));
+        MDBXC_TEST_ASSERT(table.contains(-1));
+        MDBXC_TEST_ASSERT(table.contains(0));
         MDBXC_TEST_ASSERT(table.contains(1));
         MDBXC_TEST_ASSERT(table.contains(5));
         MDBXC_TEST_ASSERT(!table.contains(3));

--- a/tests/kv_container_all_types_test.cpp
+++ b/tests/kv_container_all_types_test.cpp
@@ -265,6 +265,18 @@ int main() {
         kv.insert_or_assign(0, "zero");
         kv.insert_or_assign(1, "one");
 
+        std::vector<std::pair<int, std::string> > all_signed_pairs;
+        all_signed_pairs.push_back(std::make_pair(-2, std::string("minus-two")));
+        all_signed_pairs.push_back(std::make_pair(-1, std::string("minus-one")));
+        all_signed_pairs.push_back(std::make_pair(0, std::string("zero")));
+        all_signed_pairs.push_back(std::make_pair(1, std::string("one")));
+        MDBXC_TEST_ASSERT((kv.range(-2, 1) ==
+                std::map<int, std::string>(all_signed_pairs.begin(),
+                                           all_signed_pairs.end())));
+        MDBXC_TEST_ASSERT(kv.range<std::vector>(-2, 1) == all_signed_pairs);
+        MDBXC_TEST_ASSERT(kv.range_values(-2, 1) ==
+               (std::vector<std::string>{"minus-two", "minus-one", "zero", "one"}));
+
         std::vector<std::pair<int, std::string> > negative_pairs;
         negative_pairs.push_back(std::make_pair(-2, std::string("minus-two")));
         negative_pairs.push_back(std::make_pair(-1, std::string("minus-one")));
@@ -298,6 +310,29 @@ int main() {
         MDBXC_TEST_ASSERT(kv.range<std::vector>(0u, max_key) == all_pairs);
         MDBXC_TEST_ASSERT(kv.range_values(0u, max_key) ==
                (std::vector<std::string>{"zero", "one", "max"}));
+    }
+
+    {
+        mdbxc::KeyValueTable<long, std::string> kv(conn, "range_long_boundaries");
+        kv.clear();
+
+        kv.insert_or_assign(static_cast<long>(-2), "minus-two");
+        kv.insert_or_assign(static_cast<long>(-1), "minus-one");
+        kv.insert_or_assign(static_cast<long>(0), "zero");
+        kv.insert_or_assign(static_cast<long>(1), "one");
+
+        std::vector<std::pair<long, std::string> > all_pairs;
+        all_pairs.push_back(std::make_pair(static_cast<long>(-2),
+                                           std::string("minus-two")));
+        all_pairs.push_back(std::make_pair(static_cast<long>(-1),
+                                           std::string("minus-one")));
+        all_pairs.push_back(std::make_pair(static_cast<long>(0),
+                                           std::string("zero")));
+        all_pairs.push_back(std::make_pair(static_cast<long>(1),
+                                           std::string("one")));
+        MDBXC_TEST_ASSERT(kv.range<std::vector>(static_cast<long>(-2),
+                                                static_cast<long>(1)) ==
+                          all_pairs);
     }
 
     {


### PR DESCRIPTION
## Summary
- bias signed integral table keys into an unsigned order-preserving MDBX_INTEGERKEY representation
- keep value serialization unchanged and keep FastIntegerKeyOptions storage-compatible with the default policy
- broaden integral key handling to platform-specific integral types such as long
- add signed cross-zero range coverage for KeyValueTable, KeyTable, and KeyMultiValueTable
- document that signed integral key order now matches signed numeric order

## Validation
- cmake --build tmp/provenance-cpp17 --target kv_container_all_types_test key_table_test key_multi_value_table_test utils_test header_tables_umbrella_test header_all_umbrella_test -j 1
- cmake --build tmp/provenance-cpp11 --target kv_container_all_types_test key_table_test key_multi_value_table_test utils_test header_tables_umbrella_test header_all_umbrella_test -j 1
- ctest --test-dir tmp/provenance-cpp17 -R ^(kv_container_all_types_test|key_table_test|key_multi_value_table_test|utils_test)$ --output-on-failure
- ctest --test-dir tmp/provenance-cpp11 -R ^(kv_container_all_types_test|key_table_test|key_multi_value_table_test|utils_test)$ --output-on-failure
- git diff --check