### PR TITLE
docs(sync): refresh follow-up ledger after worker hooks

### DIFF
--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -57,29 +57,28 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
 
 ## Current PR Sequence
 
-### PR #180: Remote apply observer hooks
+### PR #183: Ledger and readiness refresh
 
-- Notify cache invalidation, metrics, and logging code after successful remote
-  apply commits.
+- Remove the now-merged #180-#182 work queue from this note and keep the
+  remaining follow-ups focused on unsolved tasks.
 
-### PR #181: Worker lifecycle guard
+### PR #184: Sync node ergonomics helper
 
-- Reduce repeated `start()` / `stop()` boilerplate for background
-  `SyncWorker` sessions.
+- Add a small public helper around the common application setup for sync
+  capture, worker lifecycle, and optional remote-apply observer registration.
 
-### PR #182: Worker/node ergonomics example
+### PR #185: Per-DBI remote apply invalidation
 
-- Show the new hooks and worker guard in a small application-facing sync setup.
+- Extend the remote apply observer event with affected DBI names so cached
+  wrappers and application observers can invalidate more precisely than the
+  current coarse generation-only hook.
 
 ## Later Medium-Risk Follow-ups
 
-- Per-DBI remote apply invalidation: `ISyncApplyObserver` currently reports a
-  coarse committed apply event. If more cached wrappers appear, extend the hook
-  with affected DBI names or table identity filters.
 - Framework-level pre-buffer limits: where the concrete HTTP/WebSocket library
   supports it, configure request, response, and frame caps before the complete
   payload is retained in memory. PR #170 added binding-side limits after the
   framework has surfaced the payload.
-- Higher-level node/transport helpers: reduce repeated setup code around
-  transport peer construction, identity policy, retry/backoff settings, and
-  common production policies.
+- Higher-level transport helpers: after the node ergonomics helper, reduce
+  repeated setup code around concrete transport peer construction, identity
+  policy, retry/backoff settings, and common production policies.

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -21,9 +21,13 @@ rules, see [Sync table coverage matrix](sync-table-coverage.md).
   local transaction.
 - `SyncWorker` owns the background pull loop, pagination, cancellation tokens,
   observer callbacks, retry backoff, and optional `Retry-After` backoff hints.
+- `SyncWorkerGuard` is available when an application wants one RAII-owned
+  background worker session instead of a manual `start()` / `stop()` pair.
 - `SyncWorker::status()` exposes a thread-safe snapshot for polling UIs,
   health endpoints, and structured logging code that do not subscribe to
   observer callbacks.
+- `Connection::add_sync_apply_observer()` provides a post-commit remote apply
+  hook for coarse cache invalidation, metrics, and structured logging.
 - HTTP and WebSocket framework-neutral seams use `TransportMessageCodec`; DTOs
   do not carry bearer tokens, cookies, remote addresses, request ids, or trace
   ids.
@@ -77,8 +81,11 @@ it can make replication appear successful while logical state diverges.
 
 ## Suggested Next PRs
 
-- Add small ergonomics helpers around common worker setup if examples continue
-  to repeat the same lifecycle boilerplate.
+- Add a small sync node ergonomics helper around common capture, worker
+  lifecycle, and observer setup.
+- Extend `ISyncApplyObserver` events with affected DBI names or table identity
+  filters so cache invalidation can be more precise than the current coarse
+  generation marker.
 - Prototype `KeyMultiValueTable` capture/apply using the deferred
   single-writer/serialized unordered multiset design. Add explicit wire
   sub-operation framing and repeated-pair round-trip tests before enabling


### PR DESCRIPTION
## Summary
- mark the #180-#182 observer/worker guard work as completed
- refresh the current follow-up sequence for #183-#185
- note the newly available worker guard and coarse apply observer hook in readiness docs

## Validation
- docs-only change; no local build required