### PR TITLE
fix(vector): reject lossy collection names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
 - Added `SyncResponseErrorCode::SnapshotRequired` so pull requests behind
   retained changelog history fail explicitly instead of streaming
   non-contiguous batches.
+- Breaking API behavior change: `VectorStore` collection names are now
+  validated instead of lossy-sanitized. Names must be non-empty and contain
+  only ASCII letters, digits, `_`, and `-`.
 - Breaking API cleanup: removed the historical
   `SyncEngine::pull_full_snapshot()` compatibility wrapper. Use
   `SyncEngine::pull_changelog_page()` for retained changelog replay; true full

--- a/README-RU.md
+++ b/README-RU.md
@@ -239,6 +239,9 @@ auto unique_values = table.range_values<std::set>(10, 20);
 точный `O(N * dim)`, все embeddings загружаются в RAM, а ANN/HNSW,
 metadata filtering и генерация embeddings не входят в область MVP.
 
+Имена коллекций валидируются, а не переписываются: используйте непустые имена
+только из ASCII-букв, цифр, `_` и `-`.
+
 ```cpp
 #include <mdbx_containers/vector.hpp>
 #include <iostream>

--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ Ordered key-based tables also provide `for_each_range()` for streaming scans,
 an exact RAM index on open. It is intended as a local RAG MVP: search is exact
 `O(N * dim)`, all embeddings are loaded into RAM, and ANN/HNSW, metadata
 filtering, and generated embeddings are out of scope.
+Collection names are validated, not rewritten: use non-empty names containing
+only ASCII letters, digits, `_`, and `-`.
 
 ```cpp
 #include <mdbx_containers/vector.hpp>

--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -63,10 +63,13 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
 - Return an explicit snapshot-required sync response instead of streaming
   non-contiguous retained batches.
 
+### PR #168: `VectorStore` collection naming
+
+- Reject invalid collection names before building internal DBI names.
+- Avoid silent collection-name collisions from lossy sanitization.
+
 ## Later Medium-Risk Follow-ups
 
-- `VectorStore` collection naming: reject invalid names or use a reversible
-  collision-free encoding.
 - Remote apply invalidation hooks: notify already-open table/view objects after
   sync changes their backing DBIs so cached in-memory state such as
   `VectorStore` RAM indexes can rebuild instead of going stale.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -102,6 +102,11 @@ Do not add `record_op()` paths for unsupported table types without first
 updating this design document and adding round-trip replication tests for the
 new wire-format semantics.
 
+`VectorStore` collection names are validated instead of sanitized. Names must
+be non-empty and contain only ASCII letters, digits, `_`, and `-`; unsupported
+characters are rejected before internal DBI names are built. This prevents
+different logical collections from collapsing to the same physical DBI names.
+
 ## Deferred `KeyMultiValueTable` sync design
 
 This section documents the intended direction for future

--- a/include/mdbx_containers/vector/VectorStore.hpp
+++ b/include/mdbx_containers/vector/VectorStore.hpp
@@ -24,18 +24,22 @@ namespace mdbxc {
     public:
         /// \brief Opens a vector store using a new MDBX connection.
         /// \param config MDBX environment configuration.
-        /// \param collection Logical collection name; invalid table-name characters are replaced by \c _.
+        /// \param collection Logical collection name. Allowed characters are
+        /// ASCII letters, digits, \c _ and \c -.
         /// \param metric Metric used by the in-memory index.
-        /// \throws std::invalid_argument if \c collection is empty.
+        /// \throws std::invalid_argument if \c collection is empty or contains
+        /// unsupported characters.
         VectorStore(const Config& config,
                     std::string collection = "default",
                     VectorMetric metric = VectorMetric::COSINE);
 
         /// \brief Opens a vector store using an existing connection.
         /// \param connection Shared MDBX connection.
-        /// \param collection Logical collection name; invalid table-name characters are replaced by \c _.
+        /// \param collection Logical collection name. Allowed characters are
+        /// ASCII letters, digits, \c _ and \c -.
         /// \param metric Metric used by the in-memory index.
-        /// \throws std::invalid_argument if \c connection is null or \c collection is empty.
+        /// \throws std::invalid_argument if \c connection is null, or
+        /// \c collection is empty or contains unsupported characters.
         VectorStore(std::shared_ptr<Connection> connection,
                     std::string collection = "default",
                     VectorMetric metric = VectorMetric::COSINE);
@@ -74,7 +78,7 @@ namespace mdbxc {
         /// \brief Returns the number of persisted embeddings.
         std::size_t count() const;
 
-        /// \brief Returns the sanitized collection name.
+        /// \brief Returns the validated collection name.
         const std::string& collection() const noexcept;
 
     private:
@@ -88,7 +92,7 @@ namespace mdbxc {
         FlatVectorIndex m_index;
 
         static std::shared_ptr<Connection> require_connection(std::shared_ptr<Connection> connection);
-        static std::string sanitize_collection_name(const std::string& name);
+        static std::string validate_collection_name(const std::string& name);
         static std::string make_table_name(const std::string& collection, const std::string& suffix);
     };
 

--- a/include/mdbx_containers/vector/VectorStore.ipp
+++ b/include/mdbx_containers/vector/VectorStore.ipp
@@ -12,22 +12,20 @@ namespace mdbxc {
         return connection;
     }
 
-    inline std::string VectorStore::sanitize_collection_name(const std::string& name) {
+    inline std::string VectorStore::validate_collection_name(const std::string& name) {
         if (name.empty()) {
             throw std::invalid_argument("Collection name cannot be empty");
         }
-        std::string result;
-        result.reserve(name.size());
         for (std::size_t i = 0; i < name.size(); ++i) {
-            char c = name[i];
+            const char c = name[i];
             if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
                 (c >= '0' && c <= '9') || c == '_' || c == '-') {
-                result.push_back(c);
-            } else {
-                result.push_back('_');
+                continue;
             }
+            throw std::invalid_argument(
+                "Collection name contains unsupported character");
         }
-        return result;
+        return name;
     }
 
     inline std::string VectorStore::make_table_name(const std::string& collection,
@@ -38,7 +36,7 @@ namespace mdbxc {
     inline VectorStore::VectorStore(const Config& config,
                                       std::string collection,
                                       VectorMetric metric)
-        : m_collection(sanitize_collection_name(collection))
+        : m_collection(validate_collection_name(collection))
         , m_metric(metric)
         , m_connection(Connection::create(config))
         , m_ids(m_connection, make_table_name(m_collection, "ids"))
@@ -53,7 +51,7 @@ namespace mdbxc {
     inline VectorStore::VectorStore(std::shared_ptr<Connection> connection,
                                       std::string collection,
                                       VectorMetric metric)
-        : m_collection(sanitize_collection_name(collection))
+        : m_collection(validate_collection_name(collection))
         , m_metric(metric)
         , m_connection(require_connection(std::move(connection)))
         , m_ids(m_connection, make_table_name(m_collection, "ids"))

--- a/tests/vector_store_test.cpp
+++ b/tests/vector_store_test.cpp
@@ -168,7 +168,7 @@ int main() {
         auto conn = mdbxc::Connection::create(cfg);
 
         mdbxc::VectorStore storeA(conn, "docs");
-        mdbxc::VectorStore storeB(conn, "code/raw");
+        mdbxc::VectorStore storeB(conn, "code_raw");
         storeA.clear();
         storeB.clear();
         MDBXC_TEST_ASSERT(storeB.collection() == "code_raw");
@@ -179,6 +179,24 @@ int main() {
         mdbxc::Embedding query = make_embedding({1.0f, 0.0f});
         std::vector<mdbxc::SearchResult> resultsB = storeB.search(query, 1);
         MDBXC_TEST_ASSERT(resultsB.empty());
+
+        bool rejected_slash = false;
+        try {
+            mdbxc::VectorStore invalid(conn, "code/raw");
+            (void)invalid;
+        } catch (const std::invalid_argument&) {
+            rejected_slash = true;
+        }
+        MDBXC_TEST_ASSERT(rejected_slash);
+
+        bool rejected_space = false;
+        try {
+            mdbxc::VectorStore invalid(conn, "code raw");
+            (void)invalid;
+        } catch (const std::invalid_argument&) {
+            rejected_space = true;
+        }
+        MDBXC_TEST_ASSERT(rejected_space);
     }
 
     // --- 8. FlatVectorIndex metrics and top_k=0 ---


### PR DESCRIPTION
Summary:
- Validate VectorStore collection names instead of lossy-sanitizing unsupported characters.
- Reject names that could collapse to the same internal DBI names after replacement.
- Document the breaking behavior change and update vector tests.

Validation:
- git diff --check
- cmake --build tmp/build-pr164-cpp11-mingw --target vector_store_test header_vector_umbrella_test header_all_umbrella_test
- ctest --test-dir tmp/build-pr164-cpp11-mingw -R "(vector_store_test|header_vector_umbrella_test|header_all_umbrella_test)$" --output-on-failure
- cmake --build tmp/build-pr164-cpp17-mingw --target vector_store_test header_vector_umbrella_test header_all_umbrella_test
- ctest --test-dir tmp/build-pr164-cpp17-mingw -R "(vector_store_test|header_vector_umbrella_test|header_all_umbrella_test)$" --output-on-failure
