### PR TITLE
feat(sync): cap rate-limit buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this project will be documented in this file.
   `VectorStore` operations do not run concurrently with remote
   `SyncEngine::handle_push()` apply commits; one `VectorStore` instance still
   serializes its own public methods.
+- Added optional bucket caps and expired-bucket eviction to
+  `FixedWindowHttpRateLimitPolicy`.
 - Added `CodecBounds` knobs to ready-made Simple-Web HTTP, Simple-WebSocket,
   and Kurlyk HTTP transport configs so oversized concrete transport bodies are
   rejected before sync codec decode.

--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -100,7 +100,6 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
 - Transport-level pre-buffer limits: configure framework/library request,
   response, and WebSocket frame caps, or abort through streaming callbacks
   before the complete payload is retained in memory.
-- Rate-limit bucket eviction / hard caps.
 - WebSocket connect/response/request deadlines.
 - Installed package fallback for lowercase-only `mdbxConfig.cmake`.
 - Clarify `PullRequest::max_bytes` as a soft page budget and add a separate

--- a/guides/sync-transport-production.md
+++ b/guides/sync-transport-production.md
@@ -150,6 +150,12 @@ retryable flag plus an optional relative `Retry-After` delay. The helper parses
 only `Retry-After: <delta-seconds>`; concrete HTTP bindings should handle
 absolute HTTP-date values if they need clock-aware behavior.
 
+`FixedWindowHttpRateLimitPolicy` can cap the number of tracked client identity
+buckets with its optional third constructor argument. A zero cap keeps the
+previous unbounded behavior. When the cap is non-zero, expired windows are
+evicted before admitting a new identity; if no bucket can be freed, the request
+is rejected with `429` and `Retry-After`.
+
 For WebSocket, close codes `1001`, `1005`, `1006`, `1011`, `1012`, `1013`, and
 `1014` are retryable by default. Close codes produced by policy, malformed
 payload, and size limits, such as `1007`, `1008`, and `1009`, are permanent

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -735,8 +735,11 @@ server/middleware, but they are not serialized inside sync DTOs.
 `FixedBudgetSyncTransportPolicy` is a deterministic fixed-budget limiter useful
 for tests, examples, and simple adapters; production adapters can replace it
 with a time-window or token-bucket policy while keeping the same middleware
-shape. `SyncTransportMetricsObserver` records basic call, rejection, failure,
-cancel, and batch counters without changing transport behavior.
+shape. `FixedWindowHttpRateLimitPolicy` accepts an optional non-zero bucket cap;
+expired identity buckets are evicted before a new identity is rejected with
+`429` and `Retry-After`. `SyncTransportMetricsObserver` records basic call,
+rejection, failure, cancel, and batch counters without changing transport
+behavior.
 `TransportMessageSizePolicy` is a pre-decode guard for HTTP bodies and
 WebSocket binary messages. It complements `CodecBounds`: adapters can reject
 oversized transport frames before decoding, while the codec still validates the

--- a/include/mdbx_containers/sync/TransportMiddleware.hpp
+++ b/include/mdbx_containers/sync/TransportMiddleware.hpp
@@ -680,12 +680,17 @@ namespace sync {
     /// \brief Fixed-window HTTP request limiter keyed by token or remote address.
     /// \details Uses the bearer token when present, otherwise \c remote_address,
     /// otherwise the literal "anonymous". Rejections include a \c Retry-After
-    /// header with the remaining window time in seconds.
+    /// header with the remaining window time in seconds. \p max_buckets caps
+    /// tracked client identities when non-zero; expired buckets are evicted
+    /// before a new identity is rejected.
     class FixedWindowHttpRateLimitPolicy : public ISyncTransportPolicy {
     public:
         FixedWindowHttpRateLimitPolicy(std::uint64_t max_requests,
-                                       std::chrono::seconds window)
-            : m_max_requests(max_requests), m_window(window) {
+                                       std::chrono::seconds window,
+                                       std::size_t max_buckets = 0)
+            : m_max_requests(max_requests),
+              m_window(window),
+              m_max_buckets(max_buckets) {
             if (window.count() <= 0) {
                 throw std::invalid_argument(
                     "HTTP rate-limit window must be positive");
@@ -697,6 +702,11 @@ namespace sync {
             m_buckets.clear();
         }
 
+        std::size_t bucket_count() const {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            return m_buckets.size();
+        }
+
         SyncTransportDecision check_http_request(
                 const HttpSyncRequest& request) override {
             const std::chrono::steady_clock::time_point now =
@@ -704,7 +714,25 @@ namespace sync {
             const std::string identity = client_identity(request);
 
             std::lock_guard<std::mutex> lock(m_mutex);
-            Bucket& bucket = m_buckets[identity];
+            std::map<std::string, Bucket>::iterator it =
+                m_buckets.find(identity);
+            if (it == m_buckets.end()) {
+                evict_expired_buckets(now);
+                if (m_max_buckets != 0 &&
+                    m_buckets.size() >= m_max_buckets) {
+                    SyncTransportDecision decision =
+                        SyncTransportDecision::reject(
+                            "sync HTTP rate-limit bucket cap exceeded", 429);
+                    decision.add_response_header(
+                        "Retry-After",
+                        retry_after_seconds(now, earliest_reset_at()));
+                    return decision;
+                }
+                it = m_buckets.insert(
+                    std::make_pair(identity, Bucket())).first;
+            }
+
+            Bucket& bucket = it->second;
             if (bucket.reset_at == std::chrono::steady_clock::time_point() ||
                 now >= bucket.reset_at) {
                 bucket.remaining = m_max_requests;
@@ -759,9 +787,38 @@ namespace sync {
             return std::to_string(count);
         }
 
+        void evict_expired_buckets(
+                std::chrono::steady_clock::time_point now) {
+            for (std::map<std::string, Bucket>::iterator it =
+                     m_buckets.begin();
+                 it != m_buckets.end();) {
+                if (it->second.reset_at !=
+                        std::chrono::steady_clock::time_point() &&
+                    now >= it->second.reset_at) {
+                    m_buckets.erase(it++);
+                } else {
+                    ++it;
+                }
+            }
+        }
+
+        std::chrono::steady_clock::time_point earliest_reset_at() const {
+            std::chrono::steady_clock::time_point earliest;
+            for (std::map<std::string, Bucket>::const_iterator it =
+                     m_buckets.begin();
+                 it != m_buckets.end(); ++it) {
+                if (earliest == std::chrono::steady_clock::time_point() ||
+                    it->second.reset_at < earliest) {
+                    earliest = it->second.reset_at;
+                }
+            }
+            return earliest;
+        }
+
         mutable std::mutex m_mutex;
         std::uint64_t m_max_requests;
         std::chrono::seconds m_window;
+        std::size_t m_max_buckets;
         std::map<std::string, Bucket> m_buckets;
     };
 

--- a/tests/test_transport_middleware.cpp
+++ b/tests/test_transport_middleware.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace {
@@ -845,6 +846,38 @@ void test_transport_zero_limit_policies() {
                  "zero HTTP post budget must reject");
 }
 
+void test_http_rate_limit_bucket_cap_and_eviction() {
+    mdbxc::sync::FixedWindowHttpRateLimitPolicy rate(
+        1u, std::chrono::seconds(1), 1u);
+
+    mdbxc::sync::HttpSyncRequest first;
+    first.remote_address = "192.0.2.1";
+    mdbxc::sync::SyncTransportDecision decision =
+        rate.check_http_request(first);
+    require_true(decision.allowed, "first capped rate-limit bucket rejected");
+    require_true(rate.bucket_count() == 1u,
+                 "rate-limit bucket cap did not track first identity");
+
+    mdbxc::sync::HttpSyncRequest second;
+    second.remote_address = "192.0.2.2";
+    decision = rate.check_http_request(second);
+    require_true(!decision.allowed && decision.status_code == 429,
+                 "rate-limit bucket cap did not reject new identity");
+    require_true(mdbxc::sync::http_header_value(
+                     decision.response_headers, "Retry-After") !=
+                     std::string(),
+                 "rate-limit bucket cap rejection omitted Retry-After");
+    require_true(rate.bucket_count() == 1u,
+                 "rate-limit bucket cap allowed bucket growth");
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+    decision = rate.check_http_request(second);
+    require_true(decision.allowed,
+                 "expired rate-limit bucket was not evicted for new identity");
+    require_true(rate.bucket_count() == 1u,
+                 "rate-limit bucket eviction left stale buckets");
+}
+
 void test_http_client_middleware_copies_rejection_headers() {
     mdbxc::sync::FixedWindowHttpRateLimitPolicy rate(
         0, std::chrono::seconds(7));
@@ -931,6 +964,7 @@ int main() {
     test_websocket_retry_hint();
     test_transport_message_size_policy();
     test_transport_zero_limit_policies();
+    test_http_rate_limit_bucket_cap_and_eviction();
     test_http_client_middleware_copies_rejection_headers();
     test_http_server_middleware_copies_rejection_headers();
     return 0;


### PR DESCRIPTION
## Summary
- add an optional max bucket cap to FixedWindowHttpRateLimitPolicy
- evict expired identity buckets before rejecting new identities
- return 429 + Retry-After when the hard bucket cap is still full
- document the cap/eviction contract and close the audit follow-up

## Validation
- cmake --build tmp\build-pr164-cpp11-mingw --target test_transport_middleware header_all_umbrella_test
- cmake --build tmp\build-pr164-cpp17-mingw --target test_transport_middleware header_all_umbrella_test
- ctest --test-dir tmp\build-pr164-cpp11-mingw -R (test_transport_middleware|header_all_umbrella_test)$ --output-on-failure
- ctest --test-dir tmp\build-pr164-cpp17-mingw -R (test_transport_middleware|header_all_umbrella_test)$ --output-on-failure