### PR TITLE
test(sync): cover ClearTable wrapper roundtrips

### DIFF
--- a/guides/sync-table-coverage.md
+++ b/guides/sync-table-coverage.md
@@ -18,7 +18,7 @@ values during transport, and remote apply replays the captured physical
 | `KeyTable<K>` | Supported | `Put`, `Delete`, `ClearTable`; insert, erase, range erase, and clear paths are implemented. | Raw key bytes are replayed with empty values. | `test_sync_capture`, `test_sync_engine`, `test_sync_replication` |
 | `ValueTable<V>` | Supported | `Put`, `Delete`, `ClearTable`; set, insert, update, erase, and clear paths are implemented. | The singleton physical key and serialized value bytes are replayed. | `test_sync_capture`, `test_sync_replication` |
 | `SequenceTable<V>` | Supported | `Put`, `Delete`, `ClearTable`; append, `insert_or_assign`, erase, and clear paths are implemented. | Stable `uint64_t` sequence keys and value bytes are replayed. | `test_sync_capture`, `test_sync_replication` |
-| `VectorStore` | Indirectly supported | Captured through its internal `SequenceTable` and `KeyValueTable` members. | The internal table operations are replicated; `VectorStore` has no separate wire type. | `test_sync_capture`, `test_sync_replication` |
+| `VectorStore` | Indirectly supported | Captured through its internal `SequenceTable` and `KeyValueTable` members. | The internal table operations are replicated; `VectorStore` has no separate wire type. Remote apply updates persistent internal DBIs only; already-open `VectorStore` instances must call `rebuild_index()` or be reopened before `search()`. | `test_sync_capture`, `test_sync_replication` |
 | `AnyValueTable<K>` | Deferred | No `ChangeOp` in v0.1. | Not applied by sync as a typed heterogeneous table. | `test_sync_capture` negative coverage |
 | `KeyMultiValueTable<K, V>` | Deferred | No `ChangeOp` in v0.1. | DUPSORT duplicate multiplicity and unordered multiset semantics are deferred. | `test_sync_capture` negative coverage |
 | `HashedKeyValueStore<K, V, H, Layout>` | Deferred | No `ChangeOp` in v0.1. | Hash-index identity and logical-key mapping are deferred. | `test_sync_capture` negative coverage |
@@ -40,9 +40,8 @@ remain sufficient to open or validate the destination DBI and replay the
 operation without table-specific decoding.
 
 Focused capture and round-trip tests currently cover representative write,
-delete, bulk, range-erase, indirect `VectorStore`, and deferred-table negative
-paths. `ClearTable` capture/apply support exists in the supported wrappers, but
-wrapper-specific clear capture and round-trip tests are still pending.
+delete, bulk, range-erase, `ClearTable`, indirect `VectorStore`, and
+deferred-table negative paths.
 
 ## Deferred Table Rules
 

--- a/tests/test_sync_capture.cpp
+++ b/tests/test_sync_capture.cpp
@@ -68,6 +68,25 @@ void require_no_capture(const StubSink& sink,
     }
 }
 
+void require_one_clear_capture(const StubSink& sink,
+                               const char* dbi_name,
+                               const char* operation_name) {
+    std::lock_guard<std::mutex> lk(sink.m_mutex);
+    if (sink.m_recorded.size() != 1u) {
+        throw std::runtime_error(
+            std::string(operation_name) + " expected one ClearTable op, got " +
+            std::to_string(sink.m_recorded.size()));
+    }
+    const mdbxc::sync::ChangeOp& op = sink.m_recorded[0];
+    if (op.dbi_name != dbi_name ||
+        op.op_type != mdbxc::sync::ChangeOpType::ClearTable ||
+        !op.storage_key.empty() ||
+        !op.value.empty()) {
+        throw std::runtime_error(
+            std::string(operation_name) + " ClearTable capture incorrect");
+    }
+}
+
 mdbxc::Embedding make_embedding(const std::vector<float>& values) {
     mdbxc::Embedding e;
     e.dim = static_cast<std::uint32_t>(values.size());
@@ -708,6 +727,88 @@ void test_range_erase_writes_via_sink() {
     cleanup(p);
 }
 
+void test_clear_writes_via_sink() {
+    using namespace mdbxc;
+    const std::string p = "test_capture_clear.mdbx";
+    cleanup(p);
+
+    Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    auto conn = Connection::create(cfg);
+
+    StubSink sink;
+    conn->attach_sync_capture(&sink);
+
+    {
+        KeyValueTable<int, int> kv(conn, "clear_kv");
+        kv.insert_or_assign(1, 10);
+        kv.insert_or_assign(2, 20);
+        sink.clear_recorded();
+        kv.clear();
+        require_one_clear_capture(sink, "clear_kv", "KeyValueTable::clear");
+    }
+
+    {
+        KeyTable<int> keys(conn, "clear_keys");
+        keys.insert(1);
+        keys.insert(2);
+        sink.clear_recorded();
+        keys.clear();
+        require_one_clear_capture(sink, "clear_keys", "KeyTable::clear");
+    }
+
+    {
+        ValueTable<int> value(conn, "clear_value");
+        value.set(42);
+        sink.clear_recorded();
+        value.clear();
+        require_one_clear_capture(sink, "clear_value", "ValueTable::clear");
+    }
+
+    {
+        SequenceTable<std::string> seq(conn, "clear_seq");
+        seq.append("one");
+        seq.append("two");
+        sink.clear_recorded();
+        seq.clear();
+        require_one_clear_capture(sink, "clear_seq", "SequenceTable::clear");
+    }
+
+    {
+        VectorStore store(conn, "clear_vector");
+        store.add(make_embedding({ 1.0f, 0.0f }), "one", "{}");
+        sink.clear_recorded();
+        store.clear();
+        const char* expected_dbi[] = {
+            "vectors_clear_vector_ids",
+            "vectors_clear_vector_embeddings",
+            "vectors_clear_vector_texts",
+            "vectors_clear_vector_metadata"
+        };
+        {
+            std::lock_guard<std::mutex> lk(sink.m_mutex);
+            if (sink.m_recorded.size() != 4u) {
+                throw std::runtime_error("VectorStore::clear expected four ClearTable ops");
+            }
+            for (std::size_t i = 0; i < sink.m_recorded.size(); ++i) {
+                const sync::ChangeOp& op = sink.m_recorded[i];
+                if (op.dbi_name != expected_dbi[i] ||
+                    op.op_type != sync::ChangeOpType::ClearTable ||
+                    !op.storage_key.empty() ||
+                    !op.value.empty()) {
+                    throw std::runtime_error("VectorStore::clear capture incorrect");
+                }
+            }
+        }
+    }
+
+    conn->detach_sync_capture();
+    conn->disconnect();
+    cleanup(p);
+}
+
 void test_vector_store_writes_via_sink() {
     using namespace mdbxc;
     const std::string p = "test_capture_vector_store.mdbx";
@@ -1228,6 +1329,7 @@ int main(int argc, char** argv) {
         { "test_key_value_bulk_writes_via_sink",
           &test_key_value_bulk_writes_via_sink },
         { "test_range_erase_writes_via_sink", &test_range_erase_writes_via_sink },
+        { "test_clear_writes_via_sink", &test_clear_writes_via_sink },
         { "test_vector_store_writes_via_sink",
           &test_vector_store_writes_via_sink },
         { "test_capture_flush_on_commit", &test_capture_flush_on_commit },

--- a/tests/test_sync_replication.cpp
+++ b/tests/test_sync_replication.cpp
@@ -879,6 +879,116 @@ void test_replication_vector_store_roundtrip() {
     cleanup(p); cleanup(r);
 }
 
+void test_replication_clear_table_roundtrip() {
+    using namespace mdbxc;
+    const std::string p = "test_rep_clear_roundtrip.mdbx";
+    const std::string r = "test_rep_clear_roundtrip_replica.mdbx";
+    cleanup(p); cleanup(r);
+
+    const sync::NodeId primary_node = make_node(0xA0);
+    const sync::NodeId replica_node = make_node(0xB0);
+    const sync::NodeId db_id = make_node(0xD0);
+
+    std::shared_ptr<Connection> primary = open(p);
+    std::shared_ptr<Connection> replica = open(r);
+
+    sync::SyncEngine pe(primary), re(replica);
+    pe.initialize_local_identity(primary_node, db_id);
+    re.initialize_local_identity(replica_node, db_id);
+
+    sync::ThreadLocalChangeAccumulator sink(primary);
+    primary->attach_sync_capture(&sink);
+
+    {
+        KeyValueTable<int, std::string> kv(primary, "clear_kv");
+        kv.insert_or_assign(1, "one");
+        kv.insert_or_assign(2, "two");
+
+        KeyTable<int> keys(primary, "clear_keys");
+        keys.insert(1);
+        keys.insert(2);
+
+        ValueTable<int> value(primary, "clear_value");
+        value.set(42);
+
+        SequenceTable<std::string> seq(primary, "clear_seq");
+        seq.append("one");
+        seq.append("two");
+
+        VectorStore vectors(primary, "clear_vectors");
+        vectors.add(make_embedding(1.0f, 0.0f), "one", "{}");
+        vectors.add(make_embedding(0.0f, 1.0f), "two", "{}");
+    }
+    if (pull_all_to_replica(pe, re, primary_node, replica_node, db_id, 2) == 0u) {
+        throw std::runtime_error("initial clear roundtrip sync pulled no batches");
+    }
+
+    {
+        KeyValueTable<int, std::string> kv(replica, "clear_kv");
+        KeyTable<int> keys(replica, "clear_keys");
+        ValueTable<int> value(replica, "clear_value");
+        SequenceTable<std::string> seq(replica, "clear_seq");
+        if (kv.count() != 2u || keys.count() != 2u || !value.has_value() ||
+            seq.count() != 2u) {
+            throw std::runtime_error("initial clear roundtrip state did not replicate");
+        }
+    }
+
+    VectorStore live_vectors(replica, "clear_vectors");
+    if (live_vectors.count() != 2u) {
+        throw std::runtime_error("initial vector clear roundtrip state did not replicate");
+    }
+    if (live_vectors.search(make_embedding(1.0f, 0.0f), 10).empty()) {
+        throw std::runtime_error("initial vector clear roundtrip search is empty");
+    }
+
+    {
+        KeyValueTable<int, std::string> kv(primary, "clear_kv");
+        kv.clear();
+
+        KeyTable<int> keys(primary, "clear_keys");
+        keys.clear();
+
+        ValueTable<int> value(primary, "clear_value");
+        value.clear();
+
+        SequenceTable<std::string> seq(primary, "clear_seq");
+        seq.clear();
+
+        VectorStore vectors(primary, "clear_vectors");
+        vectors.clear();
+    }
+    if (pull_all_to_replica(pe, re, primary_node, replica_node, db_id, 2) == 0u) {
+        throw std::runtime_error("clear roundtrip sync pulled no batches");
+    }
+    primary->detach_sync_capture();
+
+    {
+        KeyValueTable<int, std::string> kv(replica, "clear_kv");
+        KeyTable<int> keys(replica, "clear_keys");
+        ValueTable<int> value(replica, "clear_value");
+        SequenceTable<std::string> seq(replica, "clear_seq");
+        VectorStore vectors(replica, "clear_vectors");
+        if (kv.count() != 0u ||
+            keys.count() != 0u ||
+            value.has_value() ||
+            seq.count() != 0u ||
+            vectors.count() != 0u) {
+            throw std::runtime_error("ClearTable batch did not clear replica state");
+        }
+    }
+    live_vectors.rebuild_index();
+    if (live_vectors.count() != 0u ||
+        !live_vectors.search(make_embedding(1.0f, 0.0f), 10).empty()) {
+        throw std::runtime_error(
+            "VectorStore rebuild_index did not observe remote ClearTable apply");
+    }
+
+    primary->disconnect();
+    replica->disconnect();
+    cleanup(p); cleanup(r);
+}
+
 void test_replication_incremental_pull() {
     using namespace mdbxc;
     const std::string p = "test_rep_incr.mdbx";
@@ -1108,6 +1218,8 @@ int main() {
           &test_replication_key_table_range_delete_roundtrip },
         { "test_replication_vector_store_roundtrip",
           &test_replication_vector_store_roundtrip },
+        { "test_replication_clear_table_roundtrip",
+          &test_replication_clear_table_roundtrip },
         { "test_replication_incremental_pull",   &test_replication_incremental_pull },
         { "test_replication_idempotent_apply",   &test_replication_idempotent_apply },
         { "test_replication_make_push_request", &test_replication_make_push_request_helper },


### PR DESCRIPTION
Summary:
- Add focused ClearTable capture coverage for KeyValueTable, KeyTable, ValueTable, SequenceTable, and indirect VectorStore tables.
- Add a replication round-trip that clears all supported wrapper shapes and verifies replica state is empty after apply.
- Document the VectorStore live-index contract: remote sync updates persistent internal DBIs only, so already-open VectorStore instances must rebuild_index() or be reopened before search().
- Update the sync table coverage matrix now that wrapper-specific clear tests exist.

Validation:
- git diff --check.
- C++11 MinGW: built test_sync_capture and test_sync_replication; ctest -R test_sync_(capture|replication)$ passed.
- C++17 MinGW: built test_sync_capture and test_sync_replication; ctest -R test_sync_(capture|replication)$ passed.