### PR TITLE
feat(sync): bound concrete transport bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project will be documented in this file.
 - Added `Connection::sync_apply_generation()` and made already-open
   `VectorStore` instances lazily refresh their RAM index between completed
   operations after successful remote sync apply commits.
+- Added `CodecBounds` knobs to ready-made Simple-Web HTTP, Simple-WebSocket,
+  and Kurlyk HTTP transport configs so oversized concrete transport bodies are
+  rejected before sync codec decode.
 - Breaking API cleanup: removed the historical
   `SyncEngine::pull_full_snapshot()` compatibility wrapper. Use
   `SyncEngine::pull_changelog_page()` for retained changelog replay; true full

--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -75,6 +75,13 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
 - Make already-open `VectorStore` instances lazily rebuild their RAM index
   after the generation changes.
 
+### PR #170: Concrete transport body limits
+
+- Add ready-made binding `CodecBounds` knobs for Simple-Web HTTP,
+  Simple-WebSocket, and Kurlyk HTTP.
+- Reject oversized concrete transport bodies before sync codec decode; reject
+  Simple-Web HTTP oversized `Content-Length` before adapter body copy.
+
 ## Later Medium-Risk Follow-ups
 
 - General remote apply invalidation hooks: notify future table/view objects
@@ -85,8 +92,9 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
   apply+generation publication against cache-backed readers such as
   `VectorStore::search()`. Use `std::shared_mutex`/`shared_lock` for C++17 and
   fall back to an exclusive `std::mutex` model for C++11.
-- Transport body limits before full buffering in concrete HTTP/WebSocket
-  backends.
+- Transport-level pre-buffer limits: configure framework/library request,
+  response, and WebSocket frame caps, or abort through streaming callbacks
+  before the complete payload is retained in memory.
 - Rate-limit bucket eviction / hard caps.
 - WebSocket connect/response/request deadlines.
 - Installed package fallback for lowercase-only `mdbxConfig.cmake`.

--- a/guides/sync-transport-production.md
+++ b/guides/sync-transport-production.md
@@ -155,6 +155,15 @@ For WebSocket, close codes `1001`, `1005`, `1006`, `1011`, `1012`, `1013`, and
 payload, and size limits, such as `1007`, `1008`, and `1009`, are permanent
 until the request or session changes.
 
+Concrete ready-made transport bindings expose `CodecBounds` in their config
+objects and reject oversized request/response bodies before handing bytes to
+`TransportMessageCodec`. Simple-Web HTTP can reject an oversized
+`Content-Length` before copying the request body into the adapter DTO; messages
+without a usable length header are still checked after the framework provides
+the buffered body. Simple-WebSocket and Kurlyk/libcurl also guard before sync
+decode, but their underlying libraries may already have buffered the frame or
+response content.
+
 Concrete `ISyncPeer` implementations that can classify transport failures
 should publish the most recent hint through `ISyncPeer::last_retry_hint()`.
 The default hint is unavailable, which means the peer did not provide advice

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -739,6 +739,11 @@ cancel, and batch counters without changing transport behavior.
 WebSocket binary messages. It complements `CodecBounds`: adapters can reject
 oversized transport frames before decoding, while the codec still validates the
 structured payload.
+Ready-made concrete bindings also expose `CodecBounds` in their config objects.
+Simple-Web HTTP rejects oversized `Content-Length` before copying the request
+body into an adapter DTO and checks the actual buffered body as a fallback.
+Simple-WebSocket and Kurlyk/libcurl check their buffered messages before
+calling the framework-neutral sync decoder.
 
 These helpers do not replace server-framework authentication or
 per-remote-client rate limiting before `HttpSyncServer::handle()`. They also

--- a/include/mdbx_containers/sync/transports/kurlyk/HttpTransport.hpp
+++ b/include/mdbx_containers/sync/transports/kurlyk/HttpTransport.hpp
@@ -83,6 +83,8 @@ namespace kurlyk {
         std::string bearer_token;
         /// \brief Extra headers sent with every sync POST request.
         std::vector<HttpSyncHeader> headers;
+        /// \brief Maximum accepted response body size before decode.
+        CodecBounds bounds;
     };
 
     /// \brief Kurlyk/libcurl HTTP client binding for \c HttpSyncPeer.
@@ -147,7 +149,7 @@ namespace kurlyk {
                     return make_transport_error_response(
                         "Kurlyk HTTP client returned empty response");
                 }
-                return convert_response(*response);
+                return convert_response(*response, m_config.bounds);
             } catch (const std::exception& e) {
                 if (cancel_token.is_cancellation_requested()) {
                     return make_cancelled_response(e.what());
@@ -186,8 +188,19 @@ namespace kurlyk {
             return out;
         }
 
+        static HttpSyncResponse make_payload_too_large_response(
+                const std::string& diagnostic) {
+            HttpSyncResponse out;
+            out.status_code = 413;
+            out.content_type = "text/plain; charset=utf-8";
+            out.error = diagnostic;
+            out.body = detail::string_to_bytes(out.error);
+            return out;
+        }
+
         static HttpSyncResponse convert_response(
-                const ::kurlyk::HttpResponse& response) {
+                const ::kurlyk::HttpResponse& response,
+                const CodecBounds& bounds) {
             HttpSyncResponse out;
             out.status_code = response.status_code < 0
                 ? 0u
@@ -200,6 +213,11 @@ namespace kurlyk {
             }
             out.content_type =
                 http_header_value(out.headers, "Content-Type");
+            if (response.content.size() >
+                bounds.max_transport_message_bytes) {
+                return make_payload_too_large_response(
+                    "Kurlyk HTTP sync response exceeds max_transport_message_bytes");
+            }
             out.body = detail::string_to_bytes(response.content);
             if (!response.error_message.empty()) {
                 out.error = response.error_message;

--- a/include/mdbx_containers/sync/transports/simple_web/HttpTransport.hpp
+++ b/include/mdbx_containers/sync/transports/simple_web/HttpTransport.hpp
@@ -38,6 +38,7 @@
 #include <cstdlib>
 #include <exception>
 #include <future>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -82,6 +83,58 @@ namespace simple_web {
             return it == headers.end() ? std::string() : it->second;
         }
 
+        inline bool decimal_size_exceeds_limit(
+                const std::string& value,
+                std::uint64_t limit) {
+            std::size_t pos = 0;
+            while (pos < value.size() &&
+                   (value[pos] == ' ' || value[pos] == '\t')) {
+                ++pos;
+            }
+            if (pos == value.size()) {
+                return false;
+            }
+
+            std::uint64_t parsed = 0;
+            bool saw_digit = false;
+            for (; pos < value.size(); ++pos) {
+                const char ch = value[pos];
+                if (ch >= '0' && ch <= '9') {
+                    saw_digit = true;
+                    const std::uint64_t digit =
+                        static_cast<std::uint64_t>(ch - '0');
+                    if (parsed >
+                        (std::numeric_limits<std::uint64_t>::max() -
+                         digit) / 10u) {
+                        return true;
+                    }
+                    parsed = parsed * 10u + digit;
+                    if (parsed > limit) {
+                        return true;
+                    }
+                    continue;
+                }
+
+                while (pos < value.size() &&
+                       (value[pos] == ' ' || value[pos] == '\t')) {
+                    ++pos;
+                }
+                return false;
+            }
+            return saw_digit && parsed > limit;
+        }
+
+        inline bool content_length_exceeds_limit(
+                const SimpleWeb::CaseInsensitiveMultimap& headers,
+                const CodecBounds& bounds) {
+            const std::string value = header_value(headers, "Content-Length");
+            if (value.empty()) {
+                return false;
+            }
+            return decimal_size_exceeds_limit(
+                value, bounds.max_transport_message_bytes);
+        }
+
         inline SimpleWeb::StatusCode to_simple_status(unsigned status) {
             return SimpleWeb::status_code(
                 std::to_string(static_cast<unsigned>(status)));
@@ -100,6 +153,8 @@ namespace simple_web {
         std::string bearer_token;
         /// \brief Extra headers sent with every sync POST request.
         std::vector<HttpSyncHeader> headers;
+        /// \brief Maximum accepted response body size before decode.
+        CodecBounds bounds;
     };
 
     /// \brief Simple-Web-Server HTTP client binding for \c HttpSyncPeer.
@@ -184,8 +239,18 @@ namespace simple_web {
                      ++it) {
                     http_add_header(out.headers, it->first, it->second);
                 }
-                out.body = detail::string_to_bytes(
-                    received->content.string());
+                if (detail::content_length_exceeds_limit(
+                        received->header, m_config.bounds)) {
+                    return make_payload_too_large_response(
+                        "HTTP sync response exceeds max_transport_message_bytes");
+                }
+                const std::string content = received->content.string();
+                if (content.size() >
+                    m_config.bounds.max_transport_message_bytes) {
+                    return make_payload_too_large_response(
+                        "HTTP sync response exceeds max_transport_message_bytes");
+                }
+                out.body = detail::string_to_bytes(content);
                 return out;
             } catch (const SimpleWeb::system_error& e) {
                 if (m_cancel_generation.load(std::memory_order_acquire) !=
@@ -243,6 +308,16 @@ namespace simple_web {
             return out;
         }
 
+        static HttpSyncResponse make_payload_too_large_response(
+                const std::string& diagnostic) {
+            HttpSyncResponse out;
+            out.status_code = 413;
+            out.content_type = "text/plain; charset=utf-8";
+            out.error = diagnostic;
+            out.body = detail::string_to_bytes(out.error);
+            return out;
+        }
+
         void set_active_client(Client* client) {
             std::lock_guard<std::mutex> lock(m_mutex);
             m_active_client = client;
@@ -279,6 +354,8 @@ namespace simple_web {
         /// Use this when the same MDBX-backed \c SyncEngine is also touched
         /// by application code while the HTTP listener is running.
         std::mutex* handler_mutex = nullptr;
+        /// \brief Maximum accepted request body size before dispatch/decode.
+        CodecBounds bounds;
     };
 
     /// \brief Simple-Web-Server listener binding for \c HttpSyncServer.
@@ -395,14 +472,13 @@ namespace simple_web {
                             headers);
         }
 
-        HttpSyncRequest make_request(
+        HttpSyncRequest make_request_metadata(
                 const std::shared_ptr<Server::Request>& request) const {
             HttpSyncRequest in;
             in.method = request->method;
             in.target = request->path;
             in.content_type =
                 detail::header_value(request->header, "Content-Type");
-            in.body = detail::string_to_bytes(request->content.string());
             for (SimpleWeb::CaseInsensitiveMultimap::const_iterator it =
                      request->header.begin();
                  it != request->header.end();
@@ -416,6 +492,22 @@ namespace simple_web {
                 in.remote_address.clear();
             }
             return in;
+        }
+
+        bool load_request_body(
+                const std::shared_ptr<Server::Request>& request,
+                HttpSyncRequest& in) const {
+            if (detail::content_length_exceeds_limit(
+                    request->header, m_config.bounds)) {
+                return false;
+            }
+            const std::string body = request->content.string();
+            if (body.size() >
+                m_config.bounds.max_transport_message_bytes) {
+                return false;
+            }
+            in.body = detail::string_to_bytes(body);
+            return true;
         }
 
         static HttpSyncResponse make_rejected_response(
@@ -432,10 +524,26 @@ namespace simple_web {
             return out;
         }
 
+        static HttpSyncResponse make_payload_too_large_response(
+                const HttpSyncRequest& in) {
+            HttpSyncResponse out;
+            out.status_code = 413;
+            out.content_type = "text/plain; charset=utf-8";
+            http_copy_sync_correlation_headers(in.headers, out.headers);
+            out.error =
+                "HTTP sync request exceeds max_transport_message_bytes";
+            out.body = detail::string_to_bytes(out.error);
+            return out;
+        }
+
         void handle_post(
                 const std::shared_ptr<Server::Response>& response,
                 const std::shared_ptr<Server::Request>& request) {
-            const HttpSyncRequest in = make_request(request);
+            HttpSyncRequest in = make_request_metadata(request);
+            if (!load_request_body(request, in)) {
+                write_response(response, make_payload_too_large_response(in));
+                return;
+            }
             if (m_policy != nullptr) {
                 const SyncTransportDecision decision =
                     m_policy->check_http_request(in);

--- a/include/mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp
+++ b/include/mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp
@@ -104,6 +104,8 @@ namespace simple_web {
         std::string bearer_token;
         /// \brief Simple-WebSocket-Server opcode for binary frames.
         unsigned char binary_frame_opcode = 130;
+        /// \brief Maximum accepted binary request/response size.
+        CodecBounds bounds;
     };
 
     class WebSocketExchangeState {
@@ -164,6 +166,11 @@ namespace simple_web {
         std::vector<std::uint8_t> exchange_binary(
                 const std::vector<std::uint8_t>& binary_message,
                 const CancellationToken& cancel_token) override {
+            if (binary_message.size() >
+                m_config.bounds.max_transport_message_bytes) {
+                throw std::length_error(
+                    "WebSocket sync request exceeds max_transport_message_bytes");
+            }
             if (cancel_token.is_cancellation_requested()) {
                 throw std::runtime_error(
                     "cancelled before WebSocket exchange");
@@ -187,6 +194,7 @@ namespace simple_web {
             const std::string outbound =
                 detail::ws_bytes_to_string(binary_message);
             const unsigned char opcode = m_config.binary_frame_opcode;
+            const CodecBounds bounds = m_config.bounds;
 
             client.on_open =
                 [state, outbound, opcode](
@@ -200,11 +208,18 @@ namespace simple_web {
                 };
 
             client.on_message =
-                [state](
+                [state, bounds](
                     std::shared_ptr<Client::Connection> connection,
                     std::shared_ptr<Client::InMessage> in_message) {
-                    state->set_value(
-                        detail::ws_string_to_bytes(in_message->string()));
+                    const std::string inbound = in_message->string();
+                    if (inbound.size() >
+                        bounds.max_transport_message_bytes) {
+                        state->set_exception(
+                            "WebSocket sync response exceeds max_transport_message_bytes");
+                        connection->send_close(1009);
+                        return;
+                    }
+                    state->set_value(detail::ws_string_to_bytes(inbound));
                     connection->send_close(1000);
                 };
 
@@ -330,6 +345,8 @@ namespace simple_web {
         /// Use this when the same MDBX-backed \c SyncEngine is also touched
         /// by application code while the WebSocket listener is running.
         std::mutex* handler_mutex = nullptr;
+        /// \brief Maximum accepted binary message size before dispatch/decode.
+        CodecBounds bounds;
     };
 
     /// \brief Simple-WebSocket-Server listener binding for
@@ -381,9 +398,16 @@ namespace simple_web {
                         context.authenticated_node =
                             m_config.authenticated_node;
                         context.db_access = m_config.db_access;
+                        const std::string message = in_message->string();
+                        if (message.size() >
+                            m_config.bounds.max_transport_message_bytes) {
+                            connection->send_close(
+                                1009,
+                                "WebSocket sync request exceeds max_transport_message_bytes");
+                            return;
+                        }
                         context.binary_message =
-                            detail::ws_string_to_bytes(
-                                in_message->string());
+                            detail::ws_string_to_bytes(message);
                         std::vector<std::uint8_t> response;
                         if (m_config.handler_mutex != nullptr) {
                             std::lock_guard<std::mutex> lock(

--- a/tests/optional/test_kurlyk_http_transport.cpp
+++ b/tests/optional/test_kurlyk_http_transport.cpp
@@ -13,8 +13,10 @@
 int main() {
     mdbxc::sync::kurlyk::HttpSyncClientConfig config;
     config.base_url = "http://127.0.0.1:18080";
+    config.bounds.max_transport_message_bytes = 1024u;
 
     MDBXC_TEST_ASSERT(config.base_url == "http://127.0.0.1:18080");
+    MDBXC_TEST_ASSERT(config.bounds.max_transport_message_bytes == 1024u);
 
     return 0;
 }

--- a/tests/optional/test_simple_web_http_transport.cpp
+++ b/tests/optional/test_simple_web_http_transport.cpp
@@ -2,6 +2,12 @@
 
 #include "../test_assert.hpp"
 
+#include <cstdlib>
+#include <cstdio>
+#include <cstdint>
+#include <memory>
+#include <string>
+
 #if !defined(MDBXC_HAS_SIMPLE_WEB_HTTP_TRANSPORT)
 #error "Simple-Web HTTP transport target must define its feature macro"
 #endif
@@ -10,13 +16,88 @@
 #error "Simple-Web HTTP transport feature macro must be non-zero"
 #endif
 
+namespace {
+
+mdbxc::sync::NodeId make_node(std::uint8_t seed) {
+    mdbxc::sync::NodeId node{};
+    for (int i = 0; i < 16; ++i) {
+        node[i] = static_cast<std::uint8_t>(seed + i);
+    }
+    return node;
+}
+
+void cleanup(const std::string& path) {
+    std::remove(path.c_str());
+}
+
+std::shared_ptr<mdbxc::Connection> open_env(const std::string& path) {
+    mdbxc::Config config;
+    config.pathname = path;
+    config.no_subdir = true;
+    config.max_dbs = 16;
+    return mdbxc::Connection::create(config);
+}
+
+void test_http_listener_rejects_oversized_body() {
+    const std::string path = "test_simple_web_http_oversized.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<mdbxc::Connection> conn = open_env(path);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x10), make_node(0xD0));
+
+    mdbxc::sync::HttpSyncServer server(engine);
+    mdbxc::sync::simple_web::HttpSyncListenerConfig listener_config;
+    listener_config.host = "127.0.0.1";
+    listener_config.port = 0;
+    listener_config.bounds.max_transport_message_bytes = 4;
+
+    mdbxc::sync::simple_web::HttpSyncListener listener(
+        server, listener_config);
+    listener.start();
+
+    SimpleWeb::Client<SimpleWeb::HTTP> client(
+        std::string("127.0.0.1:") +
+        std::to_string(static_cast<unsigned>(listener.port())));
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    headers.emplace("Content-Type", mdbxc::sync::HttpSyncRoutes::content_type());
+
+    const std::shared_ptr<SimpleWeb::Client<SimpleWeb::HTTP>::Response>
+        response = client.request(
+            "POST",
+            mdbxc::sync::HttpSyncRoutes::pull_target(),
+            "12345",
+            headers);
+
+    listener.stop();
+
+    MDBXC_TEST_ASSERT(std::atoi(response->status_code.c_str()) == 413);
+    MDBXC_TEST_ASSERT(
+        response->content.string().find("max_transport_message_bytes") !=
+        std::string::npos);
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+} // namespace
+
 int main() {
     mdbxc::sync::simple_web::HttpSyncClientConfig config;
     config.host = "127.0.0.1";
     config.port = 18080;
+    config.bounds.max_transport_message_bytes = 32;
 
     MDBXC_TEST_ASSERT(config.host == "127.0.0.1");
     MDBXC_TEST_ASSERT(config.port == 18080u);
+    MDBXC_TEST_ASSERT(config.bounds.max_transport_message_bytes == 32u);
+
+    mdbxc::sync::simple_web::HttpSyncListenerConfig listener_config;
+    listener_config.bounds.max_transport_message_bytes = 64;
+    MDBXC_TEST_ASSERT(
+        listener_config.bounds.max_transport_message_bytes == 64u);
+
+    test_http_listener_rejects_oversized_body();
 
     return 0;
 }

--- a/tests/optional/test_simple_websocket_transport.cpp
+++ b/tests/optional/test_simple_websocket_transport.cpp
@@ -137,6 +137,9 @@ void test_websocket_channel_cancel_unblocks_silent_exchange() {
     mdbxc::sync::simple_web::WebSocketSyncChannelConfig config;
     config.host = "127.0.0.1";
     config.port = server.port();
+    config.bounds.max_transport_message_bytes = 1024u;
+    require_true(config.bounds.max_transport_message_bytes == 1024u,
+                 "WebSocket channel bounds field was not configurable");
     mdbxc::sync::simple_web::WebSocketSyncChannel channel(config);
 
     mdbxc::sync::PullRequest request;
@@ -197,9 +200,32 @@ void test_websocket_channel_cancel_unblocks_silent_exchange() {
                  "WebSocket cancelled exchange reported wrong result");
 }
 
+void test_websocket_channel_rejects_oversized_outbound_message() {
+    mdbxc::sync::simple_web::WebSocketSyncChannelConfig config;
+    config.host = "127.0.0.1";
+    config.port = 1;
+    config.bounds.max_transport_message_bytes = 4u;
+    mdbxc::sync::simple_web::WebSocketSyncChannel channel(config);
+
+    bool rejected = false;
+    try {
+        mdbxc::sync::CancellationToken cancel;
+        std::vector<std::uint8_t> message(5u, 0x42u);
+        (void)channel.exchange_binary(message, cancel);
+    } catch (const std::length_error& e) {
+        rejected =
+            std::string(e.what()).find("max_transport_message_bytes") !=
+            std::string::npos;
+    }
+
+    require_true(rejected,
+                 "WebSocket channel accepted oversized outbound message");
+}
+
 } // namespace
 
 int main() {
     test_websocket_channel_cancel_unblocks_silent_exchange();
+    test_websocket_channel_rejects_oversized_outbound_message();
     return 0;
 }


### PR DESCRIPTION
## Summary
- add CodecBounds knobs to Simple-Web HTTP, Simple-WebSocket, and Kurlyk HTTP transport configs
- reject oversized Simple-Web HTTP Content-Length before adapter body copy, and reject oversized concrete bodies before sync codec decode
- add optional HTTP socket regression plus backend config smoke coverage

## Validation
- git diff --check
- cmake --build tmp\build-pr164-cpp11-mingw --target header_sync_transport_umbrella_test header_all_umbrella_test test_http_transport test_websocket_transport test_transport_middleware
- ctest --test-dir tmp\build-pr164-cpp11-mingw -R (header_sync_transport_umbrella_test|header_all_umbrella_test|test_http_transport|test_websocket_transport|test_transport_middleware)$ --output-on-failure
- cmake --build tmp\build-pr164-cpp17-mingw --target header_sync_transport_umbrella_test header_all_umbrella_test test_http_transport test_websocket_transport test_transport_middleware
- ctest --test-dir tmp\build-pr164-cpp17-mingw -R (header_sync_transport_umbrella_test|header_all_umbrella_test|test_http_transport|test_websocket_transport|test_transport_middleware)$ --output-on-failure
- cmake -S . -B tmp\build-pr170-simple-http-cpp11-mingw ... -DMDBXC_SIMPLE_WEB_HTTP_TRANSPORT=ON
- cmake --build tmp\build-pr170-simple-http-cpp11-mingw --target test_simple_web_http_transport
- ctest --test-dir tmp\build-pr170-simple-http-cpp11-mingw -R test_simple_web_http_transport$ --output-on-failure
- cmake -S . -B tmp\build-pr170-simple-http-cpp17-mingw ... -DMDBXC_SIMPLE_WEB_HTTP_TRANSPORT=ON
- cmake --build tmp\build-pr170-simple-http-cpp17-mingw --target test_simple_web_http_transport
- ctest --test-dir tmp\build-pr170-simple-http-cpp17-mingw -R test_simple_web_http_transport$ --output-on-failure
- cmake -S . -B tmp\build-pr170-simple-ws-cpp17-mingw ... -DMDBXC_SIMPLE_WEB_WEBSOCKET_TRANSPORT=ON
- cmake --build tmp\build-pr170-simple-ws-cpp17-mingw --target test_simple_websocket_transport
- ctest --test-dir tmp\build-pr170-simple-ws-cpp17-mingw -R test_simple_websocket_transport$ --output-on-failure
- cmake -S . -B tmp\build-pr170-kurlyk-cpp17-mingw ... -DMDBXC_KURLYK_HTTP_TRANSPORT=ON
- cmake --build tmp\build-pr170-kurlyk-cpp17-mingw --target test_kurlyk_http_transport
- ctest --test-dir tmp\build-pr170-kurlyk-cpp17-mingw -R test_kurlyk_http_transport$ --output-on-failure