### PR TITLE
feat(sync): report pruned changelog pulls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 - Breaking transport-wire change: `TransportMessageCodec` is now version 3 and
   response DTOs include `SyncResponseErrorCode` plus `error_retryable` after
   the human-readable error string.
+- Added `SyncResponseErrorCode::SnapshotRequired` so pull requests behind
+  retained changelog history fail explicitly instead of streaming
+  non-contiguous batches.
 - Breaking API cleanup: removed the historical
   `SyncEngine::pull_full_snapshot()` compatibility wrapper. Use
   `SyncEngine::pull_changelog_page()` for retained changelog replay; true full

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -218,6 +218,11 @@ Operational rules:
   This is a sync-level protocol rejection, not a transport retry hint. Code
   that needs machine classification should inspect `SyncResponseErrorCode`
   instead of parsing the human-readable `error` string.
+- Pull from a cursor older than retained changelog history fails as
+  `PullResponse{ok=false, error_code=SnapshotRequired}`. The response carries no
+  batches because applying a later retained batch would produce a sequence gap
+  on the receiver. Until a snapshot protocol is implemented, the caller must
+  provision a fresh replica or use an out-of-band snapshot.
 - `PushResponse::error_retryable` describes sync-level recovery. Sequence gaps
   are retryable after the receiver catches up from its persistent applied
   cursor; DBI name/flag conflicts, reserved DBI writes, and unsupported

--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -57,10 +57,14 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
 - Keep transport retry hints transport-owned; sync-level protocol errors should
   be visible without parsing free-form strings.
 
+### PR #167: Pruning recovery
+
+- Detect pull requests whose cursor is behind retained changelog history.
+- Return an explicit snapshot-required sync response instead of streaming
+  non-contiguous retained batches.
+
 ## Later Medium-Risk Follow-ups
 
-- Pruning recovery: track earliest retained sequence and report
-  snapshot-required when a replica is behind retained history.
 - `VectorStore` collection naming: reject invalid names or use a reversible
   collision-free encoding.
 - Remote apply invalidation hooks: notify already-open table/view objects after

--- a/guides/sync-transport-production.md
+++ b/guides/sync-transport-production.md
@@ -131,7 +131,8 @@ For HTTP, transport status and sync DTO status are separate:
   success or conflict;
 - decoded responses may also carry `SyncResponseErrorCode` and
   `error_retryable` for sync-level failures such as DB id mismatch, unsupported
-  full-snapshot requests, or apply conflicts;
+  full-snapshot requests, changelog pruning that requires a snapshot, or apply
+  conflicts;
 - sync-level retryability means protocol recovery, for example re-pulling from
   the persistent cursor after a sequence gap, not blindly resending the same
   request;

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -309,6 +309,12 @@ is rejected.
 `prune_up_to` opens a cursor, walks from `(origin, 0)` until `mdbx_cmp > (origin, up_to)`,
 deletes each hit, then closes. The boundary comparison is on the bytewise
 key, which is why `seq` is big-endian in the key.
+Pull detects when `request.have + 1` is older than the earliest retained
+changelog record for a known origin and returns
+`PullResponse{ok=false, error_code=SnapshotRequired}` instead of streaming a
+later non-contiguous batch. Until the reserved full snapshot protocol exists,
+callers must provision a fresh replica or use an application-defined snapshot
+outside sync v0.1.
 
 ### `_mdbxc_origins` (OriginIndexStore)
 
@@ -410,9 +416,10 @@ Locked contract:
   recovery, not blind replay of the identical request: for example a
   `SequenceGap` apply conflict is retryable after the caller catches up from a
   fresher cursor, while DBI flag conflicts and unsupported full snapshots are
-  permanent until the caller changes behavior. Transport-local errors remain
-  represented by adapter status, close codes, response headers, and
-  `SyncTransportRetryHint`.
+  permanent until the caller changes behavior. `SnapshotRequired` means the
+  requested changelog range was pruned and cannot be recovered through
+  incremental pull. Transport-local errors remain represented by adapter
+  status, close codes, response headers, and `SyncTransportRetryHint`.
 - `CancellationToken` fields in request DTOs are local call-control state and
   are never serialized. Decoded request DTOs contain default non-cancellable
   tokens.
@@ -494,6 +501,9 @@ format is implemented. In v0.1 this is a sync-level protocol rejection carried
 as `PullResponse{ok=false, error=..., error_code=UnsupportedFullSnapshot}`; it
 does not produce a transport retry hint because the server returned a valid
 sync response rather than a transport failure.
+If changelog pruning removed entries needed by the requester's cursor,
+`handle_pull()` returns `SnapshotRequired` with no batches. This is also a
+valid sync response, not a transport failure.
 `SyncWorkerPermanentFailurePolicy` is transport-only; workers still expose
 sync-level response errors through round results, stage events, and status
 snapshots without treating them as permanent transport failures.

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -335,6 +335,12 @@ namespace sync {
             out.remote_have = read_applied_cursor(txn, out.remote_have);
             const std::vector<PullOrigin> origins = collect_known_origins(txn, dbi);
             out.remote_tail_known = copy_known_tail(origins, out.remote_tail);
+            for (std::size_t i = 0; i < origins.size(); ++i) {
+                if (!request_has_retained_start(txn, dbi, origins[i], request,
+                                                out)) {
+                    return out;
+                }
+            }
             std::size_t total_bytes = 0;
             bool truncated = false;
             for (std::size_t i = 0; i < origins.size(); ++i) {
@@ -718,6 +724,62 @@ namespace sync {
                    request.have.last_seq_for(origin.origin) >= origin.last_seq;
         }
 
+        static void set_snapshot_required(PullResponse& out,
+                                          const PullOrigin& origin,
+                                          std::uint64_t have_seq,
+                                          bool earliest_known,
+                                          std::uint64_t earliest_seq) {
+            out.ok = false;
+            out.batches.clear();
+            out.has_more = false;
+            out.error_code = SyncResponseErrorCode::SnapshotRequired;
+            out.error_retryable = false;
+            out.error = "requested changelog history was pruned for origin";
+            out.error += " (have_seq=" + std::to_string(have_seq);
+            if (origin.has_last_seq) {
+                out.error += ", tail_seq=" + std::to_string(origin.last_seq);
+            }
+            if (earliest_known) {
+                out.error += ", earliest_retained_seq=" +
+                             std::to_string(earliest_seq);
+            } else {
+                out.error += ", earliest_retained_seq=none";
+            }
+            out.error += ")";
+        }
+
+        static bool request_has_retained_start(MDBX_txn* txn,
+                                               MDBX_dbi dbi,
+                                               const PullOrigin& origin,
+                                               const PullRequest& request,
+                                               PullResponse& out) {
+            if (origin_is_at_tail(origin, request)) {
+                return true;
+            }
+            const std::uint64_t have_seq =
+                request.have.last_seq_for(origin.origin);
+            if (have_seq == std::numeric_limits<std::uint64_t>::max()) {
+                return true;
+            }
+            std::uint64_t earliest_seq = 0;
+            const bool earliest_known =
+                changelog_earliest_seq(txn, dbi, origin.origin, earliest_seq);
+            if (!earliest_known) {
+                if (origin.has_last_seq && have_seq < origin.last_seq) {
+                    set_snapshot_required(out, origin, have_seq,
+                                          false, earliest_seq);
+                    return false;
+                }
+                return true;
+            }
+            if (have_seq + 1 < earliest_seq) {
+                set_snapshot_required(out, origin, have_seq,
+                                      true, earliest_seq);
+                return false;
+            }
+            return true;
+        }
+
         static bool copy_known_tail(const std::vector<PullOrigin>& origins,
                                     SyncCursor& out) {
             for (std::size_t i = 0; i < origins.size(); ++i) {
@@ -840,6 +902,33 @@ namespace sync {
                 check_mdbx(rc, "pull_full: origin batch cursor walk failed");
             }
             return false;
+        }
+
+        static bool changelog_earliest_seq(MDBX_txn* txn,
+                                           MDBX_dbi dbi,
+                                           const NodeId& origin,
+                                           std::uint64_t& out) {
+            MDBX_cursor* raw = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, dbi, &raw),
+                       "pull_full: earliest retained cursor open failed");
+            CursorGuard guard(raw);
+
+            std::vector<std::uint8_t> key_buf = make_changelog_key(origin, 0);
+            MDBX_val k = {
+                key_buf.empty() ? nullptr : &key_buf[0],
+                key_buf.size()
+            };
+            MDBX_val v;
+            const int rc = mdbx_cursor_get(raw, &k, &v, MDBX_SET_RANGE);
+            if (rc == MDBX_NOTFOUND) {
+                return false;
+            }
+            check_mdbx(rc, "pull_full: earliest retained cursor get failed");
+            if (!changelog_key_matches_origin(k, origin)) {
+                return false;
+            }
+            out = changelog_key_seq(k);
+            return true;
         }
 
         /// \brief Opens \c _mdbxc_changelog read-only when it exists; 0 otherwise.

--- a/include/mdbx_containers/sync/TransportMessageCodec.hpp
+++ b/include/mdbx_containers/sync/TransportMessageCodec.hpp
@@ -322,6 +322,7 @@ namespace sync {
                 case SyncResponseErrorCode::DbIdMismatch:
                 case SyncResponseErrorCode::UnsupportedFullSnapshot:
                 case SyncResponseErrorCode::ApplyConflict:
+                case SyncResponseErrorCode::SnapshotRequired:
                     detail::append_u16_le(out,
                         static_cast<std::uint16_t>(code));
                     return;
@@ -460,6 +461,9 @@ namespace sync {
                 case static_cast<std::uint16_t>(
                         SyncResponseErrorCode::ApplyConflict):
                     return SyncResponseErrorCode::ApplyConflict;
+                case static_cast<std::uint16_t>(
+                        SyncResponseErrorCode::SnapshotRequired):
+                    return SyncResponseErrorCode::SnapshotRequired;
             }
             throw std::runtime_error("Invalid SyncResponseErrorCode");
         }

--- a/include/mdbx_containers/sync/protocol.hpp
+++ b/include/mdbx_containers/sync/protocol.hpp
@@ -27,6 +27,7 @@ namespace sync {
         DbIdMismatch            = 1, ///< Request targeted a different db_id.
         UnsupportedFullSnapshot = 2, ///< Full snapshot protocol is not implemented.
         ApplyConflict           = 3, ///< Push apply failed on a sync conflict.
+        SnapshotRequired        = 4, ///< Requested changelog history was pruned.
     };
 
     /// \brief Returns a stable diagnostic name for a sync response error code.
@@ -41,6 +42,8 @@ namespace sync {
                 return "unsupported_full_snapshot";
             case SyncResponseErrorCode::ApplyConflict:
                 return "apply_conflict";
+            case SyncResponseErrorCode::SnapshotRequired:
+                return "snapshot_required";
         }
         return "unknown";
     }

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -113,6 +113,10 @@ int main() {
         std::string(mdbxc::sync::sync_response_error_code_name(
             mdbxc::sync::SyncResponseErrorCode::UnsupportedFullSnapshot)) ==
         "unsupported_full_snapshot");
+    MDBXC_TEST_ASSERT(
+        std::string(mdbxc::sync::sync_response_error_code_name(
+            mdbxc::sync::SyncResponseErrorCode::SnapshotRequired)) ==
+        "snapshot_required");
     mdbxc::sync::SyncCaptureScope* capture_scope = nullptr;
     HeaderSyncSink header_sink;
     (void)capture_scope;

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1181,6 +1181,59 @@ void test_engine_changelog_page_rejects_full_snapshot_request() {
     cleanup(p);
 }
 
+void test_engine_pull_reports_snapshot_required_after_prune() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_pull_snapshot_required_after_prune.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    const sync::NodeId local = make_node(0xA2);
+    const sync::NodeId origin = make_node(0xB2);
+    const sync::DbId db_id = make_node(0xD2);
+    engine.initialize_local_identity(local, db_id);
+
+    {
+        auto txn = conn->transaction(TransactionMode::WRITABLE);
+        sync::ChangeLogStore log(conn->env_handle());
+        log.open(txn.handle());
+        append_raw_batch(log, txn.handle(), origin, 1, "t", 0x01);
+        append_raw_batch(log, txn.handle(), origin, 2, "t", 0x02);
+        append_raw_batch(log, txn.handle(), origin, 3, "t", 0x03);
+        const std::size_t removed = log.prune_up_to(txn.handle(), origin, 2);
+        if (removed != 2u) {
+            throw std::runtime_error("test prune did not remove first two batches");
+        }
+        txn.commit();
+    }
+
+    sync::PullRequest req;
+    req.requester = make_node(0xC2);
+    req.db_id = db_id;
+
+    const sync::PullResponse resp = engine.handle_pull(req);
+    if (resp.ok) {
+        throw std::runtime_error("pruned changelog pull should fail");
+    }
+    if (!resp.batches.empty() || resp.has_more) {
+        throw std::runtime_error("snapshot-required pull returned batches");
+    }
+    if (resp.error_code != sync::SyncResponseErrorCode::SnapshotRequired ||
+        resp.error_retryable) {
+        throw std::runtime_error("snapshot-required pull code incorrect");
+    }
+    if (!resp.remote_tail_known ||
+        resp.remote_tail.last_seq_for(origin) != 3u) {
+        throw std::runtime_error("snapshot-required pull lost remote tail");
+    }
+    if (resp.error.find("earliest_retained_seq=3") == std::string::npos) {
+        throw std::runtime_error("snapshot-required pull error lacks earliest seq");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 void test_engine_handle_push_wrong_db_id() {
     using namespace mdbxc;
     const std::string p = "test_engine_push_wrong_db.mdbx";
@@ -1582,6 +1635,8 @@ int main() {
           &test_engine_rejects_full_snapshot_request },
         { "test_engine_changelog_page_rejects_full_snapshot_request",
           &test_engine_changelog_page_rejects_full_snapshot_request },
+        { "test_engine_pull_reports_snapshot_required_after_prune",
+          &test_engine_pull_reports_snapshot_required_after_prune },
         { "test_engine_handle_push_wrong_db_id",&test_engine_handle_push_wrong_db_id },
         { "test_engine_rejects_last_writer_wins_policy",
           &test_engine_rejects_last_writer_wins_policy },

--- a/tests/test_transport_codec.cpp
+++ b/tests/test_transport_codec.cpp
@@ -99,7 +99,7 @@ void test_pull_response_roundtrip() {
     response.has_more = true;
     response.ok = false;
     response.error = "temporary upstream timeout";
-    response.error_code = SyncResponseErrorCode::UnsupportedFullSnapshot;
+    response.error_code = SyncResponseErrorCode::SnapshotRequired;
     response.error_retryable = false;
 
     const std::vector<std::uint8_t> bytes =
@@ -126,7 +126,7 @@ void test_pull_response_roundtrip() {
     require_true(decoded.has_more, "PullResponse has_more mismatch");
     require_true(!decoded.ok, "PullResponse ok mismatch");
     require_true(decoded.error == response.error, "PullResponse error mismatch");
-    require_true(decoded.error_code == response.error_code,
+    require_true(decoded.error_code == SyncResponseErrorCode::SnapshotRequired,
                  "PullResponse error_code mismatch");
     require_true(decoded.error_retryable == response.error_retryable,
                  "PullResponse error_retryable mismatch");


### PR DESCRIPTION
Summary:
- Add SyncResponseErrorCode::SnapshotRequired for pull cursors behind retained changelog history.
- Detect pruned changelog ranges before streaming batches so responders do not send non-contiguous pages.
- Document the retained-changelog replay contract and add regression coverage.

Validation:
- git diff --check
- cmake --build tmp/build-pr164-cpp11-mingw --target test_sync_engine test_transport_codec header_sync_umbrella_test
- ctest --test-dir tmp/build-pr164-cpp11-mingw -R "(test_sync_engine|test_transport_codec|header_sync_umbrella_test)$" --output-on-failure
- cmake --build tmp/build-pr164-cpp17-mingw --target test_sync_engine test_transport_codec header_sync_umbrella_test
- ctest --test-dir tmp/build-pr164-cpp17-mingw -R "(test_sync_engine|test_transport_codec|header_sync_umbrella_test)$" --output-on-failure
