### PR TITLE
fix(tables): harden floating point key edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.
   storage, and wider integral keys use a bytewise order-preserving encoding.
   Existing development DBIs using older bytewise integral key storage must be
   rebuilt.
+- Breaking storage-format change: floating-point keys now canonicalize `-0.0`
+  and `+0.0` to one physical zero key and reject NaN keys. Existing
+  development DBIs containing older `-0.0` or NaN keys must be rebuilt.
 
 ## [v1.0.2] - 2026-05-02
 - Added this changelog to track release history in a compact, release-oriented format.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,6 +482,11 @@ if(MDBXC_BUILD_TESTS)
         mdbxc_add_test_target(${test_name} ${test_file})
     endforeach()
 
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        mdbxc_add_test_target(utils_fast_math_test tests/utils_test.cpp)
+        target_compile_options(utils_fast_math_test PRIVATE -ffast-math)
+    endif()
+
     set(_mdbxc_generated_test_dir "${CMAKE_CURRENT_BINARY_DIR}/generated_tests")
     file(MAKE_DIRECTORY "${_mdbxc_generated_test_dir}")
     foreach(header IN LISTS MDBXC_STANDALONE_PUBLIC_HEADERS)

--- a/include/mdbx_containers/detail/utils.hpp
+++ b/include/mdbx_containers/detail/utils.hpp
@@ -81,8 +81,16 @@ namespace mdbxc {
     /// \param f Input float value.
     /// \return Unsigned 32-bit integer with preserved numeric order.
     inline uint32_t sortable_key_from_float(float f) {
-        uint32_t u; 
+        uint32_t u;
         std::memcpy(&u, &f, sizeof(uint32_t));
+        const uint32_t magnitude = u & 0x7fffffffu;
+        if (magnitude > 0x7f800000u) {
+            throw std::invalid_argument(
+                "serialize_key: NaN floating-point keys are not supported");
+        }
+        if (magnitude == 0u) {
+            u = 0u;
+        }
         return (u & 0x80000000u) ? ~u : (u ^ 0x80000000u);
     }
     
@@ -90,8 +98,16 @@ namespace mdbxc {
     /// \param d Input double value.
     /// \return Unsigned 64-bit integer with preserved numeric order.
     inline uint64_t sortable_key_from_double(double d) {
-        uint64_t u; 
+        uint64_t u;
         std::memcpy(&u, &d, sizeof(uint64_t));
+        const uint64_t magnitude = u & 0x7fffffffffffffffull;
+        if (magnitude > 0x7ff0000000000000ull) {
+            throw std::invalid_argument(
+                "serialize_key: NaN floating-point keys are not supported");
+        }
+        if (magnitude == 0ull) {
+            u = 0ull;
+        }
         return (u & 0x8000000000000000ull) ? ~u : (u ^ 0x8000000000000000ull);
     }
 

--- a/tests/kv_container_all_types_test.cpp
+++ b/tests/kv_container_all_types_test.cpp
@@ -18,6 +18,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <cmath>
 
 #include <mdbx_containers/KeyValueTable.hpp>
 
@@ -223,7 +224,7 @@ struct ConcurrentStruct {
 int main() {
     mdbxc::Config cfg;
     cfg.pathname       = "data/kv_container_all_types_v2";
-    cfg.max_dbs        = 40;
+    cfg.max_dbs        = 64;
     cfg.no_subdir      = false;
     cfg.relative_to_exe= true;
 
@@ -455,6 +456,43 @@ int main() {
         MDBXC_TEST_ASSERT(kv.range<std::vector>(-1.0, 1.0) == all_pairs);
         MDBXC_TEST_ASSERT(kv.range_values(-1.0, 1.0) ==
                (std::vector<std::string>{"minus-one", "zero", "one"}));
+    }
+
+    std::cout << "[case] floating point key edge cases\n";
+    {
+        mdbxc::KeyValueTable<float, std::string> floats(conn, "float_key_edges");
+        floats.clear();
+        floats.insert_or_assign(-0.0f, "negative-zero");
+        floats.insert_or_assign(0.0f, "positive-zero");
+        MDBXC_TEST_ASSERT(floats.count() == 1);
+        ASSERT_FOUND(floats, -0.0f, std::string("positive-zero"));
+        ASSERT_FOUND(floats, 0.0f, std::string("positive-zero"));
+
+        bool float_nan_rejected = false;
+        try {
+            floats.insert_or_assign(
+                std::numeric_limits<float>::quiet_NaN(), "nan");
+        } catch (const std::invalid_argument&) {
+            float_nan_rejected = true;
+        }
+        MDBXC_TEST_ASSERT(float_nan_rejected);
+
+        mdbxc::KeyValueTable<double, std::string> doubles(conn, "double_key_edges");
+        doubles.clear();
+        doubles.insert_or_assign(-0.0, "negative-zero");
+        doubles.insert_or_assign(0.0, "positive-zero");
+        MDBXC_TEST_ASSERT(doubles.count() == 1);
+        ASSERT_FOUND(doubles, -0.0, std::string("positive-zero"));
+        ASSERT_FOUND(doubles, 0.0, std::string("positive-zero"));
+
+        bool double_nan_rejected = false;
+        try {
+            doubles.insert_or_assign(
+                std::numeric_limits<double>::quiet_NaN(), "nan");
+        } catch (const std::invalid_argument&) {
+            double_nan_rejected = true;
+        }
+        MDBXC_TEST_ASSERT(double_nan_rejected);
     }
 
     std::cout << "[case] string -> POD(SimpleStruct)\n";

--- a/tests/utils_test.cpp
+++ b/tests/utils_test.cpp
@@ -1,6 +1,8 @@
 #include "test_assert.hpp"
 #include <bitset>
+#include <cmath>
 #include <iostream>
+#include <limits>
 #include <mdbx_containers/common.hpp>
 
 namespace {
@@ -107,6 +109,19 @@ void assert_same_serialized_key(LeftT lhs, RightT rhs) {
     MDBXC_TEST_ASSERT(lhs_value.iov_len == rhs_value.iov_len);
     MDBXC_TEST_ASSERT(
         std::memcmp(lhs_value.iov_base, rhs_value.iov_base, lhs_value.iov_len) == 0);
+}
+
+template<typename T>
+void assert_rejects_nan_key() {
+    mdbxc::SerializeScratch scratch;
+    bool thrown = false;
+    try {
+        (void)mdbxc::serialize_key(
+            std::numeric_limits<T>::quiet_NaN(), scratch);
+    } catch (const std::invalid_argument&) {
+        thrown = true;
+    }
+    MDBXC_TEST_ASSERT(thrown);
 }
 
 #if defined(__SIZEOF_INT128__)
@@ -224,6 +239,13 @@ int main() {
     assert_same_serialized_key<char, std::uint32_t>(
         static_cast<char>(static_cast<unsigned char>(0xFFu)),
         static_cast<std::uint32_t>(0xFFu));
+
+    assert_same_serialized_key<float>(-0.0f, 0.0f);
+    assert_same_serialized_key<double>(-0.0, 0.0);
+    assert_key_roundtrip<float>(0.0f);
+    assert_key_roundtrip<double>(0.0);
+    assert_rejects_nan_key<float>();
+    assert_rejects_nan_key<double>();
 
 #if defined(__SIZEOF_INT128__)
     assert_not_integer_key_flag<__int128>();


### PR DESCRIPTION
Summary:
- Canonicalize floating-point zero keys so -0.0 and +0.0 map to the same key.
- Reject NaN float/double keys with std::invalid_argument using IEEE-754 bit-pattern checks rather than floating-point comparisons.
- Add codec and KeyValueTable regression coverage for zero and NaN behavior.
- Add a GCC/Clang fast-math utils smoke target so consumer -ffast-math flags cannot bypass the key contract.
- Increase the all-types test DBI budget to cover the additional float/double edge tables.

Breaking change:
- Floating-point key storage now treats -0.0 and +0.0 as the same physical key and rejects NaN keys. Existing development DBIs containing older -0.0 or NaN floating keys must be rebuilt.

Validation:
- C++11 MinGW configure/build/ctest for utils_test, utils_fast_math_test, and kv_container_all_types_test.
- C++17 MinGW configure/build/ctest for utils_test, utils_fast_math_test, and kv_container_all_types_test.
- git diff --check.