### PR TITLE
feat(sync): split pull page and batch byte budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
-- Breaking transport-wire change: `TransportMessageCodec` is now version 3 and
-  response DTOs include `SyncResponseErrorCode` plus `error_retryable` after
-  the human-readable error string.
+- Breaking transport-wire change: `TransportMessageCodec` is now version 4.
+  Response DTOs include `SyncResponseErrorCode` plus `error_retryable` after
+  the human-readable error string, and pull request DTOs include
+  `max_single_batch_bytes` after the full-snapshot flag.
+- Clarified `PullRequest::max_bytes` as a soft page budget and added
+  `PullRequest::max_single_batch_bytes` plus `BatchTooLarge` rejection for
+  retained changelog batches that exceed the hard per-batch limit.
 - Added `SyncResponseErrorCode::SnapshotRequired` so pull requests behind
   retained changelog history fail explicitly instead of streaming
   non-contiguous batches.

--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -100,5 +100,3 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
 - Transport-level pre-buffer limits: configure framework/library request,
   response, and WebSocket frame caps, or abort through streaming callbacks
   before the complete payload is retained in memory.
-- Clarify `PullRequest::max_bytes` as a soft page budget and add a separate
-  max single-batch limit.

--- a/guides/sync-transport-production.md
+++ b/guides/sync-transport-production.md
@@ -173,6 +173,14 @@ the buffered body. Simple-WebSocket and Kurlyk/libcurl also guard before sync
 decode, but their underlying libraries may already have buffered the frame or
 response content.
 
+Pull pagination has two separate byte budgets. `PullRequest::max_bytes` is a
+soft page target: if the next retained changelog batch is larger than the page
+target, the responder may still return that one batch so progress remains
+possible. `PullRequest::max_single_batch_bytes` is the hard limit for one
+encoded retained batch. A batch above that value returns
+`SyncResponseErrorCode::BatchTooLarge` and no page data; the caller must raise
+the limit, reduce writer-side batch size, or use an out-of-band snapshot path.
+
 Concrete `ISyncPeer` implementations that can classify transport failures
 should publish the most recent hint through `ISyncPeer::last_retry_hint()`.
 The default hint is unavailable, which means the peer did not provide advice

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -413,7 +413,7 @@ payload itself.
 Locked contract:
 
 - Magic: 8 bytes `MDBXCPRT`.
-- Version: u16 little-endian, currently `3`.
+- Version: u16 little-endian, currently `4`.
 - Message type: u8 (`1=PullRequest`, `2=PullResponse`, `3=PushRequest`,
   `4=PushResponse`).
 - Message flags: u32 little-endian, currently zero. Unknown non-zero flags are
@@ -426,6 +426,10 @@ Locked contract:
 - `PullResponse` carries both `remote_have` (responder applied cursor) and
   optional `remote_tail` (responder changelog tail) so receivers can report
   catch-up progress without changing pagination semantics.
+- `PullRequest::max_bytes` is a soft page budget. A responder may return one
+  retained changelog batch whose encoded size exceeds `max_bytes` when that
+  batch is the next required batch. `PullRequest::max_single_batch_bytes` is
+  the hard per-batch budget; exceeding it returns `BatchTooLarge`.
 - `PullResponse` and `PushResponse` carry a structured
   `SyncResponseErrorCode` plus an `error_retryable` boolean after their
   human-readable error string. `None` means no structured sync-level
@@ -435,8 +439,11 @@ Locked contract:
   fresher cursor, while DBI flag conflicts and unsupported full snapshots are
   permanent until the caller changes behavior. `SnapshotRequired` means the
   requested changelog range was pruned and cannot be recovered through
-  incremental pull. Transport-local errors remain represented by adapter
-  status, close codes, response headers, and `SyncTransportRetryHint`.
+  incremental pull. `BatchTooLarge` means a retained changelog entry exceeds
+  the requester's hard per-batch limit and is permanent until the requester
+  raises that limit or obtains the data through another path. Transport-local
+  errors remain represented by adapter status, close codes, response headers,
+  and `SyncTransportRetryHint`.
 - `CancellationToken` fields in request DTOs are local call-control state and
   are never serialized. Decoded request DTOs contain default non-cancellable
   tokens.

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -268,8 +268,10 @@ namespace sync {
         /// \c request.db_id against the local \c db_uuid; mismatched peers
         /// receive an empty response with \c ok=false.
         /// \c has_more is set to \c true when the loop stopped because of
-        /// \c request.max_batches or \c request.max_bytes rather than
-        /// running out of changelog entries.
+        /// \c request.max_batches or the soft page budget
+        /// \c request.max_bytes rather than running out of changelog entries.
+        /// A single retained batch may exceed \c max_bytes but is rejected
+        /// when it exceeds \c request.max_single_batch_bytes.
         PullResponse handle_pull(const PullRequest& request) {
             PullResponse out;
             if (!db_id_matches(request.db_id)) {
@@ -320,7 +322,10 @@ namespace sync {
         /// still used for exact \c have_seq+1 seeks so old values are not
         /// decoded.
         /// Sets \c has_more=true when the walk stopped because of
-        /// \c request.max_batches or \c request.max_bytes.
+        /// \c request.max_batches or the soft page budget
+        /// \c request.max_bytes. A single retained batch may exceed
+        /// \c max_bytes but is rejected when it exceeds
+        /// \c request.max_single_batch_bytes.
         PullResponse pull_changelog_page(MDBX_txn* txn, MDBX_dbi dbi,
                                         const PullRequest& request) {
             PullResponse out;
@@ -349,6 +354,9 @@ namespace sync {
                 }
                 if (pull_origin_batches(txn, dbi, origins[i].origin,
                                         request, out, total_bytes)) {
+                    if (!out.ok) {
+                        return out;
+                    }
                     truncated = true;
                     break;
                 }
@@ -758,6 +766,24 @@ namespace sync {
             out.error += ")";
         }
 
+        static void set_batch_too_large(PullResponse& out,
+                                        const NodeId& origin,
+                                        std::uint64_t seq,
+                                        std::uint64_t batch_bytes,
+                                        std::uint64_t limit) {
+            (void)origin;
+            out.ok = false;
+            out.batches.clear();
+            out.has_more = false;
+            out.error_code = SyncResponseErrorCode::BatchTooLarge;
+            out.error_retryable = false;
+            out.error = "retained changelog batch exceeds max_single_batch_bytes";
+            out.error += " (seq=" + std::to_string(seq);
+            out.error += ", batch_bytes=" + std::to_string(batch_bytes);
+            out.error += ", max_single_batch_bytes=" + std::to_string(limit);
+            out.error += ")";
+        }
+
         static bool request_has_retained_start(MDBX_txn* txn,
                                                MDBX_dbi dbi,
                                                const PullOrigin& origin,
@@ -894,6 +920,13 @@ namespace sync {
                 }
 
                 const std::uint64_t key_seq = changelog_key_seq(k);
+                if (v.iov_len > request.max_single_batch_bytes) {
+                    set_batch_too_large(
+                        out, origin, key_seq,
+                        static_cast<std::uint64_t>(v.iov_len),
+                        request.max_single_batch_bytes);
+                    return true;
+                }
                 std::vector<std::uint8_t> buf(v.iov_len);
                 if (v.iov_len > 0) {
                     std::memcpy(buf.data(), v.iov_base, v.iov_len);

--- a/include/mdbx_containers/sync/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/SyncWorker.hpp
@@ -64,6 +64,12 @@ namespace sync {
         /// \brief Max encoded batch bytes requested from the peer per pull page.
         std::uint64_t max_bytes = 4ULL * 1024ULL * 1024ULL;
 
+        /// \brief Hard limit for one encoded retained changelog batch.
+        /// \details \c max_bytes is a soft page budget; a peer may still
+        /// return one batch larger than \c max_bytes when that batch fits
+        /// this per-batch limit.
+        std::uint64_t max_single_batch_bytes = 4ULL * 1024ULL * 1024ULL;
+
         /// \brief Delay between successful background sync rounds.
         std::chrono::milliseconds idle_interval =
             std::chrono::milliseconds(1000);
@@ -481,6 +487,10 @@ namespace sync {
                 throw std::invalid_argument(
                     "SyncWorkerOptions::max_bytes must be greater than zero");
             }
+            if (options.max_single_batch_bytes == 0) {
+                throw std::invalid_argument(
+                    "SyncWorkerOptions::max_single_batch_bytes must be greater than zero");
+            }
             if (options.idle_interval < std::chrono::milliseconds::zero()) {
                 throw std::invalid_argument(
                     "SyncWorkerOptions::idle_interval must not be negative");
@@ -512,6 +522,8 @@ namespace sync {
                 request.have = m_engine.applied_cursor();
                 request.max_batches = m_options.max_batches;
                 request.max_bytes = m_options.max_bytes;
+                request.max_single_batch_bytes =
+                    m_options.max_single_batch_bytes;
 
                 bool has_more = false;
                 do {

--- a/include/mdbx_containers/sync/TransportMessageCodec.hpp
+++ b/include/mdbx_containers/sync/TransportMessageCodec.hpp
@@ -8,7 +8,7 @@
 /// Envelope layout for all messages:
 /// \code
 ///   magic             "MDBXCPRT"   8 bytes
-///   codec_version     u16 le       = 3
+///   codec_version     u16 le       = 4
 ///   message_type      u8           1=pull request, 2=pull response,
 ///                                  3=push request, 4=push response
 ///   message_flags     u32 le       = 0 in v0.1
@@ -61,7 +61,7 @@ namespace sync {
         static std::size_t magic_size() { return 8; }
 
         /// \brief Supported transport codec version.
-        static std::uint16_t codec_version() { return 3; }
+        static std::uint16_t codec_version() { return 4; }
 
         /// \brief Reads the message type from a transport envelope.
         /// \details Validates magic, codec version, and mandatory flags but
@@ -87,6 +87,7 @@ namespace sync {
             detail::append_u64_le(out, request.max_batches);
             detail::append_u64_le(out, request.max_bytes);
             append_bool(out, request.request_full_snapshot);
+            detail::append_u64_le(out, request.max_single_batch_bytes);
             validate_message_size(out, bounds);
             return out;
         }
@@ -155,6 +156,7 @@ namespace sync {
             request.max_batches = read_u64_le(cur);
             request.max_bytes = read_u64_le(cur);
             request.request_full_snapshot = read_bool(cur);
+            request.max_single_batch_bytes = read_u64_le(cur);
             check_consumed(cur);
             return request;
         }
@@ -323,6 +325,7 @@ namespace sync {
                 case SyncResponseErrorCode::UnsupportedFullSnapshot:
                 case SyncResponseErrorCode::ApplyConflict:
                 case SyncResponseErrorCode::SnapshotRequired:
+                case SyncResponseErrorCode::BatchTooLarge:
                     detail::append_u16_le(out,
                         static_cast<std::uint16_t>(code));
                     return;
@@ -464,6 +467,9 @@ namespace sync {
                 case static_cast<std::uint16_t>(
                         SyncResponseErrorCode::SnapshotRequired):
                     return SyncResponseErrorCode::SnapshotRequired;
+                case static_cast<std::uint16_t>(
+                        SyncResponseErrorCode::BatchTooLarge):
+                    return SyncResponseErrorCode::BatchTooLarge;
             }
             throw std::runtime_error("Invalid SyncResponseErrorCode");
         }

--- a/include/mdbx_containers/sync/protocol.hpp
+++ b/include/mdbx_containers/sync/protocol.hpp
@@ -28,6 +28,7 @@ namespace sync {
         UnsupportedFullSnapshot = 2, ///< Full snapshot protocol is not implemented.
         ApplyConflict           = 3, ///< Push apply failed on a sync conflict.
         SnapshotRequired        = 4, ///< Requested changelog history was pruned.
+        BatchTooLarge           = 5, ///< A single retained batch exceeds the requested limit.
     };
 
     /// \brief Returns a stable diagnostic name for a sync response error code.
@@ -44,6 +45,8 @@ namespace sync {
                 return "apply_conflict";
             case SyncResponseErrorCode::SnapshotRequired:
                 return "snapshot_required";
+            case SyncResponseErrorCode::BatchTooLarge:
+                return "batch_too_large";
         }
         return "unknown";
     }
@@ -54,6 +57,9 @@ namespace sync {
         DbId         db_id{};
         SyncCursor   have;
         std::uint64_t max_batches = 1000;
+        /// \brief Soft target for the total encoded batch bytes in one page.
+        /// \details A single retained batch may exceed this value and still be
+        /// returned alone when it does not exceed \c max_single_batch_bytes.
         std::uint64_t max_bytes   = 4ULL * 1024ULL * 1024ULL;
         /// \brief Requests a full snapshot instead of an incremental delta.
         /// \details Reserved for a future snapshot protocol. v0.1
@@ -63,6 +69,11 @@ namespace sync {
         /// \details Optional; default-constructed tokens never cancel.
         /// Transports may poll it while waiting on interruptible operations.
         CancellationToken cancel_token;
+        /// \brief Hard limit for one encoded retained changelog batch.
+        /// \details Responders reject a pull with \c BatchTooLarge when the
+        /// next required retained batch exceeds this value. This differs from
+        /// \c max_bytes, which is a soft page budget.
+        std::uint64_t max_single_batch_bytes = 4ULL * 1024ULL * 1024ULL;
     };
 
     /// \brief Response to a \c PullRequest.

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -117,6 +117,10 @@ int main() {
         std::string(mdbxc::sync::sync_response_error_code_name(
             mdbxc::sync::SyncResponseErrorCode::SnapshotRequired)) ==
         "snapshot_required");
+    MDBXC_TEST_ASSERT(
+        std::string(mdbxc::sync::sync_response_error_code_name(
+            mdbxc::sync::SyncResponseErrorCode::BatchTooLarge)) ==
+        "batch_too_large");
     mdbxc::sync::SyncCaptureScope* capture_scope = nullptr;
     HeaderSyncSink header_sink;
     (void)capture_scope;

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -102,6 +102,18 @@ mdbxc::sync::ChangeBatch make_raw_batch(const mdbxc::sync::NodeId& origin,
     return batch;
 }
 
+mdbxc::sync::ChangeBatch make_raw_batch_with_value_size(
+        const mdbxc::sync::NodeId& origin,
+        std::uint64_t seq,
+        const std::string& dbi_name,
+        std::uint8_t key_seed,
+        std::size_t value_size) {
+    mdbxc::sync::ChangeBatch batch =
+        make_raw_batch(origin, seq, dbi_name, key_seed);
+    batch.ops[0].value.assign(value_size, key_seed);
+    return batch;
+}
+
 std::vector<std::uint8_t> make_changelog_key(const mdbxc::sync::NodeId& origin,
                                              std::uint64_t seq) {
     std::vector<std::uint8_t> out(24);
@@ -135,6 +147,14 @@ void append_raw_batch(mdbxc::sync::ChangeLogStore& log,
     const mdbxc::sync::ChangeBatch batch = make_raw_batch(origin, seq, dbi_name, key_seed);
     const std::vector<std::uint8_t> bytes = mdbxc::sync::ChangeBatchCodec::encode(batch);
     log.append(txn, origin, seq, bytes);
+}
+
+void append_raw_batch(mdbxc::sync::ChangeLogStore& log,
+                      MDBX_txn* txn,
+                      const mdbxc::sync::ChangeBatch& batch) {
+    const std::vector<std::uint8_t> bytes =
+        mdbxc::sync::ChangeBatchCodec::encode(batch);
+    log.append(txn, batch.origin_node_id, batch.seq, bytes);
 }
 
 void append_raw_bytes(mdbxc::sync::ChangeLogStore& log,
@@ -1250,6 +1270,112 @@ void test_engine_pull_reports_snapshot_required_after_prune() {
     cleanup(p);
 }
 
+void test_engine_pull_max_bytes_is_soft_page_budget() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_pull_soft_max_bytes.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    const sync::NodeId local = make_node(0xA3);
+    const sync::NodeId origin = make_node(0xB3);
+    const sync::DbId db_id = make_node(0xD3);
+    engine.initialize_local_identity(local, db_id);
+
+    const sync::ChangeBatch large =
+        make_raw_batch_with_value_size(origin, 1, "kv", 0xA1, 2048u);
+    const sync::ChangeBatch small =
+        make_raw_batch_with_value_size(origin, 2, "kv", 0xA2, 8u);
+    const std::size_t large_bytes =
+        sync::ChangeBatchCodec::encode(large).size();
+
+    {
+        auto txn = conn->transaction(TransactionMode::WRITABLE);
+        sync::ChangeLogStore log(conn->env_handle());
+        log.open(txn.handle());
+        append_raw_batch(log, txn.handle(), large);
+        append_raw_batch(log, txn.handle(), small);
+        txn.commit();
+    }
+
+    sync::PullRequest req;
+    req.requester = make_node(0xC3);
+    req.db_id = db_id;
+    req.max_bytes = 1;
+    req.max_single_batch_bytes =
+        static_cast<std::uint64_t>(large_bytes + 1024u);
+
+    const sync::PullResponse resp = engine.handle_pull(req);
+    if (!resp.ok) {
+        throw std::runtime_error("soft max_bytes pull failed: " + resp.error);
+    }
+    if (resp.batches.size() != 1u || resp.batches[0].seq != 1u) {
+        throw std::runtime_error(
+            "soft max_bytes did not return the first oversized page batch");
+    }
+    if (!resp.has_more) {
+        throw std::runtime_error(
+            "soft max_bytes should report more retained batches");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_pull_rejects_oversized_single_batch() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_pull_single_batch_limit.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    const sync::NodeId local = make_node(0xA4);
+    const sync::NodeId origin = make_node(0xB4);
+    const sync::DbId db_id = make_node(0xD4);
+    engine.initialize_local_identity(local, db_id);
+
+    const sync::ChangeBatch large =
+        make_raw_batch_with_value_size(origin, 1, "kv", 0xA4, 2048u);
+    const std::size_t large_bytes =
+        sync::ChangeBatchCodec::encode(large).size();
+
+    {
+        auto txn = conn->transaction(TransactionMode::WRITABLE);
+        sync::ChangeLogStore log(conn->env_handle());
+        log.open(txn.handle());
+        append_raw_batch(log, txn.handle(), large);
+        txn.commit();
+    }
+
+    sync::PullRequest req;
+    req.requester = make_node(0xC4);
+    req.db_id = db_id;
+    req.max_single_batch_bytes =
+        static_cast<std::uint64_t>(large_bytes - 1u);
+
+    const sync::PullResponse resp = engine.handle_pull(req);
+    if (resp.ok) {
+        throw std::runtime_error(
+            "oversized single batch pull should have failed");
+    }
+    if (!resp.batches.empty() || resp.has_more) {
+        throw std::runtime_error(
+            "oversized single batch rejection returned page data");
+    }
+    if (resp.error_code != sync::SyncResponseErrorCode::BatchTooLarge ||
+        resp.error_retryable) {
+        throw std::runtime_error(
+            "oversized single batch rejection code incorrect");
+    }
+    if (resp.error.find("max_single_batch_bytes") == std::string::npos) {
+        throw std::runtime_error(
+            "oversized single batch rejection error lacks limit name");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 void test_engine_handle_push_wrong_db_id() {
     using namespace mdbxc;
     const std::string p = "test_engine_push_wrong_db.mdbx";
@@ -1653,6 +1779,10 @@ int main() {
           &test_engine_changelog_page_rejects_full_snapshot_request },
         { "test_engine_pull_reports_snapshot_required_after_prune",
           &test_engine_pull_reports_snapshot_required_after_prune },
+        { "test_engine_pull_max_bytes_is_soft_page_budget",
+          &test_engine_pull_max_bytes_is_soft_page_budget },
+        { "test_engine_pull_rejects_oversized_single_batch",
+          &test_engine_pull_rejects_oversized_single_batch },
         { "test_engine_handle_push_wrong_db_id",&test_engine_handle_push_wrong_db_id },
         { "test_engine_rejects_last_writer_wins_policy",
           &test_engine_rejects_last_writer_wins_policy },

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -1594,6 +1594,10 @@ void test_worker_rejects_invalid_options() {
     expect_invalid_options(engine, peer, invalid, "max_bytes");
 
     invalid = options;
+    invalid.max_single_batch_bytes = 0;
+    expect_invalid_options(engine, peer, invalid, "max_single_batch_bytes");
+
+    invalid = options;
     invalid.idle_interval = std::chrono::milliseconds(-1);
     expect_invalid_options(engine, peer, invalid, "idle_interval");
 

--- a/tests/test_transport_boundary.cpp
+++ b/tests/test_transport_boundary.cpp
@@ -72,6 +72,8 @@ public:
             std::lock_guard<std::mutex> lock(m_mutex);
             ++m_pull_count;
             m_last_token_can_be_cancelled = request.cancel_token.can_be_cancelled();
+            m_last_max_single_batch_bytes =
+                request.max_single_batch_bytes;
         }
         m_changed.notify_all();
         return mdbxc::sync::PullResponse();
@@ -120,6 +122,11 @@ public:
         return m_last_token_can_be_cancelled;
     }
 
+    std::uint64_t last_max_single_batch_bytes() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_last_max_single_batch_bytes;
+    }
+
     bool last_push_token_can_be_cancelled() const {
         std::lock_guard<std::mutex> lock(m_mutex);
         return m_last_push_token_can_be_cancelled;
@@ -132,6 +139,7 @@ private:
     std::size_t m_push_count = 0;
     bool m_last_token_can_be_cancelled = false;
     bool m_last_push_token_can_be_cancelled = false;
+    std::uint64_t m_last_max_single_batch_bytes = 0;
 };
 
 /// Minimal \c ISyncPeer that uses the default \c request_cancel() no-op.
@@ -164,6 +172,7 @@ void test_contract_sync_worker_delivers_cancellable_pull_token() {
     RecordingPeer peer;
     sync::SyncWorkerOptions options;
     options.idle_interval = std::chrono::milliseconds(10000);
+    options.max_single_batch_bytes = 123456u;
     sync::SyncWorker worker(engine, peer, options);
 
     worker.start();
@@ -177,6 +186,12 @@ void test_contract_sync_worker_delivers_cancellable_pull_token() {
         throw std::runtime_error(
             "transport contract violated: SyncWorker did not deliver a "
             "cancellable CancellationToken to ISyncPeer::pull()");
+    }
+    if (peer.last_max_single_batch_bytes() !=
+        options.max_single_batch_bytes) {
+        throw std::runtime_error(
+            "transport contract violated: SyncWorker did not propagate "
+            "max_single_batch_bytes to ISyncPeer::pull()");
     }
 
     conn->disconnect();
@@ -239,6 +254,7 @@ void test_contract_dto_values_round_trip_through_peer() {
     pull_request.have.last_seq_by_origin[make_node(0x99)] = 5u;
     pull_request.max_batches = 7u;
     pull_request.max_bytes = 1024u;
+    pull_request.max_single_batch_bytes = 2048u;
     pull_request.request_full_snapshot = true;
 
     sync::PullResponse pull_response{};
@@ -287,6 +303,8 @@ void test_contract_dto_values_round_trip_through_peer() {
         carrier.seen_pull_request.db_id != pull_request.db_id ||
         carrier.seen_pull_request.max_batches != pull_request.max_batches ||
         carrier.seen_pull_request.max_bytes != pull_request.max_bytes ||
+        carrier.seen_pull_request.max_single_batch_bytes !=
+            pull_request.max_single_batch_bytes ||
         carrier.seen_pull_request.request_full_snapshot !=
             pull_request.request_full_snapshot ||
         carrier.seen_pull_request.have.last_seq_by_origin.size() != 1u) {

--- a/tests/test_transport_codec.cpp
+++ b/tests/test_transport_codec.cpp
@@ -60,6 +60,7 @@ void test_pull_request_roundtrip() {
     request.max_batches = 17;
     request.max_bytes = 4096;
     request.request_full_snapshot = true;
+    request.max_single_batch_bytes = 8192;
     CancellationSource source;
     request.cancel_token = source.token();
 
@@ -82,6 +83,8 @@ void test_pull_request_roundtrip() {
                  "PullRequest max_bytes mismatch");
     require_true(decoded.request_full_snapshot,
                  "PullRequest full snapshot mismatch");
+    require_true(decoded.max_single_batch_bytes == 8192,
+                 "PullRequest max_single_batch_bytes mismatch");
     require_true(!decoded.cancel_token.can_be_cancelled(),
                  "PullRequest cancel token must not be serialized");
 }
@@ -99,7 +102,7 @@ void test_pull_response_roundtrip() {
     response.has_more = true;
     response.ok = false;
     response.error = "temporary upstream timeout";
-    response.error_code = SyncResponseErrorCode::SnapshotRequired;
+    response.error_code = SyncResponseErrorCode::BatchTooLarge;
     response.error_retryable = false;
 
     const std::vector<std::uint8_t> bytes =
@@ -126,7 +129,7 @@ void test_pull_response_roundtrip() {
     require_true(decoded.has_more, "PullResponse has_more mismatch");
     require_true(!decoded.ok, "PullResponse ok mismatch");
     require_true(decoded.error == response.error, "PullResponse error mismatch");
-    require_true(decoded.error_code == SyncResponseErrorCode::SnapshotRequired,
+    require_true(decoded.error_code == SyncResponseErrorCode::BatchTooLarge,
                  "PullResponse error_code mismatch");
     require_true(decoded.error_retryable == response.error_retryable,
                  "PullResponse error_retryable mismatch");
@@ -253,7 +256,7 @@ void test_message_header_rejections() {
 
     expect_throw("invalid bool", [bytes] {
         std::vector<std::uint8_t> bad = bytes;
-        bad[bad.size() - 1u] = 2u;
+        bad[bad.size() - 9u] = 2u;
         (void)TransportMessageCodec::decode_pull_request(bad);
     });
 
@@ -349,7 +352,7 @@ void test_golden_header_shape() {
         require_true(bytes[i] == expected_magic[i],
                      "TransportMessageCodec magic mismatch");
     }
-    require_true(bytes[8] == 3u && bytes[9] == 0u,
+    require_true(bytes[8] == 4u && bytes[9] == 0u,
                  "TransportMessageCodec version mismatch");
     require_true(bytes[10] == 1u,
                  "TransportMessageCodec pull request type mismatch");


### PR DESCRIPTION
## Summary
- clarify `PullRequest::max_bytes` as a soft pull-page byte budget
- add `PullRequest::max_single_batch_bytes` as the hard limit for one retained changelog batch
- return `SyncResponseErrorCode::BatchTooLarge` when the next required batch exceeds that hard limit
- bump `TransportMessageCodec` to v4 and propagate the limit through `SyncWorkerOptions`

## Validation
- `cmake --build tmp\build-pr164-cpp11-mingw --target test_transport_codec test_sync_engine test_sync_worker test_transport_boundary header_sync_umbrella_test header_all_umbrella_test`
- `ctest --test-dir tmp\build-pr164-cpp11-mingw -R (test_transport_codec|test_sync_engine|test_sync_worker|test_transport_boundary|header_sync_umbrella_test|header_all_umbrella_test)$ --output-on-failure`
- `cmake --build tmp\build-pr164-cpp17-mingw --target test_transport_codec test_sync_engine test_sync_worker test_transport_boundary header_sync_umbrella_test header_all_umbrella_test`
- `ctest --test-dir tmp\build-pr164-cpp17-mingw -R (test_transport_codec|test_sync_engine|test_sync_worker|test_transport_boundary|header_sync_umbrella_test|header_all_umbrella_test)$ --output-on-failure`

## Notes
- This is a breaking transport-wire change: `TransportMessageCodec` v4 adds `max_single_batch_bytes` to pull requests.