### PR TITLE
chore(sync): clean transport backend include graph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,6 +434,13 @@ if(MDBXC_BUILD_TESTS)
         mdbx_containers/SequenceTable.hpp
         mdbx_containers/ValueTable.hpp
     )
+    set(MDBXC_SYNC_STANDALONE_HEADERS
+        mdbx_containers/sync/codec_flags.hpp
+        mdbx_containers/sync/ChangeOp.hpp
+        mdbx_containers/sync/ChangeBatch.hpp
+        mdbx_containers/sync/ChangeBatchCodec.hpp
+        mdbx_containers/sync/TransportMessageCodec.hpp
+    )
 
     function(mdbxc_add_test_target test_name test_file)
         add_executable(${test_name} ${test_file})
@@ -496,6 +503,13 @@ if(MDBXC_BUILD_TESTS)
     set(_mdbxc_generated_test_dir "${CMAKE_CURRENT_BINARY_DIR}/generated_tests")
     file(MAKE_DIRECTORY "${_mdbxc_generated_test_dir}")
     foreach(header IN LISTS MDBXC_STANDALONE_PUBLIC_HEADERS)
+        string(MAKE_C_IDENTIFIER "${header}" header_target_suffix)
+        set(test_name "header_standalone_${header_target_suffix}")
+        set(test_file "${_mdbxc_generated_test_dir}/${test_name}.cpp")
+        file(WRITE "${test_file}" "#include <${header}>\n\nint main() {\n    return 0;\n}\n")
+        mdbxc_add_test_target(${test_name} ${test_file})
+    endforeach()
+    foreach(header IN LISTS MDBXC_SYNC_STANDALONE_HEADERS)
         string(MAKE_C_IDENTIFIER "${header}" header_target_suffix)
         set(test_name "header_standalone_${header_target_suffix}")
         set(test_file "${_mdbxc_generated_test_dir}/${test_name}.cpp")

--- a/include/mdbx_containers/sync/ChangeBatch.hpp
+++ b/include/mdbx_containers/sync/ChangeBatch.hpp
@@ -5,6 +5,13 @@
 /// \file ChangeBatch.hpp
 /// \brief A single atomic group of replicated \c ChangeOp operations.
 
+#include <cstdint>
+#include <vector>
+
+#include "ChangeOp.hpp"
+#include "codec_flags.hpp"
+#include "common.hpp"
+
 namespace mdbxc {
 namespace sync {
 

--- a/include/mdbx_containers/sync/ChangeBatchCodec.hpp
+++ b/include/mdbx_containers/sync/ChangeBatchCodec.hpp
@@ -34,6 +34,7 @@
 /// decode error. \c BATCH_COMPRESSED_ZSTD is reserved and explicitly
 /// rejected.
 
+#include "ChangeBatch.hpp"
 #include "CodecBounds.hpp"
 #include "codec_flags.hpp"
 #include "common.hpp"

--- a/include/mdbx_containers/sync/ChangeOp.hpp
+++ b/include/mdbx_containers/sync/ChangeOp.hpp
@@ -6,6 +6,8 @@
 /// \brief A single replicated operation: typed MDBX DBI write.
 
 #include <cstdint>
+#include <string>
+#include <vector>
 
 #include "codec_flags.hpp"
 

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -35,6 +35,7 @@
 
 #include <mdbx.h>
 
+#include "../common.hpp"
 #include "common.hpp"
 #include "ConflictPolicy.hpp"
 #include "ChangeBatch.hpp"
@@ -43,6 +44,7 @@
 #include "protocol.hpp"
 #include "SyncCursor.hpp"
 #include "stores/AppliedStore.hpp"
+#include "stores/ChangeLogStore.hpp"
 #include "stores/MetaStore.hpp"
 #include "stores/OriginIndexStore.hpp"
 

--- a/include/mdbx_containers/sync/codec_flags.hpp
+++ b/include/mdbx_containers/sync/codec_flags.hpp
@@ -5,6 +5,8 @@
 /// \file CodecFlags.hpp
 /// \brief Codec flag bits for \c ChangeBatch and \c ChangeOp.
 
+#include <cstdint>
+
 namespace mdbxc {
 namespace sync {
 

--- a/include/mdbx_containers/sync/stores/AppliedStore.hpp
+++ b/include/mdbx_containers/sync/stores/AppliedStore.hpp
@@ -5,6 +5,15 @@
 /// \file AppliedStore.hpp
 /// \brief Tracks the last contiguous applied \c seq per origin \c NodeId.
 
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#include <mdbx.h>
+
+#include "../../detail/utils.hpp"
+#include "../common.hpp"
+
 namespace mdbxc {
 namespace sync {
 

--- a/include/mdbx_containers/sync/stores/ChangeLogStore.hpp
+++ b/include/mdbx_containers/sync/stores/ChangeLogStore.hpp
@@ -5,6 +5,16 @@
 /// \file ChangeLogStore.hpp
 /// \brief Per-origin changelog of raw \c ChangeBatch bytes.
 
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mdbx.h>
+
+#include "../../detail/utils.hpp"
+#include "../common.hpp"
 #include "OriginIndexStore.hpp"
 
 namespace mdbxc {

--- a/include/mdbx_containers/sync/stores/MetaStore.hpp
+++ b/include/mdbx_containers/sync/stores/MetaStore.hpp
@@ -6,6 +6,16 @@
 /// \brief Persistent metadata for the sync subsystem: db identity, local node
 /// identity, schema version, monotonic local seq, creation timestamp.
 
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+#include <mdbx.h>
+
+#include "../../detail/utils.hpp"
+#include "../common.hpp"
+
 namespace mdbxc {
 namespace sync {
 

--- a/include/mdbx_containers/sync/stores/OriginIndexStore.hpp
+++ b/include/mdbx_containers/sync/stores/OriginIndexStore.hpp
@@ -5,6 +5,17 @@
 /// \file OriginIndexStore.hpp
 /// \brief Compact index of origins present in the local changelog.
 
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mdbx.h>
+
+#include "../../detail/utils.hpp"
+#include "../common.hpp"
+
 namespace mdbxc {
 namespace sync {
 

--- a/include/mdbx_containers/sync/transport.hpp
+++ b/include/mdbx_containers/sync/transport.hpp
@@ -6,9 +6,9 @@
 /// \brief Aggregate header for framework-neutral sync transport adapters.
 /// \details
 /// This header pulls in the sync core plus the HTTP/WebSocket transport seams
-/// and adapter-local middleware. It can be included directly by concrete
-/// transport backends. It does not include concrete socket backend
-/// integrations such as Simple-Web-Server.
+/// and adapter-local middleware. It does not include concrete socket backend
+/// integrations such as Simple-Web-Server. Concrete backend headers include
+/// the specific framework-neutral headers they need instead of this aggregate.
 
 #include <mdbx_containers/sync.hpp>
 

--- a/include/mdbx_containers/sync/transports/kurlyk/HttpTransport.hpp
+++ b/include/mdbx_containers/sync/transports/kurlyk/HttpTransport.hpp
@@ -39,7 +39,8 @@
 #include <string>
 #include <vector>
 
-#include <mdbx_containers/sync/transport.hpp>
+#include <mdbx_containers/sync/sync_module.hpp>
+#include <mdbx_containers/sync/HttpTransport.hpp>
 
 #if !MDBXC_SYNC_ENABLED
 #error "mdbx_containers/sync/transports/kurlyk/HttpTransport.hpp requires MDBXC_SYNC_ENABLED=1"

--- a/include/mdbx_containers/sync/transports/simple_web/HttpTransport.hpp
+++ b/include/mdbx_containers/sync/transports/simple_web/HttpTransport.hpp
@@ -45,7 +45,9 @@
 #include <thread>
 #include <vector>
 
-#include <mdbx_containers/sync/transport.hpp>
+#include <mdbx_containers/sync/sync_module.hpp>
+#include <mdbx_containers/sync/HttpTransport.hpp>
+#include <mdbx_containers/sync/TransportMiddleware.hpp>
 
 #if !MDBXC_SYNC_ENABLED
 #error "mdbx_containers/sync/transports/simple_web/HttpTransport.hpp requires MDBXC_SYNC_ENABLED=1"

--- a/include/mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp
+++ b/include/mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp
@@ -45,7 +45,9 @@
 #include <thread>
 #include <vector>
 
-#include <mdbx_containers/sync/transport.hpp>
+#include <mdbx_containers/sync/sync_module.hpp>
+#include <mdbx_containers/sync/TransportMiddleware.hpp>
+#include <mdbx_containers/sync/WebSocketTransport.hpp>
 
 #if !MDBXC_SYNC_ENABLED
 #error "mdbx_containers/sync/transports/simple_web/WebSocketTransport.hpp requires MDBXC_SYNC_ENABLED=1"


### PR DESCRIPTION
## Summary
- replace concrete backend includes of sync.hpp/sync/transport.hpp with direct framework-neutral headers
- make the sync core/store/codec headers needed by transport seams self-contained
- add isolated sync header smoke targets for codec_flags, ChangeOp, ChangeBatch, ChangeBatchCodec, and TransportMessageCodec
- clarify that sync/transport.hpp is an aggregate, not a backend dependency

## Validation
- cmake -S . -B tmp\\build-pr164-cpp11-mingw
- cmake -S . -B tmp\\build-pr164-cpp17-mingw
- cmake --build tmp\\build-pr164-cpp11-mingw --target header_standalone_mdbx_containers_sync_codec_flags_hpp header_standalone_mdbx_containers_sync_ChangeOp_hpp header_standalone_mdbx_containers_sync_ChangeBatch_hpp header_standalone_mdbx_containers_sync_ChangeBatchCodec_hpp header_standalone_mdbx_containers_sync_TransportMessageCodec_hpp
- cmake --build tmp\\build-pr164-cpp17-mingw --target header_standalone_mdbx_containers_sync_codec_flags_hpp header_standalone_mdbx_containers_sync_ChangeOp_hpp header_standalone_mdbx_containers_sync_ChangeBatch_hpp header_standalone_mdbx_containers_sync_ChangeBatchCodec_hpp header_standalone_mdbx_containers_sync_TransportMessageCodec_hpp
- cmake --build tmp\\build-pr164-cpp11-mingw --target header_sync_transport_umbrella_test header_sync_umbrella_test header_all_umbrella_test
- cmake --build tmp\\build-pr164-cpp17-mingw --target header_sync_transport_umbrella_test header_sync_umbrella_test header_all_umbrella_test
- cmake --build tmp\\build-pr170-simple-http-cpp17-mingw --target test_simple_web_http_transport
- cmake --build tmp\\build-pr170-simple-ws-cpp17-mingw --target test_simple_websocket_transport
- cmake --build tmp\\build-pr170-kurlyk-cpp17-mingw --target test_kurlyk_http_transport