### PR TITLE
feat(sync): add remote apply observer hooks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,6 +439,7 @@ if(MDBXC_BUILD_TESTS)
         mdbx_containers/sync/ChangeOp.hpp
         mdbx_containers/sync/ChangeBatch.hpp
         mdbx_containers/sync/ChangeBatchCodec.hpp
+        mdbx_containers/sync/SyncApplyObserver.hpp
         mdbx_containers/sync/TransportMessageCodec.hpp
     )
 

--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -48,6 +48,8 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
 - PR #173 added whole-exchange deadlines for the Simple-WebSocket sync client.
 - PR #174 supports installed packages that provide lowercase `mdbxConfig`.
 - PR #175 split pull page byte budgets from per-batch byte budgets.
+- PR #180 added connection-level remote apply observer hooks for cache
+  invalidation, metrics, and logging after successful remote apply commits.
 
 ## Current PR Sequence
 
@@ -79,10 +81,9 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
 
 ## Later Medium-Risk Follow-ups
 
-- General remote apply invalidation hooks: notify future table/view objects
-  with their own caches after sync changes their backing DBIs. `VectorStore`
-  currently uses the connection-level generation marker; richer per-DBI or
-  callback-based invalidation can be added if more cached wrappers appear.
+- Per-DBI remote apply invalidation: `ISyncApplyObserver` currently reports a
+  coarse committed apply event. If more cached wrappers appear, extend the hook
+  with affected DBI names or table identity filters.
 - Framework-level pre-buffer limits: where the concrete HTTP/WebSocket library
   supports it, configure request, response, and frame caps before the complete
   payload is retained in memory. PR #170 added binding-side limits after the

--- a/include/mdbx_containers/common.hpp
+++ b/include/mdbx_containers/common.hpp
@@ -48,6 +48,7 @@
 #include "detail/path_utils.hpp"
 #if MDBXC_SYNC_ENABLED
 #include "sync/ISyncCaptureSink.hpp"
+#include "sync/SyncApplyObserver.hpp"
 #endif
 #include "common/Connection.hpp"
 #include "detail/BaseTable.hpp"

--- a/include/mdbx_containers/common/Connection.hpp
+++ b/include/mdbx_containers/common/Connection.hpp
@@ -6,12 +6,15 @@
 /// \brief Manages an MDBX database connection using a provided configuration.
 
 #include <chrono>
+#include <condition_variable>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <vector>
 
 #if __cplusplus >= 201703L
 #   include <optional>
@@ -29,6 +32,7 @@ namespace mdbxc {
 
     namespace sync {
         class ISyncCaptureSink;
+        class ISyncApplyObserver;
         class SyncCaptureScope;
         class SyncEngine;
     }
@@ -202,6 +206,26 @@ namespace mdbxc {
         /// incoming batch. Table/view wrappers with RAM caches may compare a
         /// stored generation with this value and rebuild when it changes.
         std::uint64_t sync_apply_generation() const;
+
+        /// \brief Registers a non-owning remote apply observer.
+        /// \details The observer is called after successful remote sync apply
+        /// commits that changed user data. The pointer is non-owning; the
+        /// observer must outlive the registration. Observer callbacks run
+        /// after the connection apply/write barrier is released, and observer
+        /// exceptions are swallowed.
+        /// \return Token that can be passed to
+        /// \c remove_sync_apply_observer().
+        /// \throws std::invalid_argument if \p observer is null.
+        std::uint64_t add_sync_apply_observer(
+            sync::ISyncApplyObserver* observer);
+
+        /// \brief Removes a previously registered remote apply observer.
+        /// \details When this returns \c true, no callback for \p token is
+        /// still running or will start later. If this is called from that
+        /// observer's own callback, it waits for other in-flight callbacks for
+        /// the same token but not for the current callback.
+        /// \return true when a matching registration was removed.
+        bool remove_sync_apply_observer(std::uint64_t token);
 #       endif
 
         /// \brief Copies the whole MDBX environment to a file or directory path.
@@ -268,7 +292,29 @@ namespace mdbxc {
                                              std::uint64_t expected_token,
                                              sync::ISyncCaptureSink* restore_sink,
                                              std::uint64_t restore_token);
-        void mark_sync_apply_committed();
+        struct SyncApplyObserverState;
+
+        struct SyncApplyObserverCallback {
+            std::shared_ptr<SyncApplyObserverState> state;
+            sync::ISyncApplyObserver* observer;
+        };
+
+        struct SyncApplyNotification {
+            std::uint64_t generation = 0;
+            std::size_t applied_batches = 0;
+            std::size_t applied_ops = 0;
+            std::vector<SyncApplyObserverCallback> callbacks;
+        };
+
+        SyncApplyNotification mark_sync_apply_committed(
+            std::size_t applied_batches,
+            std::size_t applied_ops);
+        void notify_sync_apply_observers(
+            const SyncApplyNotification& notification);
+        void begin_sync_apply_observer_callback(
+            const std::shared_ptr<SyncApplyObserverState>& state);
+        void finish_sync_apply_observer_callback(
+            const std::shared_ptr<SyncApplyObserverState>& state);
 
         friend class sync::SyncEngine;
         friend class VectorStore;
@@ -284,10 +330,21 @@ namespace mdbxc {
         SyncApplyReadGuard sync_apply_read_guard() const;
         SyncApplyWriteGuard sync_apply_write_guard() const;
 
+        struct SyncApplyObserverState {
+            std::uint64_t token;
+            sync::ISyncApplyObserver* observer;
+            std::size_t in_flight;
+            bool removed;
+            std::vector<std::thread::id> active_callback_threads;
+        };
+
         sync::ISyncCaptureSink* m_sync_capture = nullptr;
         std::uint64_t m_sync_capture_token = 0;
         std::uint64_t m_next_sync_capture_token = 0;
+        std::uint64_t m_next_sync_apply_observer_token = 0;
         std::uint64_t m_sync_apply_generation = 0;
+        std::vector<std::shared_ptr<SyncApplyObserverState>> m_sync_apply_observers;
+        std::condition_variable m_sync_apply_observer_cv;
         mutable SyncApplyMutex m_sync_apply_mutex;
 #       endif
 

--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -14,6 +14,7 @@
 #ifndef MDBX_CONTAINERS_HEADER_ONLY
 #if MDBXC_SYNC_ENABLED
 #include <mdbx_containers/sync/ISyncCaptureSink.hpp>
+#include <mdbx_containers/sync/SyncApplyObserver.hpp>
 #endif
 #endif
 
@@ -191,6 +192,61 @@ namespace mdbxc {
         return m_sync_apply_generation;
     }
 
+    inline std::uint64_t Connection::add_sync_apply_observer(
+        sync::ISyncApplyObserver* observer) {
+        if (observer == nullptr) {
+            throw std::invalid_argument(
+                "Connection::add_sync_apply_observer observer cannot be null");
+        }
+        std::lock_guard<std::mutex> locker(m_mdbx_mutex);
+        std::shared_ptr<SyncApplyObserverState> entry(
+            new SyncApplyObserverState);
+        entry->token = ++m_next_sync_apply_observer_token;
+        entry->observer = observer;
+        entry->in_flight = 0;
+        entry->removed = false;
+        m_sync_apply_observers.push_back(entry);
+        return entry->token;
+    }
+
+    inline bool Connection::remove_sync_apply_observer(std::uint64_t token) {
+        std::unique_lock<std::mutex> locker(m_mdbx_mutex);
+        std::shared_ptr<SyncApplyObserverState> removed;
+        for (std::vector<std::shared_ptr<SyncApplyObserverState>>::iterator it =
+                 m_sync_apply_observers.begin();
+             it != m_sync_apply_observers.end(); ++it) {
+            if ((*it)->token == token) {
+                removed = *it;
+                removed->removed = true;
+                m_sync_apply_observers.erase(it);
+                break;
+            }
+        }
+        if (!removed) {
+            return false;
+        }
+        std::size_t own_in_flight = 0;
+        for (std::size_t i = 0; i < removed->active_callback_threads.size();
+             ++i) {
+            if (removed->active_callback_threads[i] ==
+                std::this_thread::get_id()) {
+                ++own_in_flight;
+            }
+        }
+        while (removed->in_flight > own_in_flight) {
+            m_sync_apply_observer_cv.wait(locker);
+            own_in_flight = 0;
+            for (std::size_t i = 0;
+                 i < removed->active_callback_threads.size(); ++i) {
+                if (removed->active_callback_threads[i] ==
+                    std::this_thread::get_id()) {
+                    ++own_in_flight;
+                }
+            }
+        }
+        return true;
+    }
+
     inline std::uint64_t Connection::sync_capture_token() const {
         return m_sync_capture_token;
     }
@@ -218,9 +274,78 @@ namespace mdbxc {
         return true;
     }
 
-    inline void Connection::mark_sync_apply_committed() {
+    inline Connection::SyncApplyNotification Connection::mark_sync_apply_committed(
+        std::size_t applied_batches,
+        std::size_t applied_ops) {
+        SyncApplyNotification notification;
         std::lock_guard<std::mutex> locker(m_mdbx_mutex);
         ++m_sync_apply_generation;
+        notification.generation = m_sync_apply_generation;
+        notification.applied_batches = applied_batches;
+        notification.applied_ops = applied_ops;
+        notification.callbacks.reserve(m_sync_apply_observers.size());
+        for (std::size_t i = 0; i < m_sync_apply_observers.size(); ++i) {
+            const std::shared_ptr<SyncApplyObserverState>& state =
+                m_sync_apply_observers[i];
+            if (!state->removed && state->observer != nullptr) {
+                ++state->in_flight;
+                SyncApplyObserverCallback callback;
+                callback.state = state;
+                callback.observer = state->observer;
+                notification.callbacks.push_back(callback);
+            }
+        }
+        return notification;
+    }
+
+    inline void Connection::notify_sync_apply_observers(
+        const SyncApplyNotification& notification) {
+        if (notification.callbacks.empty()) {
+            return;
+        }
+        sync::SyncApplyEvent event;
+        event.generation = notification.generation;
+        event.applied_batches = notification.applied_batches;
+        event.applied_ops = notification.applied_ops;
+        for (std::size_t i = 0; i < notification.callbacks.size(); ++i) {
+            try {
+                begin_sync_apply_observer_callback(
+                    notification.callbacks[i].state);
+                if (notification.callbacks[i].observer != nullptr) {
+                    notification.callbacks[i].observer
+                        ->on_sync_apply_committed(event);
+                }
+            } catch (...) {
+                // Remote apply has already committed; observers are best-effort.
+            }
+            finish_sync_apply_observer_callback(
+                notification.callbacks[i].state);
+        }
+    }
+
+    inline void Connection::begin_sync_apply_observer_callback(
+        const std::shared_ptr<SyncApplyObserverState>& state) {
+        std::lock_guard<std::mutex> locker(m_mdbx_mutex);
+        state->active_callback_threads.push_back(std::this_thread::get_id());
+    }
+
+    inline void Connection::finish_sync_apply_observer_callback(
+        const std::shared_ptr<SyncApplyObserverState>& state) {
+        std::lock_guard<std::mutex> locker(m_mdbx_mutex);
+        for (std::vector<std::thread::id>::iterator it =
+                 state->active_callback_threads.begin();
+             it != state->active_callback_threads.end(); ++it) {
+            if (*it == std::this_thread::get_id()) {
+                state->active_callback_threads.erase(it);
+                break;
+            }
+        }
+        if (state->in_flight != 0u) {
+            --state->in_flight;
+        }
+        if (state->in_flight == 0u) {
+            m_sync_apply_observer_cv.notify_all();
+        }
     }
 
     inline void Connection::on_pre_commit(MDBX_txn* txn) {

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -24,6 +24,7 @@
 #include "sync/cancellation.hpp"
 #include "sync/ConflictPolicy.hpp"
 #include "sync/ISyncCaptureSink.hpp"
+#include "sync/SyncApplyObserver.hpp"
 #include "sync/IdentityProvider.hpp"
 #include "sync/ISyncPeer.hpp"
 #include "sync/SyncCursor.hpp"

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -111,13 +111,22 @@ different logical collections from collapsing to the same physical DBI names.
 remote sync apply. `SyncEngine::handle_push()` increments it after a successful
 commit that applied at least one incoming operation. `VectorStore` stores the
 last seen generation and rebuilds its in-memory index before index-dependent
-operations when the value changes. A connection-level apply/read barrier
-serializes remote apply commits with cache-backed `VectorStore` operations.
-C++17 builds use `std::shared_mutex` so different cache-backed readers can
-share the connection read side. Each `VectorStore` instance still serializes
-its own public operations with an instance mutex to preserve the existing table
-wrapper thread-safety contract. C++11 builds fall back to an exclusive
-connection mutex model.
+operations when the value changes. Applications and future cached wrappers may
+also register `ISyncApplyObserver` instances on the connection. Observers are
+called after the remote apply transaction commits and after the generation
+increments. The connection apply/write barrier is released before callbacks run,
+so observers may use table and cache-backed APIs on the same connection for
+invalidation. Observer exceptions are swallowed because the database state has
+already changed. Registrations are non-owning lifecycle hooks. A successful
+`remove_sync_apply_observer()` call is a callback drain barrier for that token,
+so the observer can be destroyed after removal returns.
+
+A connection-level apply/read barrier serializes remote apply commits with
+cache-backed `VectorStore` operations. C++17 builds use `std::shared_mutex` so
+different cache-backed readers can share the connection read side. Each
+`VectorStore` instance still serializes its own public operations with an
+instance mutex to preserve the existing table wrapper thread-safety contract.
+C++11 builds fall back to an exclusive connection mutex model.
 
 ## Deferred `KeyMultiValueTable` sync design
 

--- a/include/mdbx_containers/sync/SyncApplyObserver.hpp
+++ b/include/mdbx_containers/sync/SyncApplyObserver.hpp
@@ -1,0 +1,44 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_SYNC_APPLY_OBSERVER_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_SYNC_APPLY_OBSERVER_HPP_INCLUDED
+
+/// \file SyncApplyObserver.hpp
+/// \brief Observer hook for successful remote sync apply commits.
+
+#include <cstddef>
+#include <cstdint>
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Summary of one committed remote sync apply.
+    /// \details Emitted after \c SyncEngine::handle_push() commits at least
+    /// one non-empty incoming batch, after the connection apply generation
+    /// has been incremented, and after the connection apply/write barrier has
+    /// been released.
+    struct SyncApplyEvent {
+        std::uint64_t generation = 0;       ///< New connection apply generation.
+        std::size_t applied_batches = 0;    ///< Number of applied non-empty batches.
+        std::size_t applied_ops = 0;        ///< Number of applied operations.
+    };
+
+    /// \brief Non-owning observer for successful remote sync apply commits.
+    /// \details Register through \c Connection::add_sync_apply_observer().
+    /// Implementations are intended for cache invalidation, metrics, and
+    /// structured logging. Callbacks run after the remote apply write barrier
+    /// is released, so an observer may use table and cache-backed APIs on the
+    /// same connection. Exceptions thrown by observers are swallowed by the
+    /// connection so they cannot roll back an already committed sync apply.
+    class ISyncApplyObserver {
+    public:
+        virtual ~ISyncApplyObserver() = default;
+
+        /// \brief Called after a remote sync apply commit changes user data.
+        virtual void on_sync_apply_committed(
+            const SyncApplyEvent& event) = 0;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_SYNC_APPLY_OBSERVER_HPP_INCLUDED

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -382,32 +382,41 @@ namespace sync {
                 out.receiver_have = applied_cursor();
                 return out;
             }
-            const Connection::SyncApplyWriteGuard sync_apply_guard =
-                m_conn->sync_apply_write_guard();
-            auto txn = m_conn->transaction(TransactionMode::WRITABLE);
-            bool applied_any = false;
-            for (const ChangeBatch& batch : request.batches) {
-                const ApplyOutcome outcome = apply_batch_ex(txn.handle(), batch);
-                if (outcome.result == ApplyResult::Conflict) {
-                    txn.rollback();
-                    out.ok = false;
-                    out.error = apply_conflict_message(outcome);
-                    out.error_code = SyncResponseErrorCode::ApplyConflict;
-                    out.error_retryable =
-                        outcome.conflict_reason ==
-                            ApplyConflictReason::SequenceGap;
-                    out.receiver_have = applied_cursor();
-                    return out;
+            Connection::SyncApplyNotification notification;
+            std::size_t applied_batches = 0;
+            std::size_t applied_ops = 0;
+            {
+                const Connection::SyncApplyWriteGuard sync_apply_guard =
+                    m_conn->sync_apply_write_guard();
+                auto txn = m_conn->transaction(TransactionMode::WRITABLE);
+                for (const ChangeBatch& batch : request.batches) {
+                    const ApplyOutcome outcome =
+                        apply_batch_ex(txn.handle(), batch);
+                    if (outcome.result == ApplyResult::Conflict) {
+                        txn.rollback();
+                        out.ok = false;
+                        out.error = apply_conflict_message(outcome);
+                        out.error_code = SyncResponseErrorCode::ApplyConflict;
+                        out.error_retryable =
+                            outcome.conflict_reason ==
+                                ApplyConflictReason::SequenceGap;
+                        out.receiver_have = applied_cursor();
+                        return out;
+                    }
+                    if (outcome.result == ApplyResult::Applied &&
+                        !batch.ops.empty()) {
+                        ++applied_batches;
+                        applied_ops += batch.ops.size();
+                    }
                 }
-                if (outcome.result == ApplyResult::Applied &&
-                    !batch.ops.empty()) {
-                    applied_any = true;
+                txn.commit();
+                if (applied_batches != 0u) {
+                    notification =
+                        m_conn->mark_sync_apply_committed(applied_batches,
+                                                          applied_ops);
                 }
             }
-            txn.commit();
-            if (applied_any) {
-                m_conn->mark_sync_apply_committed();
-            }
+            m_conn->notify_sync_apply_observers(notification);
             out.ok = true;
             out.receiver_have = applied_cursor();
             return out;

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -50,6 +50,20 @@ public:
     }
 };
 
+class HeaderSyncApplyObserver : public mdbxc::sync::ISyncApplyObserver {
+public:
+    HeaderSyncApplyObserver() : calls(0) {}
+
+    void on_sync_apply_committed(
+        const mdbxc::sync::SyncApplyEvent& event) override {
+        ++calls;
+        last_event = event;
+    }
+
+    unsigned calls;
+    mdbxc::sync::SyncApplyEvent last_event;
+};
+
 int main() {
     mdbxc::sync::NodeId node = mdbxc::sync::make_zero_node();
     MDBXC_TEST_ASSERT(node.size() == 16u);
@@ -123,6 +137,14 @@ int main() {
         "batch_too_large");
     mdbxc::sync::SyncCaptureScope* capture_scope = nullptr;
     HeaderSyncSink header_sink;
+    HeaderSyncApplyObserver apply_observer;
+    mdbxc::sync::SyncApplyEvent apply_event;
+    apply_event.generation = 1u;
+    apply_event.applied_batches = 1u;
+    apply_event.applied_ops = 1u;
+    apply_observer.on_sync_apply_committed(apply_event);
+    MDBXC_TEST_ASSERT(apply_observer.calls == 1u);
+    MDBXC_TEST_ASSERT(apply_observer.last_event.applied_ops == 1u);
     (void)capture_scope;
     (void)header_sink;
     mdbxc::sync::TransportMessageSizePolicy size_policy(1024u);

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1,6 +1,8 @@
 #include <mdbx_containers.hpp>
 #include <mdbx_containers/sync.hpp>
 
+#include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -8,6 +10,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace {
@@ -51,6 +54,89 @@ std::shared_ptr<mdbxc::Connection> open_env(const std::string& path) {
     cfg.no_subdir = true;
     return Connection::create(cfg);
 }
+
+class CountingApplyObserver : public mdbxc::sync::ISyncApplyObserver {
+public:
+    CountingApplyObserver()
+        : calls(0), generation(0), applied_batches(0), applied_ops(0) {}
+
+    void on_sync_apply_committed(
+        const mdbxc::sync::SyncApplyEvent& event) override {
+        ++calls;
+        generation = event.generation;
+        applied_batches = event.applied_batches;
+        applied_ops = event.applied_ops;
+    }
+
+    std::size_t calls;
+    std::uint64_t generation;
+    std::size_t applied_batches;
+    std::size_t applied_ops;
+};
+
+class ThrowingApplyObserver : public mdbxc::sync::ISyncApplyObserver {
+public:
+    void on_sync_apply_committed(
+        const mdbxc::sync::SyncApplyEvent&) override {
+        throw std::runtime_error("observer failure");
+    }
+};
+
+class ReentrantVectorApplyObserver : public mdbxc::sync::ISyncApplyObserver {
+public:
+    explicit ReentrantVectorApplyObserver(mdbxc::VectorStore* store)
+        : m_store(store), calls(0), last_count(0) {}
+
+    void on_sync_apply_committed(
+        const mdbxc::sync::SyncApplyEvent&) override {
+        ++calls;
+        last_count = m_store->count();
+    }
+
+    mdbxc::VectorStore* m_store;
+    std::size_t calls;
+    std::size_t last_count;
+};
+
+class BlockingApplyObserver : public mdbxc::sync::ISyncApplyObserver {
+public:
+    BlockingApplyObserver() : m_entered(false), m_release(false), calls(0) {}
+
+    void on_sync_apply_committed(
+        const mdbxc::sync::SyncApplyEvent&) override {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        ++calls;
+        m_entered = true;
+        m_cv.notify_all();
+        while (!m_release) {
+            m_cv.wait(lock);
+        }
+    }
+
+    bool wait_until_entered(std::chrono::milliseconds timeout) {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        return m_cv.wait_for(lock, timeout,
+            [this]() { return m_entered; });
+    }
+
+    void release_callback() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_release = true;
+        m_cv.notify_all();
+    }
+
+    std::size_t call_count() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return calls;
+    }
+
+private:
+    mutable std::mutex m_mutex;
+    std::condition_variable m_cv;
+    bool m_entered;
+    bool m_release;
+    std::size_t calls;
+};
 
 template<class Fn>
 void expect_invalid_argument(const char* name, Fn fn) {
@@ -935,6 +1021,16 @@ void test_engine_handle_push_to_remote() {
     sync::PushRequest req;
     req.sender = make_node(0xA0);
     req.db_id  = make_node(0xD0);
+    CountingApplyObserver observer;
+    ThrowingApplyObserver throwing_observer;
+    VectorStore remote_vectors(remote_conn, "observer_reentrant");
+    ReentrantVectorApplyObserver reentrant_observer(&remote_vectors);
+    const std::uint64_t observer_token =
+        remote_conn->add_sync_apply_observer(&observer);
+    const std::uint64_t throwing_token =
+        remote_conn->add_sync_apply_observer(&throwing_observer);
+    const std::uint64_t reentrant_token =
+        remote_conn->add_sync_apply_observer(&reentrant_observer);
     if (remote_conn->sync_apply_generation() != 0u) {
         throw std::runtime_error("fresh replica should have sync apply generation 0");
     }
@@ -965,6 +1061,15 @@ void test_engine_handle_push_to_remote() {
     if (remote_conn->sync_apply_generation() != 1u) {
         throw std::runtime_error("remote apply should increment generation");
     }
+    if (observer.calls != 1u || observer.generation != 1u ||
+        observer.applied_batches != 1u || observer.applied_ops != 1u) {
+        throw std::runtime_error("remote apply observer did not receive event");
+    }
+    if (reentrant_observer.calls != 1u ||
+        reentrant_observer.last_count != 0u) {
+        throw std::runtime_error(
+            "remote apply observer could not use cache-backed table API");
+    }
 
     KeyValueTable<int, int> remote_kv(remote_conn, "kv");
     if (kv_or_throw(remote_conn, remote_kv, 7, "remote kv[7]") != 0x77) {
@@ -979,6 +1084,17 @@ void test_engine_handle_push_to_remote() {
     if (remote_conn->sync_apply_generation() != 1u) {
         throw std::runtime_error(
             "skipped idempotent replay should not increment generation");
+    }
+    if (observer.calls != 1u) {
+        throw std::runtime_error("idempotent replay should not notify observer");
+    }
+    if (!remote_conn->remove_sync_apply_observer(observer_token) ||
+        !remote_conn->remove_sync_apply_observer(throwing_token) ||
+        !remote_conn->remove_sync_apply_observer(reentrant_token)) {
+        throw std::runtime_error("failed to remove sync apply observer");
+    }
+    if (remote_conn->remove_sync_apply_observer(observer_token)) {
+        throw std::runtime_error("observer token was removed twice");
     }
 
     origin_conn->disconnect();
@@ -995,6 +1111,8 @@ void test_engine_push_gap_rolls_back() {
     auto conn = open_env(p);
     sync::SyncEngine engine(conn);
     engine.initialize_local_identity(make_node(0x10), make_node(0xD0));
+    CountingApplyObserver observer;
+    conn->add_sync_apply_observer(&observer);
 
     auto make_batch = [](std::uint64_t seq) {
         sync::ChangeBatch b;
@@ -1038,6 +1156,9 @@ void test_engine_push_gap_rolls_back() {
             resp.receiver_have.last_seq_for(make_node(0x20)) != 1u) {
             throw std::runtime_error("push with gap error code incorrect");
         }
+        if (observer.calls != 0u) {
+            throw std::runtime_error("failed push should not notify apply observer");
+        }
     }
 
     // After rejected push, table 't' should still be empty (rollback worked)
@@ -1054,6 +1175,100 @@ void test_engine_push_gap_rolls_back() {
         if (cur.last_seq_for(make_node(0x20)) != 1u) {
             throw std::runtime_error("cursor should still be at seq=1 after rejected push");
         }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_sync_apply_observer_remove_waits_for_in_flight_callback() {
+    using namespace mdbxc;
+    const std::string p = "test_sync_apply_observer_remove_waits.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x10), make_node(0xD0));
+
+    BlockingApplyObserver observer;
+    const std::uint64_t token = conn->add_sync_apply_observer(&observer);
+
+    sync::PushRequest req;
+    req.sender = make_node(0x20);
+    req.db_id = make_node(0xD0);
+    req.batches.push_back(make_raw_batch(make_node(0x20), 1, "t", 0x31));
+
+    sync::PushResponse response;
+    std::string push_error;
+    std::thread push_thread(
+        [&engine, &req, &response, &push_error]() {
+            try {
+                response = engine.handle_push(req);
+            } catch (const std::exception& e) {
+                push_error = e.what();
+            } catch (...) {
+                push_error = "unknown push error";
+            }
+        });
+
+    if (!observer.wait_until_entered(std::chrono::milliseconds(1000))) {
+        observer.release_callback();
+        push_thread.join();
+        throw std::runtime_error(
+            "sync apply observer callback did not start");
+    }
+
+    bool removed = false;
+    bool remove_returned = false;
+    std::mutex remove_mutex;
+    std::thread remove_thread(
+        [conn, token, &removed, &remove_returned, &remove_mutex]() {
+            const bool ok = conn->remove_sync_apply_observer(token);
+            std::lock_guard<std::mutex> lock(remove_mutex);
+            removed = ok;
+            remove_returned = true;
+        });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    bool returned_while_callback_was_blocked = false;
+    {
+        std::lock_guard<std::mutex> lock(remove_mutex);
+        returned_while_callback_was_blocked = remove_returned;
+    }
+
+    observer.release_callback();
+    push_thread.join();
+    remove_thread.join();
+
+    if (returned_while_callback_was_blocked) {
+        throw std::runtime_error(
+            "remove_sync_apply_observer returned with callback in flight");
+    }
+    if (!removed) {
+        throw std::runtime_error("remove_sync_apply_observer returned false");
+    }
+    if (!push_error.empty()) {
+        throw std::runtime_error(push_error);
+    }
+    if (!response.ok) {
+        throw std::runtime_error("push should succeed: " + response.error);
+    }
+    if (observer.call_count() != 1u) {
+        throw std::runtime_error("observer should be called once");
+    }
+
+    sync::PushRequest second_req;
+    second_req.sender = make_node(0x20);
+    second_req.db_id = make_node(0xD0);
+    second_req.batches.push_back(make_raw_batch(make_node(0x20), 2, "t", 0x32));
+    const sync::PushResponse second_response = engine.handle_push(second_req);
+    if (!second_response.ok) {
+        throw std::runtime_error("second push should succeed: " +
+                                 second_response.error);
+    }
+    if (observer.call_count() != 1u) {
+        throw std::runtime_error(
+            "removed observer should not receive later callbacks");
     }
 
     conn->disconnect();
@@ -1771,6 +1986,8 @@ int main() {
         { "test_engine_applied_cursor",         &test_engine_applied_cursor },
         { "test_engine_handle_push_to_remote",  &test_engine_handle_push_to_remote },
         { "test_engine_push_gap_rolls_back",    &test_engine_push_gap_rolls_back },
+        { "test_sync_apply_observer_remove_waits",
+          &test_sync_apply_observer_remove_waits_for_in_flight_callback },
         { "test_engine_push_multi_batch_gap_cursor",&test_engine_push_multi_batch_gap_reports_persistent_cursor },
         { "test_engine_handle_pull_wrong_db_id",&test_engine_handle_pull_wrong_db_id },
         { "test_engine_rejects_full_snapshot_request",


### PR DESCRIPTION
﻿## Summary
- add ISyncApplyObserver and SyncApplyEvent for successful remote apply commits
- let Connection register/remove non-owning remote apply observers by token
- notify observers after SyncEngine::handle_push() commits and increments the apply generation
- cover successful apply, skipped replay, failed push, umbrella, and standalone header smoke

## Validation
- cmake -S . -B tmp\build-pr180-cpp11-mingw -G "MinGW Makefiles" -DCMAKE_C_COMPILER=C:/MinGW/x86_64-15.2.0-release-posix-seh-msvcrt-rt_v13-rev0/mingw64/bin/cc.exe -DCMAKE_CXX_COMPILER=C:/MinGW/x86_64-15.2.0-release-posix-seh-msvcrt-rt_v13-rev0/mingw64/bin/c++.exe -DCMAKE_MAKE_PROGRAM=C:/MinGW/x86_64-15.2.0-release-posix-seh-msvcrt-rt_v13-rev0/mingw64/bin/mingw32-make.exe -DCMAKE_CXX_STANDARD=11 -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=OFF -DMDBXC_BUILD_BENCHMARKS=OFF
- cmake -S . -B tmp\build-pr180-cpp17-mingw -G "MinGW Makefiles" -DCMAKE_C_COMPILER=C:/MinGW/x86_64-15.2.0-release-posix-seh-msvcrt-rt_v13-rev0/mingw64/bin/cc.exe -DCMAKE_CXX_COMPILER=C:/MinGW/x86_64-15.2.0-release-posix-seh-msvcrt-rt_v13-rev0/mingw64/bin/c++.exe -DCMAKE_MAKE_PROGRAM=C:/MinGW/x86_64-15.2.0-release-posix-seh-msvcrt-rt_v13-rev0/mingw64/bin/mingw32-make.exe -DCMAKE_CXX_STANDARD=17 -DMDBXC_BUILD_TESTS=ON -DMDBXC_BUILD_EXAMPLES=OFF -DMDBXC_BUILD_BENCHMARKS=OFF
- cmake --build tmp\build-pr180-cpp11-mingw --target test_sync_engine header_sync_umbrella_test header_standalone_mdbx_containers_sync_SyncApplyObserver_hpp
- cmake --build tmp\build-pr180-cpp17-mingw --target test_sync_engine header_sync_umbrella_test header_standalone_mdbx_containers_sync_SyncApplyObserver_hpp
- tmp\build-pr180-cpp11-mingw\bin\tests\test_sync_engine.exe
- tmp\build-pr180-cpp11-mingw\bin\tests\header_sync_umbrella_test.exe
- tmp\build-pr180-cpp11-mingw\bin\tests\header_standalone_mdbx_containers_sync_SyncApplyObserver_hpp.exe
- tmp\build-pr180-cpp17-mingw\bin\tests\test_sync_engine.exe
- tmp\build-pr180-cpp17-mingw\bin\tests\header_sync_umbrella_test.exe
- tmp\build-pr180-cpp17-mingw\bin\tests\header_standalone_mdbx_containers_sync_SyncApplyObserver_hpp.exe
