### PR TITLE
feat(sync): add logical table adapter registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this project will be documented in this file.
   preferred capture entry point. The previous raw-field callback remains the
   source-compatible abstract sink contract; new full-`ChangeOp` sinks can
   derive from `FullChangeSyncCaptureSink`.
+- Added `ILogicalTableAdapter` and `LogicalTableRegistry` scaffolding for
+  future two-phase logical table preflight/apply support. `SyncEngine` still
+  rejects unknown logical operations until a wire format and registry
+  integration are added.
 - Breaking transport-wire change: `TransportMessageCodec` is now version 4.
   Response DTOs include `SyncResponseErrorCode` plus `error_retryable` after
   the human-readable error string, and pull request DTOs include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,6 +440,7 @@ if(MDBXC_BUILD_TESTS)
         mdbx_containers/sync/LogicalSchema.hpp
         mdbx_containers/sync/ChangeOp.hpp
         mdbx_containers/sync/LogicalChange.hpp
+        mdbx_containers/sync/LogicalTableAdapter.hpp
         mdbx_containers/sync/ChangeBatch.hpp
         mdbx_containers/sync/ChangeBatchCodec.hpp
         mdbx_containers/sync/SyncApplyObserver.hpp

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -18,6 +18,7 @@
 #include "sync/LogicalSchema.hpp"
 #include "sync/ChangeOp.hpp"
 #include "sync/LogicalChange.hpp"
+#include "sync/LogicalTableAdapter.hpp"
 #include "sync/CodecBounds.hpp"
 #include "sync/ChangeBatch.hpp"
 #include "sync/ChangeBatchCodec.hpp"

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -484,6 +484,18 @@ The v0.1 `ChangeBatchCodec` still serializes raw DBI operations only. Adding
 the logical domain to the wire format requires an explicit codec version bump
 and compatibility tests.
 
+`LogicalTableAdapter.hpp` reserves the apply-side extension point:
+
+- `ILogicalTableAdapter::preflight()` validates one logical change without
+  mutating user tables.
+- `ILogicalTableAdapter::apply()` mutates user tables only after every logical
+  change in the same apply transaction passed preflight.
+- `LogicalTableRegistry` is a non-owning lifecycle registry keyed by
+  `LogicalSchemaRef::schema_id`.
+
+The current `SyncEngine` does not call this registry yet. Unknown logical
+payloads must not fall back to raw DBI apply.
+
 ## Codec — `ChangeBatchCodec`
 
 See `ChangeBatchCodec.hpp` layout comment for the full byte layout. Locked

--- a/include/mdbx_containers/sync/LogicalTableAdapter.hpp
+++ b/include/mdbx_containers/sync/LogicalTableAdapter.hpp
@@ -1,0 +1,201 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_TABLE_ADAPTER_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_TABLE_ADAPTER_HPP_INCLUDED
+
+/// \file LogicalTableAdapter.hpp
+/// \brief Registry interfaces for future logical sync table adapters.
+
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mdbx.h>
+
+#include "LogicalChange.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Result of logical adapter preflight or apply.
+    struct LogicalApplyResult {
+        bool ok = true;             ///< Whether the operation succeeded.
+        bool retryable = false;     ///< Whether retry may succeed after progress.
+        std::string error;          ///< Human-readable diagnostic.
+
+        static LogicalApplyResult success() {
+            return LogicalApplyResult();
+        }
+
+        static LogicalApplyResult failure(const std::string& message,
+                                          bool is_retryable = false) {
+            LogicalApplyResult out;
+            out.ok = false;
+            out.retryable = is_retryable;
+            out.error = message;
+            return out;
+        }
+    };
+
+    /// \brief Type-erased adapter for one logical table schema.
+    /// \details Implementations own table-specific decoding and apply logic.
+    /// The sync core must call \c preflight() for all logical changes in a
+    /// transaction before calling \c apply() for any of them.
+    class ILogicalTableAdapter {
+    public:
+        virtual ~ILogicalTableAdapter() {}
+
+        /// \brief Returns the logical schema served by this adapter.
+        virtual LogicalSchemaRef schema_ref() const = 0;
+
+        /// \brief Returns physical DBI names that may be read or written.
+        virtual std::vector<std::string> affected_dbis() const = 0;
+
+        /// \brief Validates a logical change without mutating user tables.
+        virtual LogicalApplyResult preflight(
+                MDBX_txn* txn,
+                const LogicalChange& change) const = 0;
+
+        /// \brief Applies a logical change after all preflights succeeded.
+        virtual LogicalApplyResult apply(
+                MDBX_txn* txn,
+                const LogicalChange& change) = 0;
+    };
+
+    /// \brief Non-owning registry of logical table adapters.
+    /// \thread_safety Not thread-safe. Treat registration as lifecycle setup.
+    class LogicalTableRegistry {
+    public:
+        /// \brief Registers \p adapter for its schema id.
+        /// \throws std::invalid_argument for null, incomplete, or duplicate
+        /// adapter registrations.
+        void register_adapter(ILogicalTableAdapter* adapter) {
+            if (adapter == nullptr) {
+                throw std::invalid_argument("Logical adapter is null");
+            }
+            const LogicalSchemaRef ref = adapter->schema_ref();
+            if (!is_logical_schema_ref_complete(ref)) {
+                throw std::invalid_argument("Logical adapter schema ref is incomplete");
+            }
+            const AdapterRegistration registration(adapter, ref);
+            const std::pair<AdapterMap::iterator, bool> inserted =
+                m_adapters.insert(
+                    AdapterMap::value_type(ref.schema_id, registration));
+            if (!inserted.second) {
+                throw std::invalid_argument("Duplicate logical adapter schema id");
+            }
+        }
+
+        /// \brief Removes adapter for \p schema_id.
+        /// \return true when an adapter was removed.
+        bool unregister_adapter(const std::string& schema_id) {
+            return m_adapters.erase(schema_id) != 0u;
+        }
+
+        /// \brief Finds an adapter by schema id.
+        ILogicalTableAdapter* find(const std::string& schema_id) const {
+            AdapterMap::const_iterator it = m_adapters.find(schema_id);
+            return it == m_adapters.end() ? nullptr : it->second.adapter;
+        }
+
+        /// \brief Returns number of registered adapters.
+        std::size_t size() const { return m_adapters.size(); }
+
+        /// \brief Runs preflight for all changes, then applies all changes.
+        /// \details This helper does not open transactions by itself. It only
+        /// enforces the two-phase adapter contract for a caller-owned write
+        /// transaction. If an adapter returns failure from \c apply() or
+        /// throws after mutating data, this helper returns failure and the
+        /// caller-owned transaction must be aborted by the caller; the
+        /// registry cannot roll back a transaction it does not own.
+        LogicalApplyResult preflight_then_apply(
+                MDBX_txn* txn,
+                const std::vector<LogicalChange>& changes) const {
+            std::vector<AdapterRegistration> registrations;
+            registrations.reserve(changes.size());
+
+            for (std::size_t i = 0; i < changes.size(); ++i) {
+                AdapterMap::const_iterator it =
+                    m_adapters.find(changes[i].schema.schema_id);
+                if (it == m_adapters.end()) {
+                    return LogicalApplyResult::failure(
+                        "No logical adapter registered for schema id");
+                }
+                const LogicalApplyResult validation =
+                    validate_change(it->second, changes[i]);
+                if (!validation.ok) return validation;
+                registrations.push_back(it->second);
+            }
+
+            for (std::size_t i = 0; i < changes.size(); ++i) {
+                const LogicalApplyResult result =
+                    registrations[i].adapter->preflight(txn, changes[i]);
+                if (!result.ok) return result;
+            }
+
+            for (std::size_t i = 0; i < changes.size(); ++i) {
+                LogicalApplyResult result;
+                try {
+                    result = registrations[i].adapter->apply(txn, changes[i]);
+                } catch (const std::exception& e) {
+                    return LogicalApplyResult::failure(
+                        std::string("Logical adapter apply threw: ") +
+                        e.what());
+                } catch (...) {
+                    return LogicalApplyResult::failure(
+                        "Logical adapter apply threw a non-std exception");
+                }
+                if (!result.ok) return result;
+            }
+
+            return LogicalApplyResult::success();
+        }
+
+    private:
+        struct AdapterRegistration {
+            AdapterRegistration()
+                : adapter(nullptr) {}
+
+            AdapterRegistration(ILogicalTableAdapter* p,
+                                const LogicalSchemaRef& ref)
+                : adapter(p),
+                  schema(ref) {}
+
+            ILogicalTableAdapter* adapter;
+            LogicalSchemaRef schema;
+        };
+
+        typedef std::map<std::string, AdapterRegistration> AdapterMap;
+
+        static bool schema_refs_equal(const LogicalSchemaRef& lhs,
+                                      const LogicalSchemaRef& rhs) {
+            return lhs.schema_id == rhs.schema_id &&
+                   lhs.kind == rhs.kind &&
+                   lhs.schema_version == rhs.schema_version;
+        }
+
+        static LogicalApplyResult validate_change(
+                const AdapterRegistration& registration,
+                const LogicalChange& change) {
+            if (!is_logical_schema_ref_complete(change.schema)) {
+                return LogicalApplyResult::failure(
+                    "Logical change schema ref is incomplete");
+            }
+            if (!schema_refs_equal(registration.schema, change.schema)) {
+                return LogicalApplyResult::failure(
+                    "Logical change schema ref does not match registered adapter");
+            }
+            if (change.flags != 0) {
+                return LogicalApplyResult::failure(
+                    "Logical change flags are reserved and must be zero");
+            }
+            return LogicalApplyResult::success();
+        }
+
+        AdapterMap m_adapters;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_TABLE_ADAPTER_HPP_INCLUDED

--- a/tests/test_logical_table_adapter.cpp
+++ b/tests/test_logical_table_adapter.cpp
@@ -1,0 +1,409 @@
+#include <mdbx_containers/sync.hpp>
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+class RecordingAdapter : public mdbxc::sync::ILogicalTableAdapter {
+public:
+    explicit RecordingAdapter(const std::string& schema_id)
+        : m_schema_id(schema_id),
+          m_kind(mdbxc::sync::LogicalTableKind::KeyMultiValue),
+          m_schema_version(1) {}
+
+    RecordingAdapter(const std::string& schema_id,
+                     mdbxc::sync::LogicalTableKind kind,
+                     std::uint32_t schema_version)
+        : m_schema_id(schema_id),
+          m_kind(kind),
+          m_schema_version(schema_version) {}
+
+    mdbxc::sync::LogicalSchemaRef schema_ref() const override {
+        mdbxc::sync::LogicalSchemaRef ref;
+        ref.schema_id = m_schema_id;
+        ref.kind = m_kind;
+        ref.schema_version = m_schema_version;
+        return ref;
+    }
+
+    std::vector<std::string> affected_dbis() const override {
+        std::vector<std::string> out;
+        out.push_back("items");
+        return out;
+    }
+
+    mdbxc::sync::LogicalApplyResult preflight(
+            MDBX_txn* txn,
+            const mdbxc::sync::LogicalChange& change) const override {
+        (void)txn;
+        ++m_preflight_calls;
+        m_events.push_back(std::string("P") + std::to_string(change.opcode));
+        if (change.opcode == 99u) {
+            return mdbxc::sync::LogicalApplyResult::failure("blocked");
+        }
+        return mdbxc::sync::LogicalApplyResult::success();
+    }
+
+    mdbxc::sync::LogicalApplyResult apply(
+            MDBX_txn* txn,
+            const mdbxc::sync::LogicalChange& change) override {
+        (void)txn;
+        ++m_apply_calls;
+        m_events.push_back(std::string("A") + std::to_string(change.opcode));
+        m_applied_opcodes.push_back(change.opcode);
+        if (change.opcode == m_throw_apply_opcode) {
+            throw std::runtime_error("apply threw");
+        }
+        if (change.opcode == m_fail_apply_opcode) {
+            return mdbxc::sync::LogicalApplyResult::failure("apply blocked");
+        }
+        return mdbxc::sync::LogicalApplyResult::success();
+    }
+
+    mutable std::size_t m_preflight_calls = 0;
+    std::size_t m_apply_calls = 0;
+    std::uint32_t m_fail_apply_opcode = 0;
+    std::uint32_t m_throw_apply_opcode = 0;
+    mutable std::vector<std::string> m_events;
+    std::vector<std::uint32_t> m_applied_opcodes;
+
+private:
+    std::string m_schema_id;
+    mdbxc::sync::LogicalTableKind m_kind;
+    std::uint32_t m_schema_version;
+};
+
+class IncompleteAdapter : public RecordingAdapter {
+public:
+    IncompleteAdapter() : RecordingAdapter("") {}
+
+    mdbxc::sync::LogicalSchemaRef schema_ref() const override {
+        return mdbxc::sync::LogicalSchemaRef();
+    }
+};
+
+mdbxc::sync::LogicalChange make_change(const std::string& schema_id,
+                                       std::uint32_t opcode) {
+    mdbxc::sync::LogicalChange change;
+    change.schema.schema_id = schema_id;
+    change.schema.kind = mdbxc::sync::LogicalTableKind::KeyMultiValue;
+    change.schema.schema_version = 1;
+    change.opcode = opcode;
+    return change;
+}
+
+void test_registry_rejects_invalid_adapters() {
+    mdbxc::sync::LogicalTableRegistry registry;
+    bool caught_null = false;
+    try {
+        registry.register_adapter(nullptr);
+    } catch (const std::invalid_argument&) {
+        caught_null = true;
+    }
+    if (!caught_null) {
+        throw std::runtime_error("null logical adapter was accepted");
+    }
+
+    IncompleteAdapter incomplete;
+    bool caught_incomplete = false;
+    try {
+        registry.register_adapter(&incomplete);
+    } catch (const std::invalid_argument&) {
+        caught_incomplete = true;
+    }
+    if (!caught_incomplete) {
+        throw std::runtime_error("incomplete logical adapter was accepted");
+    }
+}
+
+void test_registry_rejects_duplicate_schema_id() {
+    mdbxc::sync::LogicalTableRegistry registry;
+    RecordingAdapter first("schema.items.v1");
+    RecordingAdapter second("schema.items.v1");
+    registry.register_adapter(&first);
+
+    bool caught = false;
+    try {
+        registry.register_adapter(&second);
+    } catch (const std::invalid_argument&) {
+        caught = true;
+    }
+    if (!caught) {
+        throw std::runtime_error("duplicate logical adapter was accepted");
+    }
+}
+
+void test_preflight_then_apply_order() {
+    mdbxc::sync::LogicalTableRegistry registry;
+    RecordingAdapter adapter("schema.items.v1");
+    registry.register_adapter(&adapter);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(make_change("schema.items.v1", 1));
+    changes.push_back(make_change("schema.items.v1", 2));
+
+    const mdbxc::sync::LogicalApplyResult result =
+        registry.preflight_then_apply(nullptr, changes);
+    if (!result.ok ||
+        adapter.m_preflight_calls != 2u ||
+        adapter.m_apply_calls != 2u ||
+        adapter.m_events.size() != 4u ||
+        adapter.m_events[0] != "P1" ||
+        adapter.m_events[1] != "P2" ||
+        adapter.m_events[2] != "A1" ||
+        adapter.m_events[3] != "A2" ||
+        adapter.m_applied_opcodes.size() != 2u ||
+        adapter.m_applied_opcodes[0] != 1u ||
+        adapter.m_applied_opcodes[1] != 2u) {
+        throw std::runtime_error("logical preflight/apply order mismatch");
+    }
+}
+
+void test_preflight_failure_blocks_apply() {
+    mdbxc::sync::LogicalTableRegistry registry;
+    RecordingAdapter adapter("schema.items.v1");
+    registry.register_adapter(&adapter);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(make_change("schema.items.v1", 99));
+    changes.push_back(make_change("schema.items.v1", 2));
+
+    const mdbxc::sync::LogicalApplyResult result =
+        registry.preflight_then_apply(nullptr, changes);
+    if (result.ok ||
+        adapter.m_preflight_calls != 1u ||
+        adapter.m_apply_calls != 0u) {
+        throw std::runtime_error("logical preflight failure applied changes");
+    }
+}
+
+void test_schema_mismatch_blocks_adapter_calls() {
+    mdbxc::sync::LogicalTableRegistry registry;
+    RecordingAdapter adapter("schema.items.v1");
+    registry.register_adapter(&adapter);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    mdbxc::sync::LogicalChange wrong_kind =
+        make_change("schema.items.v1", 1);
+    wrong_kind.schema.kind = mdbxc::sync::LogicalTableKind::AnyValue;
+    changes.push_back(wrong_kind);
+
+    const mdbxc::sync::LogicalApplyResult result =
+        registry.preflight_then_apply(nullptr, changes);
+    if (result.ok ||
+        adapter.m_preflight_calls != 0u ||
+        adapter.m_apply_calls != 0u) {
+        throw std::runtime_error(
+            "schema kind mismatch reached logical adapter");
+    }
+}
+
+void test_schema_version_mismatch_blocks_adapter_calls() {
+    mdbxc::sync::LogicalTableRegistry registry;
+    RecordingAdapter adapter("schema.items.v1");
+    registry.register_adapter(&adapter);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    mdbxc::sync::LogicalChange wrong_version =
+        make_change("schema.items.v1", 1);
+    wrong_version.schema.schema_version = 2;
+    changes.push_back(wrong_version);
+
+    const mdbxc::sync::LogicalApplyResult result =
+        registry.preflight_then_apply(nullptr, changes);
+    if (result.ok ||
+        adapter.m_preflight_calls != 0u ||
+        adapter.m_apply_calls != 0u) {
+        throw std::runtime_error(
+            "schema version mismatch reached logical adapter");
+    }
+}
+
+void test_reserved_flags_block_adapter_calls() {
+    mdbxc::sync::LogicalTableRegistry registry;
+    RecordingAdapter adapter("schema.items.v1");
+    registry.register_adapter(&adapter);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    mdbxc::sync::LogicalChange change =
+        make_change("schema.items.v1", 1);
+    change.flags = 1u;
+    changes.push_back(change);
+
+    const mdbxc::sync::LogicalApplyResult result =
+        registry.preflight_then_apply(nullptr, changes);
+    if (result.ok ||
+        adapter.m_preflight_calls != 0u ||
+        adapter.m_apply_calls != 0u) {
+        throw std::runtime_error(
+            "reserved logical flags reached logical adapter");
+    }
+}
+
+void test_late_missing_adapter_blocks_all_preflight() {
+    mdbxc::sync::LogicalTableRegistry registry;
+    RecordingAdapter adapter("schema.items.v1");
+    registry.register_adapter(&adapter);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(make_change("schema.items.v1", 1));
+    changes.push_back(make_change("schema.missing.v1", 2));
+
+    const mdbxc::sync::LogicalApplyResult result =
+        registry.preflight_then_apply(nullptr, changes);
+    if (result.ok ||
+        adapter.m_preflight_calls != 0u ||
+        adapter.m_apply_calls != 0u) {
+        throw std::runtime_error(
+            "late missing adapter did not block preflight phase");
+    }
+}
+
+void test_late_schema_mismatch_blocks_all_preflight() {
+    mdbxc::sync::LogicalTableRegistry registry;
+    RecordingAdapter adapter("schema.items.v1");
+    registry.register_adapter(&adapter);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(make_change("schema.items.v1", 1));
+    mdbxc::sync::LogicalChange wrong_kind =
+        make_change("schema.items.v1", 2);
+    wrong_kind.schema.kind = mdbxc::sync::LogicalTableKind::AnyValue;
+    changes.push_back(wrong_kind);
+
+    const mdbxc::sync::LogicalApplyResult result =
+        registry.preflight_then_apply(nullptr, changes);
+    if (result.ok ||
+        adapter.m_preflight_calls != 0u ||
+        adapter.m_apply_calls != 0u) {
+        throw std::runtime_error(
+            "late schema kind mismatch did not block preflight phase");
+    }
+}
+
+void test_late_schema_version_mismatch_blocks_all_preflight() {
+    mdbxc::sync::LogicalTableRegistry registry;
+    RecordingAdapter adapter("schema.items.v1");
+    registry.register_adapter(&adapter);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(make_change("schema.items.v1", 1));
+    mdbxc::sync::LogicalChange wrong_version =
+        make_change("schema.items.v1", 2);
+    wrong_version.schema.schema_version = 2;
+    changes.push_back(wrong_version);
+
+    const mdbxc::sync::LogicalApplyResult result =
+        registry.preflight_then_apply(nullptr, changes);
+    if (result.ok ||
+        adapter.m_preflight_calls != 0u ||
+        adapter.m_apply_calls != 0u) {
+        throw std::runtime_error(
+            "late schema version mismatch did not block preflight phase");
+    }
+}
+
+void test_late_reserved_flags_block_all_preflight() {
+    mdbxc::sync::LogicalTableRegistry registry;
+    RecordingAdapter adapter("schema.items.v1");
+    registry.register_adapter(&adapter);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(make_change("schema.items.v1", 1));
+    mdbxc::sync::LogicalChange flagged =
+        make_change("schema.items.v1", 2);
+    flagged.flags = 1u;
+    changes.push_back(flagged);
+
+    const mdbxc::sync::LogicalApplyResult result =
+        registry.preflight_then_apply(nullptr, changes);
+    if (result.ok ||
+        adapter.m_preflight_calls != 0u ||
+        adapter.m_apply_calls != 0u) {
+        throw std::runtime_error(
+            "late reserved flags did not block preflight phase");
+    }
+}
+
+void test_apply_failure_returns_failure_after_prior_apply() {
+    mdbxc::sync::LogicalTableRegistry registry;
+    RecordingAdapter adapter("schema.items.v1");
+    adapter.m_fail_apply_opcode = 2;
+    registry.register_adapter(&adapter);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(make_change("schema.items.v1", 1));
+    changes.push_back(make_change("schema.items.v1", 2));
+
+    const mdbxc::sync::LogicalApplyResult result =
+        registry.preflight_then_apply(nullptr, changes);
+    if (result.ok ||
+        adapter.m_events.size() != 4u ||
+        adapter.m_events[0] != "P1" ||
+        adapter.m_events[1] != "P2" ||
+        adapter.m_events[2] != "A1" ||
+        adapter.m_events[3] != "A2" ||
+        adapter.m_apply_calls != 2u) {
+        throw std::runtime_error(
+            "apply failure sequence contract mismatch");
+    }
+}
+
+void test_apply_exception_returns_failure_after_prior_apply() {
+    mdbxc::sync::LogicalTableRegistry registry;
+    RecordingAdapter adapter("schema.items.v1");
+    adapter.m_throw_apply_opcode = 2;
+    registry.register_adapter(&adapter);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(make_change("schema.items.v1", 1));
+    changes.push_back(make_change("schema.items.v1", 2));
+
+    const mdbxc::sync::LogicalApplyResult result =
+        registry.preflight_then_apply(nullptr, changes);
+    if (result.ok ||
+        result.error.find("apply threw") == std::string::npos ||
+        adapter.m_events.size() != 4u ||
+        adapter.m_events[0] != "P1" ||
+        adapter.m_events[1] != "P2" ||
+        adapter.m_events[2] != "A1" ||
+        adapter.m_events[3] != "A2" ||
+        adapter.m_apply_calls != 2u) {
+        throw std::runtime_error(
+            "apply exception sequence contract mismatch");
+    }
+}
+
+void test_missing_adapter_fails_without_apply() {
+    mdbxc::sync::LogicalTableRegistry registry;
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(make_change("schema.missing.v1", 1));
+
+    const mdbxc::sync::LogicalApplyResult result =
+        registry.preflight_then_apply(nullptr, changes);
+    if (result.ok) {
+        throw std::runtime_error("missing logical adapter succeeded");
+    }
+}
+
+} // namespace
+
+int main() {
+    test_registry_rejects_invalid_adapters();
+    test_registry_rejects_duplicate_schema_id();
+    test_preflight_then_apply_order();
+    test_preflight_failure_blocks_apply();
+    test_schema_mismatch_blocks_adapter_calls();
+    test_schema_version_mismatch_blocks_adapter_calls();
+    test_reserved_flags_block_adapter_calls();
+    test_late_missing_adapter_blocks_all_preflight();
+    test_late_schema_mismatch_blocks_all_preflight();
+    test_late_schema_version_mismatch_blocks_all_preflight();
+    test_late_reserved_flags_block_all_preflight();
+    test_apply_failure_returns_failure_after_prior_apply();
+    test_apply_exception_returns_failure_after_prior_apply();
+    test_missing_adapter_fails_without_apply();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add ILogicalTableAdapter and LogicalTableRegistry scaffolding
- reserve two-phase preflight-then-apply flow for future logical sync operations
- add duplicate/missing/preflight failure coverage and standalone header smoke

## Validation
- cmake --build tmp/build-cpp17-mingw --target test_logical_table_adapter header_standalone_mdbx_containers_sync_LogicalTableAdapter_hpp header_sync_umbrella_test -- -j2
- ctest --test-dir tmp/build-cpp17-mingw --output-on-failure -R "test_logical_table_adapter|header_standalone_mdbx_containers_sync_LogicalTableAdapter_hpp|header_sync_umbrella_test"
- cmake --build tmp/build-cpp11-mingw --target test_logical_table_adapter header_standalone_mdbx_containers_sync_LogicalTableAdapter_hpp header_sync_umbrella_test -- -j2
- ctest --test-dir tmp/build-cpp11-mingw --output-on-failure -R "test_logical_table_adapter|header_standalone_mdbx_containers_sync_LogicalTableAdapter_hpp|header_sync_umbrella_test"
