### PR TITLE
feat(sync): add node session helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,6 +440,7 @@ if(MDBXC_BUILD_TESTS)
         mdbx_containers/sync/ChangeBatch.hpp
         mdbx_containers/sync/ChangeBatchCodec.hpp
         mdbx_containers/sync/SyncApplyObserver.hpp
+        mdbx_containers/sync/SyncNodeSession.hpp
         mdbx_containers/sync/SyncWorkerGuard.hpp
         mdbx_containers/sync/TransportMessageCodec.hpp
     )

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -207,7 +207,7 @@ cmake -S . -B tmp/build-ws-example `
 | `sync_18_http_node_fleet.cpp` | Fleet из нескольких процессов поверх готового Simple-Web HTTP binding. | Продвинутый |
 | `sync_19_kurlyk_http_client.cpp` | Готовый Kurlyk/libcurl HTTP client binding против Simple-Web sync listener. | Продвинутый |
 | `sync_20_observability.cpp` | Логи worker/transport observer-ов с trace IDs, progress и retry hints. | Продвинутый |
-| `sync_21_worker_guard_apply_hooks.cpp` | Жизненный цикл через `SyncWorkerGuard` и remote apply observer hooks. | Средний |
+| `sync_21_worker_guard_apply_hooks.cpp` | Жизненный цикл через `SyncNodeSession` и remote apply observer hooks. | Средний |
 
 ## Общие правила
 

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -205,7 +205,7 @@ cmake -S . -B tmp/build-ws-example `
 | `sync_18_http_node_fleet.cpp` | Multi-process node fleet using the ready-made Simple-Web HTTP binding. | Advanced |
 | `sync_19_kurlyk_http_client.cpp` | Ready-made Kurlyk/libcurl HTTP client binding against the Simple-Web sync listener. | Advanced |
 | `sync_20_observability.cpp` | Worker and transport observer logs with trace IDs, progress, and retry hints. | Advanced |
-| `sync_21_worker_guard_apply_hooks.cpp` | `SyncWorkerGuard` lifecycle plus remote apply observer hooks. | Intermediate |
+| `sync_21_worker_guard_apply_hooks.cpp` | `SyncNodeSession` lifecycle plus remote apply observer hooks. | Intermediate |
 
 ## Common Rules
 

--- a/examples/sync_21_worker_guard_apply_hooks.cpp
+++ b/examples/sync_21_worker_guard_apply_hooks.cpp
@@ -1,11 +1,11 @@
 /**
  * \ingroup mdbxc_examples
- * \brief SyncWorkerGuard and remote apply observer hooks.
+ * \brief SyncNodeSession, capture, and remote apply observer hooks.
  *
  * This example keeps DirectSyncPeer so the application-facing lifecycle is
  * visible without socket setup:
- *   - primary writes are captured through SyncCaptureScope;
- *   - replica SyncWorker runs in the background through SyncWorkerGuard;
+ *   - primary writes are captured for the session lifetime;
+ *   - replica SyncWorker runs in the background through SyncNodeSession;
  *   - the replica connection reports committed remote apply through
  *     ISyncApplyObserver.
  *
@@ -137,24 +137,23 @@ int main() {
         mdbxc::KeyValueTable<int, std::string> replica_items(
             replica_conn, "items");
 
-        ConsoleApplyObserver apply_observer(replica_conn, &replica_items);
-        const std::uint64_t observer_token =
-            replica_conn->add_sync_apply_observer(&apply_observer);
-
         mdbxc::sync::SyncWorkerOptions options;
         options.idle_interval = std::chrono::milliseconds(20);
         options.max_batches = 4;
         mdbxc::sync::SyncWorker worker(replica_engine, primary_peer, options);
 
-        {
-            mdbxc::sync::SyncWorkerGuard worker_session(worker);
+        ConsoleApplyObserver apply_observer(replica_conn, &replica_items);
+        mdbxc::sync::SyncNodeSessionOptions session_options;
+        session_options.capture_connection = primary_conn;
+        session_options.capture_sink = &capture;
+        session_options.apply_observer_connection = replica_conn;
+        session_options.apply_observer = &apply_observer;
 
-            {
-                mdbxc::sync::SyncCaptureScope capture_scope(
-                    primary_conn, capture);
-                primary_items.insert_or_assign(1, "alpha");
-                primary_items.insert_or_assign(2, "beta");
-            }
+        {
+            mdbxc::sync::SyncNodeSession session(worker, session_options);
+
+            primary_items.insert_or_assign(1, "alpha");
+            primary_items.insert_or_assign(2, "beta");
 
             sync_example::require(
                 apply_observer.wait_for_events(
@@ -178,8 +177,6 @@ int main() {
             std::printf("[replica] item 1=%s item 2=%s\n",
                         one.c_str(), two.c_str());
         }
-
-        replica_conn->remove_sync_apply_observer(observer_token);
 
         sync_example::disconnect_and_cleanup(primary_conn, primary_path);
         sync_example::disconnect_and_cleanup(replica_conn, replica_path);

--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -54,18 +54,11 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
   session.
 - PR #182 added an application-facing example that combines
   `SyncCaptureScope`, `SyncWorkerGuard`, and `ISyncApplyObserver`.
+- PR #184 added `SyncNodeSession` for one common application wiring shape:
+  capture attachment, worker session lifetime, and optional apply observer
+  registration.
 
 ## Current PR Sequence
-
-### PR #183: Ledger and readiness refresh
-
-- Remove the now-merged #180-#182 work queue from this note and keep the
-  remaining follow-ups focused on unsolved tasks.
-
-### PR #184: Sync node ergonomics helper
-
-- Add a small public helper around the common application setup for sync
-  capture, worker lifecycle, and optional remote-apply observer registration.
 
 ### PR #185: Per-DBI remote apply invalidation
 

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -23,6 +23,9 @@ rules, see [Sync table coverage matrix](sync-table-coverage.md).
   observer callbacks, retry backoff, and optional `Retry-After` backoff hints.
 - `SyncWorkerGuard` is available when an application wants one RAII-owned
   background worker session instead of a manual `start()` / `stop()` pair.
+- `SyncNodeSession` is available for one common application wiring shape:
+  attach capture, start one existing worker, and register an optional remote
+  apply observer for the session lifetime.
 - `SyncWorker::status()` exposes a thread-safe snapshot for polling UIs,
   health endpoints, and structured logging code that do not subscribe to
   observer callbacks.
@@ -81,8 +84,6 @@ it can make replication appear successful while logical state diverges.
 
 ## Suggested Next PRs
 
-- Add a small sync node ergonomics helper around common capture, worker
-  lifecycle, and observer setup.
 - Extend `ISyncApplyObserver` events with affected DBI names or table identity
   filters so cache invalidation can be more precise than the current coarse
   generation marker.

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -33,6 +33,7 @@
 #include "sync/SyncEngine.hpp"
 #include "sync/SyncWorker.hpp"
 #include "sync/SyncWorkerGuard.hpp"
+#include "sync/SyncNodeSession.hpp"
 #include "sync/DirectSyncPeer.hpp"
 #include "sync/HttpTransport.hpp"
 #include "sync/WebSocketTransport.hpp"

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -673,6 +673,9 @@ Worker invariants:
 - `SyncWorkerGuard` may own a single background run session for an existing
   worker; it starts the worker on construction and stops it on destruction,
   while the `SyncWorker` object itself must still outlive the guard;
+- `SyncNodeSession` may own one application-level sync session around an
+  existing worker: it can attach capture, start the worker, register a remote
+  apply observer, then stop and release those hooks in reverse order;
 - lifecycle mutations (`start`, `stop`, `join`, `run_once`) are caller-serialized,
   while `request_stop`, `state`, `last_error`, `last_observer_error`, and
   `wait_until_state` are thread-safe;

--- a/include/mdbx_containers/sync/SyncNodeSession.hpp
+++ b/include/mdbx_containers/sync/SyncNodeSession.hpp
@@ -1,0 +1,190 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_SYNC_NODE_SESSION_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_SYNC_NODE_SESSION_HPP_INCLUDED
+
+/// \file SyncNodeSession.hpp
+/// \brief RAII helper for common sync node application wiring.
+
+#include "sync_module.hpp"
+
+#if MDBXC_SYNC_ENABLED
+
+#include "ISyncCaptureSink.hpp"
+#include "SyncApplyObserver.hpp"
+#include "SyncCaptureScope.hpp"
+#include "SyncWorkerGuard.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Optional pieces owned by a \c SyncNodeSession.
+    /// \details The helper is intentionally transport-neutral: callers still
+    /// construct \c SyncEngine, \c ISyncPeer, and \c SyncWorker explicitly.
+    struct SyncNodeSessionOptions {
+        /// \brief Connection whose writes should be captured for the session.
+        std::shared_ptr<Connection> capture_connection;
+
+        /// \brief Non-owning capture sink attached for the session lifetime.
+        ISyncCaptureSink* capture_sink = nullptr;
+
+        /// \brief Connection used to register \c apply_observer.
+        std::shared_ptr<Connection> apply_observer_connection;
+
+        /// \brief Non-owning observer registered for the session lifetime.
+        ISyncApplyObserver* apply_observer = nullptr;
+    };
+
+    /// \brief Owns a common application-facing sync session.
+    /// \details Starts one existing \c SyncWorker, optionally attaches a
+    /// capture sink, and optionally registers a remote-apply observer. The
+    /// helper does not own the worker, peer, engine, sink, or observer objects;
+    /// those objects must outlive the session. Destruction stops the worker
+    /// first, then removes the observer registration, then detaches capture.
+    class SyncNodeSession {
+    public:
+        /// \brief Creates a session and starts \p worker immediately.
+        /// \throws std::invalid_argument when only one side of an optional
+        /// capture or observer pair is provided.
+        explicit SyncNodeSession(SyncWorker& worker,
+                                 const SyncNodeSessionOptions& options)
+            : m_worker_guard(),
+              m_capture_scope(),
+              m_apply_observer_connection(options.apply_observer_connection),
+              m_apply_observer_token(0),
+              m_apply_observer_registered(false) {
+            validate_options(options);
+            try {
+                if (options.capture_sink != nullptr) {
+                    m_capture_scope.reset(new SyncCaptureScope(
+                        options.capture_connection, options.capture_sink));
+                }
+                if (options.apply_observer != nullptr) {
+                    m_apply_observer_token =
+                        options.apply_observer_connection
+                            ->add_sync_apply_observer(
+                                options.apply_observer);
+                    m_apply_observer_registered = true;
+                }
+                m_worker_guard.reset(new SyncWorkerGuard(worker));
+            } catch (...) {
+                cleanup_noexcept();
+                throw;
+            }
+        }
+
+        ~SyncNodeSession() {
+            cleanup_noexcept();
+        }
+
+        SyncNodeSession(const SyncNodeSession&) = delete;
+        SyncNodeSession& operator=(const SyncNodeSession&) = delete;
+        SyncNodeSession(SyncNodeSession&&) = delete;
+        SyncNodeSession& operator=(SyncNodeSession&&) = delete;
+
+        /// \brief Stops the worker and releases observer/capture hooks.
+        /// \throws std::logic_error if called from the worker thread.
+        void stop() {
+            if (m_worker_guard) {
+                m_worker_guard->stop();
+                m_worker_guard.reset();
+            }
+            remove_apply_observer();
+            detach_capture();
+        }
+
+        /// \brief Returns whether the worker session is still active.
+        bool active() const {
+            return m_worker_guard && m_worker_guard->active();
+        }
+
+        /// \brief Returns whether a capture scope is still attached.
+        bool capture_active() const {
+            return m_capture_scope && m_capture_scope->active();
+        }
+
+        /// \brief Returns whether an apply observer is still registered.
+        bool apply_observer_registered() const {
+            return m_apply_observer_registered;
+        }
+
+        /// \brief Returns the observer token, or zero when none was registered.
+        std::uint64_t apply_observer_token() const {
+            return m_apply_observer_token;
+        }
+
+        /// \brief Detaches the session capture scope if one is active.
+        void detach_capture() {
+            if (m_capture_scope) {
+                m_capture_scope->detach();
+                m_capture_scope.reset();
+            }
+        }
+
+        /// \brief Removes the session apply observer if one is registered.
+        void remove_apply_observer() {
+            if (m_apply_observer_registered &&
+                m_apply_observer_connection) {
+                m_apply_observer_connection->remove_sync_apply_observer(
+                    m_apply_observer_token);
+            }
+            m_apply_observer_registered = false;
+            m_apply_observer_token = 0;
+        }
+
+    private:
+        static void validate_options(const SyncNodeSessionOptions& options) {
+            if (static_cast<bool>(options.capture_connection) !=
+                (options.capture_sink != nullptr)) {
+                throw std::invalid_argument(
+                    "SyncNodeSession capture connection and sink must be "
+                    "provided together");
+            }
+            if (static_cast<bool>(options.apply_observer_connection) !=
+                (options.apply_observer != nullptr)) {
+                throw std::invalid_argument(
+                    "SyncNodeSession observer connection and observer must be "
+                    "provided together");
+            }
+        }
+
+        void cleanup_noexcept() noexcept {
+            try {
+                if (m_worker_guard) {
+                    m_worker_guard->stop();
+                    m_worker_guard.reset();
+                }
+            } catch (...) {
+                try {
+                    if (m_worker_guard) {
+                        m_worker_guard->worker().request_stop();
+                    }
+                } catch (...) {
+                }
+            }
+            try {
+                remove_apply_observer();
+            } catch (...) {
+            }
+            try {
+                detach_capture();
+            } catch (...) {
+            }
+        }
+
+        std::unique_ptr<SyncWorkerGuard> m_worker_guard;
+        std::unique_ptr<SyncCaptureScope> m_capture_scope;
+        std::shared_ptr<Connection> m_apply_observer_connection;
+        std::uint64_t m_apply_observer_token;
+        bool m_apply_observer_registered;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBXC_SYNC_ENABLED
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_SYNC_NODE_SESSION_HPP_INCLUDED

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -137,6 +137,8 @@ int main() {
         "batch_too_large");
     mdbxc::sync::SyncCaptureScope* capture_scope = nullptr;
     mdbxc::sync::SyncWorkerGuard* worker_guard = nullptr;
+    mdbxc::sync::SyncNodeSession* node_session = nullptr;
+    mdbxc::sync::SyncNodeSessionOptions node_session_options;
     HeaderSyncSink header_sink;
     HeaderSyncApplyObserver apply_observer;
     mdbxc::sync::SyncApplyEvent apply_event;
@@ -148,6 +150,8 @@ int main() {
     MDBXC_TEST_ASSERT(apply_observer.last_event.applied_ops == 1u);
     (void)capture_scope;
     (void)worker_guard;
+    (void)node_session;
+    (void)node_session_options;
     (void)header_sink;
     mdbxc::sync::TransportMessageSizePolicy size_policy(1024u);
     (void)size_policy;

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -98,6 +98,45 @@ private:
     int m_cancel_count;
 };
 
+class NodeSessionApplyObserver : public mdbxc::sync::ISyncApplyObserver {
+public:
+    NodeSessionApplyObserver() : m_events(0), m_generation(0) {}
+
+    void on_sync_apply_committed(
+            const mdbxc::sync::SyncApplyEvent& event) override {
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            ++m_events;
+            m_generation = event.generation;
+        }
+        m_changed.notify_all();
+    }
+
+    bool wait_for_events(std::size_t count,
+                         std::chrono::milliseconds timeout) const {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        return m_changed.wait_for(
+            lock, timeout,
+            [this, count] { return m_events >= count; });
+    }
+
+    std::size_t events() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_events;
+    }
+
+    std::uint64_t generation() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_generation;
+    }
+
+private:
+    mutable std::mutex m_mutex;
+    mutable std::condition_variable m_changed;
+    std::size_t m_events;
+    std::uint64_t m_generation;
+};
+
 class FixedPeer : public mdbxc::sync::ISyncPeer {
 public:
     explicit FixedPeer(const mdbxc::sync::PullResponse& response)
@@ -2096,6 +2135,94 @@ void test_worker_guard_starts_and_stops_background_session() {
     cleanup(path);
 }
 
+void test_sync_node_session_wires_capture_worker_and_observer() {
+    using namespace mdbxc;
+    const std::string primary_path = "test_sync_node_session_primary.mdbx";
+    const std::string replica_path = "test_sync_node_session_replica.mdbx";
+    cleanup(primary_path);
+    cleanup(replica_path);
+
+    std::shared_ptr<Connection> primary_conn = open_env(primary_path);
+    std::shared_ptr<Connection> replica_conn = open_env(replica_path);
+
+    const sync::NodeId primary_node = make_node(0x91);
+    const sync::NodeId replica_node = make_node(0x92);
+    const sync::NodeId db_id = make_node(0xD9);
+
+    sync::SyncEngine primary_engine(primary_conn);
+    sync::SyncEngine replica_engine(replica_conn);
+    primary_engine.initialize_local_identity(primary_node, db_id);
+    replica_engine.initialize_local_identity(replica_node, db_id);
+
+    sync::ThreadLocalChangeAccumulator capture(primary_conn);
+    sync::DirectSyncPeer primary_peer(&primary_engine);
+    NodeSessionApplyObserver observer;
+
+    sync::SyncWorkerOptions worker_options;
+    worker_options.idle_interval = std::chrono::milliseconds(20);
+    worker_options.max_batches = 4;
+    sync::SyncWorker worker(replica_engine, primary_peer, worker_options);
+
+    KeyValueTable<int, std::string> primary_items(primary_conn, "items");
+    KeyValueTable<int, std::string> replica_items(replica_conn, "items");
+
+    std::uint64_t observer_token = 0;
+    {
+        sync::SyncNodeSessionOptions session_options;
+        session_options.capture_connection = primary_conn;
+        session_options.capture_sink = &capture;
+        session_options.apply_observer_connection = replica_conn;
+        session_options.apply_observer = &observer;
+
+        sync::SyncNodeSession session(worker, session_options);
+        observer_token = session.apply_observer_token();
+        if (!session.active() || !session.capture_active() ||
+            !session.apply_observer_registered() ||
+            observer_token == 0u) {
+            throw std::runtime_error("SyncNodeSession did not activate");
+        }
+        if (primary_conn->sync_capture() != &capture) {
+            throw std::runtime_error("SyncNodeSession did not attach capture");
+        }
+
+        primary_items.insert_or_assign(11, "eleven");
+
+        if (!observer.wait_for_events(1u, std::chrono::milliseconds(3000))) {
+            throw std::runtime_error("SyncNodeSession observer did not fire");
+        }
+        const std::string value = kv_or_throw(
+            replica_conn, replica_items, 11, "replica item 11");
+        if (value != "eleven") {
+            throw std::runtime_error("replica item mismatch");
+        }
+        if (observer.generation() != replica_conn->sync_apply_generation()) {
+            throw std::runtime_error("observer generation mismatch");
+        }
+
+        session.stop();
+        if (session.active() || session.capture_active() ||
+            session.apply_observer_registered()) {
+            throw std::runtime_error("SyncNodeSession stop did not release hooks");
+        }
+    }
+
+    if (worker.state() != sync::SyncWorkerState::Stopped) {
+        throw std::runtime_error("SyncNodeSession did not stop worker");
+    }
+    if (primary_conn->sync_capture() != nullptr) {
+        throw std::runtime_error("SyncNodeSession did not detach capture");
+    }
+    if (replica_conn->remove_sync_apply_observer(observer_token)) {
+        throw std::runtime_error(
+            "SyncNodeSession did not remove observer registration");
+    }
+
+    primary_conn->disconnect();
+    replica_conn->disconnect();
+    cleanup(primary_path);
+    cleanup(replica_path);
+}
+
 } // namespace
 
 int main() {
@@ -2146,6 +2273,8 @@ int main() {
         { "test_worker_rejects_self_join", &test_worker_rejects_self_join },
         { "test_worker_guard_starts_and_stops_background_session",
           &test_worker_guard_starts_and_stops_background_session },
+        { "test_sync_node_session_wires_capture_worker_observer",
+          &test_sync_node_session_wires_capture_worker_and_observer },
     };
 
     int rc = 0;


### PR DESCRIPTION
## Summary
- add SyncNodeSession for one common app-level sync wiring shape
- wire capture attachment, worker lifetime, and optional apply observer registration through RAII
- update the worker/apply-hook example to use the helper

## Validation
- cmake --build tmp\\build-pr180-cpp11-mingw --target test_sync_worker header_sync_umbrella_test
- cmake --build tmp\\build-pr180-cpp17-mingw --target test_sync_worker header_sync_umbrella_test
- cmake --build tmp\\build-pr180-cpp11-mingw --target header_standalone_mdbx_containers_sync_SyncNodeSession_hpp
- cmake --build tmp\\build-pr180-cpp17-mingw --target header_standalone_mdbx_containers_sync_SyncNodeSession_hpp
- sync_21_worker_guard_apply_hooks example run in C++11 and C++17