### PR TITLE
feat: add KeyOrderedMultiValueTable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -429,6 +429,7 @@ if(MDBXC_BUILD_TESTS)
         mdbx_containers/Hash.hpp
         mdbx_containers/HashedKeyValueStore.hpp
         mdbx_containers/KeyMultiValueTable.hpp
+        mdbx_containers/KeyOrderedMultiValueTable.hpp
         mdbx_containers/KeyTable.hpp
         mdbx_containers/KeyValueTable.hpp
         mdbx_containers/SequenceTable.hpp

--- a/README-RU.md
+++ b/README-RU.md
@@ -34,6 +34,9 @@
 - `KeyMultiValueTable<K, V>` хранит несколько значений на один ключ со
   `std::multimap`-подобным API, потоковыми и материализованными range-scan методами,
   обратным сканированием, удалением диапазонов и сохранением повторяющихся одинаковых пар `(key, value)`.
+- `KeyOrderedMultiValueTable<K, V>` хранит несколько значений на один ключ,
+  когда текущий порядок append является частью API; повторяющиеся одинаковые значения
+  остаются видимыми, а `find(key)` возвращает значения в порядке append.
 - `SequenceTable<ValueT>` хранит значения по стабильному uint64_t id с
   append-only семантикой и разреженными индексами. Append возвращает
   стабильный id; удаление не переиндексирует следующие записи.
@@ -78,14 +81,13 @@
 - v0.1 захватывает обычные write-path'ы `KeyValueTable`, `KeyTable`,
   `ValueTable` и `SequenceTable`; `VectorStore` реплицируется косвенно через
   внутренние `SequenceTable` и `KeyValueTable`.
-- `AnyValueTable`, `KeyMultiValueTable` и `HashedKeyValueStore` не
-  реплицируются в v0.1. Для `KeyMultiValueTable` в `sync/DESIGN.md` описан
-  отложенный unordered multiset sync design для single-writer или causally
-  serialized updates; общие concurrent multi-writer conflict semantics и
-  сохраняющие порядок распределённые histories отложены в будущую работу,
-  например `KeyOrderedMultiValueTable<K, V>`. Реализация остаётся выключенной,
-  пока не появятся capture и round-trip tests. Для `AnyValueTable` и
-  `HashedKeyValueStore` ещё нужны дизайны type tags и hash-index identity.
+- `AnyValueTable`, `KeyMultiValueTable`, `KeyOrderedMultiValueTable` и
+  `HashedKeyValueStore` не реплицируются в v0.1. Для `KeyMultiValueTable` в
+  `sync/DESIGN.md` описан отложенный unordered multiset sync design.
+  `KeyOrderedMultiValueTable` является order-sensitive table API, но её
+  sync capture/apply контракт остаётся выключенным, пока не появятся capture и
+  round-trip tests. Для `AnyValueTable` и `HashedKeyValueStore` ещё нужны
+  дизайны type tags и hash-index identity.
 - Для поддерживаемых таблиц прикладной CRUD-код не нужно оборачивать
   отдельными sync-вызовами на каждый метод. Прикрепите
   `ThreadLocalChangeAccumulator` к пишущему `Connection`; используйте
@@ -328,6 +330,19 @@ events.insert(7, "created"); // одинаковые повторы сохран
 events.insert(7, "sent");
 
 std::vector<std::string> values = events.find(7);
+```
+
+### Упорядоченная таблица с несколькими значениями на ключ
+
+```cpp
+#include <mdbx_containers/KeyOrderedMultiValueTable.hpp>
+
+mdbxc::KeyOrderedMultiValueTable<int, std::string> timeline(conn, "timeline");
+timeline.append(7, "created");
+timeline.append(7, "created"); // одинаковые повторы сохраняются
+timeline.append(7, "sent");
+
+std::vector<std::string> ordered_values = timeline.find(7);
 ```
 
 ### Ручная транзакция

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - `AnyValueTable<K>` stores heterogeneous values by caller-selected type and supports typed `set`, `insert`, `get`, `find`, `get_or`, `update`, `contains`, `erase`, and `keys`.
 - `KeyTable<K>` stores unique keys with a `std::set`-like API: `insert`, `contains`, `range`, `for_each_range`, `filter_range`, `lower_bound`, `upper_bound`, `range_reverse`, `erase_range`, `clear`, `load`, `reconcile`, and related helpers.
 - `KeyMultiValueTable<K, V>` stores multiple values per key with a `std::multimap`-like API, streaming and materialized key-range scans, reverse scans, range erasure, and repeated identical `(key, value)` pair preservation.
+- `KeyOrderedMultiValueTable<K, V>` stores multiple values per key where current append order is part of the API; repeated identical values stay visible and `find(key)` returns values in order.
 - `SequenceTable<ValueT>` stores values by stable uint64_t id with append-only semantics and sparse index support. Append returns a stable id; erase does not reindex following records.
 - `AnyValueTable` type-tag prefix verification is opt-in via `set_type_tag_check(true)` and is disabled by default for compatibility with existing raw records.
 - `VectorStore` is an MVP embedded vector store for local RAG: persistent MDBX
@@ -56,14 +57,13 @@
 - v0.1 captures normal write paths for `KeyValueTable`, `KeyTable`,
   `ValueTable`, and `SequenceTable`; `VectorStore` is replicated indirectly
   through its internal `SequenceTable` and `KeyValueTable` members.
-- `AnyValueTable`, `KeyMultiValueTable`, and `HashedKeyValueStore` are not
-  replicated in v0.1. `KeyMultiValueTable` has a deferred unordered multiset
-  sync design for single-writer or causally serialized updates in
-  `sync/DESIGN.md`; general concurrent multi-writer conflict semantics and
-  order-preserving distributed histories are deferred to future work such as
-  `KeyOrderedMultiValueTable<K, V>`. Implementation remains disabled until
-  capture and round-trip tests exist. `AnyValueTable` and `HashedKeyValueStore`
-  still need type-tag and hash-index identity designs.
+- `AnyValueTable`, `KeyMultiValueTable`, `KeyOrderedMultiValueTable`, and
+  `HashedKeyValueStore` are not replicated in v0.1. `KeyMultiValueTable` has a
+  deferred unordered multiset sync design in `sync/DESIGN.md`.
+  `KeyOrderedMultiValueTable` is the order-sensitive table API, but its sync
+  capture/apply contract remains disabled until capture and round-trip tests
+  exist. `AnyValueTable` and `HashedKeyValueStore` still need type-tag and
+  hash-index identity designs.
 - Application CRUD code does not need per-method sync wrappers for supported
   tables. Attach `ThreadLocalChangeAccumulator` to the writing `Connection`;
   use `SyncCaptureScope` for bounded write phases, or the lower-level
@@ -298,6 +298,19 @@ events.insert(7, "created"); // exact repeats are preserved
 events.insert(7, "sent");
 
 std::vector<std::string> values = events.find(7);
+```
+
+### Ordered multi-value table
+
+```cpp
+#include <mdbx_containers/KeyOrderedMultiValueTable.hpp>
+
+mdbxc::KeyOrderedMultiValueTable<int, std::string> timeline(conn, "timeline");
+timeline.append(7, "created");
+timeline.append(7, "created"); // exact repeats are preserved
+timeline.append(7, "sent");
+
+std::vector<std::string> ordered_values = timeline.find(7);
 ```
 
 ### Manual transaction

--- a/guides/codebase-orientation.md
+++ b/guides/codebase-orientation.md
@@ -36,6 +36,7 @@ Primary entry points:
   `include/mdbx_containers/AnyValueTable.hpp`,
   `include/mdbx_containers/KeyTable.hpp`,
   `include/mdbx_containers/KeyMultiValueTable.hpp`,
+  `include/mdbx_containers/KeyOrderedMultiValueTable.hpp`,
   `include/mdbx_containers/SequenceTable.hpp`.
 - Shared public components: `include/mdbx_containers/common.hpp`.
 - Transactions/config: `common/Connection.hpp`, `common/Transaction.hpp`,
@@ -54,7 +55,8 @@ Real subdomains:
 
 - **Persistent tables**: active `KeyValueTable`, active
   `HashedKeyValueStore`, active `ValueTable`, active `AnyValueTable`, active
-  `KeyTable`, active `KeyMultiValueTable`, active `SequenceTable`.
+  `KeyTable`, active `KeyMultiValueTable`, active
+  `KeyOrderedMultiValueTable`, active `SequenceTable`.
 - **MDBX environment and transactions**: `Connection`, `Transaction`,
   `TransactionTracker`, `BaseTable`.
 - **Serialization**: `serialize_key`, `serialize_value`,

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -246,15 +246,15 @@ Operational rules:
 - Nested `SyncCaptureScope` objects are a stack discipline: detach or destroy
   the innermost scope first. Do not replace the connection capture sink through
   raw attach/detach while a scope owns it.
-- `HashedKeyValueStore`, `KeyMultiValueTable`, and `AnyValueTable` are
-  not replicated in v0.1. `KeyMultiValueTable` has a deferred unordered
-  multiset design for single-writer or causally serialized updates in
-  `sync/DESIGN.md`; general concurrent multi-writer conflict semantics and
-  order-preserving distributed histories are deferred to future work such as
-  `KeyOrderedMultiValueTable<K, V>`. `HashedKeyValueStore` and
-  `AnyValueTable` still need their own wire-format designs. Do not add
-  `record_op()` paths for any unsupported table without capture/apply code and
-  round-trip tests in the same change.
+- `HashedKeyValueStore`, `KeyMultiValueTable`,
+  `KeyOrderedMultiValueTable`, and `AnyValueTable` are not replicated in v0.1.
+  `KeyMultiValueTable` has a deferred unordered multiset design for
+  single-writer or causally serialized updates in `sync/DESIGN.md`.
+  `KeyOrderedMultiValueTable` exists as a local ordered table API, but its
+  distributed ordered-history wire contract is still deferred.
+  `HashedKeyValueStore` and `AnyValueTable` still need their own wire-format
+  designs. Do not add `record_op()` paths for any unsupported table without
+  capture/apply code and round-trip tests in the same change.
 - Unsupported specialized tables must keep emitting no `ChangeOp` while sync
   capture is attached until their wire-format semantics are designed and tested.
 

--- a/guides/project-overview.md
+++ b/guides/project-overview.md
@@ -28,6 +28,7 @@ and compiles in the consumer's translation units.
 | `AnyValueTable<K>` | Active | Heterogeneous values by caller-specified type with optional type-tag prefix checks. |
 | `KeyTable<K>` | Active | Key-only table with `std::set`-like membership semantics. |
 | `KeyMultiValueTable<K, V>` | Active | Multimap-like table with multiple values per key, including repeated identical pairs. |
+| `KeyOrderedMultiValueTable<K, V>` | Active | Multi-value table where repeated values and current append order within one key are part of the API. |
 
 For method selection, bulk operation semantics, and table-specific constraints,
 see [Table API guide](table-api-guide.md).

--- a/guides/sync-table-coverage.md
+++ b/guides/sync-table-coverage.md
@@ -21,6 +21,7 @@ values during transport, and remote apply replays the captured physical
 | `VectorStore` | Indirectly supported | Captured through its internal `SequenceTable` and `KeyValueTable` members. | The internal table operations are replicated; `VectorStore` has no separate wire type. Already-open instances compare `Connection::sync_apply_generation()` and lazily rebuild their RAM index before index-dependent operations after remote apply. A connection apply/read barrier serializes remote `handle_push()` apply commits with cache-backed `VectorStore` operations. Each `VectorStore` instance serializes its own methods; C++17 builds let different readers share the connection read side, while C++11 builds use an exclusive connection mutex fallback. | `test_sync_capture`, `test_sync_replication` |
 | `AnyValueTable<K>` | Deferred | No `ChangeOp` in v0.1. | Not applied by sync as a typed heterogeneous table. | `test_sync_capture` negative coverage |
 | `KeyMultiValueTable<K, V>` | Deferred | No `ChangeOp` in v0.1. | DUPSORT duplicate multiplicity and unordered multiset semantics are deferred. | `test_sync_capture` negative coverage |
+| `KeyOrderedMultiValueTable<K, V>` | Deferred | No `ChangeOp` in v0.1. | Per-key append order is explicit in local storage, but sync capture/apply is deferred until ordered multi-value wire semantics are tested. | `test_sync_capture` negative coverage |
 | `HashedKeyValueStore<K, V, H, Layout>` | Deferred | No `ChangeOp` in v0.1. | Hash-index identity and logical-key mapping are deferred. | `test_sync_capture` negative coverage |
 
 ## Supported Capture Contract
@@ -66,8 +67,9 @@ must preserve multiplicity under single-writer or causally serialized updates.
 The detailed deferred contract lives in
 `include/mdbx_containers/sync/DESIGN.md`: it requires explicit multivalue wire
 sub-operations and receiver-side logical apply helpers before capture can be
-enabled. Order-sensitive distributed histories are a separate design and should
-use a future ordered table type, such as `KeyOrderedMultiValueTable<K, V>`.
+enabled. Order-sensitive histories belong to `KeyOrderedMultiValueTable<K, V>`;
+that table exists for local storage, but its sync capture/apply contract is
+still deferred.
 
 `AnyValueTable<K>` needs value type-tag propagation or another explicit
 compatibility policy. The current sync wire operation only carries raw value

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -76,6 +76,8 @@ These table families intentionally emit no `ChangeOp` in v0.1:
 - `KeyMultiValueTable`, until the deferred unordered multiset design for
   single-writer or causally serialized updates in `sync/DESIGN.md` is
   implemented and covered by capture and round-trip tests.
+- `KeyOrderedMultiValueTable`, until its ordered multi-value sync wire contract
+  and round-trip tests are implemented.
 - `HashedKeyValueStore`, until the relationship between logical key bytes,
   physical storage keys, and hash-index entries is specified.
 
@@ -96,8 +98,8 @@ it can make replication appear successful while logical state diverges.
   `SnapshotRequired` as automatically recoverable by sync itself.
 - Define explicit conflict/CRDT semantics before claiming general concurrent
   multi-writer convergence for `KeyMultiValueTable`.
-- Design `KeyOrderedMultiValueTable<K, V>` separately if distributed histories
-  need order convergence across multi-writer nodes.
+- Add sync capture/apply for `KeyOrderedMultiValueTable<K, V>` only after its
+  ordered-history wire identity and conflict semantics are specified.
 - Evaluate whether any `KeyMultiValueTable` framing ideas carry over to
   `AnyValueTable` and `HashedKeyValueStore`.
 

--- a/guides/table-api-guide.md
+++ b/guides/table-api-guide.md
@@ -19,6 +19,7 @@ source of truth.
 | One true singleton object in a named table | `ValueTable<V>` | persistent variable | Best for metadata, config snapshots, module state, schema/version records, and checkpoints. |
 | Unique keys only | `KeyTable<K>` | `std::set` | Stores serialized keys with empty values. |
 | Multiple values per key | `KeyMultiValueTable<K, V>` | `std::multimap` | Preserves repeated identical `(key, value)` pairs. |
+| Ordered values per key | `KeyOrderedMultiValueTable<K, V>` | grouped append log | Preserves repeated values and current append order within each key. |
 | Append-only stable-id sequence | `SequenceTable<V>` | `std::vector`-like append, but sparse | Stable uint64_t ids; erase does not shift indices. |
 | Different value types by key | `AnyValueTable<K>` | Heterogeneous key-value store | Caller names value type on each access. |
 
@@ -33,7 +34,11 @@ Choose the narrowest table that represents the data:
 - Use `HashedKeyValueStore` when keys are strings or byte vectors and a compact
   hash-index lookup path is preferable to ordering by full original key bytes.
 - Use `KeyMultiValueTable` for event lists, secondary indexes, histories, and
-  any model where repeated values for the same key must remain visible.
+  any model where repeated values for the same key must remain visible but
+  unordered multiset reconciliation is enough.
+- Use `KeyOrderedMultiValueTable` when repeated values for one key must remain
+  visible in their current append order, such as per-entity timelines or ordered
+  histories.
 - Use `AnyValueTable` only for small heterogeneous keyed settings where values
   under one stable key domain genuinely need different C++ types. It is not a
   replacement for schema design or a typed singleton object.
@@ -111,6 +116,10 @@ Important differences:
 - `KeyMultiValueTable::append()` inserts every source pair as a stored pair.
 - `KeyMultiValueTable::reconcile()` compares pair multiplicity, keeps matching
   records, deletes surplus records, and inserts missing records.
+- `KeyOrderedMultiValueTable::append()` appends after the currently last value
+  for that key.
+- `KeyOrderedMultiValueTable::replace_with()` clears the table and appends
+  source pairs in source iteration order.
 
 ## KeyValueTable
 
@@ -163,7 +172,8 @@ Use it for:
 
 Avoid it when:
 
-- Repeated values for a key are meaningful. Use `KeyMultiValueTable`.
+- Repeated values for a key are meaningful. Use `KeyMultiValueTable`, or
+  `KeyOrderedMultiValueTable` when their order is meaningful too.
 - Only membership matters. Use `KeyTable`.
 
 ## HashedKeyValueStore
@@ -210,7 +220,8 @@ Use it for:
 before `mdbx_put` when set to a positive value. The default is `-1`, so the
 proactive check is disabled and MDBX returns its own storage error. Set an
 explicit positive limit, such as `16 * 1024`, to enable an application-level
-guard. This limit applies to `KeyMultiValueTable` stored values and
+guard. This limit applies to `KeyMultiValueTable` and
+`KeyOrderedMultiValueTable` stored duplicate values, and to
 `HashedKeyValueStore<..., HashedStoreLayout::SmallValues>`.
 
 ## KeyTable
@@ -253,7 +264,8 @@ Use it for:
 Avoid it when:
 
 - A key needs a payload. Use `KeyValueTable`.
-- A key needs multiple payloads. Use `KeyMultiValueTable`.
+- A key needs multiple payloads. Use `KeyMultiValueTable`, or
+  `KeyOrderedMultiValueTable` when per-key order is part of the model.
 
 ## ValueTable
 
@@ -427,6 +439,70 @@ Avoid it when:
 - Only one current value per key matters. Use `KeyValueTable`.
 - Exact repeat preservation is not needed and a unique set is enough. Consider
   `KeyTable` or `KeyValueTable` depending on shape.
+
+## KeyOrderedMultiValueTable
+
+`KeyOrderedMultiValueTable<K, V>` stores multiple values for the same key and
+makes current append order part of the public contract. It uses an MDBX DUPSORT
+table where duplicate values are stored as `big-endian-order || serialized-value`.
+Public reads strip the order prefix and return only user values. The internal
+order prefix is not a stable public record id and may be reused after deleting
+the tail value for a key, deleting the key, or clearing the table.
+
+`MDBX_DB_ACCEDE` is intended only for DBIs previously created with the same
+`KeyOrderedMultiValueTable` storage contract. The wrapper validates persistent
+MDBX flags and, for a non-empty `MDBX_INTEGERKEY` DBI, the physical key width.
+No persistent format marker is stored yet, so the caller remains responsible
+for ensuring that duplicate values use the `KeyOrderedMultiValueTable`
+order-prefix format and the same key/value serialization contract.
+
+Write methods:
+
+- `append(key, value)` always creates a separate stored value after the
+  currently last value for that key.
+- `insert(key, value)` is an alias for `append(key, value)`.
+- `append(vector<pair<K, V>>)` appends source pairs in vector iteration order.
+- `replace_with(vector<pair<K, V>>)` clears the table and appends the source
+  pairs in vector iteration order.
+- `operator=(vector<pair<K, V>>)` delegates to `replace_with()`.
+- `erase(key)` removes all values for a key.
+- `erase(key, value)` removes all exact matching values under a key.
+- `erase_at(key, index)` removes the zero-based value position under a key.
+- `clear()` removes all pairs.
+
+Read/meta methods:
+
+- `find(key)` returns `std::vector<ValueT>` in current append order for that key.
+- `range_vector(from_key, to_key)` returns pairs in MDBX key order and current
+  per-key append order.
+- `retrieve_all_vector()` returns every stored pair as a vector element.
+- `contains()` and `count()` mirror the key and key-value helpers from
+  `KeyMultiValueTable`.
+
+Comparison with `KeyMultiValueTable`:
+
+| Property | `KeyMultiValueTable` | `KeyOrderedMultiValueTable` |
+| --- | --- | --- |
+| Single insert | Adds one physical pair. | Appends one value to the current per-key sequence. |
+| Bulk assignment | `reconcile()` treats pair multiplicity as state and keeps matching records. | `replace_with()` treats vector iteration order as state and rebuilds the table. |
+| Repeated identical values | Preserved. | Preserved. |
+| Internal sequence prefix | Hidden physical detail for duplicate preservation. | Hidden physical detail for current per-key presentation order. |
+| Public order/id returned from append | None. | None. |
+| Sync capture | Deferred. | Deferred. |
+
+Use it for:
+
+- Per-entity timelines.
+- Ordered histories where repeated identical values are meaningful.
+- Grouped append logs that need key-range scans and current per-key order.
+
+Avoid it when:
+
+- Only pair multiplicity matters. Use `KeyMultiValueTable`.
+- One global sequence is enough. Use `SequenceTable`.
+- Sync v0.1 replication is required. This wrapper intentionally emits no
+  `ChangeOp` until its ordered multi-value sync contract is implemented and
+  tested.
 
 ## AnyValueTable
 

--- a/include/mdbx_containers/KeyOrderedMultiValueTable.hpp
+++ b/include/mdbx_containers/KeyOrderedMultiValueTable.hpp
@@ -1,0 +1,823 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_KEY_ORDERED_MULTI_VALUE_TABLE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_KEY_ORDERED_MULTI_VALUE_TABLE_HPP_INCLUDED
+
+/// \file KeyOrderedMultiValueTable.hpp
+/// \brief Ordered multi-value table storing an append sequence per key.
+/// \details
+/// Stores every appended key-value pair as a separate MDBX DUPSORT duplicate.
+/// Duplicate values are prefixed with an internal per-key order number. Reads
+/// for one key therefore preserve the order of currently stored values,
+/// including repeated identical values.
+
+#include "common.hpp"
+#include <limits>
+#include <vector>
+
+namespace mdbxc {
+
+    /// \class KeyOrderedMultiValueTable
+    /// \ingroup mdbxc_tables
+    /// \brief Multi-value table where value order is part of the contract.
+    /// \tparam KeyT Type of the keys.
+    /// \tparam ValueT Type of the values.
+    /// \tparam Options Compile-time table policy. Does not change the database
+    ///         storage format.
+    /// \details
+    /// The MDBX key is the serialized user key. The MDBX duplicate value is
+    /// \c big-endian-order || serialized-value. The order prefix is hidden from
+    /// public reads and is local to each key. It is an internal presentation
+    /// order for current records, not a stable public record identifier. The
+    /// numeric prefix can be reused after deleting the last value for a key,
+    /// erasing the key, or clearing the table.
+    ///
+    /// Use this table when repeated values and their current append order are
+    /// significant. Use \ref KeyMultiValueTable when only pair multiplicity is
+    /// significant and reconciliation by unordered multiset semantics is desired.
+    ///
+    /// \note Sync v0.1 does not capture this wrapper yet. The physical format is
+    ///       intentionally explicit, but wire-level ordered multi-value
+    ///       replication needs separate capture/apply tests before being enabled.
+    ///
+    /// \note \c MDBX_DB_ACCEDE is accepted only for DBIs created with a
+    ///       compatible \c KeyOrderedMultiValueTable storage contract: the same
+    ///       key comparator choice, ascending bytewise duplicate ordering, and
+    ///       duplicate values encoded with this table's internal order prefix.
+    template<class KeyT, class ValueT, class Options = DefaultTableOptions>
+    class KeyOrderedMultiValueTable final : public BaseTable {
+    public:
+        typedef std::pair<KeyT, ValueT> value_type;
+
+        /// \brief Constructs table using existing connection.
+        /// \param connection Existing connection.
+        /// \param name Name of the table within the MDBX environment.
+        /// \param flags Additional MDBX database flags.
+        KeyOrderedMultiValueTable(std::shared_ptr<Connection> connection,
+                                  std::string name = "ordered_multi_value_store",
+                                  MDBX_db_flags_t flags = MDBX_DB_DEFAULTS | MDBX_CREATE)
+            : BaseTable(std::move(connection),
+                        std::move(name),
+                        make_open_flags(flags)) {
+            validate_storage_flags();
+        }
+
+        /// \brief Constructs table using configuration.
+        /// \param config Configuration settings.
+        /// \param name Name of the table within the MDBX environment.
+        /// \param flags Additional MDBX database flags.
+        explicit KeyOrderedMultiValueTable(const Config& config,
+                                           std::string name = "ordered_multi_value_store",
+                                           MDBX_db_flags_t flags = MDBX_DB_DEFAULTS | MDBX_CREATE)
+            : BaseTable(Connection::create(config),
+                        std::move(name),
+                        make_open_flags(flags)) {
+            validate_storage_flags();
+        }
+
+        /// \brief Destructor.
+        ~KeyOrderedMultiValueTable() override = default;
+
+        /// \brief Replaces table content with pairs from a vector.
+        /// \param container Source pairs in the desired stored order.
+        /// \return Reference to this table.
+        KeyOrderedMultiValueTable& operator=(const std::vector<value_type>& container) {
+            replace_with(container);
+            return *this;
+        }
+
+        /// \brief Loads all key-value pairs into a vector.
+        /// \param container Output vector.
+        /// \param txn Optional transaction handle.
+        void load(std::vector<value_type>& container, MDBX_txn* txn = nullptr) const {
+            with_transaction([this, &container](MDBX_txn* t) {
+                db_load(container, t);
+            }, TransactionMode::READ_ONLY, txn);
+        }
+
+        /// \brief Loads all key-value pairs into a vector.
+        /// \param container Output vector.
+        /// \param txn Active transaction wrapper.
+        void load(std::vector<value_type>& container, const Transaction& txn) const {
+            load(container, txn.handle());
+        }
+
+        /// \brief Retrieves all key-value pairs into a vector.
+        /// \param txn Optional transaction handle.
+        /// \return Vector containing all pairs in key order and current per-key append order.
+        std::vector<value_type> retrieve_all_vector(MDBX_txn* txn = nullptr) const {
+            std::vector<value_type> container;
+            load(container, txn);
+            return container;
+        }
+
+        /// \brief Retrieves all key-value pairs into a vector.
+        /// \param txn Active transaction wrapper.
+        /// \return Vector containing all pairs in key order and current per-key append order.
+        std::vector<value_type> retrieve_all_vector(const Transaction& txn) const {
+            return retrieve_all_vector(txn.handle());
+        }
+
+        /// \brief Convenience wrapper around \ref retrieve_all_vector().
+        std::vector<value_type> operator()() const {
+            return retrieve_all_vector();
+        }
+
+        /// \brief Retrieves key-value pairs within an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Optional transaction handle.
+        /// \return Vector containing matching pairs in key order and current per-key append order.
+        std::vector<value_type> range_vector(const KeyT& from_key, const KeyT& to_key,
+                                             MDBX_txn* txn = nullptr) const {
+            std::vector<value_type> pairs;
+            with_transaction([this, &from_key, &to_key, &pairs](MDBX_txn* t) {
+                db_range(from_key, to_key, pairs, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return pairs;
+        }
+
+        /// \brief Retrieves key-value pairs within an inclusive key range.
+        /// \param from_key Start key in MDBX key order.
+        /// \param to_key End key in MDBX key order.
+        /// \param txn Active transaction wrapper.
+        /// \return Vector containing matching pairs in key order and current per-key append order.
+        std::vector<value_type> range_vector(const KeyT& from_key, const KeyT& to_key,
+                                             const Transaction& txn) const {
+            return range_vector(from_key, to_key, txn.handle());
+        }
+
+        /// \brief Appends one value under a key.
+        /// \param key Key to append to.
+        /// \param value Value to append.
+        /// \param txn Optional transaction handle.
+        void append(const KeyT& key, const ValueT& value, MDBX_txn* txn = nullptr) {
+            with_transaction([this, &key, &value](MDBX_txn* t) {
+                db_append_one(key, value, t);
+            }, TransactionMode::WRITABLE, txn);
+        }
+
+        /// \brief Appends one value under a key.
+        /// \param key Key to append to.
+        /// \param value Value to append.
+        /// \param txn Active transaction wrapper.
+        void append(const KeyT& key, const ValueT& value, const Transaction& txn) {
+            append(key, value, txn.handle());
+        }
+
+        /// \brief Alias for \ref append().
+        void insert(const KeyT& key, const ValueT& value, MDBX_txn* txn = nullptr) {
+            append(key, value, txn);
+        }
+
+        /// \brief Alias for \ref append().
+        void insert(const KeyT& key, const ValueT& value, const Transaction& txn) {
+            append(key, value, txn.handle());
+        }
+
+        /// \brief Appends pairs from a vector in vector iteration order.
+        /// \param container Source pairs.
+        /// \param txn Optional transaction handle.
+        void append(const std::vector<value_type>& container, MDBX_txn* txn = nullptr) {
+            with_transaction([this, &container](MDBX_txn* t) {
+                db_append(container, t);
+            }, TransactionMode::WRITABLE, txn);
+        }
+
+        /// \brief Appends pairs from a vector in vector iteration order.
+        /// \param container Source pairs.
+        /// \param txn Active transaction wrapper.
+        void append(const std::vector<value_type>& container, const Transaction& txn) {
+            append(container, txn.handle());
+        }
+
+        /// \brief Replaces all table content with pairs from a vector.
+        /// \param container Source pairs in the desired stored order.
+        /// \param txn Optional transaction handle.
+        void replace_with(const std::vector<value_type>& container, MDBX_txn* txn = nullptr) {
+            with_transaction([this, &container](MDBX_txn* t) {
+                db_clear(t);
+                db_append(container, t);
+            }, TransactionMode::WRITABLE, txn);
+        }
+
+        /// \brief Replaces all table content with pairs from a vector.
+        /// \param container Source pairs in the desired stored order.
+        /// \param txn Active transaction wrapper.
+        void replace_with(const std::vector<value_type>& container, const Transaction& txn) {
+            replace_with(container, txn.handle());
+        }
+
+        /// \brief Finds all values for a key.
+        /// \param key Key to search for.
+        /// \param txn Optional transaction handle.
+        /// \return Values stored for the key in current append order.
+        std::vector<ValueT> find(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            std::vector<ValueT> values;
+            with_transaction([this, &key, &values](MDBX_txn* t) {
+                db_find(key, values, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return values;
+        }
+
+        /// \brief Finds all values for a key.
+        /// \param key Key to search for.
+        /// \param txn Active transaction wrapper.
+        /// \return Values stored for the key in current append order.
+        std::vector<ValueT> find(const KeyT& key, const Transaction& txn) const {
+            return find(key, txn.handle());
+        }
+
+        /// \brief Checks whether a key exists.
+        bool contains(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            bool result = false;
+            with_transaction([this, &key, &result](MDBX_txn* t) {
+                result = db_contains_key(key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Checks whether a key exists.
+        bool contains(const KeyT& key, const Transaction& txn) const {
+            return contains(key, txn.handle());
+        }
+
+        /// \brief Checks whether a key-value pair exists.
+        bool contains(const KeyT& key, const ValueT& value, MDBX_txn* txn = nullptr) const {
+            return count(key, value, txn) > 0;
+        }
+
+        /// \brief Checks whether a key-value pair exists.
+        bool contains(const KeyT& key, const ValueT& value, const Transaction& txn) const {
+            return contains(key, value, txn.handle());
+        }
+
+        /// \brief Counts all stored pairs.
+        std::size_t count(MDBX_txn* txn = nullptr) const {
+            std::size_t result = 0;
+            with_transaction([this, &result](MDBX_txn* t) {
+                result = db_count(t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Counts all stored pairs.
+        std::size_t count(const Transaction& txn) const {
+            return count(txn.handle());
+        }
+
+        /// \brief Counts values stored for a key.
+        std::size_t count(const KeyT& key, MDBX_txn* txn = nullptr) const {
+            std::size_t result = 0;
+            with_transaction([this, &key, &result](MDBX_txn* t) {
+                result = db_count_key(key, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Counts values stored for a key.
+        std::size_t count(const KeyT& key, const Transaction& txn) const {
+            return count(key, txn.handle());
+        }
+
+        /// \brief Counts exact value matches under a key.
+        std::size_t count(const KeyT& key, const ValueT& value, MDBX_txn* txn = nullptr) const {
+            std::size_t result = 0;
+            with_transaction([this, &key, &value, &result](MDBX_txn* t) {
+                result = db_count_pair(key, value, t);
+            }, TransactionMode::READ_ONLY, txn);
+            return result;
+        }
+
+        /// \brief Counts exact value matches under a key.
+        std::size_t count(const KeyT& key, const ValueT& value, const Transaction& txn) const {
+            return count(key, value, txn.handle());
+        }
+
+        /// \brief Checks whether the table has no pairs.
+        bool empty(MDBX_txn* txn = nullptr) const {
+            return count(txn) == 0;
+        }
+
+        /// \brief Checks whether the table has no pairs.
+        bool empty(const Transaction& txn) const {
+            return empty(txn.handle());
+        }
+
+        /// \brief Erases all values for a key.
+        /// \return \c true if the key existed.
+        bool erase(const KeyT& key, MDBX_txn* txn = nullptr) {
+            bool result = false;
+            with_transaction([this, &key, &result](MDBX_txn* t) {
+                result = db_erase_key(key, t);
+            }, TransactionMode::WRITABLE, txn);
+            return result;
+        }
+
+        /// \brief Erases all values for a key.
+        /// \return \c true if the key existed.
+        bool erase(const KeyT& key, const Transaction& txn) {
+            return erase(key, txn.handle());
+        }
+
+        /// \brief Erases all exact value matches under a key.
+        /// \return Number of removed values.
+        std::size_t erase(const KeyT& key, const ValueT& value, MDBX_txn* txn = nullptr) {
+            std::size_t removed = 0;
+            with_transaction([this, &key, &value, &removed](MDBX_txn* t) {
+                removed = db_erase_pair(key, value, t);
+            }, TransactionMode::WRITABLE, txn);
+            return removed;
+        }
+
+        /// \brief Erases all exact value matches under a key.
+        /// \return Number of removed values.
+        std::size_t erase(const KeyT& key, const ValueT& value, const Transaction& txn) {
+            return erase(key, value, txn.handle());
+        }
+
+        /// \brief Erases the value at a zero-based position within one key.
+        /// \param key Key whose ordered value is removed.
+        /// \param index Zero-based append-order index under \p key.
+        /// \param txn Optional transaction handle.
+        /// \return \c true if the indexed value existed and was removed.
+        bool erase_at(const KeyT& key, std::size_t index, MDBX_txn* txn = nullptr) {
+            bool removed = false;
+            with_transaction([this, &key, &index, &removed](MDBX_txn* t) {
+                removed = db_erase_at(key, index, t);
+            }, TransactionMode::WRITABLE, txn);
+            return removed;
+        }
+
+        /// \brief Erases the value at a zero-based position within one key.
+        bool erase_at(const KeyT& key, std::size_t index, const Transaction& txn) {
+            return erase_at(key, index, txn.handle());
+        }
+
+        /// \brief Removes all pairs.
+        void clear(MDBX_txn* txn = nullptr) {
+            with_transaction([this](MDBX_txn* t) {
+                db_clear(t);
+            }, TransactionMode::WRITABLE, txn);
+        }
+
+        /// \brief Removes all pairs.
+        void clear(const Transaction& txn) {
+            clear(txn.handle());
+        }
+
+    private:
+        static const std::size_t order_size = sizeof(std::uint64_t);
+
+        static MDBX_db_flags_t make_open_flags(MDBX_db_flags_t flags) {
+            validate_requested_flags(flags);
+            const unsigned requested = static_cast<unsigned>(flags);
+            if ((requested & MDBX_DB_ACCEDE) != 0 &&
+                (requested & MDBX_CREATE) == 0) {
+                return flags;
+            }
+            return static_cast<MDBX_db_flags_t>(
+                flags | MDBX_DUPSORT | get_mdbx_flags<KeyT>());
+        }
+
+        static bool expects_integer_key() {
+            const unsigned expected =
+                static_cast<unsigned>(get_mdbx_flags<KeyT>());
+            return (expected & static_cast<unsigned>(MDBX_INTEGERKEY)) != 0u;
+        }
+
+        template<typename T>
+        static typename std::enable_if<is_key_integral<T>::value, std::size_t>::type
+        expected_integer_key_size_for() {
+            return mdbx_integer_key_storage_size<T>::value;
+        }
+
+        template<typename T>
+        static typename std::enable_if<std::is_same<T, float>::value, std::size_t>::type
+        expected_integer_key_size_for() {
+            return sizeof(std::uint32_t);
+        }
+
+        template<typename T>
+        static typename std::enable_if<std::is_same<T, double>::value, std::size_t>::type
+        expected_integer_key_size_for() {
+            return sizeof(std::uint64_t);
+        }
+
+        template<typename T>
+        static typename std::enable_if<
+            !is_key_integral<T>::value &&
+            !std::is_same<T, float>::value &&
+            !std::is_same<T, double>::value,
+            std::size_t>::type
+        expected_integer_key_size_for() {
+            return 0u;
+        }
+
+        static std::size_t expected_integer_key_size() {
+            return expected_integer_key_size_for<KeyT>();
+        }
+
+        static void validate_requested_flags(MDBX_db_flags_t flags) {
+            const unsigned requested = static_cast<unsigned>(flags);
+            if (requested & MDBX_REVERSEDUP) {
+                throw std::invalid_argument(
+                    "KeyOrderedMultiValueTable requires bytewise ascending duplicate ordering");
+            }
+            if (requested & MDBX_INTEGERDUP) {
+                throw std::invalid_argument(
+                    "KeyOrderedMultiValueTable duplicate values are not MDBX_INTEGERDUP records");
+            }
+            if (requested & MDBX_DUPFIXED) {
+                throw std::invalid_argument(
+                    "KeyOrderedMultiValueTable duplicate values are variable-sized");
+            }
+            if ((requested & static_cast<unsigned>(MDBX_INTEGERKEY)) != 0u &&
+                !expects_integer_key()) {
+                throw std::invalid_argument(
+                    "KeyOrderedMultiValueTable MDBX_INTEGERKEY is incompatible with KeyT");
+            }
+        }
+
+        void validate_storage_flags() const {
+            const std::uint32_t flags = m_dbi_flags;
+            if ((flags & MDBX_DUPSORT) == 0) {
+                throw std::invalid_argument(
+                    "KeyOrderedMultiValueTable requires an MDBX_DUPSORT DBI");
+            }
+            if ((flags & MDBX_REVERSEDUP) != 0) {
+                throw std::invalid_argument(
+                    "KeyOrderedMultiValueTable cannot use MDBX_REVERSEDUP");
+            }
+            if ((flags & MDBX_INTEGERDUP) != 0) {
+                throw std::invalid_argument(
+                    "KeyOrderedMultiValueTable cannot use MDBX_INTEGERDUP");
+            }
+            if ((flags & MDBX_DUPFIXED) != 0) {
+                throw std::invalid_argument(
+                    "KeyOrderedMultiValueTable cannot use MDBX_DUPFIXED");
+            }
+
+            const bool actual_integer_key =
+                (flags & static_cast<std::uint32_t>(MDBX_INTEGERKEY)) != 0u;
+            if (actual_integer_key != expects_integer_key()) {
+                throw std::invalid_argument(
+                    "KeyOrderedMultiValueTable DBI key comparator is incompatible with KeyT");
+            }
+            if (actual_integer_key) {
+                validate_existing_integer_key_width();
+            }
+        }
+
+        void validate_existing_integer_key_width() const {
+            const std::size_t expected_size = expected_integer_key_size();
+            if (expected_size == 0u) {
+                return;
+            }
+
+            auto txn = m_connection->transaction(TransactionMode::READ_ONLY);
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn.handle(), m_dbi, cursor.out()),
+                       "Failed to open cursor for ordered key comparator validation");
+
+            MDBX_val key;
+            MDBX_val value;
+            const int rc = mdbx_cursor_get(cursor.get(), &key, &value, MDBX_FIRST);
+            if (rc == MDBX_NOTFOUND) {
+                return;
+            }
+            check_mdbx(rc, "Failed to read first key for ordered key comparator validation");
+            if (key.iov_len != expected_size) {
+                throw std::invalid_argument(
+                    "KeyOrderedMultiValueTable existing INTEGERKEY DBI key width is incompatible with KeyT");
+            }
+        }
+
+        template<typename F>
+        void with_transaction(F&& action, TransactionMode mode, MDBX_txn* txn = nullptr) const {
+            if (txn) {
+                action(checked_external_txn(txn));
+                return;
+            }
+            txn = thread_txn();
+            if (txn) {
+                action(txn);
+                return;
+            }
+
+            auto txn_guard = m_connection->transaction(mode);
+            try {
+                action(txn_guard.handle());
+                txn_guard.commit();
+            } catch (...) {
+                try { txn_guard.rollback(); } catch (...) {}
+                throw;
+            }
+        }
+
+        static void encode_order(std::uint64_t order, std::uint8_t* out) {
+            for (std::size_t i = 0; i < order_size; ++i) {
+                out[i] = static_cast<std::uint8_t>((order >> ((order_size - 1 - i) * 8)) & 0xffu);
+            }
+        }
+
+        static std::uint64_t decode_order(const MDBX_val& stored) {
+            if (stored.iov_len < order_size) {
+                throw std::runtime_error("Corrupted ordered multi-value record");
+            }
+            const std::uint8_t* bytes = static_cast<const std::uint8_t*>(stored.iov_base);
+            std::uint64_t order = 0;
+            for (std::size_t i = 0; i < order_size; ++i) {
+                order = (order << 8) | static_cast<std::uint64_t>(bytes[i]);
+            }
+            return order;
+        }
+
+        static MDBX_val strip_order(const MDBX_val& stored) {
+            if (stored.iov_len < order_size) {
+                throw std::runtime_error("Corrupted ordered multi-value record");
+            }
+            MDBX_val raw;
+            raw.iov_base = static_cast<std::uint8_t*>(stored.iov_base) + order_size;
+            raw.iov_len = stored.iov_len - order_size;
+            return raw;
+        }
+
+        MDBX_val make_stored_value(std::uint64_t order,
+                                   const ValueT& value,
+                                   SerializeScratch& sc_value) const {
+            SerializeScratch raw_scratch;
+            MDBX_val raw_value = serialize_value(value, raw_scratch);
+            sc_value.bytes.resize(order_size + raw_value.iov_len);
+            encode_order(order, sc_value.bytes.data());
+            if (raw_value.iov_len) {
+                std::memcpy(sc_value.bytes.data() + order_size, raw_value.iov_base, raw_value.iov_len);
+            }
+            return sc_value.view_bytes();
+        }
+
+        MDBX_val make_comparable_value(const ValueT& value, SerializeScratch& sc_value) const {
+            SerializeScratch raw_scratch;
+            MDBX_val raw_value = serialize_value(value, raw_scratch);
+            sc_value.bytes.resize(raw_value.iov_len);
+            if (raw_value.iov_len) {
+                std::memcpy(sc_value.bytes.data(), raw_value.iov_base, raw_value.iov_len);
+            }
+            return sc_value.view_bytes();
+        }
+
+        bool stored_value_matches(const MDBX_val& stored, const MDBX_val& raw_value) const {
+            MDBX_val stored_raw = strip_order(stored);
+            if (stored_raw.iov_len != raw_value.iov_len) {
+                return false;
+            }
+            if (stored_raw.iov_len == 0) {
+                return true;
+            }
+            return std::memcmp(stored_raw.iov_base, raw_value.iov_base, stored_raw.iov_len) == 0;
+        }
+
+        std::uint64_t next_order(const KeyT& key, MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_KEY);
+            if (rc == MDBX_NOTFOUND) {
+                return 0;
+            }
+            check_mdbx(rc, "Failed to seek key");
+            rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_LAST_DUP);
+            check_mdbx(rc, "Failed to seek last ordered value");
+            const std::uint64_t last = decode_order(db_val);
+            if (last == std::numeric_limits<std::uint64_t>::max()) {
+                throw std::overflow_error("Per-key ordered multi-value sequence exhausted");
+            }
+            return last + 1;
+        }
+
+        void db_load(std::vector<value_type>& container, MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            MDBX_val db_key, db_val;
+            int rc = MDBX_SUCCESS;
+            while ((rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT)) == MDBX_SUCCESS) {
+                KeyT key = deserialize_key<KeyT>(db_key);
+                ValueT value = deserialize_value<ValueT>(strip_order(db_val));
+                container.push_back(value_type(std::move(key), std::move(value)));
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to read ordered multi-value table");
+            }
+        }
+
+        void db_range(const KeyT& from_key, const KeyT& to_key,
+                      std::vector<value_type>& pairs, MDBX_txn* txn) const {
+            SerializeScratch sc_from_key;
+            SerializeScratch sc_to_key;
+            MDBX_val db_from_key = serialize_key<Options::safe_integer_key>(from_key, sc_from_key);
+            MDBX_val db_to_key = serialize_key<Options::safe_integer_key>(to_key, sc_to_key);
+
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+            if (mdbx_cmp(txn, m_dbi, &db_from_key, &db_to_key) > 0) {
+                return;
+            }
+
+            MDBX_val db_key = db_from_key;
+            MDBX_val db_val;
+            bool stopped_by_upper_bound = false;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_RANGE);
+            while (rc == MDBX_SUCCESS) {
+                if (mdbx_cmp(txn, m_dbi, &db_key, &db_to_key) > 0) {
+                    stopped_by_upper_bound = true;
+                    break;
+                }
+                KeyT key = deserialize_key<KeyT>(db_key);
+                ValueT value = deserialize_value<ValueT>(strip_order(db_val));
+                pairs.push_back(value_type(std::move(key), std::move(value)));
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+            }
+            if (!stopped_by_upper_bound && rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to read ordered multi-value key range");
+            }
+        }
+
+        void db_append_one(const KeyT& key, const ValueT& value, MDBX_txn* txn) {
+            SerializeScratch sc_key;
+            SerializeScratch sc_value;
+            const std::uint64_t order = next_order(key, txn);
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_val = make_stored_value(order, value, sc_value);
+            check_dupsort_value_size(db_val);
+            check_mdbx(mdbx_put(txn, m_dbi, &db_key, &db_val, MDBX_UPSERT),
+                       "Failed to append ordered multi-value record");
+        }
+
+        void db_append(const std::vector<value_type>& container, MDBX_txn* txn) {
+            for (typename std::vector<value_type>::const_iterator it = container.begin();
+                 it != container.end(); ++it) {
+                db_append_one(it->first, it->second, txn);
+            }
+        }
+
+        void db_find(const KeyT& key, std::vector<ValueT>& values, MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_KEY);
+            if (rc == MDBX_NOTFOUND) {
+                return;
+            }
+            check_mdbx(rc, "Failed to seek key");
+            while (rc == MDBX_SUCCESS) {
+                values.push_back(deserialize_value<ValueT>(strip_order(db_val)));
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT_DUP);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to read ordered duplicate values");
+            }
+        }
+
+        bool db_contains_key(const KeyT& key, MDBX_txn* txn) const {
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_val;
+            int rc = mdbx_get(txn, m_dbi, &db_key, &db_val);
+            if (rc == MDBX_SUCCESS) return true;
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "Failed to check ordered multi-value key presence");
+            return false;
+        }
+
+        std::size_t db_count(MDBX_txn* txn) const {
+            MDBX_stat stat;
+            check_mdbx(mdbx_dbi_stat(txn, m_dbi, &stat, sizeof(stat)),
+                       "Failed to query ordered multi-value table statistics");
+            return stat.ms_entries;
+        }
+
+        std::size_t db_count_key(const KeyT& key, MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_KEY);
+            if (rc == MDBX_NOTFOUND) {
+                return 0;
+            }
+            check_mdbx(rc, "Failed to seek key");
+            size_t found = 0;
+            check_mdbx(mdbx_cursor_count(cursor.get(), &found), "Failed to count ordered duplicate values");
+            return found;
+        }
+
+        std::size_t db_count_pair(const KeyT& key, const ValueT& value, MDBX_txn* txn) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            SerializeScratch sc_key;
+            SerializeScratch sc_value;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val raw_value = make_comparable_value(value, sc_value);
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_KEY);
+            if (rc == MDBX_NOTFOUND) {
+                return 0;
+            }
+            check_mdbx(rc, "Failed to seek key");
+            std::size_t found = 0;
+            while (rc == MDBX_SUCCESS) {
+                if (stored_value_matches(db_val, raw_value)) {
+                    ++found;
+                }
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT_DUP);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to scan ordered duplicate values");
+            }
+            return found;
+        }
+
+        bool db_erase_key(const KeyT& key, MDBX_txn* txn) {
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            int rc = mdbx_del(txn, m_dbi, &db_key, nullptr);
+            if (rc == MDBX_SUCCESS) return true;
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "Failed to erase ordered multi-value key");
+            return false;
+        }
+
+        std::size_t db_erase_pair(const KeyT& key, const ValueT& value, MDBX_txn* txn) {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            SerializeScratch sc_key;
+            SerializeScratch sc_value;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val raw_value = make_comparable_value(value, sc_value);
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_KEY);
+            if (rc == MDBX_NOTFOUND) {
+                return 0;
+            }
+            check_mdbx(rc, "Failed to seek key");
+            std::size_t removed = 0;
+            while (rc == MDBX_SUCCESS) {
+                if (stored_value_matches(db_val, raw_value)) {
+                    check_mdbx(mdbx_cursor_del(cursor.get(), MDBX_CURRENT),
+                               "Failed to erase ordered duplicate value");
+                    ++removed;
+                }
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT_DUP);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to scan ordered duplicate values");
+            }
+            return removed;
+        }
+
+        bool db_erase_at(const KeyT& key, std::size_t index, MDBX_txn* txn) {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()), "Failed to open MDBX cursor");
+
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_KEY);
+            if (rc == MDBX_NOTFOUND) {
+                return false;
+            }
+            check_mdbx(rc, "Failed to seek key");
+            std::size_t current = 0;
+            while (rc == MDBX_SUCCESS) {
+                if (current == index) {
+                    check_mdbx(mdbx_cursor_del(cursor.get(), MDBX_CURRENT),
+                               "Failed to erase ordered duplicate by index");
+                    return true;
+                }
+                ++current;
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT_DUP);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to scan ordered duplicate values");
+            }
+            return false;
+        }
+
+        void db_clear(MDBX_txn* txn) {
+            check_mdbx(mdbx_drop(txn, m_dbi, 0), "Failed to clear ordered multi-value table");
+        }
+    };
+
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_KEY_ORDERED_MULTI_VALUE_TABLE_HPP_INCLUDED

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -96,6 +96,7 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
 | `VectorStore` | Supported indirectly | Does not own a separate wire format. Its persistent writes go through `SequenceTable` and `KeyValueTable` member tables. Already-open instances refresh their RAM index lazily after completed remote apply when the connection sync-apply generation changes. |
 | `AnyValueTable` | Not supported in v0.1 | Deferred until heterogeneous value type tags are part of the sync wire format. |
 | `KeyMultiValueTable` | Not supported in v0.1 | Deferred until unordered multiset replication and DUPSORT duplicate-value payload framing are implemented and tested. |
+| `KeyOrderedMultiValueTable` | Not supported in v0.1 | Local ordered multi-value table exists, but sync capture/apply is deferred until ordered-history wire identity and conflict semantics are specified and tested. |
 | `HashedKeyValueStore` | Not supported in v0.1 | Deferred until hash-index and identity-key mapping semantics are specified. |
 
 Do not add `record_op()` paths for unsupported table types without first
@@ -176,8 +177,8 @@ Order-sensitive APIs such as `find(key)`, `retrieve_all_vector()`, and
 multiple nodes write values for the same key. The order and multiplicity
 converge only when the application uses one authoritative writer for the
 relevant key/logical dataset or otherwise serializes conflicting updates before
-they are replicated. Ordered distributed history belongs to a separate future
-table.
+they are replicated. Ordered distributed history belongs to the separate
+`KeyOrderedMultiValueTable` API and still needs its own sync contract.
 
 Planned logical operations:
 
@@ -246,13 +247,21 @@ Neither order-sensitive iteration nor concurrent destructive-update convergence
 is guaranteed for general multi-writer `KeyMultiValueTable` replication. The
 sequence prefix remains a local storage detail and is not a cross-node identity.
 
-### Future ordered table
+### Deferred `KeyOrderedMultiValueTable` sync design
 
-If the library needs replicated per-key histories, event timelines, queues, or
-other APIs where cross-node order is part of the contract, add a separate
-`KeyOrderedMultiValueTable<K, V>` instead of overloading
-`KeyMultiValueTable`. That table should store an explicit globally stable order
-identity, for example:
+`KeyOrderedMultiValueTable<K, V>` exists as a local table API for replicated
+per-key histories, event timelines, queues, and other local models where
+per-key append order is part of the contract. Sync support for it remains
+deferred. The local storage format is:
+
+```text
+MDBX key                 = serialized-key
+ordered duplicate value  = local-order-prefix || serialized-value
+local-order-prefix       = per-key uint64_t assigned by the destination DBI
+```
+
+The local-order prefix is a storage detail, not a cross-node identity. A future
+sync format must carry an explicit globally stable order identity, for example:
 
 ```text
 ordered duplicate value = global-order-key || serialized-value
@@ -299,8 +308,10 @@ anchors, see the
 - `HashedKeyValueStore` — internal hash index layout complicates the wire
   format; deferred until an explicit identity-mapping scheme lands.
 - `KeyMultiValueTable` — DUPSORT duplicate values need the unordered multiset
-  model described above before capture can be enabled. Ordered distributed
-  histories are deferred to a future `KeyOrderedMultiValueTable<K, V>`.
+  model described above before capture can be enabled.
+- `KeyOrderedMultiValueTable` — local ordered storage exists, but ordered
+  distributed histories need the explicit sync wire identity described above
+  before capture can be enabled.
 - `AnyValueTable` — heterogeneous values need type-tag propagation on the wire.
 - `IdentityProvider` integration in `BaseTable` — declared in v0.1, no
   write path until HashedKeyValueStore.

--- a/include/mdbx_containers/tables.hpp
+++ b/include/mdbx_containers/tables.hpp
@@ -6,13 +6,15 @@
 /// \brief Includes the table wrappers only.
 /// \details
 /// Pulls in every table wrapper (KeyValue, Key, Value, Sequence,
-/// HashedKeyValue, KeyMultiValue, AnyValue, Hash) but NOT the sync or
-/// vector subsystems. Use when the project only needs the table API.
+/// HashedKeyValue, KeyMultiValue, KeyOrderedMultiValue, AnyValue, Hash) but
+/// NOT the sync or vector subsystems. Use when the project only needs the
+/// table API.
 
 #include "mdbx_containers/AnyValueTable.hpp"
 #include "mdbx_containers/Hash.hpp"
 #include "mdbx_containers/HashedKeyValueStore.hpp"
 #include "mdbx_containers/KeyMultiValueTable.hpp"
+#include "mdbx_containers/KeyOrderedMultiValueTable.hpp"
 #include "mdbx_containers/KeyTable.hpp"
 #include "mdbx_containers/KeyValueTable.hpp"
 #include "mdbx_containers/SequenceTable.hpp"

--- a/tests/header_all_umbrella_test.cpp
+++ b/tests/header_all_umbrella_test.cpp
@@ -21,6 +21,9 @@ int main() {
     mdbxc::KeyValueTable<std::uint64_t, std::string>* key_value_table = nullptr;
     MDBXC_TEST_ASSERT(key_value_table == nullptr);
 
+    mdbxc::KeyOrderedMultiValueTable<std::uint64_t, std::string>* ordered_multi_value_table = nullptr;
+    MDBXC_TEST_ASSERT(ordered_multi_value_table == nullptr);
+
     mdbxc::sync::NodeId node = mdbxc::sync::make_zero_node();
     MDBXC_TEST_ASSERT(node.size() == 16u);
 

--- a/tests/header_tables_umbrella_test.cpp
+++ b/tests/header_tables_umbrella_test.cpp
@@ -18,6 +18,9 @@ int main() {
     mdbxc::KeyMultiValueTable<std::uint64_t, std::string>* multi_value_table = nullptr;
     MDBXC_TEST_ASSERT(multi_value_table == nullptr);
 
+    mdbxc::KeyOrderedMultiValueTable<std::uint64_t, std::string>* ordered_multi_value_table = nullptr;
+    MDBXC_TEST_ASSERT(ordered_multi_value_table == nullptr);
+
     mdbxc::SequenceTable<std::uint64_t>* sequence_table = nullptr;
     MDBXC_TEST_ASSERT(sequence_table == nullptr);
 

--- a/tests/key_ordered_multi_value_table_test.cpp
+++ b/tests/key_ordered_multi_value_table_test.cpp
@@ -1,0 +1,386 @@
+#include "test_assert.hpp"
+
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mdbx_containers/KeyOrderedMultiValueTable.hpp>
+
+namespace {
+
+template<class T>
+void assert_vector_equal(const std::vector<T>& actual, const std::vector<T>& expected) {
+    MDBXC_TEST_ASSERT(actual.size() == expected.size());
+    for (std::size_t i = 0; i < actual.size(); ++i) {
+        MDBXC_TEST_ASSERT(actual[i] == expected[i]);
+    }
+}
+
+template<class Fn>
+void assert_throws_length_error(Fn fn) {
+    bool thrown = false;
+    try {
+        fn();
+    } catch (const std::length_error&) {
+        thrown = true;
+    }
+    MDBXC_TEST_ASSERT(thrown);
+}
+
+template<class Fn>
+void assert_throws_invalid_argument(Fn fn) {
+    bool thrown = false;
+    try {
+        fn();
+    } catch (const std::invalid_argument&) {
+        thrown = true;
+    }
+    MDBXC_TEST_ASSERT(thrown);
+}
+
+void create_raw_dbi(const std::shared_ptr<mdbxc::Connection>& conn,
+                    const std::string& name,
+                    MDBX_db_flags_t flags) {
+    auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+    MDBX_dbi dbi = 0;
+    mdbxc::check_mdbx(mdbx_dbi_open(txn.handle(), name.c_str(), flags, &dbi),
+                      "Failed to create raw DBI for ordered multi-value test");
+    txn.commit();
+}
+
+void create_raw_integer_dbi_with_u32_key(const std::shared_ptr<mdbxc::Connection>& conn,
+                                         const std::string& name) {
+    auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+    MDBX_dbi dbi = 0;
+    mdbxc::check_mdbx(
+        mdbx_dbi_open(txn.handle(),
+                      name.c_str(),
+                      static_cast<MDBX_db_flags_t>(MDBX_CREATE |
+                                                   MDBX_DUPSORT |
+                                                   MDBX_INTEGERKEY),
+                      &dbi),
+        "Failed to create raw INTEGERKEY DBI for ordered multi-value test");
+
+    std::uint32_t key = 1u;
+    char raw_value = 'x';
+    MDBX_val db_key;
+    db_key.iov_base = &key;
+    db_key.iov_len = sizeof(key);
+    MDBX_val db_value;
+    db_value.iov_base = &raw_value;
+    db_value.iov_len = sizeof(raw_value);
+    mdbxc::check_mdbx(mdbx_put(txn.handle(), dbi, &db_key, &db_value, MDBX_UPSERT),
+                      "Failed to seed raw INTEGERKEY DBI for ordered multi-value test");
+    txn.commit();
+}
+
+} // namespace
+
+int main() {
+    mdbxc::Config cfg;
+    cfg.pathname = "data/key_ordered_multi_value_table_v2_test.mdbx";
+    cfg.max_dbs = 32;
+    cfg.no_subdir = true;
+    cfg.relative_to_exe = true;
+
+    auto conn = mdbxc::Connection::create(cfg);
+
+    {
+        mdbxc::KeyOrderedMultiValueTable<int, std::string> table(conn, "ordered_multi_values");
+        table.clear();
+
+        MDBXC_TEST_ASSERT(table.empty());
+        table.append(7, "created");
+        table.append(7, "created");
+        table.append(7, "sent");
+        table.append(8, "queued");
+
+        MDBXC_TEST_ASSERT(table.count() == 4u);
+        MDBXC_TEST_ASSERT(table.count(7) == 3u);
+        MDBXC_TEST_ASSERT(table.count(7, std::string("created")) == 2u);
+        MDBXC_TEST_ASSERT(table.count(7, std::string("missing")) == 0u);
+        MDBXC_TEST_ASSERT(table.contains(7));
+        MDBXC_TEST_ASSERT(table.contains(7, std::string("sent")));
+        MDBXC_TEST_ASSERT(!table.contains(9));
+
+        std::vector<std::string> key_values;
+        key_values.push_back("created");
+        key_values.push_back("created");
+        key_values.push_back("sent");
+        assert_vector_equal(table.find(7), key_values);
+
+        std::vector<std::pair<int, std::string> > expected_pairs;
+        expected_pairs.push_back(std::make_pair(7, std::string("created")));
+        expected_pairs.push_back(std::make_pair(7, std::string("created")));
+        expected_pairs.push_back(std::make_pair(7, std::string("sent")));
+        expected_pairs.push_back(std::make_pair(8, std::string("queued")));
+        assert_vector_equal(table.retrieve_all_vector(), expected_pairs);
+        assert_vector_equal(table.range_vector(7, 8), expected_pairs);
+
+        MDBXC_TEST_ASSERT(table.erase_at(7, 1u));
+        std::vector<std::string> after_erase_at;
+        after_erase_at.push_back("created");
+        after_erase_at.push_back("sent");
+        assert_vector_equal(table.find(7), after_erase_at);
+
+        MDBXC_TEST_ASSERT(!table.erase_at(7, 9u));
+        MDBXC_TEST_ASSERT(table.erase(7, std::string("created")) == 1u);
+        std::vector<std::string> sent_only;
+        sent_only.push_back("sent");
+        assert_vector_equal(table.find(7), sent_only);
+
+        MDBXC_TEST_ASSERT(table.erase(7));
+        MDBXC_TEST_ASSERT(!table.contains(7));
+        MDBXC_TEST_ASSERT(table.count() == 1u);
+    }
+
+    {
+        mdbxc::KeyOrderedMultiValueTable<int, std::string> table(conn, "ordered_lifecycle");
+        table.clear();
+        table.append(1, "a");
+        table.append(1, "b");
+        table.append(1, "c");
+        MDBXC_TEST_ASSERT(table.erase_at(1, 2u));
+        table.append(1, "d");
+
+        std::vector<std::string> after_tail_delete;
+        after_tail_delete.push_back("a");
+        after_tail_delete.push_back("b");
+        after_tail_delete.push_back("d");
+        assert_vector_equal(table.find(1), after_tail_delete);
+
+        MDBXC_TEST_ASSERT(table.erase(1));
+        table.append(1, "after-key-erase");
+        std::vector<std::string> after_key_erase;
+        after_key_erase.push_back("after-key-erase");
+        assert_vector_equal(table.find(1), after_key_erase);
+
+        table.clear();
+        table.append(1, "after-clear");
+        std::vector<std::string> after_clear;
+        after_clear.push_back("after-clear");
+        assert_vector_equal(table.find(1), after_clear);
+    }
+
+    {
+        mdbxc::KeyOrderedMultiValueTable<int, std::string> table(conn, "ordered_signed_keys");
+        table.clear();
+        table.append(1, "one");
+        table.append(-2, "minus-two-a");
+        table.append(0, "zero");
+        table.append(-2, "minus-two-b");
+        table.append(-1, "minus-one");
+
+        std::vector<std::pair<int, std::string> > expected;
+        expected.push_back(std::make_pair(-2, std::string("minus-two-a")));
+        expected.push_back(std::make_pair(-2, std::string("minus-two-b")));
+        expected.push_back(std::make_pair(-1, std::string("minus-one")));
+        expected.push_back(std::make_pair(0, std::string("zero")));
+        expected.push_back(std::make_pair(1, std::string("one")));
+
+        assert_vector_equal(table.retrieve_all_vector(), expected);
+        assert_vector_equal(table.range_vector(-2, 1), expected);
+
+        std::vector<std::string> minus_two;
+        minus_two.push_back("minus-two-a");
+        minus_two.push_back("minus-two-b");
+        assert_vector_equal(table.find(-2), minus_two);
+    }
+
+    {
+        mdbxc::KeyOrderedMultiValueTable<int, std::string> table(conn, "ordered_replace");
+        table.clear();
+
+        std::vector<mdbxc::KeyOrderedMultiValueTable<int, std::string>::value_type> input;
+        input.push_back(std::make_pair(3, std::string("a")));
+        input.push_back(std::make_pair(3, std::string("b")));
+        input.push_back(std::make_pair(3, std::string("a")));
+        table.append(input);
+
+        std::vector<std::string> first;
+        first.push_back("a");
+        first.push_back("b");
+        first.push_back("a");
+        assert_vector_equal(table.find(3), first);
+
+        std::vector<mdbxc::KeyOrderedMultiValueTable<int, std::string>::value_type> replacement;
+        replacement.push_back(std::make_pair(4, std::string("x")));
+        replacement.push_back(std::make_pair(4, std::string("y")));
+        table = replacement;
+
+        MDBXC_TEST_ASSERT(!table.contains(3));
+        std::vector<std::string> second;
+        second.push_back("x");
+        second.push_back("y");
+        assert_vector_equal(table.find(4), second);
+
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        table.append(4, "z", txn);
+        txn.commit();
+
+        second.push_back("z");
+        assert_vector_equal(table.find(4), second);
+    }
+
+    {
+        mdbxc::KeyOrderedMultiValueTable<int, std::string> table(conn, "ordered_rollback");
+        table.clear();
+        table.append(1, "committed");
+
+        {
+            auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+            table.append(1, "rolled-back", txn);
+            txn.rollback();
+        }
+
+        table.append(1, "after-rollback");
+        std::vector<std::string> expected;
+        expected.push_back("committed");
+        expected.push_back("after-rollback");
+        assert_vector_equal(table.find(1), expected);
+    }
+
+    {
+        mdbxc::Config reopen_cfg;
+        reopen_cfg.pathname = "data/key_ordered_multi_value_reopen_v2_test.mdbx";
+        reopen_cfg.max_dbs = 4;
+        reopen_cfg.no_subdir = true;
+        reopen_cfg.relative_to_exe = true;
+
+        {
+            auto reopen_conn = mdbxc::Connection::create(reopen_cfg);
+            mdbxc::KeyOrderedMultiValueTable<int, std::string> table(
+                reopen_conn, "ordered_reopen");
+            table.clear();
+            table.append(1, "first");
+            table.append(1, "second");
+        }
+        {
+            auto reopen_conn = mdbxc::Connection::create(reopen_cfg);
+            mdbxc::KeyOrderedMultiValueTable<int, std::string> reopened(
+                reopen_conn, "ordered_reopen");
+            reopened.append(1, "third");
+            std::vector<std::string> expected;
+            expected.push_back("first");
+            expected.push_back("second");
+            expected.push_back("third");
+            assert_vector_equal(reopened.find(1), expected);
+        }
+    }
+
+    {
+        assert_throws_invalid_argument([conn]() {
+            mdbxc::KeyOrderedMultiValueTable<int, std::string> table(
+                conn, "ordered_bad_reversedup",
+                static_cast<MDBX_db_flags_t>(MDBX_CREATE | MDBX_REVERSEDUP));
+            (void)table;
+        });
+        assert_throws_invalid_argument([conn]() {
+            mdbxc::KeyOrderedMultiValueTable<int, std::string> table(
+                conn, "ordered_bad_integerdup",
+                static_cast<MDBX_db_flags_t>(MDBX_CREATE | MDBX_INTEGERDUP));
+            (void)table;
+        });
+        assert_throws_invalid_argument([conn]() {
+            mdbxc::KeyOrderedMultiValueTable<int, std::string> table(
+                conn, "ordered_bad_dupfixed",
+                static_cast<MDBX_db_flags_t>(MDBX_CREATE | MDBX_DUPFIXED));
+            (void)table;
+        });
+
+        create_raw_dbi(conn,
+                       "ordered_accede_reversedup",
+                       static_cast<MDBX_db_flags_t>(MDBX_CREATE |
+                                                    MDBX_DUPSORT |
+                                                    MDBX_REVERSEDUP));
+        assert_throws_invalid_argument([conn]() {
+            mdbxc::KeyOrderedMultiValueTable<int, std::string> table(
+                conn, "ordered_accede_reversedup",
+                static_cast<MDBX_db_flags_t>(MDBX_DB_ACCEDE));
+            (void)table;
+        });
+
+        create_raw_dbi(conn,
+                       "ordered_accede_non_dupsort",
+                       static_cast<MDBX_db_flags_t>(MDBX_CREATE));
+        assert_throws_invalid_argument([conn]() {
+            mdbxc::KeyOrderedMultiValueTable<std::string, std::string> table(
+                conn, "ordered_accede_non_dupsort",
+                static_cast<MDBX_db_flags_t>(MDBX_DB_ACCEDE));
+            (void)table;
+        });
+
+        create_raw_dbi(conn,
+                       "ordered_accede_missing_integerkey",
+                       static_cast<MDBX_db_flags_t>(MDBX_CREATE |
+                                                    MDBX_DUPSORT));
+        assert_throws_invalid_argument([conn]() {
+            mdbxc::KeyOrderedMultiValueTable<int, std::string> table(
+                conn, "ordered_accede_missing_integerkey",
+                static_cast<MDBX_db_flags_t>(MDBX_DB_ACCEDE));
+            (void)table;
+        });
+
+        create_raw_dbi(conn,
+                       "ordered_accede_unexpected_integerkey",
+                       static_cast<MDBX_db_flags_t>(MDBX_CREATE |
+                                                    MDBX_DUPSORT |
+                                                    MDBX_INTEGERKEY));
+        assert_throws_invalid_argument([conn]() {
+            mdbxc::KeyOrderedMultiValueTable<std::string, std::string> table(
+                conn, "ordered_accede_unexpected_integerkey",
+                static_cast<MDBX_db_flags_t>(MDBX_DB_ACCEDE));
+            (void)table;
+        });
+
+        assert_throws_invalid_argument([conn]() {
+            mdbxc::KeyOrderedMultiValueTable<std::string, std::string> table(
+                conn, "ordered_requested_bad_integerkey",
+                static_cast<MDBX_db_flags_t>(MDBX_CREATE | MDBX_INTEGERKEY));
+            (void)table;
+        });
+
+        create_raw_dbi(conn,
+                       "ordered_accede_integerkey_ok",
+                       static_cast<MDBX_db_flags_t>(MDBX_CREATE |
+                                                    MDBX_DUPSORT |
+                                                    MDBX_INTEGERKEY));
+        mdbxc::KeyOrderedMultiValueTable<int, std::string> compatible(
+            conn,
+            "ordered_accede_integerkey_ok",
+            static_cast<MDBX_db_flags_t>(MDBX_DB_ACCEDE));
+        compatible.append(-1, "minus-one");
+        compatible.append(0, "zero");
+        compatible.append(256, "two-fifty-six");
+
+        create_raw_integer_dbi_with_u32_key(conn, "ordered_accede_wrong_integerkey_width");
+        assert_throws_invalid_argument([conn]() {
+            mdbxc::KeyOrderedMultiValueTable<long long, std::string> table(
+                conn, "ordered_accede_wrong_integerkey_width",
+                static_cast<MDBX_db_flags_t>(MDBX_DB_ACCEDE));
+            (void)table;
+        });
+    }
+
+    {
+        mdbxc::Config limit_cfg;
+        limit_cfg.pathname = "data/key_ordered_multi_value_oversized_v2_test.mdbx";
+        limit_cfg.max_dbs = 4;
+        limit_cfg.max_dupsort_value_size = 128;
+        limit_cfg.no_subdir = true;
+        limit_cfg.relative_to_exe = true;
+
+        auto limit_conn = mdbxc::Connection::create(limit_cfg);
+        mdbxc::KeyOrderedMultiValueTable<int, std::string> table(limit_conn, "ordered_oversized");
+        table.clear();
+        std::string large(1024, 'x');
+        assert_throws_length_error([&table, &large]() {
+            table.append(1, large);
+        });
+    }
+
+    std::cout << "KeyOrderedMultiValueTable test passed.\n";
+    return 0;
+}

--- a/tests/test_sync_capture.cpp
+++ b/tests/test_sync_capture.cpp
@@ -892,6 +892,7 @@ void test_any_value_table_does_not_capture_in_v01() {
 void test_key_multi_value_table_does_not_capture_in_v01() {
     using namespace mdbxc;
     typedef KeyMultiValueTable<int, std::string> MultiTable;
+    typedef KeyOrderedMultiValueTable<int, std::string> OrderedMultiTable;
     const std::string p = "test_capture_key_multi_value_deferred.mdbx";
     cleanup(p);
 
@@ -943,6 +944,18 @@ void test_key_multi_value_table_does_not_capture_in_v01() {
         }
         multi_values.clear();
         require_no_capture(sink, "KeyMultiValueTable", "clear");
+
+        OrderedMultiTable ordered_multi_values(conn, "ordered_multi_values");
+        ordered_multi_values.append(1, "one");
+        require_no_capture(sink, "KeyOrderedMultiValueTable", "append");
+        ordered_multi_values.append(1, "uno");
+        require_no_capture(sink, "KeyOrderedMultiValueTable", "append repeated key");
+        if (!ordered_multi_values.erase_at(1, 0u)) {
+            throw std::runtime_error("KeyOrderedMultiValueTable::erase_at did not remove prepared row");
+        }
+        require_no_capture(sink, "KeyOrderedMultiValueTable", "erase_at");
+        ordered_multi_values.clear();
+        require_no_capture(sink, "KeyOrderedMultiValueTable", "clear");
     }
 
     conn->disconnect();

--- a/tests/test_transaction_provenance.cpp
+++ b/tests/test_transaction_provenance.cpp
@@ -3,6 +3,7 @@
 #include <mdbx_containers/AnyValueTable.hpp>
 #include <mdbx_containers/HashedKeyValueStore.hpp>
 #include <mdbx_containers/KeyMultiValueTable.hpp>
+#include <mdbx_containers/KeyOrderedMultiValueTable.hpp>
 #include <mdbx_containers/KeyTable.hpp>
 #include <mdbx_containers/KeyValueTable.hpp>
 #include <mdbx_containers/SequenceTable.hpp>
@@ -88,6 +89,7 @@ void test_public_tables_reject_foreign_transactions() {
     mdbxc::SequenceTable<int> sequence(conn_a, "sequence");
     mdbxc::AnyValueTable<int> any(conn_a, "any");
     mdbxc::KeyMultiValueTable<int, std::string> multi(conn_a, "multi");
+    mdbxc::KeyOrderedMultiValueTable<int, std::string> ordered_multi(conn_a, "ordered_multi");
     mdbxc::HashedKeyValueStore<std::string, std::string> hashed(conn_a, "hashed");
 
     {
@@ -122,6 +124,10 @@ void test_public_tables_reject_foreign_transactions() {
                                 [&multi, raw] {
                                     multi.insert(1, std::string("value"), raw);
                                 });
+        expect_invalid_argument("KeyOrderedMultiValueTable raw txn",
+                                [&ordered_multi, raw] {
+                                    ordered_multi.append(1, std::string("value"), raw);
+                                });
         expect_invalid_argument("HashedKeyValueStore raw txn",
                                 [&hashed, raw] {
                                     hashed.insert_or_assign(std::string("key"),
@@ -137,6 +143,7 @@ void test_public_tables_reject_foreign_transactions() {
     MDBXC_TEST_ASSERT(sequence.count() == 0u);
     MDBXC_TEST_ASSERT(!any.contains(1));
     MDBXC_TEST_ASSERT(multi.count() == 0u);
+    MDBXC_TEST_ASSERT(ordered_multi.count() == 0u);
     MDBXC_TEST_ASSERT(hashed.count() == 0u);
 
     conn_a->disconnect();


### PR DESCRIPTION
## Summary
- add KeyOrderedMultiValueTable<K,V> for per-key append-ordered multi-value storage
- expose it through tables/all umbrellas and standalone header smoke list
- add table behavior tests, transaction provenance coverage, and sync negative capture coverage
- document that local ordered table API exists while sync capture/apply remains deferred

## Validation
- C++11: built and ran key_ordered_multi_value_table_test, umbrella tests, standalone header smoke, test_sync_capture, and test_transaction_provenance
- C++17: built and ran the same focused test set