### PR TITLE
feat(tables): broaden integral key support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
   `MDBX_INTEGERKEY` now use an order-preserving unsigned rank representation
   instead of raw signed bytes. Existing DBIs created with older signed integer
   key encoding must be rebuilt.
+- Breaking storage-format change: all integral key types with `sizeof(T) <= 8`
+  now use `MDBX_INTEGERKEY`; narrow integer and character-code-unit keys use
+  canonical 4-byte storage, `long`/`long long` keys use canonical 8-byte
+  storage, and wider integral keys use a bytewise order-preserving encoding.
+  Existing development DBIs using older bytewise integral key storage must be
+  rebuilt.
 
 ## [v1.0.2] - 2026-05-02
 - Added this changelog to track release history in a compact, release-oriented format.

--- a/include/mdbx_containers/detail/utils.hpp
+++ b/include/mdbx_containers/detail/utils.hpp
@@ -177,6 +177,126 @@ namespace mdbxc {
             std::is_same<T, std::unordered_set<std::string>>::value;
     };
 
+    /// \brief Integral trait used by key serialization.
+    /// \details Some compilers expose 128-bit integers as extensions without
+    /// necessarily treating them exactly like standard integer types in all
+    /// type traits. Keep the public key policy centralized here.
+    template<typename T>
+    struct is_key_integral {
+        static const bool value = std::is_integral<T>::value;
+    };
+
+#if defined(__SIZEOF_INT128__)
+    template<>
+    struct is_key_integral<__int128> {
+        static const bool value = true;
+    };
+
+    template<>
+    struct is_key_integral<unsigned __int128> {
+        static const bool value = true;
+    };
+#endif
+
+    template<typename T>
+    struct is_key_signed_integral {
+        static const bool value =
+            is_key_integral<T>::value && std::is_signed<T>::value;
+    };
+
+#if defined(__SIZEOF_INT128__)
+    template<>
+    struct is_key_signed_integral<__int128> {
+        static const bool value = true;
+    };
+
+    template<>
+    struct is_key_signed_integral<unsigned __int128> {
+        static const bool value = false;
+    };
+#endif
+
+    template<typename T>
+    struct make_key_unsigned {
+        typedef typename std::make_unsigned<T>::type type;
+    };
+
+#if defined(__SIZEOF_INT128__)
+    template<>
+    struct make_key_unsigned<__int128> {
+        typedef unsigned __int128 type;
+    };
+
+    template<>
+    struct make_key_unsigned<unsigned __int128> {
+        typedef unsigned __int128 type;
+    };
+#endif
+
+    /// \brief True for character code-unit key types.
+    /// \details These types are treated as unsigned code units for physical
+    /// key storage even when the platform reports \c char or \c wchar_t as a
+    /// signed type. The serializer widens their unsigned object bits instead
+    /// of applying signed numeric conversion.
+    template<typename T>
+    struct is_key_character_code_unit {
+        static const bool value =
+            std::is_same<T, char>::value ||
+            std::is_same<T, wchar_t>::value ||
+            std::is_same<T, char16_t>::value ||
+            std::is_same<T, char32_t>::value;
+    };
+
+    /// \brief True when an integral key uses 8-byte MDBX_INTEGERKEY storage.
+    /// \details \c long is intentionally widened to 8 bytes on LLP64 targets
+    /// so \c KeyValueTable<long, V> does not switch between 4-byte Windows
+    /// storage and 8-byte LP64 storage. Narrow integers and character code
+    /// units use 4-byte INTEGERKEY storage.
+    template<typename T>
+    struct uses_64bit_mdbx_integer_key_storage {
+        static const bool value =
+            is_key_integral<T>::value &&
+            sizeof(T) <= 8 &&
+            (sizeof(T) > 4 ||
+             std::is_same<T, long>::value ||
+             std::is_same<T, unsigned long>::value ||
+             std::is_same<T, long long>::value ||
+             std::is_same<T, unsigned long long>::value);
+    };
+
+    template<typename T>
+    struct mdbx_integer_key_storage_size {
+        static const std::size_t value =
+            sizeof(T) > 8
+                ? sizeof(T)
+                : (uses_64bit_mdbx_integer_key_storage<T>::value
+                    ? sizeof(std::uint64_t)
+                    : sizeof(std::uint32_t));
+    };
+
+    template<typename T>
+    inline std::uint32_t code_unit_key_bits(T key) {
+        typedef typename make_key_unsigned<T>::type UnsignedT;
+        UnsignedT bits = 0;
+        std::memcpy(&bits, &key, sizeof(T));
+        return static_cast<std::uint32_t>(bits);
+    }
+
+    template<typename T>
+    inline T code_unit_key_from_bits(std::uint32_t raw) {
+        typedef typename make_key_unsigned<T>::type UnsignedT;
+        const std::uint32_t max_value =
+            static_cast<std::uint32_t>(static_cast<UnsignedT>(~UnsignedT(0)));
+        if (raw > max_value) {
+            throw std::runtime_error("deserialize_key: code unit value out of range");
+        }
+
+        const UnsignedT bits = static_cast<UnsignedT>(raw);
+        T out;
+        std::memcpy(&out, &bits, sizeof(T));
+        return out;
+    }
+
     /// \brief True for signed integral key types stored with MDBX_INTEGERKEY.
     /// \details Signed keys use an unsigned rank representation before MDBX
     /// sees them, so the physical INTEGERKEY order matches numeric signed
@@ -185,17 +305,14 @@ namespace mdbxc {
     template<typename T>
     struct is_signed_mdbx_integer_key {
         static const bool value =
-            std::is_integral<T>::value &&
-            std::is_signed<T>::value &&
-            (std::is_same<T, int>::value ||
-             std::is_same<T, int32_t>::value ||
-             std::is_same<T, int64_t>::value ||
-             std::is_same<T, char>::value);
+            is_key_signed_integral<T>::value &&
+            sizeof(T) <= 8 &&
+            !is_key_character_code_unit<T>::value;
     };
 
     /// \brief Compile-time policy options for table behavior.
-    /// \tparam SafeIntegerKey Copy 32/64-bit integer keys into aligned scratch
-    ///         storage before MDBX calls when true.
+    /// \tparam SafeIntegerKey Copy direct-view-compatible integer keys into
+    ///         aligned scratch storage before MDBX calls when true.
     template<bool SafeIntegerKey = true>
     struct TableOptions {
         static const bool safe_integer_key = SafeIntegerKey;
@@ -204,7 +321,9 @@ namespace mdbxc {
     /// \brief Default table policy using safe integer key serialization.
     typedef TableOptions<true> DefaultTableOptions;
 
-    /// \brief Table policy using direct views for 32/64-bit integer keys.
+    /// \brief Table policy using direct views for storage-compatible unsigned
+    ///        32/64-bit integer keys when no widening or key transformation is
+    ///        required.
     ///
     /// \warning This mode is a lifetime/alignment tradeoff and does not change
     ///          the database storage format.
@@ -217,12 +336,9 @@ namespace mdbxc {
     /// \return MDBX_INTEGERKEY if \c T is an integer-like type; 0 otherwise.
     template<typename T>
     inline MDBX_db_flags_t get_mdbx_flags() {
-        return
-            std::is_same<T, int>::value || std::is_same<T, int32_t>::value ||
-            std::is_same<T, uint32_t>::value || std::is_same<T, int64_t>::value ||
-            std::is_same<T, uint64_t>::value || std::is_same<T, float>::value ||
-            std::is_same<T, double>::value || std::is_same<T, char>::value ||
-            std::is_same<T, unsigned char>::value
+        return ((is_key_integral<T>::value && sizeof(T) <= 8) ||
+            std::is_same<T, float>::value ||
+            std::is_same<T, double>::value)
             ? MDBX_INTEGERKEY : static_cast<MDBX_db_flags_t>(0);
     }
     
@@ -233,39 +349,68 @@ namespace mdbxc {
     /// \param key The key value.
     /// \return Size in bytes suitable for filling MDBX_val.
     template<typename T>
-    size_t get_key_size(const T& key) {
-        // std::string
-        if (std::is_same<T, std::string>::value) {
-            return key.size();
-        }
-
-        // 32-bit types
-        if (std::is_same<T, int>::value ||
-            std::is_same<T, int32_t>::value ||
-            std::is_same<T, uint32_t>::value ||
-            std::is_same<T, float>::value) {
-            return sizeof(uint32_t);
-        }
-
-        // 64-bit types
-        if (std::is_same<T, int64_t>::value ||
-            std::is_same<T, uint64_t>::value ||
-            std::is_same<T, double>::value) {
-            return sizeof(uint64_t);
-        }
-
-        // byte vectors
-        if (
+    struct is_key_byte_vector {
+        static const bool value =
 #           if __cplusplus >= 201703L
             std::is_same<T, std::vector<std::byte> >::value ||
 #           endif
             std::is_same<T, std::vector<uint8_t> >::value ||
             std::is_same<T, std::vector<char> >::value ||
-            std::is_same<T, std::vector<unsigned char> >::value) {
-            return key.size();
-        }
+            std::is_same<T, std::vector<unsigned char> >::value;
+    };
 
-        // fallback
+    template<typename T>
+    struct is_key_bitset {
+        static const bool value = false;
+    };
+
+    template<std::size_t N>
+    struct is_key_bitset<std::bitset<N> > {
+        static const bool value = true;
+    };
+
+    inline size_t get_key_size(const std::string& key) {
+        return key.size();
+    }
+
+    template<typename T>
+    typename std::enable_if<is_key_byte_vector<T>::value, size_t>::type
+    get_key_size(const T& key) {
+        return key.size();
+    }
+
+    template<typename T>
+    typename std::enable_if<is_key_integral<T>::value, size_t>::type
+    get_key_size(const T&) {
+        return mdbx_integer_key_storage_size<T>::value;
+    }
+
+    template<typename T>
+    typename std::enable_if<std::is_same<T, float>::value, size_t>::type
+    get_key_size(const T&) {
+        return sizeof(uint32_t);
+    }
+
+    template<typename T>
+    typename std::enable_if<std::is_same<T, double>::value, size_t>::type
+    get_key_size(const T&) {
+        return sizeof(uint64_t);
+    }
+
+    template<std::size_t N>
+    inline size_t get_key_size(const std::bitset<N>&) {
+        return (N + 7u) / 8u;
+    }
+
+    template<typename T>
+    typename std::enable_if<
+        !std::is_same<T, std::string>::value &&
+        !is_key_byte_vector<T>::value &&
+        !is_key_bitset<T>::value &&
+        !is_key_integral<T>::value &&
+        !std::is_same<T, float>::value &&
+        !std::is_same<T, double>::value, size_t>::type
+    get_key_size(const T&) {
         return sizeof(T);
     }
     
@@ -343,6 +488,47 @@ namespace mdbxc {
         inline void clear() noexcept { bytes.clear(); bytes.shrink_to_fit(); }
     };
 
+    template<typename T>
+    inline MDBX_val serialize_wide_integral_key(const T& key,
+                                                SerializeScratch& sc) {
+        typedef typename make_key_unsigned<T>::type UnsignedT;
+        UnsignedT sortable = 0;
+        std::memcpy(&sortable, &key, sizeof(T));
+        if (is_key_signed_integral<T>::value) {
+            sortable ^= (UnsignedT(1) << (sizeof(T) * 8u - 1u));
+        }
+
+        sc.bytes.assign(sizeof(T), 0u);
+        for (size_t i = 0; i < sizeof(T); ++i) {
+            sc.bytes[sizeof(T) - 1u - i] =
+                static_cast<uint8_t>(sortable & UnsignedT(0xffu));
+            sortable >>= 8;
+        }
+        return sc.view_bytes();
+    }
+
+    template<typename T>
+    inline T deserialize_wide_integral_key(const MDBX_val& val) {
+        if (val.iov_len != sizeof(T)) {
+            throw std::runtime_error("deserialize_key: size mismatch");
+        }
+
+        typedef typename make_key_unsigned<T>::type UnsignedT;
+        const uint8_t* bytes = static_cast<const uint8_t*>(val.iov_base);
+        UnsignedT raw = 0;
+        for (size_t i = 0; i < sizeof(T); ++i) {
+            raw <<= 8;
+            raw |= UnsignedT(bytes[i]);
+        }
+        if (is_key_signed_integral<T>::value) {
+            raw ^= (UnsignedT(1) << (sizeof(T) * 8u - 1u));
+        }
+
+        T out;
+        std::memcpy(&out, &raw, sizeof(T));
+        return out;
+    }
+
     // --- serialize_key overloads ---
 
 
@@ -388,17 +574,39 @@ namespace mdbxc {
         (void)sc;
         return SerializeScratch::view(static_cast<const void*>(key.data()), key.size());
     }
+
+    /// \brief Serializes a character code-unit key into canonical 4-byte storage.
+    /// \details Plain \c char and \c wchar_t may have platform-dependent
+    /// signedness. Preserve their unsigned object bits before widening so
+    /// high-bit code units have the same physical key on signed-char and
+    /// unsigned-char builds.
+    template<bool SafeIntegerKey = true, typename T>
+    typename std::enable_if<
+        is_key_character_code_unit<T>::value &&
+        (mdbx_integer_key_storage_size<T>::value == sizeof(uint32_t)), MDBX_val>::type
+    serialize_key(const T& key, SerializeScratch& sc) {
+        (void)SafeIntegerKey;
+        static_assert(sizeof(uint32_t) == 4, "Expected 4-byte wrapper");
+        const uint32_t temp = code_unit_key_bits(key);
+        return sc.view_small_copy(&temp, sizeof(uint32_t));
+    }
     
     /// \brief Serializes a small integral key (<=16 bits).
     /// \tparam T Integral type.
     template<bool SafeIntegerKey = true, typename T>
     typename std::enable_if<
-        std::is_integral<T>::value &&
-        (sizeof(T) <= 2) &&
+        is_key_integral<T>::value &&
+        (mdbx_integer_key_storage_size<T>::value == sizeof(uint32_t)) &&
+        !is_key_character_code_unit<T>::value &&
         !is_signed_mdbx_integer_key<T>::value, MDBX_val>::type
     serialize_key(const T& key, SerializeScratch& sc) {
-        (void)SafeIntegerKey;
         static_assert(sizeof(uint32_t) == 4, "Expected 4-byte wrapper");
+        if (!SafeIntegerKey &&
+            sizeof(T) == sizeof(uint32_t) &&
+            std::is_unsigned<T>::value) {
+            return SerializeScratch::view(
+                static_cast<const void*>(&key), sizeof(uint32_t));
+        }
         uint32_t temp = static_cast<uint32_t>(key);
         return sc.view_small_copy(&temp, sizeof(uint32_t));
     }
@@ -409,7 +617,7 @@ namespace mdbxc {
     template<bool SafeIntegerKey = true, typename T>
     typename std::enable_if<
         is_signed_mdbx_integer_key<T>::value &&
-        (sizeof(T) <= 4), MDBX_val>::type
+        (mdbx_integer_key_storage_size<T>::value == sizeof(uint32_t)), MDBX_val>::type
     serialize_key(const T& key, SerializeScratch& sc) {
         (void)SafeIntegerKey;
         static_assert(sizeof(uint32_t) == 4, "Expected 4-byte integer");
@@ -418,20 +626,6 @@ namespace mdbxc {
         return sc.view_small_copy(&temp, sizeof(uint32_t));
     }
 
-    /// \brief Serializes a 32-bit integral key.
-    /// \tparam T Supported 32-bit type.
-    template<bool SafeIntegerKey = true, typename T>
-    typename std::enable_if<
-        (std::is_same<T, int32_t>::value ||
-         std::is_same<T, uint32_t>::value) &&
-        !is_signed_mdbx_integer_key<T>::value, MDBX_val>::type
-    serialize_key(const T& key, SerializeScratch& sc) {
-        static_assert(sizeof(uint32_t) == 4, "Expected 4-byte integer");
-        return SafeIntegerKey
-            ? sc.view_small_copy(&key, sizeof(uint32_t))
-            : SerializeScratch::view(static_cast<const void*>(&key), sizeof(uint32_t));
-    }
-    
     /// \brief Serializes a 32-bit float key.
     /// \tparam T Supported 32-bit type.
     template<bool SafeIntegerKey = true, typename T>
@@ -450,8 +644,7 @@ namespace mdbxc {
     template<bool SafeIntegerKey = true, typename T>
     typename std::enable_if<
         is_signed_mdbx_integer_key<T>::value &&
-        (sizeof(T) > 4) &&
-        (sizeof(T) <= 8), MDBX_val>::type
+        (mdbx_integer_key_storage_size<T>::value == sizeof(uint64_t)), MDBX_val>::type
     serialize_key(const T& key, SerializeScratch& sc) {
         (void)SafeIntegerKey;
         static_assert(sizeof(uint64_t) == 8, "Expected 8-byte integer");
@@ -461,17 +654,37 @@ namespace mdbxc {
     }
 
     /// \brief Serializes a 64-bit integral key.
-    /// \tparam T Supported 64-bit type.
+    /// \tparam T Integral type.
     template<bool SafeIntegerKey = true, typename T>
     typename std::enable_if<
-        (std::is_same<T, int64_t>::value ||
-         std::is_same<T, uint64_t>::value) &&
+        is_key_integral<T>::value &&
+        (mdbx_integer_key_storage_size<T>::value == sizeof(uint64_t)) &&
         !is_signed_mdbx_integer_key<T>::value, MDBX_val>::type
     serialize_key(const T& key, SerializeScratch& sc) {
         static_assert(sizeof(uint64_t) == 8, "Expected 8-byte integer");
-        return SafeIntegerKey
-            ? sc.view_small_copy(&key, sizeof(uint64_t))
-            : SerializeScratch::view(static_cast<const void*>(&key), sizeof(uint64_t));
+        uint64_t temp = 0;
+        if (sizeof(T) == sizeof(uint64_t)) {
+            std::memcpy(&temp, &key, sizeof(uint64_t));
+        } else {
+            temp = static_cast<uint64_t>(key);
+        }
+        if (!SafeIntegerKey && sizeof(T) == sizeof(uint64_t)) {
+            return SerializeScratch::view(
+                static_cast<const void*>(&key), sizeof(uint64_t));
+        }
+        return sc.view_small_copy(&temp, sizeof(uint64_t));
+    }
+
+    /// \brief Serializes an integral key wider than MDBX_INTEGERKEY supports.
+    /// \details Wide integer keys use MDBX bytewise order. The on-disk bytes are
+    /// big-endian; signed values are biased by flipping the sign bit.
+    template<bool SafeIntegerKey = true, typename T>
+    typename std::enable_if<
+        is_key_integral<T>::value &&
+        (sizeof(T) > 8), MDBX_val>::type
+    serialize_key(const T& key, SerializeScratch& sc) {
+        (void)SafeIntegerKey;
+        return serialize_wide_integral_key(key, sc);
     }
     
     /// \brief Serializes a 64-bit double key.
@@ -492,13 +705,8 @@ namespace mdbxc {
     typename std::enable_if<
         std::is_trivially_copyable<T>::value &&
         !std::is_same<T, std::string>::value &&
-        !(std::is_integral<T>::value && sizeof(T) <= 2) &&
-        !is_signed_mdbx_integer_key<T>::value &&
-        !std::is_same<T, int32_t>::value &&
-        !std::is_same<T, uint32_t>::value &&
+        !is_key_integral<T>::value &&
         !std::is_same<T, float>::value &&
-        !std::is_same<T, int64_t>::value &&
-        !std::is_same<T, uint64_t>::value &&
         !std::is_same<T, double>::value, MDBX_val>::type
     serialize_key(const T& key, SerializeScratch& sc) {
         (void)SafeIntegerKey;
@@ -943,8 +1151,22 @@ namespace mdbxc {
 
     template<typename T>
     typename std::enable_if<
-        std::is_integral<T>::value &&
-        (sizeof(T) <= 2) &&
+        is_key_character_code_unit<T>::value &&
+        (mdbx_integer_key_storage_size<T>::value == sizeof(uint32_t)), T>::type
+    deserialize_key(const MDBX_val& val) {
+        if (val.iov_len != sizeof(uint32_t)) {
+            throw std::runtime_error("deserialize_key: size mismatch");
+        }
+        uint32_t raw;
+        std::memcpy(&raw, val.iov_base, sizeof(uint32_t));
+        return code_unit_key_from_bits<T>(raw);
+    }
+
+    template<typename T>
+    typename std::enable_if<
+        is_key_integral<T>::value &&
+        (mdbx_integer_key_storage_size<T>::value == sizeof(uint32_t)) &&
+        !is_key_character_code_unit<T>::value &&
         !is_signed_mdbx_integer_key<T>::value, T>::type
     deserialize_key(const MDBX_val& val) {
         if (val.iov_len != sizeof(uint32_t)) {
@@ -958,7 +1180,7 @@ namespace mdbxc {
     template<typename T>
     typename std::enable_if<
         is_signed_mdbx_integer_key<T>::value &&
-        (sizeof(T) <= 4), T>::type
+        (mdbx_integer_key_storage_size<T>::value == sizeof(uint32_t)), T>::type
     deserialize_key(const MDBX_val& val) {
         if (val.iov_len != sizeof(uint32_t)) {
             throw std::runtime_error("deserialize_key: size mismatch");
@@ -971,8 +1193,7 @@ namespace mdbxc {
     template<typename T>
     typename std::enable_if<
         is_signed_mdbx_integer_key<T>::value &&
-        (sizeof(T) > 4) &&
-        (sizeof(T) <= 8), T>::type
+        (mdbx_integer_key_storage_size<T>::value == sizeof(uint64_t)), T>::type
     deserialize_key(const MDBX_val& val) {
         if (val.iov_len != sizeof(uint64_t)) {
             throw std::runtime_error("deserialize_key: size mismatch");
@@ -984,13 +1205,30 @@ namespace mdbxc {
 
     template<typename T>
     typename std::enable_if<
-        (std::is_same<T, int32_t>::value ||
-         std::is_same<T, uint32_t>::value ||
-         std::is_same<T, int64_t>::value ||
-         std::is_same<T, uint64_t>::value) &&
+        is_key_integral<T>::value &&
+        (mdbx_integer_key_storage_size<T>::value == sizeof(uint64_t)) &&
         !is_signed_mdbx_integer_key<T>::value, T>::type
     deserialize_key(const MDBX_val& val) {
-        return deserialize_value<T>(val);
+        if (val.iov_len != sizeof(uint64_t)) {
+            throw std::runtime_error("deserialize_key: size mismatch");
+        }
+
+        uint64_t raw = 0;
+        std::memcpy(&raw, val.iov_base, sizeof(uint64_t));
+        if (sizeof(T) == sizeof(uint64_t)) {
+            T out;
+            std::memcpy(&out, &raw, sizeof(T));
+            return out;
+        }
+        return static_cast<T>(raw);
+    }
+
+    template<typename T>
+    typename std::enable_if<
+        is_key_integral<T>::value &&
+        (sizeof(T) > 8), T>::type
+    deserialize_key(const MDBX_val& val) {
+        return deserialize_wide_integral_key<T>(val);
     }
 
     inline float float_from_sortable_key(uint32_t key) {
@@ -1049,13 +1287,8 @@ namespace mdbxc {
     typename std::enable_if<
         std::is_trivially_copyable<T>::value &&
         !std::is_same<T, std::string>::value &&
-        !(std::is_integral<T>::value && sizeof(T) <= 2) &&
-        !is_signed_mdbx_integer_key<T>::value &&
-        !std::is_same<T, int32_t>::value &&
-        !std::is_same<T, uint32_t>::value &&
+        !is_key_integral<T>::value &&
         !std::is_same<T, float>::value &&
-        !std::is_same<T, int64_t>::value &&
-        !std::is_same<T, uint64_t>::value &&
         !std::is_same<T, double>::value, T>::type
     deserialize_key(const MDBX_val& val) {
         return deserialize_value<T>(val);

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -263,6 +263,14 @@ Required tests before enabling capture:
 | `IdentityIndexStore` length prefix `u32 dbi_name_len` | little-endian | Read and written as a single u32, never sorted. |
 | All other key bytes (origins, raw `storage_key`, raw `identity_key`, dbi_name bytes) | opaque bytes | Layout defined by the application, not by the codec. |
 
+Sync v0.1 replicates application table keys as raw physical `storage_key`
+bytes. For `MDBX_INTEGERKEY` tables this targets ordinary Windows/Linux/macOS
+deployments on little-endian x86_64/aarch64-class platforms. It is not a
+cross-endian typed key wire format. Use fixed-width key types for schemas that
+must be replicated between different C++ ABIs; ABI-dependent source types such
+as `long` and `wchar_t` have canonical storage widths, but their value domain
+is still the local C++ type domain.
+
 If you add a new ordered numeric key in the future: big-endian. If you add
 any new payload integer: little-endian.
 

--- a/tests/kv_container_all_types_test.cpp
+++ b/tests/kv_container_all_types_test.cpp
@@ -17,6 +17,7 @@
 #include <stdexcept>
 #include <limits>
 #include <map>
+#include <memory>
 
 #include <mdbx_containers/KeyValueTable.hpp>
 
@@ -94,6 +95,82 @@ inline void safe_join(std::thread& t) noexcept {
     if (t.joinable()) t.join();
 }
 
+template<typename KeyT>
+void assert_signed_key_range_order(
+        const std::shared_ptr<mdbxc::Connection>& conn,
+        const std::string& db_name) {
+    mdbxc::KeyValueTable<KeyT, std::string> kv(conn, db_name);
+    kv.clear();
+
+    kv.insert_or_assign(static_cast<KeyT>(-2), "minus-two");
+    kv.insert_or_assign(static_cast<KeyT>(-1), "minus-one");
+    kv.insert_or_assign(static_cast<KeyT>(0), "zero");
+    kv.insert_or_assign(static_cast<KeyT>(1), "one");
+
+    std::vector<std::pair<KeyT, std::string> > expected;
+    expected.push_back(std::make_pair(static_cast<KeyT>(-2), std::string("minus-two")));
+    expected.push_back(std::make_pair(static_cast<KeyT>(-1), std::string("minus-one")));
+    expected.push_back(std::make_pair(static_cast<KeyT>(0), std::string("zero")));
+    expected.push_back(std::make_pair(static_cast<KeyT>(1), std::string("one")));
+
+    std::vector<std::pair<KeyT, std::string> > loaded;
+    kv.load(loaded);
+    MDBXC_TEST_ASSERT(loaded == expected);
+    MDBXC_TEST_ASSERT(kv.template range<std::vector>(
+        static_cast<KeyT>(-2), static_cast<KeyT>(1)) == expected);
+    MDBXC_TEST_ASSERT(kv.range_values(
+        static_cast<KeyT>(-2), static_cast<KeyT>(1)) ==
+        (std::vector<std::string>{"minus-two", "minus-one", "zero", "one"}));
+
+    std::vector<std::pair<KeyT, std::string> > reverse_expected;
+    reverse_expected.push_back(std::make_pair(static_cast<KeyT>(1), std::string("one")));
+    reverse_expected.push_back(std::make_pair(static_cast<KeyT>(0), std::string("zero")));
+    reverse_expected.push_back(std::make_pair(static_cast<KeyT>(-1), std::string("minus-one")));
+    reverse_expected.push_back(std::make_pair(static_cast<KeyT>(-2), std::string("minus-two")));
+
+    MDBXC_TEST_ASSERT(kv.range_reverse(
+        static_cast<KeyT>(-2), static_cast<KeyT>(1)) == reverse_expected);
+    MDBXC_TEST_ASSERT(kv.count_range(
+        static_cast<KeyT>(-2), static_cast<KeyT>(1)) == 4);
+
+#if __cplusplus >= 201703L
+    auto first = kv.first();
+    MDBXC_TEST_ASSERT(first.has_value() && first->first == static_cast<KeyT>(-2));
+    auto last = kv.last();
+    MDBXC_TEST_ASSERT(last.has_value() && last->first == static_cast<KeyT>(1));
+    auto upper = kv.upper_bound(static_cast<KeyT>(-1));
+    MDBXC_TEST_ASSERT(upper.has_value() && upper->first == static_cast<KeyT>(0));
+#else
+    std::pair<bool, std::pair<KeyT, std::string> > first = kv.first_compat();
+    MDBXC_TEST_ASSERT(first.first && first.second.first == static_cast<KeyT>(-2));
+    std::pair<bool, std::pair<KeyT, std::string> > last = kv.last_compat();
+    MDBXC_TEST_ASSERT(last.first && last.second.first == static_cast<KeyT>(1));
+    std::pair<bool, std::pair<KeyT, std::string> > upper =
+        kv.upper_bound_compat(static_cast<KeyT>(-1));
+    MDBXC_TEST_ASSERT(upper.first && upper.second.first == static_cast<KeyT>(0));
+#endif
+}
+
+template<typename KeyT>
+void assert_unsigned_key_table(
+        const std::shared_ptr<mdbxc::Connection>& conn,
+        const std::string& db_name) {
+    mdbxc::KeyValueTable<KeyT, std::string> kv(conn, db_name);
+    kv.clear();
+
+    const KeyT one = static_cast<KeyT>(1);
+    const KeyT two = static_cast<KeyT>(2);
+    kv.insert_or_assign(two, "two");
+    kv.insert_or_assign(one, "one");
+    ASSERT_FOUND(kv, one, std::string("one"));
+    ASSERT_FOUND(kv, two, std::string("two"));
+
+    std::vector<std::pair<KeyT, std::string> > expected;
+    expected.push_back(std::make_pair(one, std::string("one")));
+    expected.push_back(std::make_pair(two, std::string("two")));
+    MDBXC_TEST_ASSERT(kv.template range<std::vector>(one, two) == expected);
+}
+
 // ---- sample serializable structs ----
 struct SimpleStruct {
     int   x{};
@@ -145,7 +222,7 @@ struct ConcurrentStruct {
 
 int main() {
     mdbxc::Config cfg;
-    cfg.pathname       = "data/kv_container_all_types";
+    cfg.pathname       = "data/kv_container_all_types_v2";
     cfg.max_dbs        = 40;
     cfg.no_subdir      = false;
     cfg.relative_to_exe= true;
@@ -340,6 +417,26 @@ int main() {
         MDBXC_TEST_ASSERT(kv.range_values(0u, max_key) ==
                (std::vector<std::string>{"zero", "one", "max"}));
     }
+
+    std::cout << "[case] additional integral key table support\n";
+    {
+        assert_signed_key_range_order<short>(conn, "range_short_boundaries");
+        assert_signed_key_range_order<long>(conn, "range_long_boundaries");
+        assert_signed_key_range_order<long long>(conn, "range_llong_boundaries");
+        assert_unsigned_key_table<unsigned short>(conn, "range_ushort_boundaries");
+        assert_unsigned_key_table<unsigned long>(conn, "range_ulong_boundaries");
+        assert_unsigned_key_table<wchar_t>(conn, "range_wchar_boundaries");
+        assert_unsigned_key_table<char16_t>(conn, "range_char16_boundaries");
+        assert_unsigned_key_table<char32_t>(conn, "range_char32_boundaries");
+    }
+
+#if defined(__SIZEOF_INT128__)
+    std::cout << "[case] wide integral bytewise key support\n";
+    {
+        assert_signed_key_range_order<__int128>(conn, "range_i128_boundaries");
+        assert_unsigned_key_table<unsigned __int128>(conn, "range_u128_boundaries");
+    }
+#endif
 
     {
         mdbxc::KeyValueTable<double, std::string> kv(conn, "range_double_boundaries");

--- a/tests/utils_test.cpp
+++ b/tests/utils_test.cpp
@@ -1,4 +1,5 @@
 #include "test_assert.hpp"
+#include <bitset>
 #include <iostream>
 #include <mdbx_containers/common.hpp>
 
@@ -67,6 +68,71 @@ void assert_unordered_uint32_values(const std::unordered_set<std::uint32_t>& out
     MDBXC_TEST_ASSERT(out.find(3u) != out.end());
 }
 
+template<typename T>
+void assert_integer_key_flag() {
+    MDBXC_TEST_ASSERT(
+        (mdbxc::get_mdbx_flags<T>() & MDBX_INTEGERKEY) !=
+        static_cast<MDBX_db_flags_t>(0));
+}
+
+template<typename T>
+void assert_not_integer_key_flag() {
+    MDBXC_TEST_ASSERT(
+        (mdbxc::get_mdbx_flags<T>() & MDBX_INTEGERKEY) ==
+        static_cast<MDBX_db_flags_t>(0));
+}
+
+template<typename T>
+void assert_key_roundtrip(T value) {
+    mdbxc::SerializeScratch scratch;
+    const MDBX_val serialized = mdbxc::serialize_key(value, scratch);
+    const T restored = mdbxc::deserialize_key<T>(serialized);
+    MDBXC_TEST_ASSERT(restored == value);
+}
+
+template<typename T>
+void assert_key_storage_size(T value, std::size_t expected_size) {
+    MDBXC_TEST_ASSERT(mdbxc::get_key_size(value) == expected_size);
+    mdbxc::SerializeScratch scratch;
+    const MDBX_val serialized = mdbxc::serialize_key(value, scratch);
+    MDBXC_TEST_ASSERT(serialized.iov_len == expected_size);
+}
+
+template<typename LeftT, typename RightT>
+void assert_same_serialized_key(LeftT lhs, RightT rhs) {
+    mdbxc::SerializeScratch lhs_scratch;
+    mdbxc::SerializeScratch rhs_scratch;
+    const MDBX_val lhs_value = mdbxc::serialize_key(lhs, lhs_scratch);
+    const MDBX_val rhs_value = mdbxc::serialize_key(rhs, rhs_scratch);
+    MDBXC_TEST_ASSERT(lhs_value.iov_len == rhs_value.iov_len);
+    MDBXC_TEST_ASSERT(
+        std::memcmp(lhs_value.iov_base, rhs_value.iov_base, lhs_value.iov_len) == 0);
+}
+
+#if defined(__SIZEOF_INT128__)
+int compare_serialized_keys(const MDBX_val& lhs, const MDBX_val& rhs) {
+    const std::size_t common =
+        lhs.iov_len < rhs.iov_len ? lhs.iov_len : rhs.iov_len;
+    const int cmp = std::memcmp(lhs.iov_base, rhs.iov_base, common);
+    if (cmp != 0) {
+        return cmp;
+    }
+    if (lhs.iov_len == rhs.iov_len) {
+        return 0;
+    }
+    return lhs.iov_len < rhs.iov_len ? -1 : 1;
+}
+
+template<typename T>
+void assert_serialized_key_less(T lhs, T rhs) {
+    mdbxc::SerializeScratch lhs_scratch;
+    mdbxc::SerializeScratch rhs_scratch;
+    const MDBX_val lhs_value = mdbxc::serialize_key(lhs, lhs_scratch);
+    const MDBX_val rhs_value = mdbxc::serialize_key(rhs, rhs_scratch);
+    MDBXC_TEST_ASSERT(compare_serialized_keys(lhs_value, rhs_value) < 0);
+}
+#endif
+
 } // namespace
 
 int main() {
@@ -96,6 +162,92 @@ int main() {
     assert_rejects_oversized_string_length<std::list<std::string>>();
     assert_rejects_oversized_string_length<std::set<std::string>>();
     assert_rejects_oversized_string_length<std::unordered_set<std::string>>();
+
+    assert_integer_key_flag<short>();
+    assert_integer_key_flag<unsigned short>();
+    assert_integer_key_flag<long>();
+    assert_integer_key_flag<unsigned long>();
+    assert_integer_key_flag<long long>();
+    assert_integer_key_flag<unsigned long long>();
+    assert_integer_key_flag<wchar_t>();
+    assert_integer_key_flag<char16_t>();
+    assert_integer_key_flag<char32_t>();
+    assert_integer_key_flag<bool>();
+
+    assert_key_roundtrip<short>(static_cast<short>(-123));
+    assert_key_roundtrip<unsigned short>(static_cast<unsigned short>(123));
+    assert_key_roundtrip<long>(static_cast<long>(-123456));
+    assert_key_roundtrip<unsigned long>(static_cast<unsigned long>(123456));
+    assert_key_roundtrip<long long>(static_cast<long long>(-1234567890123LL));
+    assert_key_roundtrip<unsigned long long>(
+        static_cast<unsigned long long>(1234567890123ULL));
+    assert_key_roundtrip<wchar_t>(static_cast<wchar_t>(42));
+    assert_key_roundtrip<char16_t>(static_cast<char16_t>(42));
+    assert_key_roundtrip<char32_t>(static_cast<char32_t>(42));
+    assert_key_roundtrip<bool>(true);
+    assert_key_roundtrip<char>(
+        static_cast<char>(static_cast<unsigned char>(0xFFu)));
+
+    assert_key_storage_size<int>(42, sizeof(std::uint32_t));
+    assert_key_storage_size<short>(static_cast<short>(-1), sizeof(std::uint32_t));
+    assert_key_storage_size<unsigned short>(
+        static_cast<unsigned short>(1), sizeof(std::uint32_t));
+    assert_key_storage_size<long>(static_cast<long>(-1), sizeof(std::uint64_t));
+    assert_key_storage_size<unsigned long>(
+        static_cast<unsigned long>(1), sizeof(std::uint64_t));
+    assert_key_storage_size<long long>(
+        static_cast<long long>(-1), sizeof(std::uint64_t));
+    assert_key_storage_size<unsigned long long>(
+        static_cast<unsigned long long>(1), sizeof(std::uint64_t));
+    assert_key_storage_size<wchar_t>(
+        static_cast<wchar_t>(42), sizeof(std::uint32_t));
+    assert_key_storage_size<char16_t>(
+        static_cast<char16_t>(42), sizeof(std::uint32_t));
+    assert_key_storage_size<char32_t>(
+        static_cast<char32_t>(42), sizeof(std::uint32_t));
+    assert_key_storage_size<bool>(true, sizeof(std::uint32_t));
+    assert_key_storage_size<std::bitset<1> >(std::bitset<1>(1u), 1u);
+    assert_key_storage_size<std::bitset<9> >(std::bitset<9>(0x101u), 2u);
+
+    assert_same_serialized_key<long, std::int64_t>(
+        static_cast<long>(42), static_cast<std::int64_t>(42));
+    assert_same_serialized_key<unsigned long, std::uint64_t>(
+        static_cast<unsigned long>(42), static_cast<std::uint64_t>(42));
+    assert_same_serialized_key<char, std::uint32_t>(
+        static_cast<char>(42), static_cast<std::uint32_t>(42));
+    assert_same_serialized_key<wchar_t, std::uint32_t>(
+        static_cast<wchar_t>(42), static_cast<std::uint32_t>(42));
+    assert_same_serialized_key<char16_t, std::uint32_t>(
+        static_cast<char16_t>(42), static_cast<std::uint32_t>(42));
+    assert_same_serialized_key<char32_t, std::uint32_t>(
+        static_cast<char32_t>(42), static_cast<std::uint32_t>(42));
+    assert_same_serialized_key<char, std::uint32_t>(
+        static_cast<char>(static_cast<unsigned char>(0xFFu)),
+        static_cast<std::uint32_t>(0xFFu));
+
+#if defined(__SIZEOF_INT128__)
+    assert_not_integer_key_flag<__int128>();
+    assert_not_integer_key_flag<unsigned __int128>();
+    assert_key_storage_size<__int128>(
+        static_cast<__int128>(1), sizeof(__int128));
+    assert_key_storage_size<unsigned __int128>(
+        static_cast<unsigned __int128>(1), sizeof(unsigned __int128));
+    assert_key_roundtrip<__int128>(static_cast<__int128>(-123456789));
+    assert_key_roundtrip<unsigned __int128>(
+        static_cast<unsigned __int128>(123456789u));
+    assert_serialized_key_less<__int128>(
+        static_cast<__int128>(-2),
+        static_cast<__int128>(-1));
+    assert_serialized_key_less<__int128>(
+        static_cast<__int128>(-1),
+        static_cast<__int128>(0));
+    assert_serialized_key_less<__int128>(
+        static_cast<__int128>(0),
+        static_cast<__int128>(1));
+    assert_serialized_key_less<unsigned __int128>(
+        static_cast<unsigned __int128>(1),
+        static_cast<unsigned __int128>(2));
+#endif
 
     return 0;
 }


### PR DESCRIPTION
Summary:
- Treat every integral key type with sizeof(T) <= 8 as an MDBX_INTEGERKEY-compatible key.
- Preserve signed ordering through the signed-rank encoding introduced by PR #158.
- Use canonical INTEGERKEY storage widths: narrow integer and character code-unit keys use 4 bytes; long/long long and unsigned variants use 8 bytes; wider integral keys use bytewise order-preserving encoding.
- Replace get_key_size() runtime trait branches with C++11-compatible overloads, including std::bitset<N> key-size support.
- Serialize character code-unit keys through unsigned object bits so high-bit char keys are independent of signed-char vs unsigned-char builds.
- Extend key flag, storage-size, byte-identity, roundtrip, and table ordering coverage across small, wide, signed, unsigned, character, and ABI-dependent integral key types.

Breaking change:
- Integral key DBI flags/storage are broadened intentionally. Existing development DBIs using older bytewise integral key storage for newly integer-key types must be rebuilt.
- Sync v0.1 still replicates raw physical storage_key bytes and targets ordinary little-endian Windows/Linux/macOS deployments. Use fixed-width integer key types for schemas that must be portable across different C++ ABIs.

Validation:
- C++17 MinGW build/ctest for utils_test, kv_container_all_types_test, header_tables_umbrella_test, header_all_umbrella_test.
- C++11 MinGW build/ctest for the same targets.
- C++17 MinGW utils_test with -fsigned-char.
- C++17 MinGW utils_test with -funsigned-char.
- git diff --check.