### PR TITLE
docs(sync): refresh audit follow-up ledger

### DIFF
--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -4,53 +4,58 @@ This note records the follow-up order from the repository-wide sync audit at
 `main` commit `60a5b32479f2d69a78ec9f9e404ab717fb59e92c`. Keep the fixes split
 into small PRs so behavior, storage format, and build hygiene remain reviewable.
 
-## Immediate PR Sequence
+## Completed Audit Fixes
 
-### PR #150: Reserved DBI hardening
+- PR #150 hardened reserved `_mdbxc_` DBI handling for public table names and
+  incoming sync apply operations.
+- PR #97 added standalone public header smoke coverage.
+- PR #128 exposed transport backend feature macros.
+- PR #131 covered installed transport provider targets.
+- PR #152 tightened the `SyncWorker` stop-before-apply boundary.
+- PR #154 rejected foreign external transactions before table, sync engine,
+  sync store, or accumulator code can use handles from another environment.
+- PR #155 made unsupported sync protocol modes explicit:
+  `PullRequest::request_full_snapshot=true` is rejected, and
+  `ConflictPolicy::LastWriterWins` cannot be selected until the apply semantics
+  exist.
+- PR #156 renamed the changelog pull internals enough to clarify that empty
+  cursors replay retained changelog history rather than exporting a database
+  snapshot.
+- PR #158 fixed signed `MDBX_INTEGERKEY` range/cursor ordering by storing signed
+  integral keys through an order-preserving unsigned rank.
+- PR #159 made integral key storage canonical for supported integer-key widths
+  and documented the storage-format break for development DBIs.
+- PR #160 canonicalized floating-point zero keys and rejected NaN keys.
+- PR #161 added fast-math floating-key regression coverage.
+- PR #162 added the sync table coverage matrix.
 
-- Add one shared `is_reserved_dbi_name()` check for the `_mdbxc_` namespace.
-- Reject public user table names that use reserved internal DBI prefixes.
-- Reject incoming `ChangeOp` entries targeting reserved DBIs before apply.
-- Keep internal stores able to open their reserved DBIs through an internal
-  bypass path, not through the public table-name path.
-- Add tests for `Put`, `Delete`, and `ClearTable` attempts against reserved
-  DBIs, including full rollback of the rejected push page.
+## Current PR Sequence
 
-### PR #151: External transaction provenance
+### PR #163: Audit follow-up ledger refresh
 
-- Expose enough `Transaction` identity to verify its owning MDBX environment.
-- Add a central `BaseTable` helper for external transaction validation.
-- Reject `Transaction&` / raw transaction handles that belong to another
-  `Connection` before table code uses the table DBI handle.
-- Cover cross-connection negative cases for the main table families and
-  multi-table helpers such as `VectorStore` / `HashedKeyValueStore`.
+- Keep this file aligned with the PRs that have already landed.
+- Preserve the unresolved audit items as small, reviewable future PRs.
 
-### PR #152: SyncWorker stop-before-apply contract
+### PR #164: ClearTable focused coverage
 
-- Re-check stop/cancellation after `PullResponse` is received and after the
-  `ApplyStarted` observer callback.
-- Re-check immediately before `SyncEngine::handle_push()`.
-- Add a deterministic test where the observer calls `request_stop()` from
-  `ApplyStarted` and verifies the pulled page is not applied.
+- Add wrapper-specific `clear()` capture and replication tests for supported
+  sync wrappers.
+- Keep implementation status and focused test coverage aligned with
+  `guides/sync-table-coverage.md`.
 
-### PR #153: Not-implemented public protocol modes
+### PR #165: Changelog replay API naming cleanup
 
-- Make `PullRequest::request_full_snapshot=true` return an explicit sync-level
-  protocol rejection until full snapshot export/import is implemented.
-- Reject or otherwise make unavailable `ConflictPolicy::LastWriterWins` until
-  timestamp/version-based apply semantics exist.
-- Update docs/tests so public API no longer appears to support these modes.
+- Finish removing the misleading public `pull_full_snapshot()` name from the
+  sync engine API.
+- Keep empty-cursor semantics documented as retained changelog replay, not a
+  full database snapshot.
 
-## Next Agreement Point
+### PR #166: Structured sync-level errors
 
-After PR #150-#153 are reviewed, agree on the next batch before implementation:
-
-- PR #154: standalone public header coverage for the full installed include
-  tree, C++11/C++17, sync enabled/disabled, and transport feature macros.
-- PR #155+: signed integral key ordering. Choose the storage-format strategy
-  explicitly: order-preserving signed encoding with migration/versioning,
-  temporary compile-time rejection for ordered signed keys, or documented
-  unsigned physical ordering.
+- Add machine-readable sync response error metadata for permanent protocol
+  rejections such as unsupported `request_full_snapshot`.
+- Keep transport retry hints transport-owned; sync-level protocol errors should
+  be visible without parsing free-form strings.
 
 ## Later Medium-Risk Follow-ups
 
@@ -58,6 +63,9 @@ After PR #150-#153 are reviewed, agree on the next batch before implementation:
   snapshot-required when a replica is behind retained history.
 - `VectorStore` collection naming: reject invalid names or use a reversible
   collision-free encoding.
+- Remote apply invalidation hooks: notify already-open table/view objects after
+  sync changes their backing DBIs so cached in-memory state such as
+  `VectorStore` RAM indexes can rebuild instead of going stale.
 - Transport body limits before full buffering in concrete HTTP/WebSocket
   backends.
 - Rate-limit bucket eviction / hard caps.
@@ -65,4 +73,3 @@ After PR #150-#153 are reviewed, agree on the next batch before implementation:
 - Installed package fallback for lowercase-only `mdbxConfig.cmake`.
 - Clarify `PullRequest::max_bytes` as a soft page budget and add a separate
   max single-batch limit.
-- Canonicalize floating-point zero keys and define NaN key semantics.


### PR DESCRIPTION
Summary:
- Refresh the sync audit follow-up note after the completed merged audit fixes through PR #162.
- Record the next small PR sequence for ClearTable tests, changelog replay naming, and structured sync errors.
- Keep later medium-risk follow-ups in one place, including apply invalidation hooks for live in-memory indexes.

Validation:
- Documentation-only change.
- git diff --check.