### PR TITLE
docs(sync): define staged logical sync contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,26 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 - Added a persistent sync schema registry store for future logical table
   adapters. The registry records logical schema ids, table kinds, schema
-  versions, and owned DBI names without enabling logical replication yet.
+  versions, and canonical sorted unique owned DBI names without enabling
+  logical replication yet.
 - Added public `ChangeDomain`, `LogicalSchemaRef`, and `LogicalChange` model
   types for future logical table adapters. The current wire codec remains
   raw-DBI only.
 - Added `ISyncCaptureSink::record_change_op(MDBX_txn*, const ChangeOp&)` as the
   preferred capture entry point. The previous raw-field callback remains the
   source-compatible abstract sink contract; new full-`ChangeOp` sinks can
-  derive from `FullChangeSyncCaptureSink`.
+  derive from `FullChangeSyncCaptureSink`. Capture record or flush failures now
+  prevent committing the affected explicit transaction, and unmanaged raw
+  writable `MDBX_txn*` calls are rejected while sync capture is attached.
 - Added `ILogicalTableAdapter` and `LogicalTableRegistry` scaffolding for
-  future two-phase logical table preflight/apply support. `SyncEngine` still
-  rejects unknown logical operations until a wire format and registry
-  integration are added.
+  future two-phase logical table preflight/apply support. Apply exceptions are
+  converted to failure results so the caller-owned transaction can be aborted.
+  `SyncEngine` still rejects unknown logical operations until a wire format and
+  registry integration are added.
+- Documented the staged logical sync contract: schema marker, logical wire
+  frame, adapter preflight/apply, then capture. Deferred logical tables still
+  require single-writer or application-serialized conflicting writes until a
+  causal conflict model exists.
 - Breaking transport-wire change: `TransportMessageCodec` is now version 4.
   Response DTOs include `SyncResponseErrorCode` plus `error_retryable` after
   the human-readable error string, and pull request DTOs include

--- a/README-RU.md
+++ b/README-RU.md
@@ -100,6 +100,13 @@
   поддерживаемых таблиц, становится одним атомарным локальным batch.
   Read/search-вызовы не захватываются. Отдельный `SyncWorker` плюс транспорт
   `ISyncPeer` переносят закоммиченные batches между узлами.
+- При активном sync capture мутирующие вызовы поддерживаемых таблиц должны
+  использовать транзакции, созданные через `mdbx_containers::Transaction` или
+  `Connection::begin()` / `commit()`. Caller-created raw writable `MDBX_txn*`
+  не может вызвать capture pre-commit hook и отклоняется до мутации.
+  Caller-created raw read-only transactions остаются допустимыми для
+  read/search snapshot operations. Любое исключение из capture recording или
+  flush делает transaction rollback-only; повторный `commit()` отклоняется.
 - `SyncEngine` предоставляет pull/push/apply primitives, `DirectSyncPeer`
   используется для in-process синхронизации в тестах и примерах,
   `HttpSyncPeer` задаёт HTTP-shaped adapter seam, `WebSocketSyncPeer` задаёт

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@
   atomic local batch. Read/search calls are not captured. A separate
   `SyncWorker` plus an `ISyncPeer` transport moves committed batches between
   nodes.
+- When sync capture is attached, mutating supported table calls must use
+  connection-managed transactions (`mdbx_containers::Transaction` or
+  `Connection::begin()` / `commit()`). Caller-created raw writable
+  `MDBX_txn*` handles cannot run the capture pre-commit hook and are rejected
+  before mutation. Caller-created raw read-only transactions remain valid for
+  read/search snapshot operations. Any exception from capture recording or
+  flushing makes that transaction rollback-only; retrying `commit()` is
+  rejected.
 - `SyncEngine` exposes pull/push/apply primitives, `DirectSyncPeer` provides
   in-process sync for tests and examples, `HttpSyncPeer` defines an HTTP-shaped
   adapter seam, `WebSocketSyncPeer` defines a binary message seam, and

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -243,6 +243,15 @@ Operational rules:
   for a deliberate component lifecycle and keep the same lifecycle-only rule as
   `Connection`: do not change capture attachment concurrently with table
   operations or active transactions.
+- When capture is attached, mutating supported table calls must use
+  connection-managed transactions. Caller-created raw writable `MDBX_txn*`
+  handles are rejected before mutation because native `mdbx_txn_commit()`
+  cannot run the sync pre-commit hook. Caller-created raw read-only
+  transactions remain valid for read/search snapshot operations.
+- Any exception from capture recording or `flush_in_txn()` marks that write
+  transaction as failed for sync capture. The caller must roll it back or let
+  the transaction guard abort it; retrying `commit()` is rejected before a
+  second flush attempt.
 - Nested `SyncCaptureScope` objects are a stack discipline: detach or destroy
   the innermost scope first. Do not replace the connection capture sink through
   raw attach/detach while a scope owns it.

--- a/guides/sync-table-coverage.md
+++ b/guides/sync-table-coverage.md
@@ -40,6 +40,20 @@ The captured DBI name, DBI flags, physical key bytes, and value bytes must
 remain sufficient to open or validate the destination DBI and replay the
 operation without table-specific decoding.
 
+Logical table sync is still a reserved extension. The scaffolding added for it
+has three separate pieces that must not be treated as support by themselves:
+
+- `_mdbxc_sync_schema` records an explicit application schema id, logical kind,
+  schema version, and owned DBI names. Owned DBI names are treated as a
+  canonical sorted unique set;
+- `LogicalChange` describes an opaque adapter-owned payload;
+- `LogicalTableRegistry` reserves a two-phase preflight/apply path and validates
+  the full schema tuple plus reserved flags before invoking adapters.
+
+Until a wrapper has a codec extension, a registered adapter, capture tests, and
+round-trip tests, it must remain in the deferred rows below and must not emit
+logical or raw `ChangeOp` records.
+
 Focused capture and round-trip tests currently cover representative write,
 delete, bulk, range-erase, wrapper-specific `ClearTable`, indirect
 `VectorStore`, and deferred-table negative paths.
@@ -49,8 +63,13 @@ delete, bulk, range-erase, wrapper-specific `ClearTable`, indirect
 Do not add `record_op()` calls to deferred wrappers until the same PR also
 defines:
 
+- a persistent logical schema id and `SchemaRegistryStore` record, when the
+  wrapper needs table-specific logical apply;
 - the wire representation, including any table-specific metadata;
+- the `ILogicalTableAdapter` implementation and preflight/apply rules;
 - apply-side reconstruction or validation rules;
+- a transaction owner that aborts the whole apply transaction if an adapter
+  reports failure or throws after any mutation;
 - capture tests for every mutating method that can change logical state;
 - round-trip replication tests that compare source and destination logical
   state;

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -85,15 +85,37 @@ Do not add `record_op()` calls to these tables until their wire format and
 round-trip tests exist. A partial capture path is worse than no capture because
 it can make replication appear successful while logical state diverges.
 
+The logical sync scaffolding is preparatory only:
+
+- `_mdbxc_sync_schema` is a persistent compatibility marker, not an apply path.
+- `LogicalChange` payloads are opaque and are not serialized by the current
+  `ChangeBatchCodec`.
+- `LogicalTableRegistry` defines the future two-phase preflight/apply contract,
+  including full schema tuple validation before adapter callbacks, but
+  `SyncEngine` still applies raw DBI operations only.
+- Future `SyncEngine` integration must own the MDBX write transaction around
+  logical apply and abort it if an adapter reports failure or throws after any
+  mutation.
+
+Until a causal context or another conflict model is implemented, future logical
+table support should document either one authoritative writer for the affected
+logical dataset or application-level serialization of conflicting writes.
+General concurrent multi-writer convergence must not be claimed for deferred
+tables.
+
 ## Suggested Next PRs
 
 - Add optional table identity filters on top of the affected DBI names already
   reported by `ISyncApplyObserver`, if more cached wrappers need narrower
   subscriptions.
+- Add codec framing for logical table changes, including capability bits and
+  fail-closed tests for old or capability-limited decoders.
+- Integrate `LogicalTableRegistry` with `SyncEngine::handle_push()` only after
+  logical changes can be parsed separately from raw DBI operations.
 - Prototype `KeyMultiValueTable` capture/apply using the deferred
   single-writer/serialized unordered multiset design. Add explicit wire
-  sub-operation framing and repeated-pair round-trip tests before enabling
-  capture.
+  sub-operation framing, registry integration, and repeated-pair round-trip
+  tests before enabling capture.
 - Implement the deferred full snapshot protocol before treating
   `SnapshotRequired` as automatically recoverable by sync itself.
 - Define explicit conflict/CRDT semantics before claiming general concurrent

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -626,13 +626,13 @@ Application integration contract:
   pre-commit hook;
 - `BaseTable::record_op()` constructs a full `ChangeOp` and forwards it through
   `ISyncCaptureSink::record_change_op(txn, change)`. The older raw-field callback
-  remains the source-compatible abstract sink callback for existing custom
+  remains the source-compatible abstract sink contract for existing custom
   sinks; new full-`ChangeOp` sinks may derive from `FullChangeSyncCaptureSink`;
-- if `record_change()` throws after the user-table MDBX write succeeded, or
-  `flush_in_txn()` throws during pre-commit capture flush, the transaction is
-  marked as failed for sync capture. A later commit is rejected before another
-  flush attempt, so the caller must roll back or let the transaction guard
-  abort it;
+- if `record_change_op()` throws after the user-table MDBX write succeeded
+  including from legacy `record_change()` forwarding, or `flush_in_txn()`
+  throws during pre-commit capture flush, the transaction is marked as failed
+  for sync capture. A later commit is rejected before another flush attempt, so
+  the caller must roll back or let the transaction guard abort it;
 - mutating supported table calls must use connection-managed transactions while
   capture is attached. Caller-created raw writable `MDBX_txn*` handles are
   rejected before mutation because native `mdbx_txn_commit()` cannot invoke the

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -452,7 +452,7 @@ Real removal is explicit via `erase()`.
 | | |
 |---|---|
 | Key | application-defined logical schema id string |
-| Value | `LogicalSchemaRecord { kind, schema_version, flags, dbi_name, dbi_names[] }` |
+| Value | `schema_id` repeated in the versioned value envelope, followed by `LogicalSchemaRecord { kind, schema_version, flags, dbi_name, dbi_names[] }`; owned `dbi_names[]` are stored as a sorted unique set |
 
 This store is a persistent compatibility marker for future logical table
 adapters. It does not enable logical sync by itself. A wrapper or adapter may
@@ -462,8 +462,11 @@ application schema version, and owned physical DBI set.
 
 `SyncEngine::initialize_local_identity()` creates this DBI together with the
 required sync metadata stores in a committed setup transaction. Standalone
-maintenance code may still use `SchemaRegistryStore` directly, but must call
-`open(txn)` in each transaction before reading or writing.
+maintenance code may still use `SchemaRegistryStore` directly; public store
+operations reopen the DBI in the supplied transaction, while explicit
+`open(txn)` and `handle(txn)` remain available for low-level raw-handle
+maintenance code. `handle(txn)` also reopens the DBI in the supplied
+transaction before returning the raw DBI handle.
 
 The registry intentionally uses an explicit application schema id instead of
 `typeid`, C++ type names, or ABI-dependent layout data. Unknown logical changes
@@ -491,10 +494,33 @@ and compatibility tests.
 - `ILogicalTableAdapter::apply()` mutates user tables only after every logical
   change in the same apply transaction passed preflight.
 - `LogicalTableRegistry` is a non-owning lifecycle registry keyed by
-  `LogicalSchemaRef::schema_id`.
+  `LogicalSchemaRef::schema_id`, but dispatch validates the full
+  `(schema_id, kind, schema_version)` tuple and rejects non-zero reserved
+  logical flags before any adapter callback.
+- `LogicalTableRegistry::preflight_then_apply()` runs validation for every
+  change before any preflight, then runs every preflight before any apply. If
+  an adapter reports failure from `apply()` or throws after mutating data, the
+  helper returns failure and the caller that owns the MDBX write transaction
+  must abort that transaction; the registry cannot roll back a transaction it
+  does not own.
 
 The current `SyncEngine` does not call this registry yet. Unknown logical
 payloads must not fall back to raw DBI apply.
+
+Logical-table support therefore has a staged contract:
+
+1. Register a persistent schema marker for the table kind and physical DBI set.
+2. Add a versioned wire frame that distinguishes raw DBI operations from
+   logical operations and fails closed for unsupported capability bits.
+3. Register an adapter that can preflight every logical operation in the
+   incoming transaction before applying any of them.
+4. Enable capture only after every mutating public method maps to a tested
+   logical operation.
+
+Until a later causal-context PR defines dependency cursors, Lamport/HLC order,
+or another conflict-resolution model, logical table adapters may claim only
+single-writer or application-serialized conflicting writes for the affected
+logical dataset. General concurrent multi-writer convergence is out of scope.
 
 ## Codec — `ChangeBatchCodec`
 
@@ -602,6 +628,16 @@ Application integration contract:
   `ISyncCaptureSink::record_change_op(txn, change)`. The older raw-field callback
   remains the source-compatible abstract sink callback for existing custom
   sinks; new full-`ChangeOp` sinks may derive from `FullChangeSyncCaptureSink`;
+- if `record_change()` throws after the user-table MDBX write succeeded, or
+  `flush_in_txn()` throws during pre-commit capture flush, the transaction is
+  marked as failed for sync capture. A later commit is rejected before another
+  flush attempt, so the caller must roll back or let the transaction guard
+  abort it;
+- mutating supported table calls must use connection-managed transactions while
+  capture is attached. Caller-created raw writable `MDBX_txn*` handles are
+  rejected before mutation because native `mdbx_txn_commit()` cannot invoke the
+  capture pre-commit hook. Caller-created raw read-only transactions remain
+  valid for read/search snapshot operations;
 - choose the scope helper for bounded write phases owned by one stack frame;
   choose explicit attach/detach only for a wider component lifecycle where the
   caller can prove no concurrent table operation or active transaction races


### PR DESCRIPTION
## Summary
- document the staged logical sync contract: schema marker, logical wire frame, adapter preflight/apply, then capture
- clarify that current logical scaffolding is preparatory and not table sync support
- keep deferred logical tables limited to single-writer or application-serialized conflicting writes until a causal model exists

## Validation
- git diff --check
- documentation-only PR
