### PR TITLE
feat(sync): add worker lifecycle guard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,6 +440,7 @@ if(MDBXC_BUILD_TESTS)
         mdbx_containers/sync/ChangeBatch.hpp
         mdbx_containers/sync/ChangeBatchCodec.hpp
         mdbx_containers/sync/SyncApplyObserver.hpp
+        mdbx_containers/sync/SyncWorkerGuard.hpp
         mdbx_containers/sync/TransportMessageCodec.hpp
     )
 

--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -50,34 +50,24 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
 - PR #175 split pull page byte budgets from per-batch byte budgets.
 - PR #180 added connection-level remote apply observer hooks for cache
   invalidation, metrics, and logging after successful remote apply commits.
+- PR #181 added `SyncWorkerGuard` as an RAII helper for one background worker
+  session.
 
 ## Current PR Sequence
 
-### PR #176: Transport include graph cleanup
+### PR #180: Remote apply observer hooks
 
-- Keep concrete backend headers from depending on the aggregate
-  `sync/transport.hpp` header that names the framework-neutral transport
-  surface.
-- Preserve the public aggregate header for user convenience.
+- Notify cache invalidation, metrics, and logging code after successful remote
+  apply commits.
 
-### PR #177: Audit follow-up ledger refresh
+### PR #181: Worker lifecycle guard
 
-- Keep this file aligned with the PRs that have already landed.
-- Preserve the unresolved audit items as small, reviewable future PRs.
+- Reduce repeated `start()` / `stop()` boilerplate for background
+  `SyncWorker` sessions.
 
-### PR #178: Full snapshot protocol design
+### PR #182: Worker/node ergonomics example
 
-- Specify the future `PullRequest::request_full_snapshot=true` protocol before
-  implementing it.
-- Keep the current v0.1 behavior explicit: unsupported full snapshots and
-  pruned cursors return machine-readable sync errors.
-
-### PR #179: `KeyMultiValueTable` sync design
-
-- Define the unordered multiset framing and apply semantics for duplicate
-  values before adding capture support.
-- Keep order-sensitive histories deferred to a separate
-  `KeyOrderedMultiValueTable<K, V>` design.
+- Show the new hooks and worker guard in a small application-facing sync setup.
 
 ## Later Medium-Risk Follow-ups
 
@@ -88,6 +78,6 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
   supports it, configure request, response, and frame caps before the complete
   payload is retained in memory. PR #170 added binding-side limits after the
   framework has surfaced the payload.
-- Worker/node ergonomics helpers: reduce repeated setup code around
-  `SyncCaptureScope`, transport peer construction, worker lifecycle, and common
-  production policies.
+- Higher-level node/transport helpers: reduce repeated setup code around
+  transport peer construction, identity policy, retry/backoff settings, and
+  common production policies.

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -32,6 +32,7 @@
 #include "sync/TransportMessageCodec.hpp"
 #include "sync/SyncEngine.hpp"
 #include "sync/SyncWorker.hpp"
+#include "sync/SyncWorkerGuard.hpp"
 #include "sync/DirectSyncPeer.hpp"
 #include "sync/HttpTransport.hpp"
 #include "sync/WebSocketTransport.hpp"

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -670,6 +670,9 @@ Worker invariants:
   call from starting;
 - `stop()`, `join()`, and destruction may wait for an in-flight peer call to
   return when the concrete transport does not support cancellation;
+- `SyncWorkerGuard` may own a single background run session for an existing
+  worker; it starts the worker on construction and stops it on destruction,
+  while the `SyncWorker` object itself must still outlive the guard;
 - lifecycle mutations (`start`, `stop`, `join`, `run_once`) are caller-serialized,
   while `request_stop`, `state`, `last_error`, `last_observer_error`, and
   `wait_until_state` are thread-safe;

--- a/include/mdbx_containers/sync/SyncWorkerGuard.hpp
+++ b/include/mdbx_containers/sync/SyncWorkerGuard.hpp
@@ -1,0 +1,78 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_SYNC_WORKER_GUARD_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_SYNC_WORKER_GUARD_HPP_INCLUDED
+
+/// \file SyncWorkerGuard.hpp
+/// \brief RAII helper for a background \c SyncWorker session.
+
+#include "SyncWorker.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Starts a \c SyncWorker and stops it when the guard is destroyed.
+    /// \details This helper does not own the worker. It only owns one
+    /// background run session and is intended for examples and application
+    /// scopes where forgetting a matching \c stop() would be easy.
+    class SyncWorkerGuard {
+    public:
+        /// \brief Starts \p worker immediately.
+        explicit SyncWorkerGuard(SyncWorker& worker)
+            : m_worker(&worker), m_active(false) {
+            m_worker->start();
+            m_active = true;
+        }
+
+        /// \brief Requests stop and joins the worker if the guard is active.
+        ~SyncWorkerGuard() {
+            stop_noexcept();
+        }
+
+        SyncWorkerGuard(const SyncWorkerGuard&) = delete;
+        SyncWorkerGuard& operator=(const SyncWorkerGuard&) = delete;
+        SyncWorkerGuard(SyncWorkerGuard&&) = delete;
+        SyncWorkerGuard& operator=(SyncWorkerGuard&&) = delete;
+
+        /// \brief Explicitly stops the guarded background session.
+        /// \throws std::logic_error if called from the worker thread.
+        void stop() {
+            if (m_active && m_worker != nullptr) {
+                m_worker->stop();
+                m_active = false;
+            }
+        }
+
+        /// \brief Returns whether this guard still owns a running session.
+        bool active() const noexcept {
+            return m_active;
+        }
+
+        /// \brief Returns the guarded worker.
+        SyncWorker& worker() const {
+            return *m_worker;
+        }
+
+    private:
+        void stop_noexcept() noexcept {
+            if (!m_active || m_worker == nullptr) {
+                return;
+            }
+            try {
+                m_worker->stop();
+            } catch (...) {
+                try {
+                    m_worker->request_stop();
+                } catch (...) {
+                }
+            }
+            m_active = false;
+        }
+
+        SyncWorker* m_worker;
+        bool m_active;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_SYNC_WORKER_GUARD_HPP_INCLUDED

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -136,6 +136,7 @@ int main() {
             mdbxc::sync::SyncResponseErrorCode::BatchTooLarge)) ==
         "batch_too_large");
     mdbxc::sync::SyncCaptureScope* capture_scope = nullptr;
+    mdbxc::sync::SyncWorkerGuard* worker_guard = nullptr;
     HeaderSyncSink header_sink;
     HeaderSyncApplyObserver apply_observer;
     mdbxc::sync::SyncApplyEvent apply_event;
@@ -146,6 +147,7 @@ int main() {
     MDBXC_TEST_ASSERT(apply_observer.calls == 1u);
     MDBXC_TEST_ASSERT(apply_observer.last_event.applied_ops == 1u);
     (void)capture_scope;
+    (void)worker_guard;
     (void)header_sink;
     mdbxc::sync::TransportMessageSizePolicy size_policy(1024u);
     (void)size_policy;

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -2064,6 +2064,38 @@ void test_worker_rejects_self_join() {
     cleanup(path);
 }
 
+void test_worker_guard_starts_and_stops_background_session() {
+    using namespace mdbxc;
+    const std::string path = "test_worker_guard_session.mdbx";
+    cleanup(path);
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x71), make_node(0xD1));
+
+    EmptyPeer peer;
+    sync::SyncWorkerOptions options;
+    options.idle_interval = std::chrono::milliseconds(50);
+    sync::SyncWorker worker(engine, peer, options);
+
+    {
+        sync::SyncWorkerGuard guard(worker);
+        if (!guard.active() || &guard.worker() != &worker) {
+            throw std::runtime_error("SyncWorkerGuard did not become active");
+        }
+        if (!peer.wait_for_pulls(1, std::chrono::milliseconds(2000))) {
+            throw std::runtime_error("guarded worker did not run");
+        }
+    }
+
+    if (worker.state() != sync::SyncWorkerState::Stopped) {
+        throw std::runtime_error("SyncWorkerGuard did not stop worker");
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 } // namespace
 
 int main() {
@@ -2112,6 +2144,8 @@ int main() {
         { "test_worker_stop_cancels_request_token",
           &test_worker_stop_cancels_request_token },
         { "test_worker_rejects_self_join", &test_worker_rejects_self_join },
+        { "test_worker_guard_starts_and_stops_background_session",
+          &test_worker_guard_starts_and_stops_background_session },
     };
 
     int rc = 0;


### PR DESCRIPTION
﻿## Summary
- add SyncWorkerGuard as a non-owning RAII background session helper
- include the guard in the sync umbrella and standalone header smoke list
- cover guard start/stop behavior in SyncWorker tests
- refresh the audit ledger for the #180-#182 sequence

## Validation
- cmake -S . -B tmp\build-pr180-cpp11-mingw
- cmake -S . -B tmp\build-pr180-cpp17-mingw
- cmake --build tmp\build-pr180-cpp11-mingw --target test_sync_worker header_sync_umbrella_test header_standalone_mdbx_containers_sync_SyncWorkerGuard_hpp
- cmake --build tmp\build-pr180-cpp17-mingw --target test_sync_worker header_sync_umbrella_test header_standalone_mdbx_containers_sync_SyncWorkerGuard_hpp
- tmp\build-pr180-cpp11-mingw\bin\tests\test_sync_worker.exe
- tmp\build-pr180-cpp11-mingw\bin\tests\header_sync_umbrella_test.exe
- tmp\build-pr180-cpp11-mingw\bin\tests\header_standalone_mdbx_containers_sync_SyncWorkerGuard_hpp.exe
- tmp\build-pr180-cpp17-mingw\bin\tests\test_sync_worker.exe
- tmp\build-pr180-cpp17-mingw\bin\tests\header_sync_umbrella_test.exe
- tmp\build-pr180-cpp17-mingw\bin\tests\header_standalone_mdbx_containers_sync_SyncWorkerGuard_hpp.exe
