### PR TITLE
build: support lowercase mdbx package config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,18 @@ jobs:
           set(MDBX_FOUND TRUE)
           EOF
 
+      - name: Create lowercase fake mdbx package
+        run: |
+          set -euo pipefail
+          fake_dir="$PWD/build-fake-lowercase-mdbx/lib/cmake/mdbx"
+          mkdir -p "$fake_dir"
+          cat >"$fake_dir/mdbxConfig.cmake" <<EOF
+          add_library(libmdbx::mdbx INTERFACE IMPORTED)
+          set_target_properties(libmdbx::mdbx PROPERTIES
+              INTERFACE_INCLUDE_DIRECTORIES "$PWD/external/libmdbx")
+          set(mdbx_FOUND TRUE)
+          EOF
+
       - name: Install mdbx-containers package
         run: |
           set -euo pipefail
@@ -116,6 +128,21 @@ jobs:
         run: |
           set -euo pipefail
           cmake --build build-installed-transport-backend --parallel
+
+      - name: Configure installed consumer with lowercase mdbxConfig
+        run: |
+          set -euo pipefail
+          cmake -S tests/cmake/installed_lowercase_mdbx \
+            -B build-installed-lowercase-mdbx -G "Ninja" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_STANDARD=11 \
+            -DCMAKE_PREFIX_PATH="$PWD/build-install-prefix;$PWD/build-fake-lowercase-mdbx" \
+            -Wno-dev
+
+      - name: Build installed consumer with lowercase mdbxConfig
+        run: |
+          set -euo pipefail
+          cmake --build build-installed-lowercase-mdbx --parallel
 
       - name: Check provider argument validation
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file.
   `FixedWindowHttpRateLimitPolicy`.
 - Added `WebSocketSyncChannelConfig::exchange_timeout` for the ready-made
   Simple-WebSocket client binding.
+- Added installed-package fallback for lowercase `mdbxConfig.cmake` and common
+  libmdbx target-name variants.
 - Added `CodecBounds` knobs to ready-made Simple-Web HTTP, Simple-WebSocket,
   and Kurlyk HTTP transport configs so oversized concrete transport bodies are
   rejected before sync codec decode.

--- a/cmake/mdbx_containersConfig.cmake.in
+++ b/cmake/mdbx_containersConfig.cmake.in
@@ -5,9 +5,40 @@
 set(mdbx_containers_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
 
 include(CMakeFindDependencyMacro)
-find_dependency(MDBX CONFIG)
+find_package(MDBX CONFIG QUIET)
 if(NOT MDBX_FOUND)
     find_dependency(mdbx CONFIG)
+endif()
+
+function(_mdbxc_alias_mdbx_target maybe_target alias_target)
+    if(TARGET ${maybe_target} AND NOT TARGET ${alias_target})
+        get_target_property(_mdbxc_aliased_target ${maybe_target}
+            ALIASED_TARGET)
+        if(_mdbxc_aliased_target)
+            add_library(${alias_target} ALIAS ${_mdbxc_aliased_target})
+        else()
+            add_library(${alias_target} ALIAS ${maybe_target})
+        endif()
+    endif()
+endfunction()
+
+_mdbxc_alias_mdbx_target(mdbx mdbx::mdbx)
+_mdbxc_alias_mdbx_target(libmdbx libmdbx::mdbx)
+_mdbxc_alias_mdbx_target(mdbx-static mdbx::mdbx-static)
+_mdbxc_alias_mdbx_target(mdbx_static mdbx::mdbx-static)
+_mdbxc_alias_mdbx_target(libmdbx-static libmdbx::mdbx-static)
+_mdbxc_alias_mdbx_target(libmdbx_static libmdbx::mdbx-static)
+_mdbxc_alias_mdbx_target(libmdbx::mdbx mdbx::mdbx)
+_mdbxc_alias_mdbx_target(libmdbx::mdbx-static mdbx::mdbx-static)
+if(NOT TARGET mdbx::mdbx AND TARGET mdbx::mdbx-static)
+    _mdbxc_alias_mdbx_target(mdbx::mdbx-static mdbx::mdbx)
+endif()
+if(NOT TARGET mdbx::mdbx)
+    message(FATAL_ERROR
+        "mdbx_containers requires a package-provided MDBX target. "
+        "Expected mdbx::mdbx, mdbx, libmdbx::mdbx, libmdbx, or a static "
+        "variant from find_dependency(MDBX CONFIG) or "
+        "find_dependency(mdbx CONFIG).")
 endif()
 
 # Pull in the exported targets (namespace mdbx_containers::)

--- a/guides/build-and-test.md
+++ b/guides/build-and-test.md
@@ -54,6 +54,11 @@ The returned targets are `mdbx_containers::simple_web_http_transport`,
 link `mdbx_containers::mdbx_containers`, fetch or find the optional backend
 dependencies, and propagate the matching `MDBXC_HAS_*_TRANSPORT` macro.
 
+Installed `mdbx-containers` packages first look for `MDBXConfig.cmake` and then
+fall back to lowercase `mdbxConfig.cmake`. The installed config normalizes
+common target names such as `mdbx`, `libmdbx::mdbx`, and static variants to the
+canonical `mdbx::mdbx` target used by the exported library target.
+
 When `mdbx-containers` is added as a subproject, existing parent-provided
 `mdbx::mdbx`, `mdbx::mdbx-static`, `libmdbx::mdbx`, and
 `libmdbx::mdbx-static` targets are reused before package, submodule, or

--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -100,6 +100,5 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
 - Transport-level pre-buffer limits: configure framework/library request,
   response, and WebSocket frame caps, or abort through streaming callbacks
   before the complete payload is retained in memory.
-- Installed package fallback for lowercase-only `mdbxConfig.cmake`.
 - Clarify `PullRequest::max_bytes` as a soft page budget and add a separate
   max single-batch limit.

--- a/tests/cmake/installed_lowercase_mdbx/CMakeLists.txt
+++ b/tests/cmake/installed_lowercase_mdbx/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.18)
+
+project(mdbxc_installed_lowercase_mdbx LANGUAGES CXX)
+
+find_package(mdbx_containers CONFIG REQUIRED)
+
+if(NOT TARGET mdbx::mdbx)
+    message(FATAL_ERROR "lowercase mdbxConfig did not provide mdbx::mdbx")
+endif()
+
+add_library(installed_lowercase_mdbx_smoke OBJECT main.cpp)
+target_compile_features(installed_lowercase_mdbx_smoke PRIVATE cxx_std_11)
+target_link_libraries(installed_lowercase_mdbx_smoke PRIVATE
+    mdbx_containers::mdbx_containers)

--- a/tests/cmake/installed_lowercase_mdbx/main.cpp
+++ b/tests/cmake/installed_lowercase_mdbx/main.cpp
@@ -1,0 +1,7 @@
+#include <mdbx_containers.hpp>
+
+int main() {
+    mdbxc::Config config;
+    config.max_dbs = 4;
+    return config.max_dbs == 4 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- make the installed package config fall back from MDBXConfig.cmake to lowercase mdbxConfig.cmake
- normalize common libmdbx target variants to mdbx::mdbx for exported targets
- add a minimal installed-package consumer smoke for lowercase-only mdbxConfig.cmake
- add the smoke to CI

## Validation
- local installed-package smoke with uppercase fake MDBX for install and lowercase fake mdbxConfig.cmake exporting libmdbx::mdbx for the consumer
- cmake --build tmp\build-pr-cmake-lowercase-consumer