### PR TITLE
feat(sync): add structured response errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Breaking transport-wire change: `TransportMessageCodec` is now version 3 and
+  response DTOs include `SyncResponseErrorCode` plus `error_retryable` after
+  the human-readable error string.
 - Breaking API cleanup: removed the historical
   `SyncEngine::pull_full_snapshot()` compatibility wrapper. Use
   `SyncEngine::pull_changelog_page()` for retained changelog replay; true full

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -214,9 +214,15 @@ Operational rules:
   not a reliable conflict authority. `Custom` is deferred to v0.2.
 - `PullRequest::request_full_snapshot=true` is reserved for the future
   full export/import protocol. v0.1 responders reject it as
-  `PullResponse{ok=false, error=...}`. This is a sync-level protocol rejection,
-  not a transport retry hint; add a structured response error code before
-  treating it as machine-classified retry policy.
+  `PullResponse{ok=false, error=..., error_code=UnsupportedFullSnapshot}`.
+  This is a sync-level protocol rejection, not a transport retry hint. Code
+  that needs machine classification should inspect `SyncResponseErrorCode`
+  instead of parsing the human-readable `error` string.
+- `PushResponse::error_retryable` describes sync-level recovery. Sequence gaps
+  are retryable after the receiver catches up from its persistent applied
+  cursor; DBI name/flag conflicts, reserved DBI writes, and unsupported
+  full-snapshot requests are permanent until the caller changes behavior.
+  This flag is independent from `SyncTransportRetryHint`.
 - v0.1 sync captures normal write paths for `KeyValueTable`, `KeyTable`,
   `ValueTable`, and `SequenceTable`. `VectorStore` is sync-covered only because
   it persists through internal `SequenceTable` and `KeyValueTable` members.

--- a/guides/sync-transport-production.md
+++ b/guides/sync-transport-production.md
@@ -129,6 +129,15 @@ For HTTP, transport status and sync DTO status are separate:
 - HTTP `2xx` means the transport request succeeded;
 - the decoded `PullResponse::ok` or `PushResponse::ok` still reports sync-level
   success or conflict;
+- decoded responses may also carry `SyncResponseErrorCode` and
+  `error_retryable` for sync-level failures such as DB id mismatch, unsupported
+  full-snapshot requests, or apply conflicts;
+- sync-level retryability means protocol recovery, for example re-pulling from
+  the persistent cursor after a sequence gap, not blindly resending the same
+  request;
+- `SyncWorkerPermanentFailurePolicy` applies only to classified transport
+  failures from `SyncTransportRetryHint`; sync-level response errors are
+  surfaced in worker round results, stage events, and status snapshots;
 - HTTP `408`, `425`, `429`, `500`, `502`, `503`, and `504` are retryable by
   default;
 - HTTP policy/framing failures such as `400`, `401`, `403`, `413`, and `415`

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -390,7 +390,7 @@ payload itself.
 Locked contract:
 
 - Magic: 8 bytes `MDBXCPRT`.
-- Version: u16 little-endian, currently `2`.
+- Version: u16 little-endian, currently `3`.
 - Message type: u8 (`1=PullRequest`, `2=PullResponse`, `3=PushRequest`,
   `4=PushResponse`).
 - Message flags: u32 little-endian, currently zero. Unknown non-zero flags are
@@ -403,6 +403,16 @@ Locked contract:
 - `PullResponse` carries both `remote_have` (responder applied cursor) and
   optional `remote_tail` (responder changelog tail) so receivers can report
   catch-up progress without changing pagination semantics.
+- `PullResponse` and `PushResponse` carry a structured
+  `SyncResponseErrorCode` plus an `error_retryable` boolean after their
+  human-readable error string. `None` means no structured sync-level
+  classification is available. `error_retryable` describes protocol-level
+  recovery, not blind replay of the identical request: for example a
+  `SequenceGap` apply conflict is retryable after the caller catches up from a
+  fresher cursor, while DBI flag conflicts and unsupported full snapshots are
+  permanent until the caller changes behavior. Transport-local errors remain
+  represented by adapter status, close codes, response headers, and
+  `SyncTransportRetryHint`.
 - `CancellationToken` fields in request DTOs are local call-control state and
   are never serialized. Decoded request DTOs contain default non-cancellable
   tokens.
@@ -481,8 +491,12 @@ The reserved `seq=0, BATCH_HAS_MORE` full export/import format remains planned
 for v0.1 and is not the current cold-replica implementation.
 `PullRequest::request_full_snapshot=true` is rejected explicitly until that
 format is implemented. In v0.1 this is a sync-level protocol rejection carried
-as `PullResponse{ok=false, error=...}`; it does not produce a transport retry
-hint because pull responses do not yet carry structured error codes.
+as `PullResponse{ok=false, error=..., error_code=UnsupportedFullSnapshot}`; it
+does not produce a transport retry hint because the server returned a valid
+sync response rather than a transport failure.
+`SyncWorkerPermanentFailurePolicy` is transport-only; workers still expose
+sync-level response errors through round results, stage events, and status
+snapshots without treating them as permanent transport failures.
 
 ## Background worker lifecycle
 

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -275,11 +275,14 @@ namespace sync {
             if (!db_id_matches(request.db_id)) {
                 out.ok = false;
                 out.error = "db_id mismatch";
+                out.error_code = SyncResponseErrorCode::DbIdMismatch;
                 return out;
             }
             if (request.request_full_snapshot) {
                 out.ok = false;
                 out.error = "PullRequest::request_full_snapshot is not implemented";
+                out.error_code =
+                    SyncResponseErrorCode::UnsupportedFullSnapshot;
                 return out;
             }
 
@@ -324,6 +327,8 @@ namespace sync {
             if (request.request_full_snapshot) {
                 out.ok = false;
                 out.error = "PullRequest::request_full_snapshot is not implemented";
+                out.error_code =
+                    SyncResponseErrorCode::UnsupportedFullSnapshot;
                 return out;
             }
             txn = checked_external_txn(txn, "SyncEngine::pull_changelog_page");
@@ -357,6 +362,7 @@ namespace sync {
             if (!db_id_matches(request.db_id)) {
                 out.ok = false;
                 out.error = "db_id mismatch";
+                out.error_code = SyncResponseErrorCode::DbIdMismatch;
                 out.receiver_have = applied_cursor();
                 return out;
             }
@@ -364,9 +370,15 @@ namespace sync {
             for (const ChangeBatch& batch : request.batches) {
                 const ApplyOutcome outcome = apply_batch_ex(txn.handle(), batch);
                 if (outcome.result == ApplyResult::Conflict) {
+                    txn.rollback();
                     out.ok = false;
                     out.error = apply_conflict_message(outcome);
-                    return out;  // txn dtor rolls back; receiver_have stays stale
+                    out.error_code = SyncResponseErrorCode::ApplyConflict;
+                    out.error_retryable =
+                        outcome.conflict_reason ==
+                            ApplyConflictReason::SequenceGap;
+                    out.receiver_have = applied_cursor();
+                    return out;
                 }
             }
             txn.commit();

--- a/include/mdbx_containers/sync/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/SyncWorker.hpp
@@ -83,7 +83,9 @@ namespace sync {
         /// \details The default keeps v0.1 retry hints advisory. Set to
         /// \c StopWorker when a classified permanent transport failure should
         /// leave the worker in \c SyncWorkerState::Failed instead of entering
-        /// retry backoff.
+        /// retry backoff. Sync-level response errors are reported separately
+        /// through \c SyncWorkerRoundResult and status snapshots; this policy
+        /// does not stop on them.
         SyncWorkerPermanentFailurePolicy permanent_failure_policy =
             SyncWorkerPermanentFailurePolicy::KeepRetrying;
 
@@ -116,6 +118,12 @@ namespace sync {
         SyncWorkerProgressEstimate progress; ///< Last known progress.
         std::string error; ///< Failure detail when \c ok is false.
         SyncTransportRetryHint retry_hint; ///< Transport retry advice.
+        /// \brief Sync-level response error classification.
+        /// \details Distinct from transport retry advice. \c None means the
+        /// peer did not return a structured sync error.
+        SyncResponseErrorCode sync_error_code =
+            SyncResponseErrorCode::None;
+        bool sync_error_retryable = false; ///< Sync-level recovery hint.
     };
 
     /// \brief Fine-grained observer event for sync round stages.
@@ -132,6 +140,10 @@ namespace sync {
         SyncWorkerProgressEstimate progress; ///< Last known progress.
         std::string error; ///< Failure detail when \c ok is false.
         SyncTransportRetryHint retry_hint; ///< Transport retry advice.
+        /// \brief Sync-level response error classification.
+        SyncResponseErrorCode sync_error_code =
+            SyncResponseErrorCode::None;
+        bool sync_error_retryable = false; ///< Sync-level recovery hint.
     };
 
     /// \brief Thread-safe snapshot of the current \c SyncWorker status.
@@ -157,6 +169,9 @@ namespace sync {
         SyncWorkerRoundResult last_round; ///< Last completed round result.
         SyncWorkerProgressEstimate last_progress; ///< Last known progress.
         SyncTransportRetryHint last_retry_hint; ///< Last known retry hint.
+        SyncResponseErrorCode last_sync_error_code =
+            SyncResponseErrorCode::None; ///< Last sync-level error code.
+        bool last_sync_error_retryable = false; ///< Last sync-level hint.
         std::chrono::milliseconds last_backoff_delay =
             std::chrono::milliseconds::zero(); ///< Last scheduled backoff.
         std::chrono::steady_clock::time_point last_round_started_at;
@@ -526,6 +541,9 @@ namespace sync {
                         event.has_more = response.has_more;
                         event.ok = response.ok;
                         event.error = response.error;
+                        event.sync_error_code = response.error_code;
+                        event.sync_error_retryable =
+                            response.error_retryable;
                         if (response.ok) {
                             if (response.remote_tail_known) {
                                 progress = make_progress_estimate(
@@ -548,6 +566,9 @@ namespace sync {
                             ? "pull failed"
                             : response.error;
                         result.retry_hint = m_peer.last_retry_hint();
+                        result.sync_error_code = response.error_code;
+                        result.sync_error_retryable =
+                            response.error_retryable;
                         return result;
                     }
                     ++result.pages_pulled;
@@ -599,6 +620,9 @@ namespace sync {
                             event.has_more = has_more;
                             event.ok = applied.ok;
                             event.error = applied.error;
+                            event.sync_error_code = applied.error_code;
+                            event.sync_error_retryable =
+                                applied.error_retryable;
                             if (applied.ok) {
                                 event.batches_applied =
                                     result.batches_applied +
@@ -614,6 +638,9 @@ namespace sync {
                             result.error = applied.error.empty()
                                 ? "apply failed"
                                 : applied.error;
+                            result.sync_error_code = applied.error_code;
+                            result.sync_error_retryable =
+                                applied.error_retryable;
                             return result;
                         }
                         result.batches_applied += response.batches.size();
@@ -666,6 +693,8 @@ namespace sync {
             event.progress = result.progress;
             event.error = result.error;
             event.retry_hint = result.retry_hint;
+            event.sync_error_code = result.sync_error_code;
+            event.sync_error_retryable = result.sync_error_retryable;
             return event;
         }
 
@@ -839,6 +868,9 @@ namespace sync {
             m_status.last_stage = event;
             m_status.last_progress = event.progress;
             m_status.last_retry_hint = event.retry_hint;
+            m_status.last_sync_error_code = event.sync_error_code;
+            m_status.last_sync_error_retryable =
+                event.sync_error_retryable;
             if (event.stage == SyncWorkerStage::RoundStarted) {
                 m_status.round_active = true;
                 m_status.backoff_active = false;
@@ -857,6 +889,9 @@ namespace sync {
             m_status.last_round = result;
             m_status.last_progress = result.progress;
             m_status.last_retry_hint = result.retry_hint;
+            m_status.last_sync_error_code = result.sync_error_code;
+            m_status.last_sync_error_retryable =
+                result.sync_error_retryable;
             m_status.round_active = false;
             m_status.last_round_finished_at =
                 std::chrono::steady_clock::now();

--- a/include/mdbx_containers/sync/TransportMessageCodec.hpp
+++ b/include/mdbx_containers/sync/TransportMessageCodec.hpp
@@ -8,7 +8,7 @@
 /// Envelope layout for all messages:
 /// \code
 ///   magic             "MDBXCPRT"   8 bytes
-///   codec_version     u16 le       = 2
+///   codec_version     u16 le       = 3
 ///   message_type      u8           1=pull request, 2=pull response,
 ///                                  3=push request, 4=push response
 ///   message_flags     u32 le       = 0 in v0.1
@@ -61,7 +61,7 @@ namespace sync {
         static std::size_t magic_size() { return 8; }
 
         /// \brief Supported transport codec version.
-        static std::uint16_t codec_version() { return 2; }
+        static std::uint16_t codec_version() { return 3; }
 
         /// \brief Reads the message type from a transport envelope.
         /// \details Validates magic, codec version, and mandatory flags but
@@ -105,6 +105,8 @@ namespace sync {
             append_bool(out, response.has_more);
             append_bool(out, response.ok);
             append_string(out, response.error, bounds);
+            append_response_error_code(out, response.error_code);
+            append_bool(out, response.error_retryable);
             validate_message_size(out, bounds);
             return out;
         }
@@ -133,6 +135,8 @@ namespace sync {
             append_cursor(out, response.receiver_have, bounds);
             append_bool(out, response.ok);
             append_string(out, response.error, bounds);
+            append_response_error_code(out, response.error_code);
+            append_bool(out, response.error_retryable);
             validate_message_size(out, bounds);
             return out;
         }
@@ -170,6 +174,8 @@ namespace sync {
             response.has_more = read_bool(cur);
             response.ok = read_bool(cur);
             response.error = read_string(cur, bounds);
+            response.error_code = read_response_error_code(cur);
+            response.error_retryable = read_bool(cur);
             check_consumed(cur);
             return response;
         }
@@ -200,6 +206,8 @@ namespace sync {
             response.receiver_have = read_cursor(cur, bounds);
             response.ok = read_bool(cur);
             response.error = read_string(cur, bounds);
+            response.error_code = read_response_error_code(cur);
+            response.error_retryable = read_bool(cur);
             check_consumed(cur);
             return response;
         }
@@ -304,6 +312,21 @@ namespace sync {
 
         static void append_bool(std::vector<std::uint8_t>& out, bool value) {
             append_u8(out, value ? 1u : 0u);
+        }
+
+        static void append_response_error_code(
+                std::vector<std::uint8_t>& out,
+                SyncResponseErrorCode code) {
+            switch (code) {
+                case SyncResponseErrorCode::None:
+                case SyncResponseErrorCode::DbIdMismatch:
+                case SyncResponseErrorCode::UnsupportedFullSnapshot:
+                case SyncResponseErrorCode::ApplyConflict:
+                    detail::append_u16_le(out,
+                        static_cast<std::uint16_t>(code));
+                    return;
+            }
+            throw std::logic_error("unknown SyncResponseErrorCode");
         }
 
         static void append_bytes(std::vector<std::uint8_t>& out,
@@ -421,6 +444,24 @@ namespace sync {
             const std::uint16_t value = detail::read_u16_le(cur.data + cur.pos);
             cur.pos += 2;
             return value;
+        }
+
+        static SyncResponseErrorCode read_response_error_code(Cursor& cur) {
+            const std::uint16_t value = read_u16_le(cur);
+            switch (value) {
+                case static_cast<std::uint16_t>(SyncResponseErrorCode::None):
+                    return SyncResponseErrorCode::None;
+                case static_cast<std::uint16_t>(
+                        SyncResponseErrorCode::DbIdMismatch):
+                    return SyncResponseErrorCode::DbIdMismatch;
+                case static_cast<std::uint16_t>(
+                        SyncResponseErrorCode::UnsupportedFullSnapshot):
+                    return SyncResponseErrorCode::UnsupportedFullSnapshot;
+                case static_cast<std::uint16_t>(
+                        SyncResponseErrorCode::ApplyConflict):
+                    return SyncResponseErrorCode::ApplyConflict;
+            }
+            throw std::runtime_error("Invalid SyncResponseErrorCode");
         }
 
         static std::uint32_t read_u32_le(Cursor& cur) {

--- a/include/mdbx_containers/sync/protocol.hpp
+++ b/include/mdbx_containers/sync/protocol.hpp
@@ -17,6 +17,34 @@
 namespace mdbxc {
 namespace sync {
 
+    /// \brief Machine-readable classification for sync-level response errors.
+    /// \details This classifies errors produced by the sync protocol or
+    /// engine itself. Transport-local failures such as HTTP status codes,
+    /// WebSocket close codes, authentication rejection, and rate limits remain
+    /// represented by transport retry hints and adapter metadata.
+    enum class SyncResponseErrorCode : std::uint16_t {
+        None                    = 0, ///< No structured sync error.
+        DbIdMismatch            = 1, ///< Request targeted a different db_id.
+        UnsupportedFullSnapshot = 2, ///< Full snapshot protocol is not implemented.
+        ApplyConflict           = 3, ///< Push apply failed on a sync conflict.
+    };
+
+    /// \brief Returns a stable diagnostic name for a sync response error code.
+    inline const char* sync_response_error_code_name(
+            SyncResponseErrorCode code) {
+        switch (code) {
+            case SyncResponseErrorCode::None:
+                return "none";
+            case SyncResponseErrorCode::DbIdMismatch:
+                return "db_id_mismatch";
+            case SyncResponseErrorCode::UnsupportedFullSnapshot:
+                return "unsupported_full_snapshot";
+            case SyncResponseErrorCode::ApplyConflict:
+                return "apply_conflict";
+        }
+        return "unknown";
+    }
+
     /// \brief Request from a replica to a primary node for new change batches.
     struct PullRequest {
         NodeId       requester{};
@@ -47,6 +75,15 @@ namespace sync {
         bool                     has_more = false;
         bool                     ok       = true;
         std::string              error;
+        /// \brief Optional machine-readable sync-level error code.
+        /// \details \c None means there is no structured sync classification;
+        /// callers may still inspect \c ok and \c error. When set on
+        /// \c ok=false responses, \c error_retryable describes whether the
+        /// failure can be recovered by protocol progress such as re-pulling
+        /// missing batches or resending after a fresher cursor. It does not
+        /// mean blindly replaying the identical request is always useful.
+        SyncResponseErrorCode    error_code = SyncResponseErrorCode::None;
+        bool                     error_retryable = false;
     };
 
     /// \brief Request carrying changes that the sender wants the receiver to
@@ -65,6 +102,15 @@ namespace sync {
         SyncCursor               receiver_have;
         bool                     ok = true;
         std::string              error;
+        /// \brief Optional machine-readable sync-level error code.
+        /// \details \c None means there is no structured sync classification;
+        /// callers may still inspect \c ok and \c error. When set on
+        /// \c ok=false responses, \c error_retryable describes whether the
+        /// failure can be recovered by protocol progress such as re-pulling
+        /// missing batches or resending after a fresher cursor. It does not
+        /// mean blindly replaying the identical request is always useful.
+        SyncResponseErrorCode    error_code = SyncResponseErrorCode::None;
+        bool                     error_retryable = false;
     };
 
 } // namespace sync

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -109,6 +109,10 @@ int main() {
     MDBXC_TEST_ASSERT(
         worker_options.permanent_failure_policy ==
         mdbxc::sync::SyncWorkerPermanentFailurePolicy::StopWorker);
+    MDBXC_TEST_ASSERT(
+        std::string(mdbxc::sync::sync_response_error_code_name(
+            mdbxc::sync::SyncResponseErrorCode::UnsupportedFullSnapshot)) ==
+        "unsupported_full_snapshot");
     mdbxc::sync::SyncCaptureScope* capture_scope = nullptr;
     HeaderSyncSink header_sink;
     (void)capture_scope;

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -318,6 +318,13 @@ void test_engine_rejects_reserved_dbi_changes_and_rolls_back_page() {
                 op_type_name(op_types[i]) + " returned wrong error: " +
                 response.error);
         }
+        if (response.error_code != sync::SyncResponseErrorCode::ApplyConflict ||
+            response.error_retryable ||
+            response.receiver_have.last_seq_for(origin) != 0u) {
+            throw std::runtime_error(
+                std::string("reserved DBI ") +
+                op_type_name(op_types[i]) + " returned wrong structured error");
+        }
         if (engine.applied_cursor().last_seq_for(origin) != 0u) {
             throw std::runtime_error(
                 std::string("reserved DBI ") +
@@ -387,6 +394,12 @@ void test_engine_reserved_dbi_rolls_back_multi_batch_push() {
         response.error.find("_mdbxc_meta") == std::string::npos) {
         throw std::runtime_error("reserved DBI multi-batch push returned wrong error: " +
                                  response.error);
+    }
+    if (response.error_code != sync::SyncResponseErrorCode::ApplyConflict ||
+        response.error_retryable ||
+        response.receiver_have.last_seq_for(origin) != 0u) {
+        throw std::runtime_error(
+            "reserved DBI multi-batch push returned wrong structured error");
     }
     if (engine.applied_cursor().last_seq_for(origin) != 0u) {
         throw std::runtime_error("reserved DBI multi-batch push advanced applied cursor");
@@ -713,6 +726,83 @@ void test_engine_existing_dbi_flag_mismatch_reports_first_batch_dbi() {
     cleanup(p);
 }
 
+void test_engine_push_dbi_conflicts_are_not_retryable() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_push_dbi_conflicts_retryable.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x10), make_node(0xD0));
+    const sync::NodeId origin = make_node(0x20);
+
+    {
+        sync::ChangeBatch batch;
+        batch.origin_node_id = origin;
+        batch.seq = 1;
+
+        sync::ChangeOp first;
+        first.op_type = sync::ChangeOpType::Put;
+        first.dbi_name = "inconsistent";
+        first.dbi_flags = static_cast<std::uint32_t>(MDBX_INTEGERKEY);
+        assign_int_key(first.storage_key, 1);
+        assign_int_value(first.value, 10);
+        batch.ops.push_back(first);
+
+        sync::ChangeOp second = first;
+        second.dbi_flags = static_cast<std::uint32_t>(MDBX_REVERSEKEY);
+        assign_int_key(second.storage_key, 2);
+        assign_int_value(second.value, 20);
+        batch.ops.push_back(second);
+
+        sync::PushRequest request;
+        request.sender = origin;
+        request.db_id = make_node(0xD0);
+        request.batches.push_back(batch);
+        const sync::PushResponse response = engine.handle_push(request);
+        if (response.ok ||
+            response.error_code != sync::SyncResponseErrorCode::ApplyConflict ||
+            response.error_retryable ||
+            response.receiver_have.last_seq_for(origin) != 0u) {
+            throw std::runtime_error(
+                "inconsistent DBI flags returned wrong structured response");
+        }
+    }
+
+    {
+        KeyValueTable<int, int> existing(conn, "existing");
+        (void)existing;
+
+        sync::ChangeBatch batch;
+        batch.origin_node_id = origin;
+        batch.seq = 1;
+
+        sync::ChangeOp op;
+        op.op_type = sync::ChangeOpType::Put;
+        op.dbi_name = "existing";
+        op.dbi_flags = static_cast<std::uint32_t>(MDBX_REVERSEKEY);
+        assign_int_key(op.storage_key, 1);
+        assign_int_value(op.value, 10);
+        batch.ops.push_back(op);
+
+        sync::PushRequest request;
+        request.sender = origin;
+        request.db_id = make_node(0xD0);
+        request.batches.push_back(batch);
+        const sync::PushResponse response = engine.handle_push(request);
+        if (response.ok ||
+            response.error_code != sync::SyncResponseErrorCode::ApplyConflict ||
+            response.error_retryable ||
+            response.receiver_have.last_seq_for(origin) != 0u) {
+            throw std::runtime_error(
+                "existing DBI flags mismatch returned wrong structured response");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 void test_engine_gap_returns_conflict() {
     using namespace mdbxc;
     const std::string p = "test_engine_gap.mdbx";
@@ -907,6 +997,11 @@ void test_engine_push_gap_rolls_back() {
         if (resp.error.find("sequence_gap") == std::string::npos) {
             throw std::runtime_error("push with gap should return sequence_gap error");
         }
+        if (resp.error_code != sync::SyncResponseErrorCode::ApplyConflict ||
+            !resp.error_retryable ||
+            resp.receiver_have.last_seq_for(make_node(0x20)) != 1u) {
+            throw std::runtime_error("push with gap error code incorrect");
+        }
     }
 
     // After rejected push, table 't' should still be empty (rollback worked)
@@ -922,6 +1017,58 @@ void test_engine_push_gap_rolls_back() {
         const sync::SyncCursor cur = engine.applied_cursor();
         if (cur.last_seq_for(make_node(0x20)) != 1u) {
             throw std::runtime_error("cursor should still be at seq=1 after rejected push");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_push_multi_batch_gap_reports_persistent_cursor() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_push_multi_batch_gap_cursor.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x10), make_node(0xD0));
+
+    auto make_batch = [](std::uint64_t seq) {
+        sync::ChangeBatch b;
+        b.origin_node_id = make_node(0x20);
+        b.seq = seq;
+        sync::ChangeOp op;
+        op.op_type = sync::ChangeOpType::Put;
+        op.dbi_name = "t";
+        op.storage_key = { static_cast<std::uint8_t>(seq) };
+        op.value = { 0xFF };
+        b.ops.push_back(op);
+        return b;
+    };
+
+    sync::DirectSyncPeer peer(&engine);
+    sync::PushRequest req;
+    req.sender = make_node(0x20);
+    req.db_id = make_node(0xD0);
+    req.batches.push_back(make_batch(1));
+    req.batches.push_back(make_batch(3));
+
+    const sync::PushResponse resp = peer.push(req);
+    if (resp.ok ||
+        resp.error_code != sync::SyncResponseErrorCode::ApplyConflict ||
+        !resp.error_retryable ||
+        resp.receiver_have.last_seq_for(make_node(0x20)) != 0u) {
+        throw std::runtime_error(
+            "multi-batch gap did not report persistent retryable cursor");
+    }
+    if (engine.applied_cursor().last_seq_for(make_node(0x20)) != 0u) {
+        throw std::runtime_error("multi-batch gap advanced persistent cursor");
+    }
+    {
+        KeyValueTable<std::uint8_t, std::uint8_t> t(conn, "t");
+        if (kv_has(conn, t, static_cast<std::uint8_t>(1)) ||
+            kv_has(conn, t, static_cast<std::uint8_t>(3))) {
+            throw std::runtime_error("multi-batch gap committed partial data");
         }
     }
 
@@ -949,6 +1096,10 @@ void test_engine_handle_pull_wrong_db_id() {
     }
     if (!resp.batches.empty()) {
         throw std::runtime_error("pull with wrong db_id should not return batches");
+    }
+    if (resp.error_code != sync::SyncResponseErrorCode::DbIdMismatch ||
+        resp.error_retryable) {
+        throw std::runtime_error("pull wrong db_id error code incorrect");
     }
 
     conn->disconnect();
@@ -978,6 +1129,10 @@ void test_engine_rejects_full_snapshot_request() {
     }
     if (resp.error.find("request_full_snapshot") == std::string::npos) {
         throw std::runtime_error("full snapshot rejection error is not explicit");
+    }
+    if (resp.error_code != sync::SyncResponseErrorCode::UnsupportedFullSnapshot ||
+        resp.error_retryable) {
+        throw std::runtime_error("full snapshot rejection code incorrect");
     }
 
     conn->disconnect();
@@ -1014,6 +1169,12 @@ void test_engine_changelog_page_rejects_full_snapshot_request() {
             throw std::runtime_error(
                 "changelog page full snapshot rejection error is not explicit");
         }
+        if (resp.error_code !=
+                sync::SyncResponseErrorCode::UnsupportedFullSnapshot ||
+            resp.error_retryable) {
+            throw std::runtime_error(
+                "changelog page full snapshot rejection code incorrect");
+        }
     }
 
     conn->disconnect();
@@ -1048,6 +1209,10 @@ void test_engine_handle_push_wrong_db_id() {
     const sync::PushResponse resp = peer.push(req);
     if (resp.ok) {
         throw std::runtime_error("push with wrong db_id should return ok=false");
+    }
+    if (resp.error_code != sync::SyncResponseErrorCode::DbIdMismatch ||
+        resp.error_retryable) {
+        throw std::runtime_error("push wrong db_id error code incorrect");
     }
 
     {
@@ -1406,10 +1571,12 @@ int main() {
         { "test_engine_conflicting_dbi_flags",  &test_engine_conflicting_dbi_flags_returns_conflict },
         { "test_engine_existing_dbi_flag_mismatch",&test_engine_existing_dbi_flag_mismatch_returns_conflict },
         { "test_engine_existing_dbi_flag_mismatch_first",&test_engine_existing_dbi_flag_mismatch_reports_first_batch_dbi },
+        { "test_engine_push_dbi_conflicts_not_retryable",&test_engine_push_dbi_conflicts_are_not_retryable },
         { "test_engine_gap_returns_conflict",   &test_engine_gap_returns_conflict },
         { "test_engine_applied_cursor",         &test_engine_applied_cursor },
         { "test_engine_handle_push_to_remote",  &test_engine_handle_push_to_remote },
         { "test_engine_push_gap_rolls_back",    &test_engine_push_gap_rolls_back },
+        { "test_engine_push_multi_batch_gap_cursor",&test_engine_push_multi_batch_gap_reports_persistent_cursor },
         { "test_engine_handle_pull_wrong_db_id",&test_engine_handle_pull_wrong_db_id },
         { "test_engine_rejects_full_snapshot_request",
           &test_engine_rejects_full_snapshot_request },

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -1614,6 +1614,130 @@ void test_worker_rejects_invalid_options() {
     cleanup(path);
 }
 
+void test_worker_propagates_pull_sync_error() {
+    using namespace mdbxc;
+    const std::string path = "test_worker_pull_sync_error.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x10), make_node(0xD0));
+
+    sync::PullResponse response;
+    response.ok = false;
+    response.error = "db_id mismatch";
+    response.error_code = sync::SyncResponseErrorCode::DbIdMismatch;
+    response.error_retryable = false;
+
+    FixedPeer peer(response);
+    RecordingWorkerObserver observer;
+    sync::SyncWorkerOptions options;
+    options.observer = &observer;
+    sync::SyncWorker worker(engine, peer, options);
+
+    const sync::SyncWorkerRoundResult result = worker.run_once();
+    if (result.ok ||
+        result.sync_error_code != sync::SyncResponseErrorCode::DbIdMismatch ||
+        result.sync_error_retryable) {
+        throw std::runtime_error("worker did not propagate pull sync error");
+    }
+
+    const std::vector<sync::SyncWorkerStageEvent> stages = observer.stages();
+    bool saw_pull_finished = false;
+    for (std::size_t i = 0; i < stages.size(); ++i) {
+        if (stages[i].stage == sync::SyncWorkerStage::PullFinished) {
+            saw_pull_finished = true;
+            if (stages[i].ok ||
+                stages[i].sync_error_code !=
+                    sync::SyncResponseErrorCode::DbIdMismatch ||
+                stages[i].sync_error_retryable) {
+                throw std::runtime_error(
+                    "worker pull stage sync error mismatch");
+            }
+        }
+    }
+    if (!saw_pull_finished) {
+        throw std::runtime_error("worker did not report PullFinished");
+    }
+
+    const sync::SyncWorkerStatus status = worker.status();
+    if (!status.last_round_known ||
+        status.last_round.sync_error_code !=
+            sync::SyncResponseErrorCode::DbIdMismatch ||
+        status.last_sync_error_code !=
+            sync::SyncResponseErrorCode::DbIdMismatch ||
+        status.last_sync_error_retryable) {
+        throw std::runtime_error("worker status lost pull sync error");
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_worker_propagates_apply_sync_error() {
+    using namespace mdbxc;
+    const std::string path = "test_worker_apply_sync_error.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    const sync::NodeId replica_node = make_node(0x11);
+    const sync::NodeId remote_origin = make_node(0x21);
+    const sync::NodeId db_id = make_node(0xD1);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
+
+    sync::ChangeBatch batch;
+    batch.origin_node_id = remote_origin;
+    batch.seq = 3;
+
+    sync::PullResponse response;
+    response.batches.push_back(batch);
+
+    FixedPeer peer(response);
+    RecordingWorkerObserver observer;
+    sync::SyncWorkerOptions options;
+    options.observer = &observer;
+    sync::SyncWorker worker(engine, peer, options);
+
+    const sync::SyncWorkerRoundResult result = worker.run_once();
+    if (result.ok ||
+        result.sync_error_code != sync::SyncResponseErrorCode::ApplyConflict ||
+        !result.sync_error_retryable) {
+        throw std::runtime_error("worker did not propagate apply sync error");
+    }
+
+    const std::vector<sync::SyncWorkerStageEvent> stages = observer.stages();
+    bool saw_apply_finished = false;
+    for (std::size_t i = 0; i < stages.size(); ++i) {
+        if (stages[i].stage == sync::SyncWorkerStage::ApplyFinished) {
+            saw_apply_finished = true;
+            if (stages[i].ok ||
+                stages[i].sync_error_code !=
+                    sync::SyncResponseErrorCode::ApplyConflict ||
+                !stages[i].sync_error_retryable) {
+                throw std::runtime_error(
+                    "worker apply stage sync error mismatch");
+            }
+        }
+    }
+    if (!saw_apply_finished) {
+        throw std::runtime_error("worker did not report ApplyFinished");
+    }
+
+    const sync::SyncWorkerStatus status = worker.status();
+    if (!status.last_round_known ||
+        status.last_round.sync_error_code !=
+            sync::SyncResponseErrorCode::ApplyConflict ||
+        status.last_sync_error_code !=
+            sync::SyncResponseErrorCode::ApplyConflict ||
+        !status.last_sync_error_retryable) {
+        throw std::runtime_error("worker status lost apply sync error");
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 void test_worker_stop_while_pull_blocked_does_not_apply_returned_page() {
     using namespace mdbxc;
     const std::string path = "test_worker_blocked_stop.mdbx";
@@ -1967,6 +2091,10 @@ int main() {
           &test_worker_page_observer_exception_does_not_fail_round },
         { "test_worker_rejects_invalid_options",
           &test_worker_rejects_invalid_options },
+        { "test_worker_propagates_pull_sync_error",
+          &test_worker_propagates_pull_sync_error },
+        { "test_worker_propagates_apply_sync_error",
+          &test_worker_propagates_apply_sync_error },
         { "test_worker_stop_while_pull_blocked",
           &test_worker_stop_while_pull_blocked_does_not_apply_returned_page },
         { "test_worker_stop_from_apply_started_observer_skips_apply",

--- a/tests/test_transport_codec.cpp
+++ b/tests/test_transport_codec.cpp
@@ -99,6 +99,8 @@ void test_pull_response_roundtrip() {
     response.has_more = true;
     response.ok = false;
     response.error = "temporary upstream timeout";
+    response.error_code = SyncResponseErrorCode::UnsupportedFullSnapshot;
+    response.error_retryable = false;
 
     const std::vector<std::uint8_t> bytes =
         TransportMessageCodec::encode_pull_response(response);
@@ -124,6 +126,10 @@ void test_pull_response_roundtrip() {
     require_true(decoded.has_more, "PullResponse has_more mismatch");
     require_true(!decoded.ok, "PullResponse ok mismatch");
     require_true(decoded.error == response.error, "PullResponse error mismatch");
+    require_true(decoded.error_code == response.error_code,
+                 "PullResponse error_code mismatch");
+    require_true(decoded.error_retryable == response.error_retryable,
+                 "PullResponse error_retryable mismatch");
 }
 
 void test_push_request_roundtrip() {
@@ -161,6 +167,8 @@ void test_push_response_roundtrip() {
     response.receiver_have.last_seq_by_origin[make_node(0xD0)] = 42;
     response.ok = false;
     response.error = "sequence gap";
+    response.error_code = SyncResponseErrorCode::ApplyConflict;
+    response.error_retryable = true;
 
     const std::vector<std::uint8_t> bytes =
         TransportMessageCodec::encode_push_response(response);
@@ -171,6 +179,10 @@ void test_push_response_roundtrip() {
                  "PushResponse cursor mismatch");
     require_true(!decoded.ok, "PushResponse ok mismatch");
     require_true(decoded.error == response.error, "PushResponse error mismatch");
+    require_true(decoded.error_code == response.error_code,
+                 "PushResponse error_code mismatch");
+    require_true(decoded.error_retryable == response.error_retryable,
+                 "PushResponse error_retryable mismatch");
 }
 
 void test_peek_message_type() {
@@ -307,6 +319,26 @@ void test_bounds_rejections() {
     });
 }
 
+void test_response_error_code_rejections() {
+    using namespace mdbxc::sync;
+
+    expect_throw("pull response error code", [] {
+        std::vector<std::uint8_t> bad =
+            TransportMessageCodec::encode_pull_response(PullResponse());
+        bad[bad.size() - 3u] = 0xFFu;
+        bad[bad.size() - 2u] = 0xFFu;
+        (void)TransportMessageCodec::decode_pull_response(bad);
+    });
+
+    expect_throw("push response error code", [] {
+        std::vector<std::uint8_t> bad =
+            TransportMessageCodec::encode_push_response(PushResponse());
+        bad[bad.size() - 3u] = 0xFFu;
+        bad[bad.size() - 2u] = 0xFFu;
+        (void)TransportMessageCodec::decode_push_response(bad);
+    });
+}
+
 void test_golden_header_shape() {
     using namespace mdbxc::sync;
     const std::vector<std::uint8_t> bytes =
@@ -317,7 +349,7 @@ void test_golden_header_shape() {
         require_true(bytes[i] == expected_magic[i],
                      "TransportMessageCodec magic mismatch");
     }
-    require_true(bytes[8] == 2u && bytes[9] == 0u,
+    require_true(bytes[8] == 3u && bytes[9] == 0u,
                  "TransportMessageCodec version mismatch");
     require_true(bytes[10] == 1u,
                  "TransportMessageCodec pull request type mismatch");
@@ -336,6 +368,7 @@ int main() {
     test_peek_message_type();
     test_message_header_rejections();
     test_bounds_rejections();
+    test_response_error_code_rejections();
     test_golden_header_shape();
     return 0;
 }


### PR DESCRIPTION
Summary:
- Add machine-readable sync response error codes to pull/push responses and transport codec v3.
- Classify unsupported full snapshots, DB id mismatches, and apply conflicts without parsing human-readable error strings.
- Treat sequence-gap apply conflicts as sync-retryable protocol recovery, while DBI/name/flag conflicts remain non-retryable.
- Propagate sync-level response errors through SyncWorker round results, stage events, and status snapshots while keeping permanent-failure policy transport-only.

Validation:
- git diff --check
- cmake --build tmp/build-pr164-cpp11-mingw --target test_transport_codec test_sync_engine test_sync_worker header_sync_umbrella_test
- ctest --test-dir tmp/build-pr164-cpp11-mingw -R "(test_transport_codec|test_sync_engine|test_sync_worker|header_sync_umbrella_test)$" --output-on-failure
- cmake --build tmp/build-pr164-cpp17-mingw --target test_transport_codec test_sync_engine test_sync_worker header_sync_umbrella_test
- ctest --test-dir tmp/build-pr164-cpp17-mingw -R "(test_transport_codec|test_sync_engine|test_sync_worker|header_sync_umbrella_test)$" --output-on-failure
