### PR TITLE
docs(sync): add minimal SyncNodeSession recipe

### DIFF
--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -208,6 +208,7 @@ cmake -S . -B tmp/build-ws-example `
 | `sync_19_kurlyk_http_client.cpp` | Готовый Kurlyk/libcurl HTTP client binding против Simple-Web sync listener. | Продвинутый |
 | `sync_20_observability.cpp` | Логи worker/transport observer-ов с trace IDs, progress и retry hints. | Продвинутый |
 | `sync_21_worker_guard_apply_hooks.cpp` | Жизненный цикл через `SyncNodeSession` и remote apply observer hooks. | Средний |
+| `sync_22_node_session_minimal.cpp` | Минимальный application-facing recipe для `SyncNodeSession`. | Начальный |
 
 ## Общие правила
 
@@ -240,6 +241,10 @@ cmake -S . -B tmp/build-ws-example `
 - Чтение, поиск и range scans не запускают sync. Локальный commit также не
   обращается к другой ноде; `SyncWorker` или явный pull/push-код позже
   отправляет уже закоммиченные batches через `ISyncPeer`.
+- Минимальный recipe с `SyncNodeSession` использует `DirectSyncPeer`, чтобы не
+  требовать optional dependencies. Реальная HTTP-нода сохраняет ту же форму
+  session и заменяет только peer на готовый HTTP transport binding, например
+  Simple-Web HTTP или Kurlyk HTTP.
 - `PullRequest`, `PullResponse`, `PushRequest` и `PushResponse` - структуры
   данных протокола. Именно эти значения нужно сериализовать и передавать через
   транспорт приложения.

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -206,6 +206,7 @@ cmake -S . -B tmp/build-ws-example `
 | `sync_19_kurlyk_http_client.cpp` | Ready-made Kurlyk/libcurl HTTP client binding against the Simple-Web sync listener. | Advanced |
 | `sync_20_observability.cpp` | Worker and transport observer logs with trace IDs, progress, and retry hints. | Advanced |
 | `sync_21_worker_guard_apply_hooks.cpp` | `SyncNodeSession` lifecycle plus remote apply observer hooks. | Intermediate |
+| `sync_22_node_session_minimal.cpp` | Minimal application-facing `SyncNodeSession` recipe. | Beginner |
 
 ## Common Rules
 
@@ -237,6 +238,10 @@ cmake -S . -B tmp/build-ws-example `
 - Sync is not triggered by reads, searches, or range scans. It also does not
   contact another node during the local commit; a `SyncWorker` or explicit
   pull/push code sends already committed batches later through an `ISyncPeer`.
+- The minimal `SyncNodeSession` recipe uses `DirectSyncPeer` to stay
+  dependency-free. A real HTTP node keeps the same session shape and replaces
+  only the peer with a ready-made HTTP transport binding, for example
+  Simple-Web HTTP or Kurlyk HTTP.
 - `PullRequest`, `PullResponse`, `PushRequest`, and `PushResponse` are
   transport payload structs. Serialize and deliver these values through the
   transport used by your application.

--- a/examples/sync_22_node_session_minimal.cpp
+++ b/examples/sync_22_node_session_minimal.cpp
@@ -1,0 +1,129 @@
+/**
+ * \ingroup mdbxc_examples
+ * \brief Minimal application-facing SyncNodeSession wiring.
+ *
+ * The example uses DirectSyncPeer so it builds without optional HTTP
+ * dependencies. In a socket-backed application, keep the same
+ * SyncNodeSessionOptions shape and replace DirectSyncPeer with a ready-made
+ * HTTP peer such as the Simple-Web or Kurlyk transport binding.
+ *
+ * Expected output:
+ *   [primary] wrote two independent local transactions
+ *   [replica] order 1=created order 2=paid
+ *   OK: sync_22_node_session_minimal
+ */
+
+#include "sync_example_utils.hpp"
+
+#include <chrono>
+#include <cstdio>
+#include <exception>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+namespace {
+
+bool wait_until_replicated(
+        const std::shared_ptr<mdbxc::Connection>& replica_conn,
+        mdbxc::KeyValueTable<int, std::string>& replica_orders,
+        std::chrono::milliseconds timeout) {
+    const std::chrono::steady_clock::time_point deadline =
+        std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (sync_example::kv_has(replica_conn, replica_orders, 1) &&
+            sync_example::kv_has(replica_conn, replica_orders, 2)) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    return false;
+}
+
+} // namespace
+
+int main() {
+    const std::string primary_path = "sync_22_primary.mdbx";
+    const std::string replica_path = "sync_22_replica.mdbx";
+
+    sync_example::cleanup(primary_path);
+    sync_example::cleanup(replica_path);
+
+    std::shared_ptr<mdbxc::Connection> primary_conn;
+    std::shared_ptr<mdbxc::Connection> replica_conn;
+
+    try {
+        const mdbxc::sync::NodeId primary_node =
+            sync_example::make_node(0x31);
+        const mdbxc::sync::NodeId replica_node =
+            sync_example::make_node(0x32);
+        const mdbxc::sync::NodeId db_id =
+            sync_example::make_node(0xD2);
+
+        primary_conn = sync_example::open(primary_path);
+        replica_conn = sync_example::open(replica_path);
+
+        mdbxc::sync::SyncEngine primary_engine(primary_conn);
+        mdbxc::sync::SyncEngine replica_engine(replica_conn);
+        primary_engine.initialize_local_identity(primary_node, db_id);
+        replica_engine.initialize_local_identity(replica_node, db_id);
+
+        mdbxc::sync::ThreadLocalChangeAccumulator capture(primary_conn);
+        mdbxc::sync::DirectSyncPeer primary_peer(&primary_engine);
+
+        mdbxc::sync::SyncWorkerOptions worker_options;
+        worker_options.idle_interval = std::chrono::milliseconds(25);
+        worker_options.max_batches = 8;
+        mdbxc::sync::SyncWorker replica_worker(
+            replica_engine, primary_peer, worker_options);
+
+        mdbxc::sync::SyncNodeSessionOptions session_options;
+        session_options.capture_connection = primary_conn;
+        session_options.capture_sink = &capture;
+
+        mdbxc::KeyValueTable<int, std::string> primary_orders(
+            primary_conn, "orders");
+        mdbxc::KeyValueTable<int, std::string> replica_orders(
+            replica_conn, "orders");
+
+        {
+            mdbxc::sync::SyncNodeSession session(
+                replica_worker, session_options);
+
+            primary_orders.insert_or_assign(1, "created");
+            primary_orders.insert_or_assign(2, "paid");
+            std::puts("[primary] wrote two independent local transactions");
+
+            sync_example::require(
+                wait_until_replicated(replica_conn, replica_orders,
+                                      std::chrono::milliseconds(2000)),
+                "replica did not catch up");
+
+            const std::string first = sync_example::kv_or_throw(
+                replica_conn, replica_orders, 1, "replica order 1");
+            const std::string second = sync_example::kv_or_throw(
+                replica_conn, replica_orders, 2, "replica order 2");
+            sync_example::require(first == "created",
+                                  "replica order 1 mismatch");
+            sync_example::require(second == "paid",
+                                  "replica order 2 mismatch");
+
+            std::printf("[replica] order 1=%s order 2=%s\n",
+                        first.c_str(), second.c_str());
+        }
+
+        sync_example::disconnect_and_cleanup(primary_conn, primary_path);
+        sync_example::disconnect_and_cleanup(replica_conn, replica_path);
+        std::puts("OK: sync_22_node_session_minimal");
+        return 0;
+    } catch (const std::exception& e) {
+        std::fprintf(stderr,
+                     "sync_22_node_session_minimal failed: %s\n",
+                     e.what());
+    }
+
+    sync_example::disconnect_and_cleanup(primary_conn, primary_path);
+    sync_example::disconnect_and_cleanup(replica_conn, replica_path);
+    return 1;
+}


### PR DESCRIPTION
## Summary
- add a minimal non-interactive SyncNodeSession example using DirectSyncPeer
- document that real HTTP nodes keep the same session wiring and replace only the ISyncPeer transport
- list the recipe in EN/RU sync example indexes

## Validation
- built and ran sync_22_node_session_minimal in tmp/build-pr188-cpp11