### PR TITLE
feat(sync): add logical schema registry store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Added a persistent sync schema registry store for future logical table
+  adapters. The registry records logical schema ids, table kinds, schema
+  versions, and owned DBI names without enabling logical replication yet.
 - Breaking transport-wire change: `TransportMessageCodec` is now version 4.
   Response DTOs include `SyncResponseErrorCode` plus `error_retryable` after
   the human-readable error string, and pull request DTOs include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,12 +437,14 @@ if(MDBXC_BUILD_TESTS)
     )
     set(MDBXC_SYNC_STANDALONE_HEADERS
         mdbx_containers/sync/codec_flags.hpp
+        mdbx_containers/sync/LogicalSchema.hpp
         mdbx_containers/sync/ChangeOp.hpp
         mdbx_containers/sync/ChangeBatch.hpp
         mdbx_containers/sync/ChangeBatchCodec.hpp
         mdbx_containers/sync/SyncApplyObserver.hpp
         mdbx_containers/sync/SyncNodeSession.hpp
         mdbx_containers/sync/SyncWorkerGuard.hpp
+        mdbx_containers/sync/stores/SchemaRegistryStore.hpp
         mdbx_containers/sync/TransportMessageCodec.hpp
     )
 

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -15,6 +15,7 @@
 #include "common.hpp"
 #include "sync/common.hpp"
 #include "sync/codec_flags.hpp"
+#include "sync/LogicalSchema.hpp"
 #include "sync/ChangeOp.hpp"
 #include "sync/CodecBounds.hpp"
 #include "sync/ChangeBatch.hpp"
@@ -43,6 +44,7 @@
 #include "sync/stores/ChangeLogStore.hpp"
 #include "sync/stores/AppliedStore.hpp"
 #include "sync/stores/IdentityIndexStore.hpp"
+#include "sync/stores/SchemaRegistryStore.hpp"
 #endif
 
 #endif // MDBX_CONTAINERS_HEADER_SYNC_HPP_INCLUDED

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -447,6 +447,29 @@ back to a physical `storage_key` without re-reading the user table.
 the row readable for older incoming batches that still reference the key.
 Real removal is explicit via `erase()`.
 
+### `_mdbxc_sync_schema` (SchemaRegistryStore) — logical adapter marker
+
+| | |
+|---|---|
+| Key | application-defined logical schema id string |
+| Value | `LogicalSchemaRecord { kind, schema_version, flags, dbi_name, dbi_names[] }` |
+
+This store is a persistent compatibility marker for future logical table
+adapters. It does not enable logical sync by itself. A wrapper or adapter may
+call `register_or_verify(schema_id, record)` during lifecycle setup to ensure
+that an existing database was opened with the same logical table kind,
+application schema version, and owned physical DBI set.
+
+`SyncEngine::initialize_local_identity()` creates this DBI together with the
+required sync metadata stores in a committed setup transaction. Standalone
+maintenance code may still use `SchemaRegistryStore` directly, but must call
+`open(txn)` in each transaction before reading or writing.
+
+The registry intentionally uses an explicit application schema id instead of
+`typeid`, C++ type names, or ABI-dependent layout data. Unknown logical changes
+must still be rejected by the apply path until a matching logical adapter is
+registered.
+
 ## Codec — `ChangeBatchCodec`
 
 See `ChangeBatchCodec.hpp` layout comment for the full byte layout. Locked

--- a/include/mdbx_containers/sync/LogicalSchema.hpp
+++ b/include/mdbx_containers/sync/LogicalSchema.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_SCHEMA_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_SCHEMA_HPP_INCLUDED
+
+/// \file LogicalSchema.hpp
+/// \brief Lightweight logical sync schema model shared by stores and adapters.
+
+#include <cstdint>
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Logical table kinds reserved for future non-raw sync adapters.
+    enum class LogicalTableKind : std::uint16_t {
+        Unknown              = 0, ///< Invalid placeholder.
+        KeyMultiValue        = 1, ///< Unordered key-to-multiple-values table.
+        KeyOrderedMultiValue = 2, ///< Key-to-multiple-values table with presentation order.
+        AnyValue             = 3, ///< Dynamically typed value table.
+        HashedKeyValue       = 4, ///< Hashed key-value store.
+    };
+
+    /// \brief Returns true when \p kind is a supported logical table kind.
+    inline bool is_known_logical_table_kind(LogicalTableKind kind) {
+        switch (kind) {
+            case LogicalTableKind::KeyMultiValue:
+            case LogicalTableKind::KeyOrderedMultiValue:
+            case LogicalTableKind::AnyValue:
+            case LogicalTableKind::HashedKeyValue:
+                return true;
+            case LogicalTableKind::Unknown:
+                return false;
+        }
+        return false;
+    }
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_SCHEMA_HPP_INCLUDED

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -47,6 +47,7 @@
 #include "stores/ChangeLogStore.hpp"
 #include "stores/MetaStore.hpp"
 #include "stores/OriginIndexStore.hpp"
+#include "stores/SchemaRegistryStore.hpp"
 
 namespace mdbxc {
 namespace sync {
@@ -149,6 +150,7 @@ namespace sync {
             auto txn = m_conn->transaction(TransactionMode::WRITABLE);
             MetaStore meta(m_conn->env_handle());
             meta.open(txn.handle());
+            initialize_system_stores(txn.handle());
             const NodeId existing_node = meta.get_node_id(txn.handle());
             const NodeId zero{};
             if (compare_node_id(existing_node, zero) != 0 &&
@@ -512,6 +514,18 @@ namespace sync {
             const NodeId zero{};
             if (compare_node_id(request_db_id, zero) == 0) return false;
             return compare_node_id(request_db_id, db_uuid()) == 0;
+        }
+
+        void initialize_system_stores(MDBX_txn* txn) {
+            txn = checked_external_txn(txn, "SyncEngine::initialize_system_stores");
+            MetaStore meta(m_conn->env_handle());
+            ChangeLogStore change_log(m_conn->env_handle());
+            AppliedStore applied(m_conn->env_handle());
+            SchemaRegistryStore schemas(m_conn->env_handle());
+            meta.open(txn);
+            change_log.open(txn);
+            applied.open(txn);
+            schemas.open(txn);
         }
 
         static ApplyOutcome make_apply_outcome(ApplyResult result,

--- a/include/mdbx_containers/sync/stores/SchemaRegistryStore.hpp
+++ b/include/mdbx_containers/sync/stores/SchemaRegistryStore.hpp
@@ -1,0 +1,314 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_STORES_SCHEMA_REGISTRY_STORE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_STORES_SCHEMA_REGISTRY_STORE_HPP_INCLUDED
+
+/// \file SchemaRegistryStore.hpp
+/// \brief Persistent logical sync schema registry.
+
+#include <cstdint>
+#include <cstring>
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mdbx.h>
+
+#include "../../common/MdbxException.hpp"
+#include "../../detail/utils.hpp"
+#include "../common.hpp"
+#include "../LogicalSchema.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Persistent description of one logical sync schema.
+    struct LogicalSchemaRecord {
+        std::string dbi_name;                 ///< Primary logical DBI name.
+        LogicalTableKind kind = LogicalTableKind::Unknown; ///< Logical adapter kind.
+        std::uint32_t schema_version = 0;     ///< Application schema version.
+        std::uint32_t flags = 0;              ///< Reserved flags; must be zero for now.
+        std::vector<std::string> dbi_names;   ///< All physical DBIs owned by the schema.
+    };
+
+    /// \brief Thin wrapper around \c _mdbxc_sync_schema.
+    /// \details Key = logical schema id string bytes. Value =
+    /// \c LogicalSchemaRecord with length-prefixed UTF-8 strings.
+    class SchemaRegistryStore {
+    public:
+        explicit SchemaRegistryStore(
+                MDBX_env* env,
+                const std::string& dbi_name = "_mdbxc_sync_schema")
+            : m_env(env), m_dbi_name(dbi_name), m_dbi(0), m_open(false) {}
+
+        /// \brief Opens the registry DBI inside the supplied transaction.
+        void open(MDBX_txn* txn) {
+            txn = checked_txn(txn, "SchemaRegistryStore::open");
+            open_checked(txn);
+        }
+
+        bool is_open() const { return m_open; }
+        MDBX_dbi handle(MDBX_txn* txn) const {
+            txn = checked_txn(txn, "SchemaRegistryStore::handle");
+            open_checked(txn);
+            return m_dbi;
+        }
+
+        void reset_open() { m_open = false; }
+
+        void ensure_open() const {
+            if (!m_open) {
+                throw std::logic_error("SchemaRegistryStore is not open");
+            }
+        }
+
+        /// \brief Stores a new schema record or verifies an existing one.
+        /// \throws std::invalid_argument when \p schema_id or record fields
+        /// are structurally invalid.
+        /// \throws std::runtime_error when an existing record differs.
+        void register_or_verify(MDBX_txn* txn,
+                                const std::string& schema_id,
+                                const LogicalSchemaRecord& record) {
+            txn = checked_txn(txn, "SchemaRegistryStore::register_or_verify");
+            validate_record(schema_id, record);
+            open(txn);
+
+            LogicalSchemaRecord existing;
+            if (get(txn, schema_id, existing)) {
+                if (!records_equal(existing, record)) {
+                    throw std::runtime_error("Logical sync schema registry mismatch");
+                }
+                return;
+            }
+
+            std::vector<std::uint8_t> value;
+            encode_record(schema_id, record, value);
+            MDBX_val key = { const_cast<char*>(schema_id.data()), schema_id.size() };
+            MDBX_val val = { value.empty() ? nullptr : &value[0], value.size() };
+            check_mdbx(mdbx_put(txn, m_dbi, &key, &val, MDBX_NOOVERWRITE),
+                       "SchemaRegistryStore put failed");
+        }
+
+        /// \brief Reads a schema record.
+        /// \return true when present, false when absent.
+        bool get(MDBX_txn* txn,
+                 const std::string& schema_id,
+                 LogicalSchemaRecord& out) const {
+            txn = checked_txn(txn, "SchemaRegistryStore::get");
+            open_const(txn);
+            MDBX_val key = { const_cast<char*>(schema_id.data()), schema_id.size() };
+            MDBX_val val;
+            const int rc = mdbx_get(txn, m_dbi, &key, &val);
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "SchemaRegistryStore get failed");
+            LogicalSchemaRecord decoded;
+            decode_record(val, schema_id, decoded);
+            out = decoded;
+            return true;
+        }
+
+        /// \brief Returns all registered schema ids in MDBX key order.
+        std::vector<std::string> schema_ids(MDBX_txn* txn) const {
+            txn = checked_txn(txn, "SchemaRegistryStore::schema_ids");
+            open_const(txn);
+            std::vector<std::string> out;
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "SchemaRegistryStore cursor open failed");
+            try {
+                MDBX_val key;
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    const char* data = static_cast<const char*>(key.iov_base);
+                    const std::string schema_id(data, data + key.iov_len);
+                    LogicalSchemaRecord decoded;
+                    decode_record(value, schema_id, decoded);
+                    out.push_back(schema_id);
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "SchemaRegistryStore cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return out;
+        }
+
+    private:
+        MDBX_txn* checked_txn(MDBX_txn* txn, const char* context) const {
+            return checked_txn_env(txn, m_env, context);
+        }
+
+        void open_const(MDBX_txn* txn) const {
+            txn = checked_txn(txn, "SchemaRegistryStore::open");
+            open_checked(txn);
+        }
+
+        void open_checked(MDBX_txn* txn) const {
+            int rc = mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE, &m_dbi);
+            if (rc == MDBX_EACCESS) {
+                rc = mdbx_dbi_open(txn, m_dbi_name.c_str(),
+                                   static_cast<MDBX_db_flags_t>(0), &m_dbi);
+            }
+            check_mdbx(rc, "Failed to open SchemaRegistryStore DBI");
+            m_open = true;
+        }
+
+        static void validate_record(const std::string& schema_id,
+                                    const LogicalSchemaRecord& record) {
+            if (schema_id.empty()) {
+                throw std::invalid_argument("Logical schema id must not be empty");
+            }
+            if (record.dbi_name.empty()) {
+                throw std::invalid_argument("Logical schema DBI name must not be empty");
+            }
+            for (std::size_t i = 0; i < record.dbi_names.size(); ++i) {
+                if (record.dbi_names[i].empty()) {
+                    throw std::invalid_argument(
+                        "Logical schema owned DBI name must not be empty");
+                }
+            }
+            if (!is_known_logical_table_kind(record.kind)) {
+                throw std::invalid_argument("Logical schema kind must be known");
+            }
+            if (record.schema_version == 0) {
+                throw std::invalid_argument("Logical schema version must be non-zero");
+            }
+            if (record.flags != 0) {
+                throw std::invalid_argument("Logical schema flags are reserved");
+            }
+        }
+
+        static bool records_equal(const LogicalSchemaRecord& a,
+                                  const LogicalSchemaRecord& b) {
+            const LogicalSchemaRecord ca = canonical_record(a);
+            const LogicalSchemaRecord cb = canonical_record(b);
+            return ca.dbi_name == cb.dbi_name &&
+                   ca.kind == cb.kind &&
+                   ca.schema_version == cb.schema_version &&
+                   ca.flags == cb.flags &&
+                   ca.dbi_names == cb.dbi_names;
+        }
+
+        static void append_string(std::vector<std::uint8_t>& out,
+                                  const std::string& value) {
+            if (value.size() > std::numeric_limits<std::uint32_t>::max()) {
+                throw std::length_error("Logical schema string is too large");
+            }
+            detail::append_u32_le(out, static_cast<std::uint32_t>(value.size()));
+            out.insert(out.end(), value.begin(), value.end());
+        }
+
+        static std::string read_string(const std::uint8_t* data,
+                                       std::size_t total,
+                                       std::size_t& pos) {
+            require(data, total, pos, 4);
+            const std::uint32_t size = detail::read_u32_le(data + pos);
+            pos += 4;
+            require(data, total, pos, size);
+            const char* begin = reinterpret_cast<const char*>(data + pos);
+            pos += size;
+            return std::string(begin, begin + size);
+        }
+
+        static void require(const std::uint8_t*,
+                            std::size_t total,
+                            std::size_t pos,
+                            std::size_t size) {
+            if (pos > total || size > total - pos) {
+                throw std::runtime_error("SchemaRegistryStore decode underrun");
+            }
+        }
+
+        static void encode_record(const std::string& schema_id,
+                                  const LogicalSchemaRecord& record,
+                                  std::vector<std::uint8_t>& out) {
+            LogicalSchemaRecord canonical = canonical_record(record);
+            if (canonical.dbi_names.size() >
+                std::numeric_limits<std::uint32_t>::max()) {
+                throw std::length_error("Logical schema DBI list is too large");
+            }
+            validate_record(schema_id, canonical);
+            out.clear();
+            append_string(out, schema_id);
+            detail::append_u16_le(out, static_cast<std::uint16_t>(canonical.kind));
+            detail::append_u32_le(out, canonical.schema_version);
+            detail::append_u32_le(out, canonical.flags);
+            append_string(out, canonical.dbi_name);
+            detail::append_u32_le(out,
+                static_cast<std::uint32_t>(canonical.dbi_names.size()));
+            for (std::size_t i = 0; i < canonical.dbi_names.size(); ++i) {
+                append_string(out, canonical.dbi_names[i]);
+            }
+        }
+
+        static void decode_record(const MDBX_val& value,
+                                  const std::string& schema_id,
+                                  LogicalSchemaRecord& out) {
+            const std::uint8_t* data =
+                static_cast<const std::uint8_t*>(value.iov_base);
+            std::size_t pos = 0;
+            const std::size_t total = value.iov_len;
+            LogicalSchemaRecord decoded;
+            const std::string embedded_schema_id =
+                read_string(data, total, pos);
+            if (embedded_schema_id != schema_id) {
+                throw std::runtime_error(
+                    "SchemaRegistryStore schema id mismatch");
+            }
+            require(data, total, pos, 2);
+            decoded.kind =
+                static_cast<LogicalTableKind>(detail::read_u16_le(data + pos));
+            pos += 2;
+            require(data, total, pos, 4);
+            decoded.schema_version = detail::read_u32_le(data + pos);
+            pos += 4;
+            require(data, total, pos, 4);
+            decoded.flags = detail::read_u32_le(data + pos);
+            pos += 4;
+            decoded.dbi_name = read_string(data, total, pos);
+            require(data, total, pos, 4);
+            const std::uint32_t count = detail::read_u32_le(data + pos);
+            pos += 4;
+            if (count > (total - pos) / 4u) {
+                throw std::runtime_error(
+                    "SchemaRegistryStore DBI list count exceeds payload bounds");
+            }
+            decoded.dbi_names.reserve(count);
+            for (std::uint32_t i = 0; i < count; ++i) {
+                decoded.dbi_names.push_back(read_string(data, total, pos));
+            }
+            if (pos != total) {
+                throw std::runtime_error("SchemaRegistryStore trailing bytes");
+            }
+            validate_record(schema_id, decoded);
+            out = canonical_record(decoded);
+        }
+
+        static LogicalSchemaRecord canonical_record(
+                const LogicalSchemaRecord& record) {
+            LogicalSchemaRecord out = record;
+            std::sort(out.dbi_names.begin(), out.dbi_names.end());
+            if (std::unique(out.dbi_names.begin(), out.dbi_names.end()) !=
+                out.dbi_names.end()) {
+                throw std::invalid_argument(
+                    "Logical schema owned DBI names must be unique");
+            }
+            return out;
+        }
+
+        MDBX_env*   m_env;
+        std::string m_dbi_name;
+        mutable MDBX_dbi m_dbi;
+        mutable bool     m_open;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_STORES_SCHEMA_REGISTRY_STORE_HPP_INCLUDED

--- a/tests/test_sync_stores.cpp
+++ b/tests/test_sync_stores.cpp
@@ -1,5 +1,6 @@
 #include <mdbx_containers.hpp>
 #include <mdbx_containers/sync.hpp>
+#include <algorithm>
 #include <cstdio>
 #include <cstdint>
 #include <cstring>
@@ -43,6 +44,67 @@ void put_raw_changelog(MDBX_txn* txn,
                    bytes.size() };
     mdbxc::check_mdbx(mdbx_put(txn, dbi, &k, &v, MDBX_NOOVERWRITE),
                       "raw changelog put failed");
+}
+
+void append_schema_string(std::vector<std::uint8_t>& out,
+                          const std::string& value) {
+    mdbxc::sync::detail::append_u32_le(out,
+        static_cast<std::uint32_t>(value.size()));
+    out.insert(out.end(), value.begin(), value.end());
+}
+
+std::vector<std::uint8_t> make_schema_record_bytes(
+        const std::string& embedded_schema_id,
+        std::uint16_t kind,
+        std::uint32_t schema_version,
+        std::uint32_t flags,
+        const std::string& dbi_name,
+        const std::vector<std::string>& dbi_names) {
+    std::vector<std::uint8_t> out;
+    append_schema_string(out, embedded_schema_id);
+    mdbxc::sync::detail::append_u16_le(out, kind);
+    mdbxc::sync::detail::append_u32_le(out, schema_version);
+    mdbxc::sync::detail::append_u32_le(out, flags);
+    append_schema_string(out, dbi_name);
+    mdbxc::sync::detail::append_u32_le(out,
+        static_cast<std::uint32_t>(dbi_names.size()));
+    for (std::size_t i = 0; i < dbi_names.size(); ++i) {
+        append_schema_string(out, dbi_names[i]);
+    }
+    return out;
+}
+
+std::vector<std::uint8_t> make_schema_record_bytes_with_count(
+        const std::string& embedded_schema_id,
+        std::uint16_t kind,
+        std::uint32_t schema_version,
+        std::uint32_t flags,
+        const std::string& dbi_name,
+        std::uint32_t dbi_names_count) {
+    std::vector<std::uint8_t> out;
+    append_schema_string(out, embedded_schema_id);
+    mdbxc::sync::detail::append_u16_le(out, kind);
+    mdbxc::sync::detail::append_u32_le(out, schema_version);
+    mdbxc::sync::detail::append_u32_le(out, flags);
+    append_schema_string(out, dbi_name);
+    mdbxc::sync::detail::append_u32_le(out, dbi_names_count);
+    return out;
+}
+
+void put_raw_schema_record(MDBX_txn* txn,
+                           MDBX_dbi dbi,
+                           const std::string& schema_id,
+                           const std::vector<std::uint8_t>& bytes) {
+    MDBX_val key = {
+        const_cast<char*>(schema_id.data()),
+        schema_id.size()
+    };
+    MDBX_val value = {
+        bytes.empty() ? nullptr : const_cast<std::uint8_t*>(&bytes[0]),
+        bytes.size()
+    };
+    mdbxc::check_mdbx(mdbx_put(txn, dbi, &key, &value, MDBX_UPSERT),
+                      "raw schema registry put failed");
 }
 
 void test_meta_store() {
@@ -617,6 +679,290 @@ void test_identity_key_collision() {
     cleanup(p);
 }
 
+void test_schema_registry_store() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_schema_registry.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    LogicalSchemaRecord ordered;
+    ordered.dbi_name = "events";
+    ordered.kind = LogicalTableKind::KeyOrderedMultiValue;
+    ordered.schema_version = 1;
+    ordered.dbi_names.push_back("events");
+
+    LogicalSchemaRecord vector_like;
+    vector_like.dbi_name = "vectors";
+    vector_like.kind = LogicalTableKind::HashedKeyValue;
+    vector_like.schema_version = 3;
+    vector_like.dbi_names.push_back("vectors.ids");
+    vector_like.dbi_names.push_back("vectors.payload");
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        SchemaRegistryStore store(conn->env_handle());
+        store.register_or_verify(txn.handle(), "app.events.v1", ordered);
+        store.register_or_verify(txn.handle(), "app.vectors.v3", vector_like);
+        store.register_or_verify(txn.handle(), "app.events.v1", ordered);
+        LogicalSchemaRecord permuted = vector_like;
+        std::reverse(permuted.dbi_names.begin(), permuted.dbi_names.end());
+        store.register_or_verify(txn.handle(), "app.vectors.v3", permuted);
+        txn.commit();
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        SchemaRegistryStore store(conn->env_handle());
+
+        LogicalSchemaRecord out;
+        if (!store.get(txn.handle(), "app.events.v1", out)) {
+            throw std::runtime_error("schema registry record missing");
+        }
+        if (out.dbi_name != ordered.dbi_name ||
+            out.kind != ordered.kind ||
+            out.schema_version != ordered.schema_version ||
+            out.dbi_names != ordered.dbi_names) {
+            throw std::runtime_error("schema registry record mismatch");
+        }
+
+        const std::vector<std::string> ids = store.schema_ids(txn.handle());
+        if (ids.size() != 2u ||
+            ids[0] != "app.events.v1" ||
+            ids[1] != "app.vectors.v3") {
+            throw std::runtime_error("schema registry ids mismatch");
+        }
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        SchemaRegistryStore store(conn->env_handle());
+        LogicalSchemaRecord duplicate = ordered;
+        duplicate.dbi_names.push_back("events");
+        bool caught = false;
+        try {
+            store.register_or_verify(txn.handle(), "app.duplicate.v1", duplicate);
+        } catch (const std::invalid_argument&) {
+            caught = true;
+        }
+        if (!caught) {
+            throw std::runtime_error("duplicate owned DBI was accepted");
+        }
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        SchemaRegistryStore store(conn->env_handle());
+        LogicalSchemaRecord mismatch = ordered;
+        mismatch.kind = LogicalTableKind::KeyMultiValue;
+        bool caught = false;
+        try {
+            store.register_or_verify(txn.handle(), "app.events.v1", mismatch);
+        } catch (const std::runtime_error&) {
+            caught = true;
+        }
+        if (!caught) {
+            throw std::runtime_error("schema registry mismatch was accepted");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_schema_registry_open_after_aborted_create() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_schema_abort_reuse.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    LogicalSchemaRecord record;
+    record.dbi_name = "events";
+    record.kind = LogicalTableKind::KeyMultiValue;
+    record.schema_version = 1;
+    record.dbi_names.push_back("events");
+
+    SchemaRegistryStore store(conn->env_handle());
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        store.open(txn.handle());
+        store.register_or_verify(txn.handle(), "app.events.v1", record);
+        txn.rollback();
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        store.register_or_verify(txn.handle(), "app.events.v1", record);
+        txn.commit();
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        LogicalSchemaRecord out;
+        if (!store.get(txn.handle(), "app.events.v1", out) ||
+            out.dbi_name != "events") {
+            throw std::runtime_error(
+                "schema registry did not recover after aborted create");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_schema_registry_created_by_sync_engine_init() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_schema_engine_init.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x11), make_node(0x22));
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        SchemaRegistryStore store(conn->env_handle());
+        store.open(txn.handle());
+        if (!store.schema_ids(txn.handle()).empty()) {
+            throw std::runtime_error("new schema registry should be empty");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void expect_schema_get_failure(const std::string& label,
+                               mdbxc::sync::SchemaRegistryStore& store,
+                               MDBX_txn* txn,
+                               const std::string& schema_id) {
+    mdbxc::sync::LogicalSchemaRecord out;
+    out.dbi_name = "sentinel";
+    out.kind = mdbxc::sync::LogicalTableKind::KeyMultiValue;
+    out.schema_version = 99;
+    bool caught = false;
+    try {
+        (void)store.get(txn, schema_id, out);
+    } catch (const std::runtime_error&) {
+        caught = true;
+    } catch (const std::invalid_argument&) {
+        caught = true;
+    }
+    if (!caught) {
+        throw std::runtime_error(label + " was accepted");
+    }
+    if (out.dbi_name != "sentinel" ||
+        out.kind != mdbxc::sync::LogicalTableKind::KeyMultiValue ||
+        out.schema_version != 99u) {
+        throw std::runtime_error(label + " rewrote output on failure");
+    }
+}
+
+void test_schema_registry_rejects_malformed_records() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_schema_malformed.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        SchemaRegistryStore store(conn->env_handle());
+        const MDBX_dbi raw = store.handle(txn.handle());
+        put_raw_schema_record(
+            txn.handle(), raw, "bad.count",
+            make_schema_record_bytes_with_count(
+                "bad.count",
+                static_cast<std::uint16_t>(LogicalTableKind::KeyMultiValue),
+                1, 0, "events", 0xffffffffu));
+        put_raw_schema_record(
+            txn.handle(), raw, "bad.kind",
+            make_schema_record_bytes(
+                "bad.kind", 0xffffu, 1, 0, "events",
+                std::vector<std::string>()));
+        put_raw_schema_record(
+            txn.handle(), raw, "bad.version",
+            make_schema_record_bytes(
+                "bad.version",
+                static_cast<std::uint16_t>(LogicalTableKind::KeyMultiValue),
+                0, 0, "events", std::vector<std::string>()));
+        put_raw_schema_record(
+            txn.handle(), raw, "bad.flags",
+            make_schema_record_bytes(
+                "bad.flags",
+                static_cast<std::uint16_t>(LogicalTableKind::KeyMultiValue),
+                1, 1, "events", std::vector<std::string>()));
+        put_raw_schema_record(
+            txn.handle(), raw, "bad.dbi",
+            make_schema_record_bytes(
+                "bad.dbi",
+                static_cast<std::uint16_t>(LogicalTableKind::KeyMultiValue),
+                1, 0, "", std::vector<std::string>()));
+        std::vector<std::string> empty_owned;
+        empty_owned.push_back("");
+        put_raw_schema_record(
+            txn.handle(), raw, "bad.owned",
+            make_schema_record_bytes(
+                "bad.owned",
+                static_cast<std::uint16_t>(LogicalTableKind::KeyMultiValue),
+                1, 0, "events", empty_owned));
+        put_raw_schema_record(
+            txn.handle(), raw, "bad.schema_id",
+            make_schema_record_bytes(
+                "other.schema",
+                static_cast<std::uint16_t>(LogicalTableKind::KeyMultiValue),
+                1, 0, "events", std::vector<std::string>()));
+        txn.commit();
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        SchemaRegistryStore store(conn->env_handle());
+        expect_schema_get_failure("bad count", store, txn.handle(), "bad.count");
+        expect_schema_get_failure("bad kind", store, txn.handle(), "bad.kind");
+        expect_schema_get_failure("bad version", store, txn.handle(), "bad.version");
+        expect_schema_get_failure("bad flags", store, txn.handle(), "bad.flags");
+        expect_schema_get_failure("bad dbi", store, txn.handle(), "bad.dbi");
+        expect_schema_get_failure("bad owned dbi", store, txn.handle(), "bad.owned");
+        expect_schema_get_failure(
+            "bad schema id", store, txn.handle(), "bad.schema_id");
+
+        bool schema_ids_failed = false;
+        try {
+            (void)store.schema_ids(txn.handle());
+        } catch (const std::runtime_error&) {
+            schema_ids_failed = true;
+        } catch (const std::invalid_argument&) {
+            schema_ids_failed = true;
+        }
+        if (!schema_ids_failed) {
+            throw std::runtime_error(
+                "schema_ids accepted malformed registry records");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 template<class Store, class Op>
 void expect_open_required(const std::string& label, Store& store, Op op) {
     bool caught = false;
@@ -719,6 +1065,10 @@ int main() {
     test_changelog_prune_up_to_boundary();
     test_changelog_prune_does_not_touch_other_origin();
     test_identity_key_collision();
+    test_schema_registry_store();
+    test_schema_registry_open_after_aborted_create();
+    test_schema_registry_created_by_sync_engine_init();
+    test_schema_registry_rejects_malformed_records();
     test_stores_require_open();
     return 0;
 }


### PR DESCRIPTION
## Summary
- add persistent _mdbxc_sync_schema store for future logical sync adapters
- expose LogicalTableKind and LogicalSchemaRecord through sync.hpp
- cover register/read/list/mismatch behavior and standalone header build

## Validation
- cmake --build tmp/build-cpp17-mingw --target test_sync_stores header_standalone_mdbx_containers_sync_stores_SchemaRegistryStore_hpp header_sync_umbrella_test -- -j2
- ctest --test-dir tmp/build-cpp17-mingw --output-on-failure -R "test_sync_stores|header_standalone_mdbx_containers_sync_stores_SchemaRegistryStore_hpp|header_sync_umbrella_test"
- cmake --build tmp/build-cpp11-mingw --target test_sync_stores header_standalone_mdbx_containers_sync_stores_SchemaRegistryStore_hpp header_sync_umbrella_test -- -j2
- ctest --test-dir tmp/build-cpp11-mingw --output-on-failure -R "test_sync_stores|header_standalone_mdbx_containers_sync_stores_SchemaRegistryStore_hpp|header_sync_umbrella_test"
