### PR TITLE
feat(sync): add websocket exchange deadlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this project will be documented in this file.
   serializes its own public methods.
 - Added optional bucket caps and expired-bucket eviction to
   `FixedWindowHttpRateLimitPolicy`.
+- Added `WebSocketSyncChannelConfig::exchange_timeout` for the ready-made
+  Simple-WebSocket client binding.
 - Added `CodecBounds` knobs to ready-made Simple-Web HTTP, Simple-WebSocket,
   and Kurlyk HTTP transport configs so oversized concrete transport bodies are
   rejected before sync codec decode.

--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -100,7 +100,6 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
 - Transport-level pre-buffer limits: configure framework/library request,
   response, and WebSocket frame caps, or abort through streaming callbacks
   before the complete payload is retained in memory.
-- WebSocket connect/response/request deadlines.
 - Installed package fallback for lowercase-only `mdbxConfig.cmake`.
 - Clarify `PullRequest::max_bytes` as a soft page budget and add a separate
   max single-batch limit.

--- a/guides/sync-transport-production.md
+++ b/guides/sync-transport-production.md
@@ -160,6 +160,9 @@ For WebSocket, close codes `1001`, `1005`, `1006`, `1011`, `1012`, `1013`, and
 `1014` are retryable by default. Close codes produced by policy, malformed
 payload, and size limits, such as `1007`, `1008`, and `1009`, are permanent
 until the request or session changes.
+The ready-made Simple-WebSocket client binding exposes `exchange_timeout` as a
+whole-exchange deadline covering connect, request send, and response wait. A
+zero timeout disables the deadline; negative values are rejected.
 
 Concrete ready-made transport bindings expose `CodecBounds` in their config
 objects and reject oversized request/response bodies before handing bytes to

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -635,6 +635,10 @@ adapter owns its timeout configuration and is responsible for
 honoring it. An adapter that cannot bound a blocking call without
 the core's help must say so explicitly in its documentation; do not
 silently block forever on the worker thread.
+The ready-made Simple-WebSocket client binding exposes
+`WebSocketSyncChannelConfig::exchange_timeout` as a whole-exchange deadline
+covering connect, request send, and response wait. Zero disables the deadline;
+negative values are rejected.
 
 The timeout policy that does belong to the core is the worker
 backoff loop: repeated pull failures increase the wait between

--- a/include/mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp
+++ b/include/mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp
@@ -33,6 +33,8 @@
 #include <server_ws.hpp>
 
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <exception>
 #include <future>
@@ -106,6 +108,9 @@ namespace simple_web {
         unsigned char binary_frame_opcode = 130;
         /// \brief Maximum accepted binary request/response size.
         CodecBounds bounds;
+        /// \brief Whole exchange deadline. Zero disables the deadline.
+        std::chrono::milliseconds exchange_timeout =
+            std::chrono::milliseconds::zero();
     };
 
     class WebSocketExchangeState {
@@ -135,6 +140,32 @@ namespace simple_web {
         std::mutex m_mutex;
         bool m_completed = false;
         std::promise<std::vector<std::uint8_t> > m_promise;
+    };
+
+    class WebSocketDeadlineSignal {
+    public:
+        bool wait_until_finished(std::chrono::milliseconds timeout) {
+            std::unique_lock<std::mutex> lock(m_mutex);
+            if (!m_finished) {
+                m_changed.wait_for(lock, timeout, [this]() {
+                    return m_finished;
+                });
+            }
+            return m_finished;
+        }
+
+        void finish() {
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                m_finished = true;
+            }
+            m_changed.notify_all();
+        }
+
+    private:
+        std::mutex m_mutex;
+        std::condition_variable m_changed;
+        bool m_finished = false;
     };
 
     /// \brief Simple-WebSocket-Server channel binding for
@@ -175,6 +206,10 @@ namespace simple_web {
                 throw std::runtime_error(
                     "cancelled before WebSocket exchange");
             }
+            if (m_config.exchange_timeout.count() < 0) {
+                throw std::invalid_argument(
+                    "WebSocket exchange_timeout must not be negative");
+            }
 
             const std::uint64_t call_generation =
                 m_cancel_generation.load(std::memory_order_acquire);
@@ -195,6 +230,10 @@ namespace simple_web {
                 detail::ws_bytes_to_string(binary_message);
             const unsigned char opcode = m_config.binary_frame_opcode;
             const CodecBounds bounds = m_config.bounds;
+            const std::chrono::milliseconds exchange_timeout =
+                m_config.exchange_timeout;
+            std::shared_ptr<WebSocketDeadlineSignal> deadline_signal(
+                new WebSocketDeadlineSignal());
 
             client.on_open =
                 [state, outbound, opcode](
@@ -256,7 +295,31 @@ namespace simple_web {
                 throw std::runtime_error("cancelled before WebSocket start");
             }
 
-            client.start();
+            std::thread deadline_thread;
+            if (exchange_timeout.count() > 0) {
+                deadline_thread = std::thread(
+                    [state, deadline_signal, exchange_timeout, &client]() {
+                        if (!deadline_signal->wait_until_finished(
+                                exchange_timeout)) {
+                            state->set_exception(
+                                "WebSocket exchange deadline exceeded");
+                            client.stop();
+                        }
+                    });
+            }
+            try {
+                client.start();
+            } catch (...) {
+                deadline_signal->finish();
+                if (deadline_thread.joinable()) {
+                    deadline_thread.join();
+                }
+                throw;
+            }
+            deadline_signal->finish();
+            if (deadline_thread.joinable()) {
+                deadline_thread.join();
+            }
             if (cancel_token.is_cancellation_requested() ||
                 m_cancel_generation.load(std::memory_order_acquire) !=
                     call_generation) {

--- a/tests/optional/test_simple_websocket_transport.cpp
+++ b/tests/optional/test_simple_websocket_transport.cpp
@@ -222,10 +222,83 @@ void test_websocket_channel_rejects_oversized_outbound_message() {
                  "WebSocket channel accepted oversized outbound message");
 }
 
+void test_websocket_channel_deadline_unblocks_silent_exchange() {
+    SilentWebSocketServer server;
+    server.start();
+
+    mdbxc::sync::simple_web::WebSocketSyncChannelConfig config;
+    config.host = "127.0.0.1";
+    config.port = server.port();
+    config.bounds.max_transport_message_bytes = 1024u;
+    config.exchange_timeout = std::chrono::milliseconds(50);
+    mdbxc::sync::simple_web::WebSocketSyncChannel channel(config);
+
+    mdbxc::sync::PullRequest request;
+    request.requester = make_node(0x20);
+    request.db_id = make_node(0xD0);
+    const std::vector<std::uint8_t> message =
+        mdbxc::sync::TransportMessageCodec::encode_pull_request(request);
+
+    std::promise<std::string> result_promise;
+    std::future<std::string> result = result_promise.get_future();
+    mdbxc::sync::CancellationSource cancel;
+    std::thread client(
+        [&channel, &message, &cancel, &result_promise]() {
+            try {
+                (void)channel.exchange_binary(message, cancel.token());
+                result_promise.set_value("completed");
+            } catch (const std::exception& e) {
+                result_promise.set_value(e.what());
+            } catch (...) {
+                result_promise.set_value("unknown");
+            }
+        });
+
+    const bool exchange_ready =
+        result.wait_for(std::chrono::seconds(5)) ==
+        std::future_status::ready;
+    if (!exchange_ready) {
+        channel.request_cancel();
+    }
+    if (client.joinable()) {
+        client.join();
+    }
+    server.stop();
+
+    require_true(exchange_ready,
+                 "WebSocket exchange did not unblock after deadline");
+    require_true(result.get().find("deadline") != std::string::npos,
+                 "WebSocket deadline exchange reported wrong result");
+}
+
+void test_websocket_channel_rejects_negative_deadline() {
+    mdbxc::sync::simple_web::WebSocketSyncChannelConfig config;
+    config.host = "127.0.0.1";
+    config.port = 1;
+    config.exchange_timeout = std::chrono::milliseconds(-1);
+    mdbxc::sync::simple_web::WebSocketSyncChannel channel(config);
+
+    bool rejected = false;
+    try {
+        mdbxc::sync::CancellationToken cancel;
+        std::vector<std::uint8_t> message(1u, 0x42u);
+        (void)channel.exchange_binary(message, cancel);
+    } catch (const std::invalid_argument& e) {
+        rejected =
+            std::string(e.what()).find("exchange_timeout") !=
+            std::string::npos;
+    }
+
+    require_true(rejected,
+                 "WebSocket channel accepted a negative exchange deadline");
+}
+
 } // namespace
 
 int main() {
     test_websocket_channel_cancel_unblocks_silent_exchange();
     test_websocket_channel_rejects_oversized_outbound_message();
+    test_websocket_channel_deadline_unblocks_silent_exchange();
+    test_websocket_channel_rejects_negative_deadline();
     return 0;
 }


### PR DESCRIPTION
## Summary
- add WebSocketSyncChannelConfig::exchange_timeout
- enforce a whole-exchange client deadline covering connect, send, and response wait
- reject negative deadlines and keep zero as disabled
- add Simple-WebSocket deadline regressions

## Validation
- cmake --build tmp\build-pr170-simple-ws-cpp17-mingw --target test_simple_websocket_transport
- ctest --test-dir tmp\build-pr170-simple-ws-cpp17-mingw -R test_simple_websocket_transport$ --output-on-failure