### PR TITLE
feat(sync): accept full ChangeOp in capture sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ All notable changes to this project will be documented in this file.
   types for future logical table adapters. The current wire codec remains
   raw-DBI only.
 - Added `ISyncCaptureSink::record_change(MDBX_txn*, const ChangeOp&)` as the
-  preferred capture entry point. The previous raw-field overload remains as a
-  compatibility helper.
+  preferred capture entry point. The previous raw-field overload remains the
+  source-compatible abstract sink contract; new full-`ChangeOp` sinks can
+  derive from `FullChangeSyncCaptureSink`.
 - Breaking transport-wire change: `TransportMessageCodec` is now version 4.
   Response DTOs include `SyncResponseErrorCode` plus `error_retryable` after
   the human-readable error string, and pull request DTOs include

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
 - Added public `ChangeDomain`, `LogicalSchemaRef`, and `LogicalChange` model
   types for future logical table adapters. The current wire codec remains
   raw-DBI only.
+- Added `ISyncCaptureSink::record_change(MDBX_txn*, const ChangeOp&)` as the
+  preferred capture entry point. The previous raw-field overload remains as a
+  compatibility helper.
 - Breaking transport-wire change: `TransportMessageCodec` is now version 4.
   Response DTOs include `SyncResponseErrorCode` plus `error_retryable` after
   the human-readable error string, and pull request DTOs include

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 - Added public `ChangeDomain`, `LogicalSchemaRef`, and `LogicalChange` model
   types for future logical table adapters. The current wire codec remains
   raw-DBI only.
-- Added `ISyncCaptureSink::record_change(MDBX_txn*, const ChangeOp&)` as the
+- Added `ISyncCaptureSink::record_change_op(MDBX_txn*, const ChangeOp&)` as the
   preferred capture entry point. The previous raw-field overload remains the
   source-compatible abstract sink contract; new full-`ChangeOp` sinks can
   derive from `FullChangeSyncCaptureSink`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
   types for future logical table adapters. The current wire codec remains
   raw-DBI only.
 - Added `ISyncCaptureSink::record_change_op(MDBX_txn*, const ChangeOp&)` as the
-  preferred capture entry point. The previous raw-field overload remains the
+  preferred capture entry point. The previous raw-field callback remains the
   source-compatible abstract sink contract; new full-`ChangeOp` sinks can
   derive from `FullChangeSyncCaptureSink`.
 - Breaking transport-wire change: `TransportMessageCodec` is now version 4.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,6 +507,14 @@ if(MDBXC_BUILD_TESTS)
         target_compile_options(utils_fast_math_test PRIVATE /fp:fast)
     endif()
 
+    if(TARGET header_sync_umbrella_test AND
+            (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
+             ((CMAKE_CXX_COMPILER_ID MATCHES "Clang") AND
+              NOT CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")))
+        target_compile_options(header_sync_umbrella_test PRIVATE
+            -Woverloaded-virtual -Werror)
+    endif()
+
     set(_mdbxc_generated_test_dir "${CMAKE_CURRENT_BINARY_DIR}/generated_tests")
     file(MAKE_DIRECTORY "${_mdbxc_generated_test_dir}")
     foreach(header IN LISTS MDBXC_STANDALONE_PUBLIC_HEADERS)

--- a/include/mdbx_containers/common/Connection.hpp
+++ b/include/mdbx_containers/common/Connection.hpp
@@ -292,6 +292,11 @@ namespace mdbxc {
                                              std::uint64_t expected_token,
                                              sync::ISyncCaptureSink* restore_sink,
                                              std::uint64_t restore_token);
+        void mark_sync_capture_failed(MDBX_txn* txn) noexcept;
+        bool sync_capture_failed(MDBX_txn* txn) const noexcept;
+        void clear_sync_capture_failed(MDBX_txn* txn) noexcept;
+        void ensure_sync_capture_txn_supported(MDBX_txn* txn,
+                                               const char* context) const;
         struct SyncApplyObserverState;
 
         struct SyncApplyObserverCallback {
@@ -343,6 +348,8 @@ namespace mdbxc {
         sync::ISyncCaptureSink* m_sync_capture = nullptr;
         std::uint64_t m_sync_capture_token = 0;
         std::uint64_t m_next_sync_capture_token = 0;
+        MDBX_txn* m_sync_capture_failed_txn = nullptr;
+        mutable std::mutex m_sync_capture_failure_mutex;
         std::uint64_t m_next_sync_apply_observer_token = 0;
         std::uint64_t m_sync_apply_generation = 0;
         std::vector<std::shared_ptr<SyncApplyObserverState>> m_sync_apply_observers;

--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -172,6 +172,10 @@ namespace mdbxc {
 
 #   if MDBXC_SYNC_ENABLED
     inline void Connection::attach_sync_capture(sync::ISyncCaptureSink* sink) {
+        if (sink != nullptr && !sink->supports_change_capture()) {
+            throw std::invalid_argument(
+                "Connection::attach_sync_capture sink does not implement change capture");
+        }
         std::lock_guard<std::mutex> locker(m_mdbx_mutex);
         m_sync_capture = sink;
         m_sync_capture_token = ++m_next_sync_capture_token;
@@ -274,6 +278,52 @@ namespace mdbxc {
         return true;
     }
 
+    inline void Connection::mark_sync_capture_failed(MDBX_txn* txn) noexcept {
+        if (txn == nullptr) {
+            return;
+        }
+        std::lock_guard<std::mutex> locker(m_sync_capture_failure_mutex);
+        m_sync_capture_failed_txn = txn;
+    }
+
+    inline bool Connection::sync_capture_failed(MDBX_txn* txn) const noexcept {
+        if (txn == nullptr) {
+            return false;
+        }
+        std::lock_guard<std::mutex> locker(m_sync_capture_failure_mutex);
+        return m_sync_capture_failed_txn == txn;
+    }
+
+    inline void Connection::clear_sync_capture_failed(MDBX_txn* txn) noexcept {
+        if (txn == nullptr) {
+            return;
+        }
+        std::lock_guard<std::mutex> locker(m_sync_capture_failure_mutex);
+        if (m_sync_capture_failed_txn == txn) {
+            m_sync_capture_failed_txn = nullptr;
+        }
+    }
+
+    inline void Connection::ensure_sync_capture_txn_supported(
+            MDBX_txn* txn,
+            const char* context) const {
+        bool capture_attached = false;
+        {
+            std::lock_guard<std::mutex> locker(m_mdbx_mutex);
+            capture_attached = m_sync_capture != nullptr;
+        }
+        if (!capture_attached) {
+            return;
+        }
+        if (thread_txn() == txn) {
+            return;
+        }
+        throw std::logic_error(
+            std::string(context) +
+            " cannot use caller-created raw MDBX_txn* while sync capture is attached; "
+            "use mdbx_containers::Transaction or Connection::begin()/commit()");
+    }
+
     inline Connection::SyncApplyNotification Connection::mark_sync_apply_committed(
         std::size_t applied_batches,
         std::size_t applied_ops,
@@ -352,14 +402,24 @@ namespace mdbxc {
     }
 
     inline void Connection::on_pre_commit(MDBX_txn* txn) {
+        if (sync_capture_failed(txn)) {
+            throw std::logic_error(
+                "Cannot commit transaction after sync capture failure");
+        }
         sync::ISyncCaptureSink* sink = sync_capture();
         if (sink != nullptr) {
-            sink->flush_in_txn(txn);
+            try {
+                sink->flush_in_txn(txn);
+            } catch (...) {
+                mark_sync_capture_failed(txn);
+                throw;
+            }
         }
     }
 
     inline void Connection::on_discard(MDBX_txn* txn) noexcept {
         try {
+            clear_sync_capture_failed(txn);
             sync::ISyncCaptureSink* sink = sync_capture();
             if (sink != nullptr) {
                 sink->discard_txn(txn);

--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -172,10 +172,6 @@ namespace mdbxc {
 
 #   if MDBXC_SYNC_ENABLED
     inline void Connection::attach_sync_capture(sync::ISyncCaptureSink* sink) {
-        if (sink != nullptr && !sink->supports_change_capture()) {
-            throw std::invalid_argument(
-                "Connection::attach_sync_capture sink does not implement change capture");
-        }
         std::lock_guard<std::mutex> locker(m_mdbx_mutex);
         m_sync_capture = sink;
         m_sync_capture_token = ++m_next_sync_capture_token;
@@ -318,9 +314,14 @@ namespace mdbxc {
         if (thread_txn() == txn) {
             return;
         }
+        const MDBX_txn_flags_t flags = mdbx_txn_flags(txn);
+        if ((static_cast<int>(flags) &
+             static_cast<int>(MDBX_TXN_RDONLY)) != 0) {
+            return;
+        }
         throw std::logic_error(
             std::string(context) +
-            " cannot use caller-created raw MDBX_txn* while sync capture is attached; "
+            " cannot use caller-created raw writable MDBX_txn* while sync capture is attached; "
             "use mdbx_containers::Transaction or Connection::begin()/commit()");
     }
 

--- a/include/mdbx_containers/common/Transaction.ipp
+++ b/include/mdbx_containers/common/Transaction.ipp
@@ -50,18 +50,18 @@ namespace mdbxc {
         m_txn = nullptr;
         m_started = false;
 
+#       if MDBXC_SYNC_ENABLED
+        if (registry && txn && was_started && mode == TransactionMode::WRITABLE) {
+            registry->on_discard(txn);
+        }
+#       endif
+
         if (txn) {
             const int rc = mdbx_txn_abort(txn);
             assert((rc == MDBX_SUCCESS || rc == MDBX_THREAD_MISMATCH) &&
                    "mdbx_txn_abort() failed in Transaction::release()");
             (void)rc;
         }
-
-#       if MDBXC_SYNC_ENABLED
-        if (registry && txn && was_started && mode == TransactionMode::WRITABLE) {
-            registry->on_discard(txn);
-        }
-#       endif
 
         if (registry && txn && was_started) {
             safe_unbind_txn(registry, txn);
@@ -186,6 +186,10 @@ namespace mdbxc {
         case TransactionMode::WRITABLE:
         {
             MDBX_txn* txn = m_txn;
+
+#           if MDBXC_SYNC_ENABLED
+            m_registry->on_discard(txn);
+#           endif
             const int rc = mdbx_txn_abort(txn);
 
             if (rc == MDBX_THREAD_MISMATCH) {
@@ -199,9 +203,6 @@ namespace mdbxc {
             m_txn = nullptr;
             m_started = false;
 
-#           if MDBXC_SYNC_ENABLED
-            registry->on_discard(txn);
-#           endif
             safe_unbind_txn(registry, txn);
             safe_unregister_txn_handle(registry);
 

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -164,9 +164,15 @@ namespace mdbxc {
 
         /// \brief Validates a caller-supplied transaction for this table env.
         MDBX_txn* checked_external_txn(MDBX_txn* txn) const {
-            return checked_txn_env(txn,
-                                   m_connection->env_handle(),
-                                   "BaseTable external transaction");
+            MDBX_txn* checked = checked_txn_env(
+                txn,
+                m_connection->env_handle(),
+                "BaseTable external transaction");
+#       if MDBXC_SYNC_ENABLED
+            m_connection->ensure_sync_capture_txn_supported(
+                checked, "BaseTable external transaction");
+#       endif
+            return checked;
         }
         
         /// \brief Gets the raw DBI handle.
@@ -206,8 +212,18 @@ namespace mdbxc {
             if (m_connection->is_read_only()) return;
             sync::ISyncCaptureSink* sink = m_connection->sync_capture();
             if (sink == nullptr) return;
-            sink->record_change(txn, m_name, op_type, m_dbi_flags,
-                                storage_key, value);
+            sync::ChangeOp op;
+            op.op_type = op_type;
+            op.dbi_flags = m_dbi_flags;
+            op.dbi_name = m_name;
+            op.storage_key = storage_key;
+            op.value = value;
+            try {
+                sink->record_change(txn, op);
+            } catch (...) {
+                m_connection->mark_sync_capture_failed(txn);
+                throw;
+            }
         }
 #       endif
     };

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -219,7 +219,7 @@ namespace mdbxc {
             op.storage_key = storage_key;
             op.value = value;
             try {
-                sink->record_change(txn, op);
+                sink->record_change_op(txn, op);
             } catch (...) {
                 m_connection->mark_sync_capture_failed(txn);
                 throw;

--- a/include/mdbx_containers/sync/ChangeAccumulator.hpp
+++ b/include/mdbx_containers/sync/ChangeAccumulator.hpp
@@ -50,26 +50,34 @@ namespace sync {
               m_meta(m_env),
               m_change_log(m_env) {}
 
+        bool supports_change_capture() const override {
+            return true;
+        }
+
+        void record_change(MDBX_txn* txn, const ChangeOp& change) override {
+            txn = checked_txn_env(txn, m_env, "ThreadLocalChangeAccumulator::record_change");
+            std::lock_guard<std::mutex> lk(m_mutex);
+            m_pending[txn].push_back(change);
+        }
+
         void record_change(MDBX_txn* txn,
                            const std::string& dbi_name,
                            ChangeOpType op_type,
                            std::uint32_t dbi_flags,
                            const std::vector<std::uint8_t>& storage_key,
                            const std::vector<std::uint8_t>& value) override {
-            txn = checked_txn_env(txn, m_env, "ThreadLocalChangeAccumulator::record_change");
-            PendingOp op;
+            ChangeOp op;
             op.op_type = op_type;
             op.dbi_flags = dbi_flags;
             op.dbi_name = dbi_name;
             op.storage_key = storage_key;
             op.value = value;
-            std::lock_guard<std::mutex> lk(m_mutex);
-            m_pending[txn].push_back(std::move(op));
+            record_change(txn, op);
         }
 
         void flush_in_txn(MDBX_txn* txn) override {
             txn = checked_txn_env(txn, m_env, "ThreadLocalChangeAccumulator::flush_in_txn");
-            std::vector<PendingOp> ops;
+            std::vector<ChangeOp> ops;
             {
                 std::lock_guard<std::mutex> lk(m_mutex);
                 auto it = m_pending.find(txn);
@@ -92,14 +100,6 @@ namespace sync {
         }
 
     private:
-        struct PendingOp {
-            ChangeOpType op_type = ChangeOpType::Put;
-            std::uint32_t dbi_flags = 0;
-            std::string dbi_name;
-            std::vector<std::uint8_t> storage_key;
-            std::vector<std::uint8_t> value;
-        };
-
         void open_stores(MDBX_txn* txn) {
             /// \note Each flush_in_txn call must reopen the stores inside the
             /// about-to-commit write transaction. \c m_open is set on first
@@ -124,21 +124,12 @@ namespace sync {
             }
         }
 
-        void build_and_append_batch(MDBX_txn* txn, const std::vector<PendingOp>& ops) {
+        void build_and_append_batch(MDBX_txn* txn, const std::vector<ChangeOp>& ops) {
             ChangeBatch batch;
             batch.version = 1;
             batch.origin_node_id = m_node_id;
             batch.seq = m_meta.increment_local_seq(txn);
-            batch.ops.reserve(ops.size());
-            for (const PendingOp& op : ops) {
-                ChangeOp co;
-                co.op_type = op.op_type;
-                co.dbi_flags = op.dbi_flags;
-                co.dbi_name = op.dbi_name;
-                co.storage_key = op.storage_key;
-                co.value = op.value;
-                batch.ops.push_back(std::move(co));
-            }
+            batch.ops = ops;
             const std::vector<std::uint8_t> bytes = ChangeBatchCodec::encode(batch);
             m_change_log.append(txn, m_node_id, batch.seq, bytes);
         }
@@ -148,7 +139,7 @@ namespace sync {
         MetaStore m_meta;
         ChangeLogStore m_change_log;
         std::mutex m_mutex;
-        std::unordered_map<MDBX_txn*, std::vector<PendingOp>> m_pending;
+        std::unordered_map<MDBX_txn*, std::vector<ChangeOp>> m_pending;
 
         void discard_txn(MDBX_txn* txn) noexcept override {
             std::lock_guard<std::mutex> lk(m_mutex);

--- a/include/mdbx_containers/sync/ChangeAccumulator.hpp
+++ b/include/mdbx_containers/sync/ChangeAccumulator.hpp
@@ -50,10 +50,6 @@ namespace sync {
               m_meta(m_env),
               m_change_log(m_env) {}
 
-        bool supports_change_capture() const override {
-            return true;
-        }
-
         void record_change(MDBX_txn* txn, const ChangeOp& change) override {
             txn = checked_txn_env(txn, m_env, "ThreadLocalChangeAccumulator::record_change");
             std::lock_guard<std::mutex> lk(m_mutex);

--- a/include/mdbx_containers/sync/ChangeAccumulator.hpp
+++ b/include/mdbx_containers/sync/ChangeAccumulator.hpp
@@ -50,7 +50,7 @@ namespace sync {
               m_meta(m_env),
               m_change_log(m_env) {}
 
-        void record_change(MDBX_txn* txn, const ChangeOp& change) override {
+        void record_change_op(MDBX_txn* txn, const ChangeOp& change) override {
             txn = checked_txn_env(txn, m_env, "ThreadLocalChangeAccumulator::record_change");
             std::lock_guard<std::mutex> lk(m_mutex);
             m_pending[txn].push_back(change);
@@ -68,7 +68,7 @@ namespace sync {
             op.dbi_name = dbi_name;
             op.storage_key = storage_key;
             op.value = value;
-            record_change(txn, op);
+            record_change_op(txn, op);
         }
 
         void flush_in_txn(MDBX_txn* txn) override {

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -586,6 +586,9 @@ Application integration contract:
   attachments and restores the previous sink when the scope ends; supported
   write operations are recorded by table code and flushed by the transaction
   pre-commit hook;
+- `BaseTable::record_op()` constructs a full `ChangeOp` and forwards it through
+  `ISyncCaptureSink::record_change(txn, change)`. The older raw-field overload
+  is a compatibility adapter for existing custom sinks;
 - choose the scope helper for bounded write phases owned by one stack frame;
   choose explicit attach/detach only for a wider component lifecycle where the
   caller can prove no concurrent table operation or active transaction races

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -588,7 +588,8 @@ Application integration contract:
   pre-commit hook;
 - `BaseTable::record_op()` constructs a full `ChangeOp` and forwards it through
   `ISyncCaptureSink::record_change(txn, change)`. The older raw-field overload
-  is a compatibility adapter for existing custom sinks;
+  remains the source-compatible abstract sink contract for existing custom
+  sinks; new full-`ChangeOp` sinks may derive from `FullChangeSyncCaptureSink`;
 - choose the scope helper for bounded write phases owned by one stack frame;
   choose explicit attach/detach only for a wider component lifecycle where the
   caller can prove no concurrent table operation or active transaction races

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -587,7 +587,7 @@ Application integration contract:
   write operations are recorded by table code and flushed by the transaction
   pre-commit hook;
 - `BaseTable::record_op()` constructs a full `ChangeOp` and forwards it through
-  `ISyncCaptureSink::record_change(txn, change)`. The older raw-field overload
+  `ISyncCaptureSink::record_change_op(txn, change)`. The older raw-field overload
   remains the source-compatible abstract sink contract for existing custom
   sinks; new full-`ChangeOp` sinks may derive from `FullChangeSyncCaptureSink`;
 - choose the scope helper for bounded write phases owned by one stack frame;

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -587,8 +587,8 @@ Application integration contract:
   write operations are recorded by table code and flushed by the transaction
   pre-commit hook;
 - `BaseTable::record_op()` constructs a full `ChangeOp` and forwards it through
-  `ISyncCaptureSink::record_change_op(txn, change)`. The older raw-field overload
-  remains the source-compatible abstract sink contract for existing custom
+  `ISyncCaptureSink::record_change_op(txn, change)`. The older raw-field callback
+  remains the source-compatible abstract sink callback for existing custom
   sinks; new full-`ChangeOp` sinks may derive from `FullChangeSyncCaptureSink`;
 - choose the scope helper for bounded write phases owned by one stack frame;
   choose explicit attach/detach only for a wider component lifecycle where the

--- a/include/mdbx_containers/sync/ISyncCaptureSink.hpp
+++ b/include/mdbx_containers/sync/ISyncCaptureSink.hpp
@@ -35,14 +35,6 @@ namespace sync {
     public:
         virtual ~ISyncCaptureSink() = default;
 
-        /// \brief Returns whether this sink implements a capture dispatch path.
-        /// \details \c Connection::attach_sync_capture() rejects sinks that do
-        /// not opt in here, so a type that only implements \c flush_in_txn()
-        /// fails at attachment time instead of after a user-table write.
-        virtual bool supports_change_capture() const {
-            return false;
-        }
-
         /// \brief Called by \c BaseTable after a successful user-table write.
         /// \param txn The active MDBX write transaction that performed the
         ///        change.
@@ -81,15 +73,7 @@ namespace sync {
                                    ChangeOpType op_type,
                                    std::uint32_t dbi_flags,
                                    const std::vector<std::uint8_t>& storage_key,
-                                   const std::vector<std::uint8_t>& value) {
-            (void)txn;
-            (void)dbi_name;
-            (void)op_type;
-            (void)dbi_flags;
-            (void)storage_key;
-            (void)value;
-            throw std::logic_error("ISyncCaptureSink::record_change is not implemented");
-        }
+                                   const std::vector<std::uint8_t>& value) = 0;
 
         /// \brief Called by \c Transaction::commit() before the actual commit.
         /// \param txn The about-to-commit write transaction.
@@ -107,6 +91,32 @@ namespace sync {
         virtual void discard_txn(MDBX_txn* txn) noexcept {
             (void)txn;
         }
+    };
+
+    /// \brief Adapter base for sinks that want to implement only the full
+    ///        \c ChangeOp entry point.
+    /// \details The legacy raw-field overload is still the abstract compatibility
+    /// contract of \c ISyncCaptureSink. Derive from this helper when new code
+    /// wants every raw-shaped operation converted into a \c ChangeOp object.
+    class FullChangeSyncCaptureSink : public ISyncCaptureSink {
+    public:
+        void record_change(MDBX_txn* txn,
+                           const std::string& dbi_name,
+                           ChangeOpType op_type,
+                           std::uint32_t dbi_flags,
+                           const std::vector<std::uint8_t>& storage_key,
+                           const std::vector<std::uint8_t>& value) override {
+            ChangeOp op;
+            op.op_type = op_type;
+            op.dbi_flags = dbi_flags;
+            op.dbi_name = dbi_name;
+            op.storage_key = storage_key;
+            op.value = value;
+            record_change(txn, op);
+        }
+
+        void record_change(MDBX_txn* txn,
+                           const ChangeOp& change) override = 0;
     };
 
 } // namespace sync

--- a/include/mdbx_containers/sync/ISyncCaptureSink.hpp
+++ b/include/mdbx_containers/sync/ISyncCaptureSink.hpp
@@ -35,8 +35,36 @@ namespace sync {
     public:
         virtual ~ISyncCaptureSink() = default;
 
-        /// \brief Called by \c BaseTable after a successful \c mdbx_put /
-        /// \c mdbx_del on a user table.
+        /// \brief Returns whether this sink implements a capture dispatch path.
+        /// \details \c Connection::attach_sync_capture() rejects sinks that do
+        /// not opt in here, so a type that only implements \c flush_in_txn()
+        /// fails at attachment time instead of after a user-table write.
+        virtual bool supports_change_capture() const {
+            return false;
+        }
+
+        /// \brief Called by \c BaseTable after a successful user-table write.
+        /// \param txn The active MDBX write transaction that performed the
+        ///        change.
+        /// \param change Full raw-domain change operation.
+        /// \details Default implementation forwards to the legacy raw-field
+        /// overload only when \p change contains no enriched metadata. New
+        /// sinks should override this overload when they need access to the
+        /// complete \c ChangeOp shape.
+        virtual void record_change(MDBX_txn* txn, const ChangeOp& change) {
+            if (change.op_flags != OP_NONE ||
+                !change.identity_key.empty() ||
+                !change.revision_key.empty()) {
+                throw std::logic_error(
+                    "ISyncCaptureSink legacy record_change overload cannot accept enriched ChangeOp");
+            }
+            record_change(txn, change.dbi_name, change.op_type,
+                          change.dbi_flags, change.storage_key, change.value);
+        }
+
+        /// \brief Legacy raw-field capture entry point.
+        /// \details Existing sinks may continue overriding this overload.
+        /// New code should prefer \c record_change(MDBX_txn*, const ChangeOp&).
         /// \param txn The active MDBX write transaction that performed the
         ///        change. Implementations may stage the op in thread-local
         ///        memory and defer the on-disk write to \c flush_in_txn.
@@ -53,7 +81,15 @@ namespace sync {
                                    ChangeOpType op_type,
                                    std::uint32_t dbi_flags,
                                    const std::vector<std::uint8_t>& storage_key,
-                                   const std::vector<std::uint8_t>& value) = 0;
+                                   const std::vector<std::uint8_t>& value) {
+            (void)txn;
+            (void)dbi_name;
+            (void)op_type;
+            (void)dbi_flags;
+            (void)storage_key;
+            (void)value;
+            throw std::logic_error("ISyncCaptureSink::record_change is not implemented");
+        }
 
         /// \brief Called by \c Transaction::commit() before the actual commit.
         /// \param txn The about-to-commit write transaction.

--- a/include/mdbx_containers/sync/ISyncCaptureSink.hpp
+++ b/include/mdbx_containers/sync/ISyncCaptureSink.hpp
@@ -43,12 +43,12 @@ namespace sync {
         /// overload only when \p change contains no enriched metadata. New
         /// sinks should override this overload when they need access to the
         /// complete \c ChangeOp shape.
-        virtual void record_change(MDBX_txn* txn, const ChangeOp& change) {
+        virtual void record_change_op(MDBX_txn* txn, const ChangeOp& change) {
             if (change.op_flags != OP_NONE ||
                 !change.identity_key.empty() ||
                 !change.revision_key.empty()) {
                 throw std::logic_error(
-                    "ISyncCaptureSink legacy record_change overload cannot accept enriched ChangeOp");
+                    "ISyncCaptureSink legacy record_change_op cannot accept enriched ChangeOp");
             }
             record_change(txn, change.dbi_name, change.op_type,
                           change.dbi_flags, change.storage_key, change.value);
@@ -56,7 +56,7 @@ namespace sync {
 
         /// \brief Legacy raw-field capture entry point.
         /// \details Existing sinks may continue overriding this overload.
-        /// New code should prefer \c record_change(MDBX_txn*, const ChangeOp&).
+        /// New code should prefer \c record_change_op(MDBX_txn*, const ChangeOp&).
         /// \param txn The active MDBX write transaction that performed the
         ///        change. Implementations may stage the op in thread-local
         ///        memory and defer the on-disk write to \c flush_in_txn.
@@ -112,11 +112,11 @@ namespace sync {
             op.dbi_name = dbi_name;
             op.storage_key = storage_key;
             op.value = value;
-            record_change(txn, op);
+            record_change_op(txn, op);
         }
 
-        void record_change(MDBX_txn* txn,
-                           const ChangeOp& change) override = 0;
+        void record_change_op(MDBX_txn* txn,
+                              const ChangeOp& change) override = 0;
     };
 
 } // namespace sync

--- a/include/mdbx_containers/sync/ISyncCaptureSink.hpp
+++ b/include/mdbx_containers/sync/ISyncCaptureSink.hpp
@@ -40,15 +40,15 @@ namespace sync {
         ///        change.
         /// \param change Full raw-domain change operation.
         /// \details Default implementation forwards to the legacy raw-field
-        /// overload only when \p change contains no enriched metadata. New
-        /// sinks should override this overload when they need access to the
+        /// callback only when \p change contains no enriched metadata. New
+        /// sinks should override this entry point when they need access to the
         /// complete \c ChangeOp shape.
         virtual void record_change_op(MDBX_txn* txn, const ChangeOp& change) {
             if (change.op_flags != OP_NONE ||
                 !change.identity_key.empty() ||
                 !change.revision_key.empty()) {
                 throw std::logic_error(
-                    "ISyncCaptureSink legacy record_change_op cannot accept enriched ChangeOp");
+                    "ISyncCaptureSink default record_change_op forwarding cannot pass an enriched ChangeOp to a legacy raw-field sink");
             }
             record_change(txn, change.dbi_name, change.op_type,
                           change.dbi_flags, change.storage_key, change.value);
@@ -95,7 +95,7 @@ namespace sync {
 
     /// \brief Adapter base for sinks that want to implement only the full
     ///        \c ChangeOp entry point.
-    /// \details The legacy raw-field overload is still the abstract compatibility
+    /// \details The legacy raw-field callback is still the abstract compatibility
     /// contract of \c ISyncCaptureSink. Derive from this helper when new code
     /// wants every raw-shaped operation converted into a \c ChangeOp object.
     class FullChangeSyncCaptureSink : public ISyncCaptureSink {

--- a/include/mdbx_containers/sync/ISyncCaptureSink.hpp
+++ b/include/mdbx_containers/sync/ISyncCaptureSink.hpp
@@ -55,7 +55,7 @@ namespace sync {
         }
 
         /// \brief Legacy raw-field capture entry point.
-        /// \details Existing sinks may continue overriding this overload.
+        /// \details Existing sinks may continue overriding this raw-field callback.
         /// New code should prefer \c record_change_op(MDBX_txn*, const ChangeOp&).
         /// \param txn The active MDBX write transaction that performed the
         ///        change. Implementations may stage the op in thread-local
@@ -85,7 +85,7 @@ namespace sync {
         /// \brief Discards any pending ops recorded for a transaction that
         /// is about to be aborted or rolled back.
         /// \param txn The about-to-be-aborted write transaction.
-        /// \details Default implementation is a no-op; overloads drop the
+        /// \details Default implementation is a no-op; overrides drop the
         /// pending ops so the next transaction on the same thread (or the
         /// next MDBX_txn* address if the allocator reuses it) starts clean.
         virtual void discard_txn(MDBX_txn* txn) noexcept {

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -31,6 +31,10 @@ public:
 
 class HeaderSyncSink : public mdbxc::sync::ISyncCaptureSink {
 public:
+    bool supports_change_capture() const override {
+        return true;
+    }
+
     void record_change(MDBX_txn* txn,
                        const std::string& dbi_name,
                        mdbxc::sync::ChangeOpType op_type,

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -31,10 +31,6 @@ public:
 
 class HeaderSyncSink : public mdbxc::sync::ISyncCaptureSink {
 public:
-    bool supports_change_capture() const override {
-        return true;
-    }
-
     void record_change(MDBX_txn* txn,
                        const std::string& dbi_name,
                        mdbxc::sync::ChangeOpType op_type,

--- a/tests/header_sync_umbrella_test.cpp
+++ b/tests/header_sync_umbrella_test.cpp
@@ -50,6 +50,21 @@ public:
     }
 };
 
+class HeaderFullChangeSyncSink : public mdbxc::sync::FullChangeSyncCaptureSink {
+public:
+    void record_change_op(MDBX_txn* txn,
+                          const mdbxc::sync::ChangeOp& change) override {
+        (void)txn;
+        last_change = change;
+    }
+
+    void flush_in_txn(MDBX_txn* txn) override {
+        (void)txn;
+    }
+
+    mdbxc::sync::ChangeOp last_change;
+};
+
 class HeaderSyncApplyObserver : public mdbxc::sync::ISyncApplyObserver {
 public:
     HeaderSyncApplyObserver() : calls(0) {}
@@ -140,6 +155,7 @@ int main() {
     mdbxc::sync::SyncNodeSession* node_session = nullptr;
     mdbxc::sync::SyncNodeSessionOptions node_session_options;
     HeaderSyncSink header_sink;
+    HeaderFullChangeSyncSink header_full_sink;
     HeaderSyncApplyObserver apply_observer;
     mdbxc::sync::SyncApplyEvent apply_event;
     apply_event.generation = 1u;
@@ -156,6 +172,7 @@ int main() {
     (void)node_session;
     (void)node_session_options;
     (void)header_sink;
+    (void)header_full_sink;
     mdbxc::sync::TransportMessageSizePolicy size_policy(1024u);
     (void)size_policy;
     mdbxc::sync::IWebSocketSyncChannel* websocket_channel = nullptr;

--- a/tests/test_sync_capture.cpp
+++ b/tests/test_sync_capture.cpp
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -24,10 +25,6 @@ public:
     mutable std::mutex m_mutex;
     std::vector<mdbxc::sync::ChangeOp> m_recorded;
     std::vector<mdbxc::sync::ChangeBatch> m_flushed;
-
-    bool supports_change_capture() const override {
-        return true;
-    }
 
     void record_change(MDBX_txn* txn,
                        const std::string& dbi_name,
@@ -59,13 +56,9 @@ public:
     }
 };
 
-class FullChangeSink : public mdbxc::sync::ISyncCaptureSink {
+class FullChangeSink : public mdbxc::sync::FullChangeSyncCaptureSink {
 public:
     std::vector<mdbxc::sync::ChangeOp> m_recorded;
-
-    bool supports_change_capture() const override {
-        return true;
-    }
 
     void record_change(MDBX_txn* txn,
                        const mdbxc::sync::ChangeOp& change) override {
@@ -78,13 +71,9 @@ public:
     }
 };
 
-class ThrowingChangeSink : public mdbxc::sync::ISyncCaptureSink {
+class ThrowingChangeSink : public mdbxc::sync::FullChangeSyncCaptureSink {
 public:
     int flush_calls = 0;
-
-    bool supports_change_capture() const override {
-        return true;
-    }
 
     void record_change(MDBX_txn* txn,
                        const mdbxc::sync::ChangeOp& change) override {
@@ -99,16 +88,12 @@ public:
     }
 };
 
-class ThrowOnceFlushSink : public mdbxc::sync::ISyncCaptureSink {
+class ThrowOnceFlushSink : public mdbxc::sync::FullChangeSyncCaptureSink {
 public:
     int record_calls = 0;
     int flush_calls = 0;
     bool consume_before_throw = false;
     std::vector<mdbxc::sync::ChangeOp> pending;
-
-    bool supports_change_capture() const override {
-        return true;
-    }
 
     void record_change(MDBX_txn* txn,
                        const mdbxc::sync::ChangeOp& change) override {
@@ -1413,9 +1398,9 @@ void test_raw_external_transaction_rejected_while_capture_attached() {
     cleanup(p);
 }
 
-void test_incomplete_capture_sink_rejected_on_attach() {
+void test_raw_read_only_transaction_allowed_while_capture_attached() {
     using namespace mdbxc;
-    const std::string p = "test_capture_incomplete_sink.mdbx";
+    const std::string p = "test_capture_raw_read_only_txn_allowed.mdbx";
     cleanup(p);
 
     Config cfg;
@@ -1424,20 +1409,60 @@ void test_incomplete_capture_sink_rejected_on_attach() {
     cfg.no_subdir = true;
     auto conn = Connection::create(cfg);
 
-    FlushOnlySink sink;
-    bool rejected = false;
-    try {
-        conn->attach_sync_capture(&sink);
-    } catch (const std::invalid_argument&) {
-        rejected = true;
-    }
-    if (!rejected) {
-        throw std::runtime_error(
-            "flush-only capture sink was accepted");
-    }
+    KeyValueTable<int, int> table(conn, "data");
+    table.insert_or_assign(1, 100);
+    table.insert_or_assign(2, 200);
+    table.insert_or_assign(3, 300);
 
+    StubSink sink;
+    conn->attach_sync_capture(&sink);
+
+    MDBX_txn* raw = nullptr;
+    check_mdbx(
+        mdbx_txn_begin(conn->env_handle(),
+                       nullptr,
+                       MDBX_TXN_RDONLY,
+                       &raw),
+        "failed to begin raw read-only transaction");
+
+    try {
+        int value = 0;
+        if (!table.try_get(1, value, raw) || value != 100) {
+            throw std::runtime_error(
+                "raw read-only transaction failed point lookup");
+        }
+        if (!table.contains(2, raw)) {
+            throw std::runtime_error(
+                "raw read-only transaction failed contains");
+        }
+        if (!table.contains_range(1, 3, raw)) {
+            throw std::runtime_error(
+                "raw read-only transaction failed contains_range");
+        }
+        if (table.count(raw) != 3u) {
+            throw std::runtime_error(
+                "raw read-only transaction failed count");
+        }
+        const std::map<int, int> pairs =
+            table.range(1, 3, raw);
+        if (pairs.size() != 3u) {
+            throw std::runtime_error(
+                "raw read-only transaction failed range scan");
+        }
+    } catch (...) {
+        mdbx_txn_abort(raw);
+        throw;
+    }
+    mdbx_txn_abort(raw);
+
+    conn->detach_sync_capture();
     conn->disconnect();
     cleanup(p);
+}
+
+void test_flush_only_capture_sink_is_abstract() {
+    static_assert(std::is_abstract<FlushOnlySink>::value,
+                  "flush-only capture sink must be abstract");
 }
 
 void test_changelog_capture_roundtrip() {
@@ -1840,8 +1865,10 @@ int main(int argc, char** argv) {
           &test_partial_capture_flush_failure_blocks_commit_retry },
         { "test_raw_external_transaction_rejected_while_capture_attached",
           &test_raw_external_transaction_rejected_while_capture_attached },
-        { "test_incomplete_capture_sink_rejected_on_attach",
-          &test_incomplete_capture_sink_rejected_on_attach },
+        { "test_raw_read_only_transaction_allowed_while_capture_attached",
+          &test_raw_read_only_transaction_allowed_while_capture_attached },
+        { "test_flush_only_capture_sink_is_abstract",
+          &test_flush_only_capture_sink_is_abstract },
         { "test_any_value_table_does_not_capture_in_v01",
           &test_any_value_table_does_not_capture_in_v01 },
         { "test_key_multi_value_table_does_not_capture_in_v01",

--- a/tests/test_sync_capture.cpp
+++ b/tests/test_sync_capture.cpp
@@ -25,6 +25,10 @@ public:
     std::vector<mdbxc::sync::ChangeOp> m_recorded;
     std::vector<mdbxc::sync::ChangeBatch> m_flushed;
 
+    bool supports_change_capture() const override {
+        return true;
+    }
+
     void record_change(MDBX_txn* txn,
                        const std::string& dbi_name,
                        mdbxc::sync::ChangeOpType op_type,
@@ -52,6 +56,84 @@ public:
         std::lock_guard<std::mutex> lk(m_mutex);
         m_recorded.clear();
         m_flushed.clear();
+    }
+};
+
+class FullChangeSink : public mdbxc::sync::ISyncCaptureSink {
+public:
+    std::vector<mdbxc::sync::ChangeOp> m_recorded;
+
+    bool supports_change_capture() const override {
+        return true;
+    }
+
+    void record_change(MDBX_txn* txn,
+                       const mdbxc::sync::ChangeOp& change) override {
+        (void)txn;
+        m_recorded.push_back(change);
+    }
+
+    void flush_in_txn(MDBX_txn* txn) override {
+        (void)txn;
+    }
+};
+
+class ThrowingChangeSink : public mdbxc::sync::ISyncCaptureSink {
+public:
+    int flush_calls = 0;
+
+    bool supports_change_capture() const override {
+        return true;
+    }
+
+    void record_change(MDBX_txn* txn,
+                       const mdbxc::sync::ChangeOp& change) override {
+        (void)txn;
+        (void)change;
+        throw std::runtime_error("capture record failure");
+    }
+
+    void flush_in_txn(MDBX_txn* txn) override {
+        (void)txn;
+        ++flush_calls;
+    }
+};
+
+class ThrowOnceFlushSink : public mdbxc::sync::ISyncCaptureSink {
+public:
+    int record_calls = 0;
+    int flush_calls = 0;
+    bool consume_before_throw = false;
+    std::vector<mdbxc::sync::ChangeOp> pending;
+
+    bool supports_change_capture() const override {
+        return true;
+    }
+
+    void record_change(MDBX_txn* txn,
+                       const mdbxc::sync::ChangeOp& change) override {
+        (void)txn;
+        ++record_calls;
+        pending.push_back(change);
+    }
+
+    void flush_in_txn(MDBX_txn* txn) override {
+        (void)txn;
+        ++flush_calls;
+        if (flush_calls == 1) {
+            if (consume_before_throw) {
+                pending.clear();
+            }
+            throw std::runtime_error("capture flush failure");
+        }
+        pending.clear();
+    }
+};
+
+class FlushOnlySink : public mdbxc::sync::ISyncCaptureSink {
+public:
+    void flush_in_txn(MDBX_txn* txn) override {
+        (void)txn;
     }
 };
 
@@ -389,6 +471,70 @@ void run_capture_scope_out_of_order_destruction_child() {
     delete inner;
     conn->disconnect();
     cleanup(p);
+}
+
+void test_capture_uses_full_change_op_overload() {
+    using namespace mdbxc;
+    const std::string p = "test_capture_full_change_op.mdbx";
+    cleanup(p);
+
+    Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = Connection::create(cfg);
+
+    FullChangeSink sink;
+    conn->attach_sync_capture(&sink);
+
+    KeyValueTable<int, int> kv(conn, "full_capture");
+    kv.insert_or_assign(7, 70);
+
+    if (sink.m_recorded.size() != 1u) {
+        throw std::runtime_error("full ChangeOp sink did not receive capture");
+    }
+    const sync::ChangeOp& op = sink.m_recorded[0];
+    if (op.dbi_name != "full_capture" ||
+        op.op_type != sync::ChangeOpType::Put ||
+        op.storage_key.empty() ||
+        op.value.empty()) {
+        throw std::runtime_error("full ChangeOp capture fields mismatch");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_legacy_sink_rejects_enriched_change_op() {
+    StubSink sink;
+    mdbxc::sync::ISyncCaptureSink* base = &sink;
+
+    mdbxc::sync::ChangeOp op;
+    op.dbi_name = "legacy_capture";
+    op.op_type = mdbxc::sync::ChangeOpType::Put;
+    op.dbi_flags = MDBX_CREATE;
+    op.storage_key.push_back(0x01u);
+    op.value.push_back(0x02u);
+    op.op_flags = mdbxc::sync::OP_HAS_IDENTITY_KEY;
+    op.identity_key.push_back(0x03u);
+
+    bool rejected = false;
+    try {
+        base->record_change(nullptr, op);
+    } catch (const std::logic_error&) {
+        rejected = true;
+    }
+
+    if (!rejected) {
+        throw std::runtime_error(
+            "legacy capture sink accepted enriched ChangeOp");
+    }
+
+    std::lock_guard<std::mutex> lk(sink.m_mutex);
+    if (!sink.m_recorded.empty()) {
+        throw std::runtime_error(
+            "legacy capture sink recorded truncated enriched ChangeOp");
+    }
 }
 
 void test_capture_scope_terminates_on_out_of_order_destruction() {
@@ -1038,6 +1184,262 @@ void test_capture_flush_on_commit() {
     }
 }
 
+void test_capture_record_failure_blocks_explicit_commit() {
+    using namespace mdbxc;
+    const std::string p = "test_capture_record_failure.mdbx";
+    cleanup(p);
+
+    Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = Connection::create(cfg);
+
+    KeyValueTable<int, int> table(conn, "data");
+    ThrowingChangeSink sink;
+    conn->attach_sync_capture(&sink);
+
+    auto txn = conn->transaction(TransactionMode::WRITABLE);
+    bool record_threw = false;
+    try {
+        table.insert_or_assign(1, 100, txn.handle());
+    } catch (const std::runtime_error&) {
+        record_threw = true;
+    }
+    if (!record_threw) {
+        throw std::runtime_error("capture record failure did not throw");
+    }
+
+    bool commit_rejected = false;
+    try {
+        txn.commit();
+    } catch (const std::logic_error&) {
+        commit_rejected = true;
+    }
+    if (!commit_rejected) {
+        throw std::runtime_error(
+            "transaction committed after capture record failure");
+    }
+    if (sink.flush_calls != 0) {
+        throw std::runtime_error(
+            "capture flush ran after record failure marker");
+    }
+
+    txn.rollback();
+    conn->detach_sync_capture();
+
+    {
+        auto clean_txn = conn->transaction(TransactionMode::WRITABLE);
+        table.insert_or_assign(2, 200, clean_txn.handle());
+        clean_txn.commit();
+    }
+
+    {
+        auto ro = conn->transaction(TransactionMode::READ_ONLY);
+        int value = 0;
+        if (table.try_get(1, value, ro.handle())) {
+            throw std::runtime_error(
+                "failed capture transaction committed user value");
+        }
+        if (!table.try_get(2, value, ro.handle()) || value != 200) {
+            throw std::runtime_error(
+                "capture failure marker was not cleared after rollback");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_capture_flush_failure_blocks_commit_retry() {
+    using namespace mdbxc;
+    const std::string p = "test_capture_flush_failure.mdbx";
+    cleanup(p);
+
+    Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = Connection::create(cfg);
+
+    KeyValueTable<int, int> table(conn, "data");
+    ThrowOnceFlushSink sink;
+    conn->attach_sync_capture(&sink);
+
+    auto txn = conn->transaction(TransactionMode::WRITABLE);
+    table.insert_or_assign(1, 100, txn.handle());
+
+    bool flush_threw = false;
+    try {
+        txn.commit();
+    } catch (const std::runtime_error&) {
+        flush_threw = true;
+    }
+    if (!flush_threw || sink.flush_calls != 1) {
+        throw std::runtime_error("first commit did not fail in capture flush");
+    }
+
+    bool retry_rejected = false;
+    try {
+        txn.commit();
+    } catch (const std::logic_error&) {
+        retry_rejected = true;
+    }
+    if (!retry_rejected || sink.flush_calls != 1) {
+        throw std::runtime_error(
+            "commit retry after capture flush failure was not rejected early");
+    }
+
+    txn.rollback();
+    conn->detach_sync_capture();
+
+    {
+        auto ro = conn->transaction(TransactionMode::READ_ONLY);
+        int value = 0;
+        if (table.try_get(1, value, ro.handle())) {
+            throw std::runtime_error(
+                "failed capture flush transaction committed user value");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_partial_capture_flush_failure_blocks_commit_retry() {
+    using namespace mdbxc;
+    const std::string p = "test_capture_partial_flush_failure.mdbx";
+    cleanup(p);
+
+    Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = Connection::create(cfg);
+
+    KeyValueTable<int, int> table(conn, "data");
+    ThrowOnceFlushSink sink;
+    sink.consume_before_throw = true;
+    conn->attach_sync_capture(&sink);
+
+    auto txn = conn->transaction(TransactionMode::WRITABLE);
+    table.insert_or_assign(1, 100, txn.handle());
+
+    bool flush_threw = false;
+    try {
+        txn.commit();
+    } catch (const std::runtime_error&) {
+        flush_threw = true;
+    }
+    if (!flush_threw || !sink.pending.empty()) {
+        throw std::runtime_error(
+            "partial capture flush failure precondition mismatch");
+    }
+
+    bool retry_rejected = false;
+    try {
+        txn.commit();
+    } catch (const std::logic_error&) {
+        retry_rejected = true;
+    }
+    if (!retry_rejected || sink.flush_calls != 1) {
+        throw std::runtime_error(
+            "partial capture flush failure allowed commit retry");
+    }
+
+    txn.rollback();
+    conn->detach_sync_capture();
+
+    {
+        auto ro = conn->transaction(TransactionMode::READ_ONLY);
+        int value = 0;
+        if (table.try_get(1, value, ro.handle())) {
+            throw std::runtime_error(
+                "partial capture flush failure committed user value");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_raw_external_transaction_rejected_while_capture_attached() {
+    using namespace mdbxc;
+    const std::string p = "test_capture_raw_txn_rejected.mdbx";
+    cleanup(p);
+
+    Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = Connection::create(cfg);
+
+    KeyValueTable<int, int> table(conn, "data");
+    StubSink sink;
+    conn->attach_sync_capture(&sink);
+
+    MDBX_txn* raw = nullptr;
+    check_mdbx(
+        mdbx_txn_begin(conn->env_handle(),
+                       nullptr,
+                       MDBX_TXN_READWRITE,
+                       &raw),
+        "failed to begin raw transaction");
+
+    bool rejected = false;
+    try {
+        table.insert_or_assign(1, 100, raw);
+    } catch (const std::logic_error&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        mdbx_txn_abort(raw);
+        throw std::runtime_error(
+            "raw unmanaged transaction accepted with sync capture attached");
+    }
+    check_mdbx(mdbx_txn_commit(raw), "failed to commit empty raw transaction");
+    conn->detach_sync_capture();
+
+    {
+        auto ro = conn->transaction(TransactionMode::READ_ONLY);
+        int value = 0;
+        if (table.try_get(1, value, ro.handle())) {
+            throw std::runtime_error(
+                "raw rejected transaction still wrote user value");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_incomplete_capture_sink_rejected_on_attach() {
+    using namespace mdbxc;
+    const std::string p = "test_capture_incomplete_sink.mdbx";
+    cleanup(p);
+
+    Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = Connection::create(cfg);
+
+    FlushOnlySink sink;
+    bool rejected = false;
+    try {
+        conn->attach_sync_capture(&sink);
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error(
+            "flush-only capture sink was accepted");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 void test_changelog_capture_roundtrip() {
     using namespace mdbxc;
     const std::string p = "test_capture_changelog.mdbx";
@@ -1095,6 +1497,86 @@ void test_changelog_capture_roundtrip() {
         if (cl.contains(txn.handle(), node_id, 3)) {
             throw std::runtime_error("changelog unexpectedly has seq 3");
         }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_changelog_capture_preserves_enriched_change_op() {
+    using namespace mdbxc;
+    const std::string p = "test_capture_enriched_changelog.mdbx";
+    cleanup(p);
+
+    Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = Connection::create(cfg);
+
+    sync::NodeId node_id{};
+    for (int i = 0; i < 16; ++i) {
+        node_id[i] = static_cast<std::uint8_t>(0xB0 + i);
+    }
+
+    {
+        sync::MetaStore meta(conn->env_handle());
+        auto txn = conn->transaction(TransactionMode::WRITABLE);
+        meta.open(txn.handle());
+        meta.set_node_id(txn.handle(), node_id);
+        txn.commit();
+    }
+
+    sync::ThreadLocalChangeAccumulator sink(conn);
+    conn->attach_sync_capture(&sink);
+
+    {
+        auto txn = conn->transaction(TransactionMode::WRITABLE);
+        sync::ChangeOp op;
+        op.op_type = sync::ChangeOpType::Put;
+        op.op_flags =
+            sync::OP_HAS_IDENTITY_KEY | sync::OP_HAS_REVISION_KEY;
+        op.dbi_flags = MDBX_CREATE;
+        op.dbi_name = "logical_data";
+        op.storage_key.push_back(0x01u);
+        op.value.push_back(0x02u);
+        op.identity_key.push_back(0x03u);
+        op.revision_key.push_back(0x04u);
+        sink.record_change(txn.handle(), op);
+        txn.commit();
+    }
+
+    conn->detach_sync_capture();
+
+    sync::ChangeLogStore cl(conn->env_handle());
+    {
+        auto txn = conn->transaction(TransactionMode::WRITABLE);
+        cl.open(txn.handle());
+        txn.commit();
+    }
+
+    std::vector<std::uint8_t> bytes;
+    {
+        auto txn = conn->transaction(TransactionMode::READ_ONLY);
+        if (!cl.get(txn.handle(), node_id, 1, bytes)) {
+            throw std::runtime_error("enriched changelog batch missing");
+        }
+    }
+
+    const sync::ChangeBatch batch = sync::ChangeBatchCodec::decode(bytes);
+    if (batch.ops.size() != 1u) {
+        throw std::runtime_error("enriched changelog batch op count mismatch");
+    }
+
+    const sync::ChangeOp& decoded = batch.ops[0];
+    if (decoded.op_flags !=
+            (sync::OP_HAS_IDENTITY_KEY | sync::OP_HAS_REVISION_KEY) ||
+        decoded.identity_key.size() != 1u ||
+        decoded.identity_key[0] != 0x03u ||
+        decoded.revision_key.size() != 1u ||
+        decoded.revision_key[0] != 0x04u) {
+        throw std::runtime_error(
+            "enriched ChangeOp metadata was not preserved");
     }
 
     conn->disconnect();
@@ -1322,6 +1804,10 @@ int main(int argc, char** argv) {
     const Case cases[] = {
         { "test_no_sink_no_capture", &test_no_sink_no_capture },
         { "test_capture_writes_via_sink", &test_capture_writes_via_sink },
+        { "test_capture_uses_full_change_op_overload",
+          &test_capture_uses_full_change_op_overload },
+        { "test_legacy_sink_rejects_enriched_change_op",
+          &test_legacy_sink_rejects_enriched_change_op },
         { "test_capture_scope_restores_previous_sink",
           &test_capture_scope_restores_previous_sink },
         { "test_capture_scope_nested_scopes_restore_in_order",
@@ -1346,6 +1832,16 @@ int main(int argc, char** argv) {
         { "test_vector_store_writes_via_sink",
           &test_vector_store_writes_via_sink },
         { "test_capture_flush_on_commit", &test_capture_flush_on_commit },
+        { "test_capture_record_failure_blocks_explicit_commit",
+          &test_capture_record_failure_blocks_explicit_commit },
+        { "test_capture_flush_failure_blocks_commit_retry",
+          &test_capture_flush_failure_blocks_commit_retry },
+        { "test_partial_capture_flush_failure_blocks_commit_retry",
+          &test_partial_capture_flush_failure_blocks_commit_retry },
+        { "test_raw_external_transaction_rejected_while_capture_attached",
+          &test_raw_external_transaction_rejected_while_capture_attached },
+        { "test_incomplete_capture_sink_rejected_on_attach",
+          &test_incomplete_capture_sink_rejected_on_attach },
         { "test_any_value_table_does_not_capture_in_v01",
           &test_any_value_table_does_not_capture_in_v01 },
         { "test_key_multi_value_table_does_not_capture_in_v01",
@@ -1353,6 +1849,8 @@ int main(int argc, char** argv) {
         { "test_hashed_key_value_store_does_not_capture_in_v01",
           &test_hashed_key_value_store_does_not_capture_in_v01 },
         { "test_changelog_capture_roundtrip", &test_changelog_capture_roundtrip },
+        { "test_changelog_capture_preserves_enriched_change_op",
+          &test_changelog_capture_preserves_enriched_change_op },
         { "test_zero_node_id_rejected", &test_zero_node_id_rejected },
         { "test_aborted_transaction_does_not_flush",
           &test_aborted_transaction_does_not_flush },

--- a/tests/test_sync_capture.cpp
+++ b/tests/test_sync_capture.cpp
@@ -60,8 +60,8 @@ class FullChangeSink : public mdbxc::sync::FullChangeSyncCaptureSink {
 public:
     std::vector<mdbxc::sync::ChangeOp> m_recorded;
 
-    void record_change(MDBX_txn* txn,
-                       const mdbxc::sync::ChangeOp& change) override {
+    void record_change_op(MDBX_txn* txn,
+                          const mdbxc::sync::ChangeOp& change) override {
         (void)txn;
         m_recorded.push_back(change);
     }
@@ -75,8 +75,8 @@ class ThrowingChangeSink : public mdbxc::sync::FullChangeSyncCaptureSink {
 public:
     int flush_calls = 0;
 
-    void record_change(MDBX_txn* txn,
-                       const mdbxc::sync::ChangeOp& change) override {
+    void record_change_op(MDBX_txn* txn,
+                          const mdbxc::sync::ChangeOp& change) override {
         (void)txn;
         (void)change;
         throw std::runtime_error("capture record failure");
@@ -95,8 +95,8 @@ public:
     bool consume_before_throw = false;
     std::vector<mdbxc::sync::ChangeOp> pending;
 
-    void record_change(MDBX_txn* txn,
-                       const mdbxc::sync::ChangeOp& change) override {
+    void record_change_op(MDBX_txn* txn,
+                          const mdbxc::sync::ChangeOp& change) override {
         (void)txn;
         ++record_calls;
         pending.push_back(change);
@@ -505,7 +505,7 @@ void test_legacy_sink_rejects_enriched_change_op() {
 
     bool rejected = false;
     try {
-        base->record_change(nullptr, op);
+        base->record_change_op(nullptr, op);
     } catch (const std::logic_error&) {
         rejected = true;
     }
@@ -1567,7 +1567,7 @@ void test_changelog_capture_preserves_enriched_change_op() {
         op.value.push_back(0x02u);
         op.identity_key.push_back(0x03u);
         op.revision_key.push_back(0x04u);
-        sink.record_change(txn.handle(), op);
+        sink.record_change_op(txn.handle(), op);
         txn.commit();
     }
 

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -159,10 +159,6 @@ class NodeSessionCaptureSink : public mdbxc::sync::ISyncCaptureSink {
 public:
     NodeSessionCaptureSink() : m_records(0), m_flushes(0), m_discards(0) {}
 
-    bool supports_change_capture() const override {
-        return true;
-    }
-
     void record_change(MDBX_txn* txn,
                        const std::string& dbi_name,
                        mdbxc::sync::ChangeOpType op_type,

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -159,6 +159,10 @@ class NodeSessionCaptureSink : public mdbxc::sync::ISyncCaptureSink {
 public:
     NodeSessionCaptureSink() : m_records(0), m_flushes(0), m_discards(0) {}
 
+    bool supports_change_capture() const override {
+        return true;
+    }
+
     void record_change(MDBX_txn* txn,
                        const std::string& dbi_name,
                        mdbxc::sync::ChangeOpType op_type,


### PR DESCRIPTION
## Summary
- add `ISyncCaptureSink::record_change_op(MDBX_txn*, const ChangeOp&)` as the preferred full-object capture entry point
- keep the legacy raw-field `record_change(...)` callback as the source-compatible abstract sink contract
- add `FullChangeSyncCaptureSink` for sinks that want to implement only the full `ChangeOp` entry point
- route `BaseTable` capture through `record_change_op()` and store pending ops directly as `ChangeOp`
- preserve legacy sink compatibility, keep flush-only sinks abstract, and add strict `-Woverloaded-virtual -Werror` umbrella coverage
- reject unmanaged raw writable transactions while sync capture is attached, while allowing raw read-only snapshot operations

## Validation
- `cmake --build tmp/build-pr193-cpp17 --target test_sync_capture header_sync_umbrella_test test_sync_worker -j 4`
- `ctest --test-dir tmp/build-pr193-cpp17 -R "^(test_sync_capture|header_sync_umbrella_test|test_sync_worker)$" --output-on-failure`
- `cmake --build tmp/build-pr193-cpp11 --target test_sync_capture header_sync_umbrella_test test_sync_worker -j 4`
- `ctest --test-dir tmp/build-pr193-cpp11 -R "^(test_sync_capture|header_sync_umbrella_test|test_sync_worker)$" --output-on-failure`
