### PR TITLE
feat(sync): add logical change model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 - Added a persistent sync schema registry store for future logical table
   adapters. The registry records logical schema ids, table kinds, schema
   versions, and owned DBI names without enabling logical replication yet.
+- Added public `ChangeDomain`, `LogicalSchemaRef`, and `LogicalChange` model
+  types for future logical table adapters. The current wire codec remains
+  raw-DBI only.
 - Breaking transport-wire change: `TransportMessageCodec` is now version 4.
   Response DTOs include `SyncResponseErrorCode` plus `error_retryable` after
   the human-readable error string, and pull request DTOs include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,6 +439,7 @@ if(MDBXC_BUILD_TESTS)
         mdbx_containers/sync/codec_flags.hpp
         mdbx_containers/sync/LogicalSchema.hpp
         mdbx_containers/sync/ChangeOp.hpp
+        mdbx_containers/sync/LogicalChange.hpp
         mdbx_containers/sync/ChangeBatch.hpp
         mdbx_containers/sync/ChangeBatchCodec.hpp
         mdbx_containers/sync/SyncApplyObserver.hpp

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -17,6 +17,7 @@
 #include "sync/codec_flags.hpp"
 #include "sync/LogicalSchema.hpp"
 #include "sync/ChangeOp.hpp"
+#include "sync/LogicalChange.hpp"
 #include "sync/CodecBounds.hpp"
 #include "sync/ChangeBatch.hpp"
 #include "sync/ChangeBatchCodec.hpp"

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -470,6 +470,20 @@ The registry intentionally uses an explicit application schema id instead of
 must still be rejected by the apply path until a matching logical adapter is
 registered.
 
+`LogicalChange.hpp` defines the public in-memory model for the future logical
+domain:
+
+- `ChangeDomain::RawDbi` is the current `ChangeOp`/`ChangeBatchCodec` domain.
+- `ChangeDomain::LogicalTable` is reserved for adapter-owned logical payloads.
+- `LogicalSchemaRef` repeats the expected schema id, logical table kind, and
+  schema version on each logical operation.
+- `LogicalChange::payload` is opaque to the sync core; only a registered
+  adapter for the referenced schema may decode it.
+
+The v0.1 `ChangeBatchCodec` still serializes raw DBI operations only. Adding
+the logical domain to the wire format requires an explicit codec version bump
+and compatibility tests.
+
 ## Codec — `ChangeBatchCodec`
 
 See `ChangeBatchCodec.hpp` layout comment for the full byte layout. Locked

--- a/include/mdbx_containers/sync/LogicalChange.hpp
+++ b/include/mdbx_containers/sync/LogicalChange.hpp
@@ -1,0 +1,76 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_CHANGE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_CHANGE_HPP_INCLUDED
+
+/// \file LogicalChange.hpp
+/// \brief Public model for future logical table sync operations.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "LogicalSchema.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Distinguishes current raw DBI operations from future logical ops.
+    enum class ChangeDomain : std::uint8_t {
+        RawDbi       = 0, ///< Existing \c ChangeOp raw DBI write domain.
+        LogicalTable = 1, ///< Future adapter-driven logical table domain.
+    };
+
+    /// \brief Stable reference to a registered logical schema.
+    /// \details \c schema_id must match a record in \c SchemaRegistryStore
+    /// before a receiver can apply \c LogicalChange payloads for it.
+    struct LogicalSchemaRef {
+        std::string schema_id; ///< Application-defined schema id.
+        LogicalTableKind kind; ///< Expected adapter kind.
+        std::uint32_t schema_version; ///< Expected application schema version.
+
+        LogicalSchemaRef()
+            : kind(LogicalTableKind::Unknown),
+              schema_version(0) {}
+
+        LogicalSchemaRef(const std::string& id,
+                         LogicalTableKind table_kind,
+                         std::uint32_t version)
+            : schema_id(id),
+              kind(table_kind),
+              schema_version(version) {}
+    };
+
+    /// \brief Opaque logical table operation reserved for future adapters.
+    /// \details The sync core treats \c payload as adapter-owned bytes. It
+    /// must not guess table semantics from \c opcode.
+    struct LogicalChange {
+        LogicalSchemaRef schema;          ///< Target logical schema.
+        std::uint32_t opcode;             ///< Adapter-local operation code.
+        std::uint32_t flags;              ///< Reserved flags; must be zero for now.
+        std::vector<std::uint8_t> payload; ///< Adapter-owned operation bytes.
+
+        LogicalChange()
+            : opcode(0),
+              flags(0) {}
+
+        LogicalChange(const LogicalSchemaRef& schema_ref,
+                      std::uint32_t operation_code,
+                      std::uint32_t operation_flags,
+                      const std::vector<std::uint8_t>& operation_payload)
+            : schema(schema_ref),
+              opcode(operation_code),
+              flags(operation_flags),
+              payload(operation_payload) {}
+    };
+
+    /// \brief Returns true when \p ref names a concrete logical schema.
+    inline bool is_logical_schema_ref_complete(const LogicalSchemaRef& ref) {
+        return !ref.schema_id.empty() &&
+               is_known_logical_table_kind(ref.kind) &&
+               ref.schema_version != 0;
+    }
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_CHANGE_HPP_INCLUDED

--- a/tests/test_logical_change.cpp
+++ b/tests/test_logical_change.cpp
@@ -1,0 +1,99 @@
+#include <mdbx_containers/sync.hpp>
+
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+void test_logical_schema_ref_defaults() {
+    mdbxc::sync::LogicalSchemaRef ref;
+    if (mdbxc::sync::is_logical_schema_ref_complete(ref)) {
+        throw std::runtime_error("default LogicalSchemaRef must be incomplete");
+    }
+}
+
+void test_logical_schema_ref_complete() {
+    mdbxc::sync::LogicalSchemaRef ref;
+    ref.schema_id = "app.timeline.v1";
+    ref.kind = mdbxc::sync::LogicalTableKind::KeyOrderedMultiValue;
+    ref.schema_version = 1;
+
+    if (!mdbxc::sync::is_logical_schema_ref_complete(ref)) {
+        throw std::runtime_error("filled LogicalSchemaRef must be complete");
+    }
+}
+
+void test_logical_schema_ref_positional_construction() {
+    const mdbxc::sync::LogicalSchemaRef ref(
+        "app.timeline.v1",
+        mdbxc::sync::LogicalTableKind::KeyOrderedMultiValue,
+        1);
+
+    if (ref.schema_id != "app.timeline.v1" ||
+        ref.kind != mdbxc::sync::LogicalTableKind::KeyOrderedMultiValue ||
+        ref.schema_version != 1u ||
+        !mdbxc::sync::is_logical_schema_ref_complete(ref)) {
+        throw std::runtime_error(
+            "LogicalSchemaRef positional construction mismatch");
+    }
+}
+
+void test_logical_schema_ref_rejects_unknown_kind() {
+    mdbxc::sync::LogicalSchemaRef ref;
+    ref.schema_id = "app.unknown.v1";
+    ref.kind = static_cast<mdbxc::sync::LogicalTableKind>(0xffffu);
+    ref.schema_version = 1;
+
+    if (mdbxc::sync::is_logical_schema_ref_complete(ref)) {
+        throw std::runtime_error("unknown LogicalTableKind must be incomplete");
+    }
+}
+
+void test_logical_change_payload_is_opaque() {
+    mdbxc::sync::LogicalChange change;
+    change.schema.schema_id = "app.timeline.v1";
+    change.schema.kind = mdbxc::sync::LogicalTableKind::KeyOrderedMultiValue;
+    change.schema.schema_version = 1;
+    change.opcode = 7;
+    change.payload.push_back(0xA1);
+    change.payload.push_back(0xB2);
+
+    if (change.opcode != 7 ||
+        change.payload.size() != 2u ||
+        change.payload[0] != 0xA1 ||
+        change.payload[1] != 0xB2) {
+        throw std::runtime_error("LogicalChange payload mismatch");
+    }
+}
+
+void test_logical_change_positional_construction() {
+    const mdbxc::sync::LogicalSchemaRef ref(
+        "app.timeline.v1",
+        mdbxc::sync::LogicalTableKind::KeyOrderedMultiValue,
+        1);
+    std::vector<std::uint8_t> payload;
+    payload.push_back(0xA1);
+    payload.push_back(0xB2);
+
+    const mdbxc::sync::LogicalChange change(ref, 7, 0, payload);
+
+    if (change.schema.schema_id != "app.timeline.v1" ||
+        change.schema.kind !=
+            mdbxc::sync::LogicalTableKind::KeyOrderedMultiValue ||
+        change.schema.schema_version != 1u ||
+        change.opcode != 7u ||
+        change.flags != 0u ||
+        change.payload != payload) {
+        throw std::runtime_error(
+            "LogicalChange positional construction mismatch");
+    }
+}
+
+int main() {
+    test_logical_schema_ref_defaults();
+    test_logical_schema_ref_complete();
+    test_logical_schema_ref_positional_construction();
+    test_logical_schema_ref_rejects_unknown_kind();
+    test_logical_change_payload_is_opaque();
+    test_logical_change_positional_construction();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add public logical sync model types without changing the raw wire codec
- expose ChangeDomain, LogicalSchemaRef, LogicalChange, and schema-ref validation helper
- add C++11-friendly model tests and standalone header coverage

## Validation
- cmake --build tmp/build-cpp17-mingw --target test_logical_change header_standalone_mdbx_containers_sync_LogicalChange_hpp header_sync_umbrella_test -- -j2
- ctest --test-dir tmp/build-cpp17-mingw --output-on-failure -R "test_logical_change|header_standalone_mdbx_containers_sync_LogicalChange_hpp|header_sync_umbrella_test"
- cmake --build tmp/build-cpp11-mingw --target test_logical_change header_standalone_mdbx_containers_sync_LogicalChange_hpp header_sync_umbrella_test -- -j2
- ctest --test-dir tmp/build-cpp11-mingw --output-on-failure -R "test_logical_change|header_standalone_mdbx_containers_sync_LogicalChange_hpp|header_sync_umbrella_test"
