### PR TITLE
docs(sync): add worker guard apply hook example

### DIFF
--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -207,6 +207,7 @@ cmake -S . -B tmp/build-ws-example `
 | `sync_18_http_node_fleet.cpp` | Fleet из нескольких процессов поверх готового Simple-Web HTTP binding. | Продвинутый |
 | `sync_19_kurlyk_http_client.cpp` | Готовый Kurlyk/libcurl HTTP client binding против Simple-Web sync listener. | Продвинутый |
 | `sync_20_observability.cpp` | Логи worker/transport observer-ов с trace IDs, progress и retry hints. | Продвинутый |
+| `sync_21_worker_guard_apply_hooks.cpp` | Жизненный цикл через `SyncWorkerGuard` и remote apply observer hooks. | Средний |
 
 ## Общие правила
 

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -205,6 +205,7 @@ cmake -S . -B tmp/build-ws-example `
 | `sync_18_http_node_fleet.cpp` | Multi-process node fleet using the ready-made Simple-Web HTTP binding. | Advanced |
 | `sync_19_kurlyk_http_client.cpp` | Ready-made Kurlyk/libcurl HTTP client binding against the Simple-Web sync listener. | Advanced |
 | `sync_20_observability.cpp` | Worker and transport observer logs with trace IDs, progress, and retry hints. | Advanced |
+| `sync_21_worker_guard_apply_hooks.cpp` | `SyncWorkerGuard` lifecycle plus remote apply observer hooks. | Intermediate |
 
 ## Common Rules
 

--- a/examples/sync_21_worker_guard_apply_hooks.cpp
+++ b/examples/sync_21_worker_guard_apply_hooks.cpp
@@ -1,0 +1,197 @@
+/**
+ * \ingroup mdbxc_examples
+ * \brief SyncWorkerGuard and remote apply observer hooks.
+ *
+ * This example keeps DirectSyncPeer so the application-facing lifecycle is
+ * visible without socket setup:
+ *   - primary writes are captured through SyncCaptureScope;
+ *   - replica SyncWorker runs in the background through SyncWorkerGuard;
+ *   - the replica connection reports committed remote apply through
+ *     ISyncApplyObserver.
+ *
+ * Expected output:
+ *   [apply observer] generation=1 batches=2 ops=2 item2_visible=yes
+ *   [replica] item 1=alpha item 2=beta
+ *   OK: sync_21_worker_guard_apply_hooks
+ */
+
+#include "sync_example_utils.hpp"
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+class ConsoleApplyObserver : public mdbxc::sync::ISyncApplyObserver {
+public:
+    ConsoleApplyObserver(
+            std::shared_ptr<mdbxc::Connection> replica_conn,
+            mdbxc::KeyValueTable<int, std::string>* replica_items)
+        : m_events(0), m_last_generation(0), m_last_batches(0),
+          m_last_ops(0), m_replica_conn(replica_conn),
+          m_replica_items(replica_items), m_item_two_visible(false) {}
+
+    void on_sync_apply_committed(
+            const mdbxc::sync::SyncApplyEvent& event) override {
+        bool item_two_visible = false;
+        try {
+            const std::string two = sync_example::kv_or_throw(
+                m_replica_conn, *m_replica_items, 2,
+                "observer replica item 2");
+            item_two_visible = two == "beta";
+        } catch (...) {
+            item_two_visible = false;
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            ++m_events;
+            m_last_generation = event.generation;
+            m_last_batches = event.applied_batches;
+            m_last_ops = event.applied_ops;
+            m_item_two_visible = item_two_visible;
+            std::printf(
+                "[apply observer] generation=%llu batches=%zu ops=%zu "
+                "item2_visible=%s\n",
+                static_cast<unsigned long long>(event.generation),
+                event.applied_batches,
+                event.applied_ops,
+                item_two_visible ? "yes" : "no");
+        }
+        m_changed.notify_all();
+    }
+
+    bool wait_for_events(std::size_t count,
+                         std::chrono::milliseconds timeout) const {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        return m_changed.wait_for(
+            lock, timeout, [this, count] { return m_events >= count; });
+    }
+
+    std::size_t events() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_events;
+    }
+
+    std::uint64_t last_generation() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_last_generation;
+    }
+
+    bool item_two_visible() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_item_two_visible;
+    }
+
+private:
+    mutable std::mutex m_mutex;
+    mutable std::condition_variable m_changed;
+    std::size_t m_events;
+    std::uint64_t m_last_generation;
+    std::size_t m_last_batches;
+    std::size_t m_last_ops;
+    std::shared_ptr<mdbxc::Connection> m_replica_conn;
+    mdbxc::KeyValueTable<int, std::string>* m_replica_items;
+    bool m_item_two_visible;
+};
+
+} // namespace
+
+int main() {
+    const std::string primary_path = "sync_21_primary.mdbx";
+    const std::string replica_path = "sync_21_replica.mdbx";
+
+    sync_example::cleanup(primary_path);
+    sync_example::cleanup(replica_path);
+
+    std::shared_ptr<mdbxc::Connection> primary_conn;
+    std::shared_ptr<mdbxc::Connection> replica_conn;
+
+    try {
+        const mdbxc::sync::NodeId primary_node =
+            sync_example::make_node(0x21);
+        const mdbxc::sync::NodeId replica_node =
+            sync_example::make_node(0x22);
+        const mdbxc::sync::NodeId db_id =
+            sync_example::make_node(0xD1);
+
+        primary_conn = sync_example::open(primary_path);
+        replica_conn = sync_example::open(replica_path);
+
+        mdbxc::sync::SyncEngine primary_engine(primary_conn);
+        mdbxc::sync::SyncEngine replica_engine(replica_conn);
+        primary_engine.initialize_local_identity(primary_node, db_id);
+        replica_engine.initialize_local_identity(replica_node, db_id);
+
+        mdbxc::sync::ThreadLocalChangeAccumulator capture(primary_conn);
+        mdbxc::sync::DirectSyncPeer primary_peer(&primary_engine);
+        mdbxc::KeyValueTable<int, std::string> primary_items(
+            primary_conn, "items");
+        mdbxc::KeyValueTable<int, std::string> replica_items(
+            replica_conn, "items");
+
+        ConsoleApplyObserver apply_observer(replica_conn, &replica_items);
+        const std::uint64_t observer_token =
+            replica_conn->add_sync_apply_observer(&apply_observer);
+
+        mdbxc::sync::SyncWorkerOptions options;
+        options.idle_interval = std::chrono::milliseconds(20);
+        options.max_batches = 4;
+        mdbxc::sync::SyncWorker worker(replica_engine, primary_peer, options);
+
+        {
+            mdbxc::sync::SyncWorkerGuard worker_session(worker);
+
+            {
+                mdbxc::sync::SyncCaptureScope capture_scope(
+                    primary_conn, capture);
+                primary_items.insert_or_assign(1, "alpha");
+                primary_items.insert_or_assign(2, "beta");
+            }
+
+            sync_example::require(
+                apply_observer.wait_for_events(
+                    1, std::chrono::milliseconds(2000)),
+                "replica did not observe remote apply");
+
+            const std::string one = sync_example::kv_or_throw(
+                replica_conn, replica_items, 1, "replica item 1");
+            const std::string two = sync_example::kv_or_throw(
+                replica_conn, replica_items, 2, "replica item 2");
+            sync_example::require(one == "alpha", "replica item 1 mismatch");
+            sync_example::require(two == "beta", "replica item 2 mismatch");
+            sync_example::require(
+                apply_observer.last_generation() ==
+                    replica_conn->sync_apply_generation(),
+                "observer generation mismatch");
+            sync_example::require(
+                apply_observer.item_two_visible(),
+                "observer did not see replica item through table API");
+
+            std::printf("[replica] item 1=%s item 2=%s\n",
+                        one.c_str(), two.c_str());
+        }
+
+        replica_conn->remove_sync_apply_observer(observer_token);
+
+        sync_example::disconnect_and_cleanup(primary_conn, primary_path);
+        sync_example::disconnect_and_cleanup(replica_conn, replica_path);
+        std::puts("OK: sync_21_worker_guard_apply_hooks");
+        return 0;
+    } catch (const std::exception& e) {
+        std::fprintf(stderr,
+                     "sync_21_worker_guard_apply_hooks failed: %s\n",
+                     e.what());
+    }
+
+    sync_example::disconnect_and_cleanup(primary_conn, primary_path);
+    sync_example::disconnect_and_cleanup(replica_conn, replica_path);
+    return 1;
+}

--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -52,6 +52,8 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
   invalidation, metrics, and logging after successful remote apply commits.
 - PR #181 added `SyncWorkerGuard` as an RAII helper for one background worker
   session.
+- PR #182 added an application-facing example that combines
+  `SyncCaptureScope`, `SyncWorkerGuard`, and `ISyncApplyObserver`.
 
 ## Current PR Sequence
 


### PR DESCRIPTION
﻿## Summary
- add sync_21_worker_guard_apply_hooks.cpp as an application-facing lifecycle example
- demonstrate SyncCaptureScope writes, SyncWorkerGuard background sync, and ISyncApplyObserver notifications
- list the example in EN/RU sync examples README

## Validation
- cmake -S . -B tmp\build-pr182-examples-mingw -G "MinGW Makefiles" -DCMAKE_C_COMPILER=C:/MinGW/x86_64-15.2.0-release-posix-seh-msvcrt-rt_v13-rev0/mingw64/bin/cc.exe -DCMAKE_CXX_COMPILER=C:/MinGW/x86_64-15.2.0-release-posix-seh-msvcrt-rt_v13-rev0/mingw64/bin/c++.exe -DCMAKE_MAKE_PROGRAM=C:/MinGW/x86_64-15.2.0-release-posix-seh-msvcrt-rt_v13-rev0/mingw64/bin/mingw32-make.exe -DCMAKE_CXX_STANDARD=17 -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_BUILD_TESTS=OFF -DMDBXC_BUILD_BENCHMARKS=OFF
- cmake --build tmp\build-pr182-examples-mingw --target sync_21_worker_guard_apply_hooks
- tmp\build-pr182-examples-mingw\bin\examples\sync_21_worker_guard_apply_hooks.exe
- cmake -S . -B tmp\build-pr182-examples-cpp11-mingw -G "MinGW Makefiles" -DCMAKE_C_COMPILER=C:/MinGW/x86_64-15.2.0-release-posix-seh-msvcrt-rt_v13-rev0/mingw64/bin/cc.exe -DCMAKE_CXX_COMPILER=C:/MinGW/x86_64-15.2.0-release-posix-seh-msvcrt-rt_v13-rev0/mingw64/bin/c++.exe -DCMAKE_MAKE_PROGRAM=C:/MinGW/x86_64-15.2.0-release-posix-seh-msvcrt-rt_v13-rev0/mingw64/bin/mingw32-make.exe -DCMAKE_CXX_STANDARD=11 -DMDBXC_BUILD_EXAMPLES=ON -DMDBXC_BUILD_TESTS=OFF -DMDBXC_BUILD_BENCHMARKS=OFF
- cmake --build tmp\build-pr182-examples-cpp11-mingw --target sync_21_worker_guard_apply_hooks
- tmp\build-pr182-examples-cpp11-mingw\bin\examples\sync_21_worker_guard_apply_hooks.exe
