### PR TITLE
feat(sync): report affected DBIs in apply observer

### DIFF
--- a/examples/sync_21_worker_guard_apply_hooks.cpp
+++ b/examples/sync_21_worker_guard_apply_hooks.cpp
@@ -10,7 +10,7 @@
  *     ISyncApplyObserver.
  *
  * Expected output:
- *   [apply observer] generation=1 batches=2 ops=2 item2_visible=yes
+ *   [apply observer] generation=1 batches=2 ops=2 dbis=1 item2_visible=yes
  *   [replica] item 1=alpha item 2=beta
  *   OK: sync_21_worker_guard_apply_hooks
  */
@@ -35,7 +35,7 @@ public:
             std::shared_ptr<mdbxc::Connection> replica_conn,
             mdbxc::KeyValueTable<int, std::string>* replica_items)
         : m_events(0), m_last_generation(0), m_last_batches(0),
-          m_last_ops(0), m_replica_conn(replica_conn),
+          m_last_ops(0), m_last_dbi_count(0), m_replica_conn(replica_conn),
           m_replica_items(replica_items), m_item_two_visible(false) {}
 
     void on_sync_apply_committed(
@@ -56,13 +56,15 @@ public:
             m_last_generation = event.generation;
             m_last_batches = event.applied_batches;
             m_last_ops = event.applied_ops;
+            m_last_dbi_count = event.affected_dbi_names.size();
             m_item_two_visible = item_two_visible;
             std::printf(
                 "[apply observer] generation=%llu batches=%zu ops=%zu "
-                "item2_visible=%s\n",
+                "dbis=%zu item2_visible=%s\n",
                 static_cast<unsigned long long>(event.generation),
                 event.applied_batches,
                 event.applied_ops,
+                event.affected_dbi_names.size(),
                 item_two_visible ? "yes" : "no");
         }
         m_changed.notify_all();
@@ -97,6 +99,7 @@ private:
     std::uint64_t m_last_generation;
     std::size_t m_last_batches;
     std::size_t m_last_ops;
+    std::size_t m_last_dbi_count;
     std::shared_ptr<mdbxc::Connection> m_replica_conn;
     mdbxc::KeyValueTable<int, std::string>* m_replica_items;
     bool m_item_two_visible;

--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -57,14 +57,12 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
 - PR #184 added `SyncNodeSession` for one common application wiring shape:
   capture attachment, worker session lifetime, and optional apply observer
   registration.
+- PR #185 extended `ISyncApplyObserver` events with affected DBI names for
+  more precise cache invalidation.
 
 ## Current PR Sequence
 
-### PR #185: Per-DBI remote apply invalidation
-
-- Extend the remote apply observer event with affected DBI names so cached
-  wrappers and application observers can invalidate more precisely than the
-  current coarse generation-only hook.
+No active audit PR sequence is queued in this ledger.
 
 ## Later Medium-Risk Follow-ups
 
@@ -72,6 +70,10 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
   supports it, configure request, response, and frame caps before the complete
   payload is retained in memory. PR #170 added binding-side limits after the
   framework has surfaced the payload.
+- Table-filtered apply observer subscriptions: `ISyncApplyObserver` now reports
+  affected DBI names, but every observer still receives every committed remote
+  apply event. Add registration-side filters only if more cached wrappers need
+  narrower callback delivery.
 - Higher-level transport helpers: after the node ergonomics helper, reduce
   repeated setup code around concrete transport peer construction, identity
   policy, retry/backoff settings, and common production policies.

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -30,7 +30,8 @@ rules, see [Sync table coverage matrix](sync-table-coverage.md).
   health endpoints, and structured logging code that do not subscribe to
   observer callbacks.
 - `Connection::add_sync_apply_observer()` provides a post-commit remote apply
-  hook for coarse cache invalidation, metrics, and structured logging.
+  hook for cache invalidation, metrics, and structured logging. Events include
+  the unique affected DBI names in first-seen order.
 - HTTP and WebSocket framework-neutral seams use `TransportMessageCodec`; DTOs
   do not carry bearer tokens, cookies, remote addresses, request ids, or trace
   ids.
@@ -84,9 +85,9 @@ it can make replication appear successful while logical state diverges.
 
 ## Suggested Next PRs
 
-- Extend `ISyncApplyObserver` events with affected DBI names or table identity
-  filters so cache invalidation can be more precise than the current coarse
-  generation marker.
+- Add optional table identity filters on top of the affected DBI names already
+  reported by `ISyncApplyObserver`, if more cached wrappers need narrower
+  subscriptions.
 - Prototype `KeyMultiValueTable` capture/apply using the deferred
   single-writer/serialized unordered multiset design. Add explicit wire
   sub-operation framing and repeated-pair round-trip tests before enabling

--- a/include/mdbx_containers/common/Connection.hpp
+++ b/include/mdbx_containers/common/Connection.hpp
@@ -303,12 +303,14 @@ namespace mdbxc {
             std::uint64_t generation = 0;
             std::size_t applied_batches = 0;
             std::size_t applied_ops = 0;
+            std::vector<std::string> affected_dbi_names;
             std::vector<SyncApplyObserverCallback> callbacks;
         };
 
         SyncApplyNotification mark_sync_apply_committed(
             std::size_t applied_batches,
-            std::size_t applied_ops);
+            std::size_t applied_ops,
+            const std::vector<std::string>& affected_dbi_names);
         void notify_sync_apply_observers(
             const SyncApplyNotification& notification);
         void begin_sync_apply_observer_callback(

--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -276,13 +276,15 @@ namespace mdbxc {
 
     inline Connection::SyncApplyNotification Connection::mark_sync_apply_committed(
         std::size_t applied_batches,
-        std::size_t applied_ops) {
+        std::size_t applied_ops,
+        const std::vector<std::string>& affected_dbi_names) {
         SyncApplyNotification notification;
         std::lock_guard<std::mutex> locker(m_mdbx_mutex);
         ++m_sync_apply_generation;
         notification.generation = m_sync_apply_generation;
         notification.applied_batches = applied_batches;
         notification.applied_ops = applied_ops;
+        notification.affected_dbi_names = affected_dbi_names;
         notification.callbacks.reserve(m_sync_apply_observers.size());
         for (std::size_t i = 0; i < m_sync_apply_observers.size(); ++i) {
             const std::shared_ptr<SyncApplyObserverState>& state =
@@ -307,6 +309,7 @@ namespace mdbxc {
         event.generation = notification.generation;
         event.applied_batches = notification.applied_batches;
         event.applied_ops = notification.applied_ops;
+        event.affected_dbi_names = notification.affected_dbi_names;
         for (std::size_t i = 0; i < notification.callbacks.size(); ++i) {
             try {
                 begin_sync_apply_observer_callback(

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -119,7 +119,10 @@ so observers may use table and cache-backed APIs on the same connection for
 invalidation. Observer exceptions are swallowed because the database state has
 already changed. Registrations are non-owning lifecycle hooks. A successful
 `remove_sync_apply_observer()` call is a callback drain barrier for that token,
-so the observer can be destroyed after removal returns.
+so the observer can be destroyed after removal returns. Apply events also carry
+the unique DBI names touched by applied operations in first-seen order. The
+names are local physical DBI names for invalidation; they are not transport
+identity, auth metadata, or a substitute for table-specific sync semantics.
 
 A connection-level apply/read barrier serializes remote apply commits with
 cache-backed `VectorStore` operations. C++17 builds use `std::shared_mutex` so

--- a/include/mdbx_containers/sync/SyncApplyObserver.hpp
+++ b/include/mdbx_containers/sync/SyncApplyObserver.hpp
@@ -7,6 +7,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
+#include <vector>
 
 namespace mdbxc {
 namespace sync {
@@ -20,6 +22,10 @@ namespace sync {
         std::uint64_t generation = 0;       ///< New connection apply generation.
         std::size_t applied_batches = 0;    ///< Number of applied non-empty batches.
         std::size_t applied_ops = 0;        ///< Number of applied operations.
+        /// \brief Unique DBI names touched by applied operations.
+        /// \details Names are reported in first-seen order across applied
+        /// batches. Idempotent replays and skipped batches do not emit events.
+        std::vector<std::string> affected_dbi_names;
     };
 
     /// \brief Non-owning observer for successful remote sync apply commits.

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -385,6 +385,7 @@ namespace sync {
             Connection::SyncApplyNotification notification;
             std::size_t applied_batches = 0;
             std::size_t applied_ops = 0;
+            std::vector<std::string> affected_dbi_names;
             {
                 const Connection::SyncApplyWriteGuard sync_apply_guard =
                     m_conn->sync_apply_write_guard();
@@ -407,13 +408,18 @@ namespace sync {
                         !batch.ops.empty()) {
                         ++applied_batches;
                         applied_ops += batch.ops.size();
+                        for (std::size_t i = 0; i < batch.ops.size(); ++i) {
+                            add_unique_dbi_name(affected_dbi_names,
+                                                batch.ops[i].dbi_name);
+                        }
                     }
                 }
                 txn.commit();
                 if (applied_batches != 0u) {
                     notification =
                         m_conn->mark_sync_apply_committed(applied_batches,
-                                                          applied_ops);
+                                                          applied_ops,
+                                                          affected_dbi_names);
                 }
             }
             m_conn->notify_sync_apply_observers(notification);
@@ -557,6 +563,16 @@ namespace sync {
                 message += " (dbi='" + outcome.dbi_name + "')";
             }
             return message;
+        }
+
+        static void add_unique_dbi_name(std::vector<std::string>& names,
+                                        const std::string& dbi_name) {
+            for (std::size_t i = 0; i < names.size(); ++i) {
+                if (names[i] == dbi_name) {
+                    return;
+                }
+            }
+            names.push_back(dbi_name);
         }
 
         static std::uint32_t persistent_dbi_flags_mask() {

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -145,9 +145,12 @@ int main() {
     apply_event.generation = 1u;
     apply_event.applied_batches = 1u;
     apply_event.applied_ops = 1u;
+    apply_event.affected_dbi_names.push_back("header_table");
     apply_observer.on_sync_apply_committed(apply_event);
     MDBXC_TEST_ASSERT(apply_observer.calls == 1u);
     MDBXC_TEST_ASSERT(apply_observer.last_event.applied_ops == 1u);
+    MDBXC_TEST_ASSERT(
+        apply_observer.last_event.affected_dbi_names.size() == 1u);
     (void)capture_scope;
     (void)worker_guard;
     (void)node_session;

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -66,12 +66,14 @@ public:
         generation = event.generation;
         applied_batches = event.applied_batches;
         applied_ops = event.applied_ops;
+        affected_dbi_names = event.affected_dbi_names;
     }
 
     std::size_t calls;
     std::uint64_t generation;
     std::size_t applied_batches;
     std::size_t applied_ops;
+    std::vector<std::string> affected_dbi_names;
 };
 
 class ThrowingApplyObserver : public mdbxc::sync::ISyncApplyObserver {
@@ -1065,6 +1067,10 @@ void test_engine_handle_push_to_remote() {
         observer.applied_batches != 1u || observer.applied_ops != 1u) {
         throw std::runtime_error("remote apply observer did not receive event");
     }
+    if (observer.affected_dbi_names.size() != 1u ||
+        observer.affected_dbi_names[0] != "kv") {
+        throw std::runtime_error("remote apply observer DBI names incorrect");
+    }
     if (reentrant_observer.calls != 1u ||
         reentrant_observer.last_count != 0u) {
         throw std::runtime_error(
@@ -1269,6 +1275,57 @@ void test_sync_apply_observer_remove_waits_for_in_flight_callback() {
     if (observer.call_count() != 1u) {
         throw std::runtime_error(
             "removed observer should not receive later callbacks");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_sync_apply_observer_reports_unique_dbi_names() {
+    using namespace mdbxc;
+    const std::string p = "test_sync_apply_observer_dbi_names.mdbx";
+    cleanup(p);
+
+    auto conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x10), make_node(0xD0));
+
+    CountingApplyObserver observer;
+    const std::uint64_t token = conn->add_sync_apply_observer(&observer);
+
+    sync::ChangeBatch batch;
+    batch.origin_node_id = make_node(0x20);
+    batch.seq = 1;
+    for (int i = 0; i < 3; ++i) {
+        sync::ChangeOp op;
+        op.op_type = sync::ChangeOpType::Put;
+        op.dbi_name = i == 1 ? "second_table" : "first_table";
+        op.storage_key.push_back(static_cast<std::uint8_t>(0x40 + i));
+        op.value.push_back(static_cast<std::uint8_t>(0x50 + i));
+        batch.ops.push_back(op);
+    }
+
+    sync::PushRequest req;
+    req.sender = make_node(0x20);
+    req.db_id = make_node(0xD0);
+    req.batches.push_back(batch);
+
+    const sync::PushResponse resp = engine.handle_push(req);
+    if (!resp.ok) {
+        throw std::runtime_error("push should succeed: " + resp.error);
+    }
+    if (observer.calls != 1u || observer.applied_batches != 1u ||
+        observer.applied_ops != 3u) {
+        throw std::runtime_error("observer apply counts incorrect");
+    }
+    if (observer.affected_dbi_names.size() != 2u ||
+        observer.affected_dbi_names[0] != "first_table" ||
+        observer.affected_dbi_names[1] != "second_table") {
+        throw std::runtime_error("observer DBI names are not unique/stable");
+    }
+
+    if (!conn->remove_sync_apply_observer(token)) {
+        throw std::runtime_error("failed to remove observer");
     }
 
     conn->disconnect();
@@ -1988,6 +2045,8 @@ int main() {
         { "test_engine_push_gap_rolls_back",    &test_engine_push_gap_rolls_back },
         { "test_sync_apply_observer_remove_waits",
           &test_sync_apply_observer_remove_waits_for_in_flight_callback },
+        { "test_sync_apply_observer_reports_unique_dbi_names",
+          &test_sync_apply_observer_reports_unique_dbi_names },
         { "test_engine_push_multi_batch_gap_cursor",&test_engine_push_multi_batch_gap_reports_persistent_cursor },
         { "test_engine_handle_pull_wrong_db_id",&test_engine_handle_pull_wrong_db_id },
         { "test_engine_rejects_full_snapshot_request",


### PR DESCRIPTION
## Summary
- extend SyncApplyEvent with unique affected DBI names in first-seen order
- collect names only from batches that were actually applied
- add regression coverage for unique/stable DBI reporting and update the apply-hook example output

## Validation
- cmake --build tmp\\build-pr180-cpp11-mingw --target test_sync_engine test_sync_worker header_sync_umbrella_test header_standalone_mdbx_containers_sync_SyncApplyObserver_hpp
- cmake --build tmp\\build-pr180-cpp17-mingw --target test_sync_engine test_sync_worker header_sync_umbrella_test header_standalone_mdbx_containers_sync_SyncApplyObserver_hpp
- sync_21_worker_guard_apply_hooks example run in C++11 and C++17