### PR TITLE
refactor(sync): remove full snapshot pull wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Breaking API cleanup: removed the historical
+  `SyncEngine::pull_full_snapshot()` compatibility wrapper. Use
+  `SyncEngine::pull_changelog_page()` for retained changelog replay; true full
+  snapshot export/import remains unsupported.
 - Breaking storage-format change: signed integral keys stored with
   `MDBX_INTEGERKEY` now use an order-preserving unsigned rank representation
   instead of raw signed bytes. Existing DBIs created with older signed integer

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -346,14 +346,6 @@ namespace sync {
             return out;
         }
 
-        /// \brief Compatibility wrapper for \c pull_changelog_page().
-        /// \deprecated This method never returned a database snapshot; use
-        /// \c pull_changelog_page() for the retained changelog replay API.
-        PullResponse pull_full_snapshot(MDBX_txn* txn, MDBX_dbi dbi,
-                                        const PullRequest& request) {
-            return pull_changelog_page(txn, dbi, request);
-        }
-
         /// \brief Handles a push request: applies each batch in order.
         /// \details Atomic: when \c apply_batch returns \c Conflict for any
         /// batch, the transaction is rolled back (no partial commit) and


### PR DESCRIPTION
Summary:
- Remove the historical SyncEngine::pull_full_snapshot() compatibility wrapper.
- Keep pull_changelog_page() as the public API for retained changelog replay.
- Record the breaking API cleanup in CHANGELOG.md.

Validation:
- git diff --check.
- C++11 MinGW: built and ran test_sync_engine and header_sync_umbrella_test.
- C++17 MinGW: built and ran test_sync_engine and header_sync_umbrella_test.