### PR TITLE
fix(tables): preserve signed integer key order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+- Breaking storage-format change: signed integral keys stored with
+  `MDBX_INTEGERKEY` now use an order-preserving unsigned rank representation
+  instead of raw signed bytes. Existing DBIs created with older signed integer
+  key encoding must be rebuilt.
+
 ## [v1.0.2] - 2026-05-02
 - Added this changelog to track release history in a compact, release-oriented format.
 - Moved bundled dependency infrastructure from `libs/` to `external/`, including the `external/libmdbx` submodule path and related CMake references.

--- a/include/mdbx_containers/detail/utils.hpp
+++ b/include/mdbx_containers/detail/utils.hpp
@@ -9,11 +9,13 @@
 /// \ingroup mdbxc_utils
 /// @{
 
+#include <array>
 #include <bitset>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <deque>
+#include <type_traits>
 #include <list>
 
 #include <mdbx.h>
@@ -92,6 +94,32 @@ namespace mdbxc {
         std::memcpy(&u, &d, sizeof(uint64_t));
         return (u & 0x8000000000000000ull) ? ~u : (u ^ 0x8000000000000000ull);
     }
+
+    inline uint32_t sortable_key_from_signed_int32(int32_t key) {
+        uint32_t raw;
+        std::memcpy(&raw, &key, sizeof(uint32_t));
+        return raw ^ 0x80000000u;
+    }
+
+    inline int32_t signed_int32_from_sortable_key(uint32_t key) {
+        key ^= 0x80000000u;
+        int32_t out;
+        std::memcpy(&out, &key, sizeof(int32_t));
+        return out;
+    }
+
+    inline uint64_t sortable_key_from_signed_int64(int64_t key) {
+        uint64_t raw;
+        std::memcpy(&raw, &key, sizeof(uint64_t));
+        return raw ^ 0x8000000000000000ull;
+    }
+
+    inline int64_t signed_int64_from_sortable_key(uint64_t key) {
+        key ^= 0x8000000000000000ull;
+        int64_t out;
+        std::memcpy(&out, &key, sizeof(int64_t));
+        return out;
+    }
     
     // --- Traits --- 
 
@@ -147,6 +175,22 @@ namespace mdbxc {
         static const bool value =
             std::is_same<T, std::set<std::string>>::value ||
             std::is_same<T, std::unordered_set<std::string>>::value;
+    };
+
+    /// \brief True for signed integral key types stored with MDBX_INTEGERKEY.
+    /// \details Signed keys use an unsigned rank representation before MDBX
+    /// sees them, so the physical INTEGERKEY order matches numeric signed
+    /// order. This is a breaking storage-format choice for pre-existing DBIs
+    /// created with older raw signed key bytes.
+    template<typename T>
+    struct is_signed_mdbx_integer_key {
+        static const bool value =
+            std::is_integral<T>::value &&
+            std::is_signed<T>::value &&
+            (std::is_same<T, int>::value ||
+             std::is_same<T, int32_t>::value ||
+             std::is_same<T, int64_t>::value ||
+             std::is_same<T, char>::value);
     };
 
     /// \brief Compile-time policy options for table behavior.
@@ -350,7 +394,8 @@ namespace mdbxc {
     template<bool SafeIntegerKey = true, typename T>
     typename std::enable_if<
         std::is_integral<T>::value &&
-        (sizeof(T) <= 2), MDBX_val>::type
+        (sizeof(T) <= 2) &&
+        !is_signed_mdbx_integer_key<T>::value, MDBX_val>::type
     serialize_key(const T& key, SerializeScratch& sc) {
         (void)SafeIntegerKey;
         static_assert(sizeof(uint32_t) == 4, "Expected 4-byte wrapper");
@@ -358,12 +403,28 @@ namespace mdbxc {
         return sc.view_small_copy(&temp, sizeof(uint32_t));
     }
 
+    /// \brief Serializes a signed integral key into MDBX INTEGERKEY order.
+    /// \details The key is mapped to an unsigned rank so MDBX's unsigned
+    /// integer comparator returns signed numeric order.
+    template<bool SafeIntegerKey = true, typename T>
+    typename std::enable_if<
+        is_signed_mdbx_integer_key<T>::value &&
+        (sizeof(T) <= 4), MDBX_val>::type
+    serialize_key(const T& key, SerializeScratch& sc) {
+        (void)SafeIntegerKey;
+        static_assert(sizeof(uint32_t) == 4, "Expected 4-byte integer");
+        const uint32_t temp =
+            sortable_key_from_signed_int32(static_cast<int32_t>(key));
+        return sc.view_small_copy(&temp, sizeof(uint32_t));
+    }
+
     /// \brief Serializes a 32-bit integral key.
     /// \tparam T Supported 32-bit type.
     template<bool SafeIntegerKey = true, typename T>
     typename std::enable_if<
-        std::is_same<T, int32_t>::value ||
-        std::is_same<T, uint32_t>::value, MDBX_val>::type
+        (std::is_same<T, int32_t>::value ||
+         std::is_same<T, uint32_t>::value) &&
+        !is_signed_mdbx_integer_key<T>::value, MDBX_val>::type
     serialize_key(const T& key, SerializeScratch& sc) {
         static_assert(sizeof(uint32_t) == 4, "Expected 4-byte integer");
         return SafeIntegerKey
@@ -383,12 +444,29 @@ namespace mdbxc {
         return sc.view_small_copy(&temp, sizeof(uint32_t));
     }
 
+    /// \brief Serializes a signed 64-bit key into MDBX INTEGERKEY order.
+    /// \details The key is mapped to an unsigned rank so MDBX's unsigned
+    /// integer comparator returns signed numeric order.
+    template<bool SafeIntegerKey = true, typename T>
+    typename std::enable_if<
+        is_signed_mdbx_integer_key<T>::value &&
+        (sizeof(T) > 4) &&
+        (sizeof(T) <= 8), MDBX_val>::type
+    serialize_key(const T& key, SerializeScratch& sc) {
+        (void)SafeIntegerKey;
+        static_assert(sizeof(uint64_t) == 8, "Expected 8-byte integer");
+        const uint64_t temp =
+            sortable_key_from_signed_int64(static_cast<int64_t>(key));
+        return sc.view_small_copy(&temp, sizeof(uint64_t));
+    }
+
     /// \brief Serializes a 64-bit integral key.
     /// \tparam T Supported 64-bit type.
     template<bool SafeIntegerKey = true, typename T>
     typename std::enable_if<
-        std::is_same<T, int64_t>::value ||
-        std::is_same<T, uint64_t>::value, MDBX_val>::type
+        (std::is_same<T, int64_t>::value ||
+         std::is_same<T, uint64_t>::value) &&
+        !is_signed_mdbx_integer_key<T>::value, MDBX_val>::type
     serialize_key(const T& key, SerializeScratch& sc) {
         static_assert(sizeof(uint64_t) == 8, "Expected 8-byte integer");
         return SafeIntegerKey
@@ -415,6 +493,7 @@ namespace mdbxc {
         std::is_trivially_copyable<T>::value &&
         !std::is_same<T, std::string>::value &&
         !(std::is_integral<T>::value && sizeof(T) <= 2) &&
+        !is_signed_mdbx_integer_key<T>::value &&
         !std::is_same<T, int32_t>::value &&
         !std::is_same<T, uint32_t>::value &&
         !std::is_same<T, float>::value &&
@@ -865,7 +944,8 @@ namespace mdbxc {
     template<typename T>
     typename std::enable_if<
         std::is_integral<T>::value &&
-        (sizeof(T) <= 2), T>::type
+        (sizeof(T) <= 2) &&
+        !is_signed_mdbx_integer_key<T>::value, T>::type
     deserialize_key(const MDBX_val& val) {
         if (val.iov_len != sizeof(uint32_t)) {
             throw std::runtime_error("deserialize_key: size mismatch");
@@ -877,10 +957,38 @@ namespace mdbxc {
 
     template<typename T>
     typename std::enable_if<
-        std::is_same<T, int32_t>::value ||
-        std::is_same<T, uint32_t>::value ||
-        std::is_same<T, int64_t>::value ||
-        std::is_same<T, uint64_t>::value, T>::type
+        is_signed_mdbx_integer_key<T>::value &&
+        (sizeof(T) <= 4), T>::type
+    deserialize_key(const MDBX_val& val) {
+        if (val.iov_len != sizeof(uint32_t)) {
+            throw std::runtime_error("deserialize_key: size mismatch");
+        }
+        uint32_t raw;
+        std::memcpy(&raw, val.iov_base, sizeof(uint32_t));
+        return static_cast<T>(signed_int32_from_sortable_key(raw));
+    }
+
+    template<typename T>
+    typename std::enable_if<
+        is_signed_mdbx_integer_key<T>::value &&
+        (sizeof(T) > 4) &&
+        (sizeof(T) <= 8), T>::type
+    deserialize_key(const MDBX_val& val) {
+        if (val.iov_len != sizeof(uint64_t)) {
+            throw std::runtime_error("deserialize_key: size mismatch");
+        }
+        uint64_t raw;
+        std::memcpy(&raw, val.iov_base, sizeof(uint64_t));
+        return static_cast<T>(signed_int64_from_sortable_key(raw));
+    }
+
+    template<typename T>
+    typename std::enable_if<
+        (std::is_same<T, int32_t>::value ||
+         std::is_same<T, uint32_t>::value ||
+         std::is_same<T, int64_t>::value ||
+         std::is_same<T, uint64_t>::value) &&
+        !is_signed_mdbx_integer_key<T>::value, T>::type
     deserialize_key(const MDBX_val& val) {
         return deserialize_value<T>(val);
     }
@@ -942,6 +1050,7 @@ namespace mdbxc {
         std::is_trivially_copyable<T>::value &&
         !std::is_same<T, std::string>::value &&
         !(std::is_integral<T>::value && sizeof(T) <= 2) &&
+        !is_signed_mdbx_integer_key<T>::value &&
         !std::is_same<T, int32_t>::value &&
         !std::is_same<T, uint32_t>::value &&
         !std::is_same<T, float>::value &&

--- a/tests/key_multi_value_table_test.cpp
+++ b/tests/key_multi_value_table_test.cpp
@@ -294,6 +294,60 @@ int main() {
 
     }
 
+    {
+        mdbxc::KeyMultiValueTable<int, std::string> table(conn, "multi_signed_integer_key_order");
+        table.clear();
+        table.insert(1, "one");
+        table.insert(-2, "minus-two");
+        table.insert(0, "zero");
+        table.insert(-1, "minus-one");
+
+        std::vector<std::pair<int, std::string> > signed_pairs;
+        signed_pairs.push_back(std::make_pair(-2, std::string("minus-two")));
+        signed_pairs.push_back(std::make_pair(-1, std::string("minus-one")));
+        signed_pairs.push_back(std::make_pair(0, std::string("zero")));
+        signed_pairs.push_back(std::make_pair(1, std::string("one")));
+
+        std::vector<std::pair<int, std::string> > loaded;
+        table.load(loaded);
+        assert_vector_equal(loaded, signed_pairs);
+        assert_vector_equal(table.range_vector(-2, 1), signed_pairs);
+        assert_vector_equal(table.range_values(-2, 1),
+                            std::vector<std::string>{"minus-two", "minus-one", "zero", "one"});
+
+        std::vector<std::pair<int, std::string> > reverse_limited;
+        reverse_limited.push_back(std::make_pair(1, std::string("one")));
+        reverse_limited.push_back(std::make_pair(0, std::string("zero")));
+        reverse_limited.push_back(std::make_pair(-1, std::string("minus-one")));
+        assert_vector_equal(table.range_reverse(-2, 1, 3), reverse_limited);
+
+        table.clear();
+        table.insert(-2, "minus-two");
+        table.insert(0, "zero");
+
+#if __cplusplus >= 201703L
+        auto lower = table.lower_bound(-1);
+        MDBXC_TEST_ASSERT(lower.has_value() && lower->first == 0);
+        auto upper = table.upper_bound(-2);
+        MDBXC_TEST_ASSERT(upper.has_value() && upper->first == 0);
+        auto first = table.first();
+        MDBXC_TEST_ASSERT(first.has_value() && first->first == -2);
+        auto last = table.last();
+        MDBXC_TEST_ASSERT(last.has_value() && last->first == 0);
+#else
+        std::pair<bool, std::pair<int, std::string> > lower =
+            table.lower_bound_compat(-1);
+        MDBXC_TEST_ASSERT(lower.first && lower.second.first == 0);
+        std::pair<bool, std::pair<int, std::string> > upper =
+            table.upper_bound_compat(-2);
+        MDBXC_TEST_ASSERT(upper.first && upper.second.first == 0);
+        std::pair<bool, std::pair<int, std::string> > first = table.first_compat();
+        MDBXC_TEST_ASSERT(first.first && first.second.first == -2);
+        std::pair<bool, std::pair<int, std::string> > last = table.last_compat();
+        MDBXC_TEST_ASSERT(last.first && last.second.first == 0);
+#endif
+    }
+
 #if __cplusplus >= 201703L
     {
         mdbxc::KeyMultiValueTable<int, std::string> table(conn, "multi_range_api_opt");

--- a/tests/key_table_test.cpp
+++ b/tests/key_table_test.cpp
@@ -242,6 +242,48 @@ int main() {
     }
 #endif
 
+    {
+        mdbxc::KeyTable<int> table(conn, "signed_integer_key_order");
+        table.clear();
+        table.insert(1);
+        table.insert(-2);
+        table.insert(0);
+        table.insert(-1);
+
+        MDBXC_TEST_ASSERT(table.retrieve_all<std::vector>() ==
+                          (std::vector<int>{-2, -1, 0, 1}));
+        MDBXC_TEST_ASSERT(table.operator()<std::vector>() ==
+                          (std::vector<int>{-2, -1, 0, 1}));
+        MDBXC_TEST_ASSERT(table.range<std::vector>(-2, 1) ==
+                          (std::vector<int>{-2, -1, 0, 1}));
+        MDBXC_TEST_ASSERT(table.range_reverse(-2, 1, 3) ==
+                          (std::vector<int>{1, 0, -1}));
+
+        table.clear();
+        table.insert(-2);
+        table.insert(0);
+
+#if __cplusplus >= 201703L
+        auto lower = table.lower_bound(-1);
+        MDBXC_TEST_ASSERT(lower.has_value() && lower.value() == 0);
+        auto upper = table.upper_bound(-2);
+        MDBXC_TEST_ASSERT(upper.has_value() && upper.value() == 0);
+        auto first = table.first();
+        MDBXC_TEST_ASSERT(first.has_value() && first.value() == -2);
+        auto last = table.last();
+        MDBXC_TEST_ASSERT(last.has_value() && last.value() == 0);
+#else
+        std::pair<bool, int> lower = table.lower_bound_compat(-1);
+        MDBXC_TEST_ASSERT(lower.first && lower.second == 0);
+        std::pair<bool, int> upper = table.upper_bound_compat(-2);
+        MDBXC_TEST_ASSERT(upper.first && upper.second == 0);
+        std::pair<bool, int> first = table.first_compat();
+        MDBXC_TEST_ASSERT(first.first && first.second == -2);
+        std::pair<bool, int> last = table.last_compat();
+        MDBXC_TEST_ASSERT(last.first && last.second == 0);
+#endif
+    }
+
     std::cout << "KeyTable test passed.\n";
     return 0;
 }

--- a/tests/kv_container_all_types_test.cpp
+++ b/tests/kv_container_all_types_test.cpp
@@ -278,6 +278,47 @@ int main() {
         nonnegative_pairs.push_back(std::make_pair(1, std::string("one")));
         MDBXC_TEST_ASSERT((kv.range(0, 1) == std::map<int, std::string>(nonnegative_pairs.begin(), nonnegative_pairs.end())));
         MDBXC_TEST_ASSERT(kv.range_values(0, 1) == (std::vector<std::string>{"zero", "one"}));
+
+        std::vector<std::pair<int, std::string> > signed_pairs;
+        signed_pairs.push_back(std::make_pair(-2, std::string("minus-two")));
+        signed_pairs.push_back(std::make_pair(-1, std::string("minus-one")));
+        signed_pairs.push_back(std::make_pair(0, std::string("zero")));
+        signed_pairs.push_back(std::make_pair(1, std::string("one")));
+        std::vector<std::pair<int, std::string> > loaded_pairs;
+        kv.load(loaded_pairs);
+        MDBXC_TEST_ASSERT(loaded_pairs == signed_pairs);
+        MDBXC_TEST_ASSERT(kv.range<std::vector>(-2, 1) == signed_pairs);
+        MDBXC_TEST_ASSERT(kv.range_values(-2, 1) ==
+               (std::vector<std::string>{"minus-two", "minus-one", "zero", "one"}));
+
+        std::vector<std::pair<int, std::string> > reverse_limited;
+        reverse_limited.push_back(std::make_pair(1, std::string("one")));
+        reverse_limited.push_back(std::make_pair(0, std::string("zero")));
+        reverse_limited.push_back(std::make_pair(-1, std::string("minus-one")));
+        MDBXC_TEST_ASSERT(kv.range_reverse(-2, 1, 3) == reverse_limited);
+
+        kv.clear();
+        kv.insert_or_assign(-2, "minus-two");
+        kv.insert_or_assign(0, "zero");
+#if __cplusplus >= 201703L
+        auto lower = kv.lower_bound(-1);
+        MDBXC_TEST_ASSERT(lower.has_value() && lower->first == 0);
+        auto upper = kv.upper_bound(-2);
+        MDBXC_TEST_ASSERT(upper.has_value() && upper->first == 0);
+        auto first = kv.first();
+        MDBXC_TEST_ASSERT(first.has_value() && first->first == -2);
+        auto last = kv.last();
+        MDBXC_TEST_ASSERT(last.has_value() && last->first == 0);
+#else
+        std::pair<bool, std::pair<int, std::string> > lower = kv.lower_bound_compat(-1);
+        MDBXC_TEST_ASSERT(lower.first && lower.second.first == 0);
+        std::pair<bool, std::pair<int, std::string> > upper = kv.upper_bound_compat(-2);
+        MDBXC_TEST_ASSERT(upper.first && upper.second.first == 0);
+        std::pair<bool, std::pair<int, std::string> > first = kv.first_compat();
+        MDBXC_TEST_ASSERT(first.first && first.second.first == -2);
+        std::pair<bool, std::pair<int, std::string> > last = kv.last_compat();
+        MDBXC_TEST_ASSERT(last.first && last.second.first == 0);
+#endif
     }
 
     {

--- a/tests/test_sync_capture.cpp
+++ b/tests/test_sync_capture.cpp
@@ -75,6 +75,14 @@ mdbxc::Embedding make_embedding(const std::vector<float>& values) {
     return e;
 }
 
+std::vector<std::uint8_t> storage_key_bytes(int key) {
+    mdbxc::SerializeScratch scratch;
+    const MDBX_val value = mdbxc::serialize_key(key, scratch);
+    const std::uint8_t* data =
+        static_cast<const std::uint8_t*>(value.iov_base);
+    return std::vector<std::uint8_t>(data, data + value.iov_len);
+}
+
 void test_no_sink_no_capture() {
     using namespace mdbxc;
     const std::string p = "test_capture_no_sink.mdbx";
@@ -1056,12 +1064,6 @@ void test_explicit_rollback_does_not_flush() {
         txn.commit();
     }
 
-    auto key_bytes = [](int k) {
-        std::vector<std::uint8_t> out(sizeof(int));
-        std::memcpy(out.data(), &k, sizeof(int));
-        return out;
-    };
-
     std::vector<std::uint8_t> batch1, batch2;
     {
         auto txn = conn->transaction(TransactionMode::READ_ONLY);
@@ -1083,10 +1085,10 @@ void test_explicit_rollback_does_not_flush() {
         return false;
     };
 
-    if (!batch_has_key(batch1, key_bytes(1))) throw std::runtime_error("seq 1 should contain key=1");
-    if (batch_has_key(batch1, key_bytes(2))) throw std::runtime_error("seq 1 should not contain rolled-back key=2");
-    if (!batch_has_key(batch2, key_bytes(3))) throw std::runtime_error("seq 2 should contain key=3");
-    if (batch_has_key(batch2, key_bytes(2))) throw std::runtime_error("seq 2 leaked rolled-back key=2");
+    if (!batch_has_key(batch1, storage_key_bytes(1))) throw std::runtime_error("seq 1 should contain key=1");
+    if (batch_has_key(batch1, storage_key_bytes(2))) throw std::runtime_error("seq 1 should not contain rolled-back key=2");
+    if (!batch_has_key(batch2, storage_key_bytes(3))) throw std::runtime_error("seq 2 should contain key=3");
+    if (batch_has_key(batch2, storage_key_bytes(2))) throw std::runtime_error("seq 2 leaked rolled-back key=2");
 
     conn->disconnect();
     cleanup(p);
@@ -1146,12 +1148,6 @@ void test_aborted_transaction_does_not_flush() {
         txn.commit();
     }
 
-    auto key_bytes = [](int k) {
-        std::vector<std::uint8_t> out(sizeof(int));
-        std::memcpy(out.data(), &k, sizeof(int));
-        return out;
-    };
-
     std::vector<std::uint8_t> batch1, batch2;
     {
         auto txn = conn->transaction(TransactionMode::READ_ONLY);
@@ -1175,16 +1171,16 @@ void test_aborted_transaction_does_not_flush() {
         return false;
     };
 
-    if (!batch_has_key(batch1, key_bytes(1))) {
+    if (!batch_has_key(batch1, storage_key_bytes(1))) {
         throw std::runtime_error("seq 1 should contain op with key=1");
     }
-    if (batch_has_key(batch1, key_bytes(2))) {
+    if (batch_has_key(batch1, storage_key_bytes(2))) {
         throw std::runtime_error("seq 1 should not contain aborted op with key=2");
     }
-    if (!batch_has_key(batch2, key_bytes(3))) {
+    if (!batch_has_key(batch2, storage_key_bytes(3))) {
         throw std::runtime_error("seq 2 should contain op with key=3 (post-abort commit)");
     }
-    if (batch_has_key(batch2, key_bytes(2))) {
+    if (batch_has_key(batch2, storage_key_bytes(2))) {
         throw std::runtime_error("seq 2 leaked aborted op with key=2");
     }
 


### PR DESCRIPTION
Summary:
- Store signed MDBX_INTEGERKEY keys through an order-preserving unsigned rank representation instead of raw signed bytes.
- Keep signed range/cursor operations on the normal physical MDBX order instead of special-casing cursor traversal.
- Update capture regression expectations to compare physical keys via serialize_key(), not legacy raw int bytes.
- Add signed KeyTable, KeyValueTable, and KeyMultiValueTable ordering coverage for full scans, range, reverse range, and bound helpers.

Breaking change:
- Signed integral key storage changes for MDBX_INTEGERKEY DBIs. Existing development DBIs created with the older raw signed key encoding must be rebuilt.

Validation:
- C++17 MinGW build/ctest for test_sync_capture, key_table_test, key_multi_value_table_test, kv_container_all_types_test.
- C++11 MinGW build/ctest for the same targets.
- git diff --check.