### PR TITLE
test(sync): cover logical adapter MDBX rollback

### DIFF
--- a/tests/test_logical_table_adapter.cpp
+++ b/tests/test_logical_table_adapter.cpp
@@ -471,36 +471,53 @@ void test_mdbx_mutation_rolls_back_when_later_apply_fails() {
     if (result.ok) {
         throw std::runtime_error("failing logical apply succeeded");
     }
+
+    MDBX_dbi write_dbi = 0;
+    mdbxc::check_mdbx(
+        mdbx_dbi_open(txn.handle(), "logical_adapter_rollback_items",
+                      static_cast<MDBX_db_flags_t>(0), &write_dbi),
+        "logical adapter rollback write DBI open failed");
+    const char key_bytes[] = "logical-key";
+    MDBX_val key = {
+        const_cast<char*>(key_bytes),
+        std::strlen(key_bytes)
+    };
+    MDBX_val value;
+    mdbxc::check_mdbx(mdbx_get(txn.handle(), write_dbi, &key, &value),
+                      "logical adapter rollback write read failed");
+    const char expected_value[] = "partial-value";
+    if (value.iov_len != std::strlen(expected_value) ||
+        std::memcmp(value.iov_base, expected_value,
+                    std::strlen(expected_value)) != 0) {
+        throw std::runtime_error(
+            "logical adapter mutation was not visible before rollback");
+    }
     txn.rollback();
 
-    MDBX_txn* raw_read = nullptr;
-    mdbxc::check_mdbx(mdbx_txn_begin(conn->env_handle(), nullptr,
-                                     MDBX_TXN_RDONLY, &raw_read),
-                      "logical adapter rollback read txn begin failed");
-    struct ReadGuard {
-        MDBX_txn* txn;
-        ~ReadGuard() { if (txn != nullptr) mdbx_txn_abort(txn); }
-    } read_guard = { raw_read };
+    {
+        MDBX_txn* raw_read = nullptr;
+        mdbxc::check_mdbx(mdbx_txn_begin(conn->env_handle(), nullptr,
+                                         MDBX_TXN_RDONLY, &raw_read),
+                          "logical adapter rollback read txn begin failed");
+        struct ReadGuard {
+            MDBX_txn* txn;
+            ~ReadGuard() { if (txn != nullptr) mdbx_txn_abort(txn); }
+        } read_guard = { raw_read };
 
-    MDBX_dbi dbi = 0;
-    const int open_rc = mdbx_dbi_open(
-        raw_read, "logical_adapter_rollback_items",
-        static_cast<MDBX_db_flags_t>(0), &dbi);
-    if (open_rc != MDBX_NOTFOUND) {
-        mdbxc::check_mdbx(open_rc,
-                          "logical adapter rollback DBI open failed");
-        const char key_bytes[] = "logical-key";
-        MDBX_val key = {
-            const_cast<char*>(key_bytes),
-            std::strlen(key_bytes)
-        };
-        MDBX_val value;
-        const int get_rc = mdbx_get(raw_read, dbi, &key, &value);
-        if (get_rc != MDBX_NOTFOUND) {
-            mdbxc::check_mdbx(get_rc,
-                              "logical adapter rollback read failed");
-            throw std::runtime_error(
-                "logical adapter partial MDBX mutation survived rollback");
+        MDBX_dbi dbi = 0;
+        const int open_rc = mdbx_dbi_open(
+            raw_read, "logical_adapter_rollback_items",
+            static_cast<MDBX_db_flags_t>(0), &dbi);
+        if (open_rc != MDBX_NOTFOUND) {
+            mdbxc::check_mdbx(open_rc,
+                              "logical adapter rollback DBI open failed");
+            const int get_rc = mdbx_get(raw_read, dbi, &key, &value);
+            if (get_rc != MDBX_NOTFOUND) {
+                mdbxc::check_mdbx(get_rc,
+                                  "logical adapter rollback read failed");
+                throw std::runtime_error(
+                    "logical adapter partial MDBX mutation survived rollback");
+            }
         }
     }
 

--- a/tests/test_logical_table_adapter.cpp
+++ b/tests/test_logical_table_adapter.cpp
@@ -1,10 +1,16 @@
 #include <mdbx_containers/sync.hpp>
 
+#include <cstdio>
+#include <cstring>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 namespace {
+
+void cleanup(const std::string& p) {
+    std::remove(p.c_str());
+}
 
 class RecordingAdapter : public mdbxc::sync::ILogicalTableAdapter {
 public:
@@ -73,6 +79,52 @@ private:
     std::string m_schema_id;
     mdbxc::sync::LogicalTableKind m_kind;
     std::uint32_t m_schema_version;
+};
+
+class MdbxMutatingAdapter : public RecordingAdapter {
+public:
+    MdbxMutatingAdapter(const std::string& schema_id,
+                        const std::string& dbi_name,
+                        bool fail_apply)
+        : RecordingAdapter(schema_id),
+          m_dbi_name(dbi_name),
+          m_fail_apply(fail_apply) {}
+
+    std::vector<std::string> affected_dbis() const override {
+        std::vector<std::string> out;
+        out.push_back(m_dbi_name);
+        return out;
+    }
+
+    mdbxc::sync::LogicalApplyResult apply(
+            MDBX_txn* txn,
+            const mdbxc::sync::LogicalChange& change) override {
+        if (m_fail_apply) {
+            return mdbxc::sync::LogicalApplyResult::failure("apply blocked");
+        }
+
+        MDBX_dbi dbi = 0;
+        mdbxc::check_mdbx(
+            mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE, &dbi),
+            "logical adapter test DBI open failed");
+        const char key_bytes[] = "logical-key";
+        const char value_bytes[] = "partial-value";
+        MDBX_val key = {
+            const_cast<char*>(key_bytes),
+            std::strlen(key_bytes)
+        };
+        MDBX_val value = {
+            const_cast<char*>(value_bytes),
+            std::strlen(value_bytes)
+        };
+        mdbxc::check_mdbx(mdbx_put(txn, dbi, &key, &value, MDBX_UPSERT),
+                          "logical adapter test put failed");
+        return RecordingAdapter::apply(txn, change);
+    }
+
+private:
+    std::string m_dbi_name;
+    bool m_fail_apply;
 };
 
 class IncompleteAdapter : public RecordingAdapter {
@@ -388,6 +440,74 @@ void test_missing_adapter_fails_without_apply() {
     }
 }
 
+void test_mdbx_mutation_rolls_back_when_later_apply_fails() {
+    const std::string path = "test_logical_adapter_mdbx_rollback.mdbx";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+
+    mdbxc::sync::LogicalTableRegistry registry;
+    MdbxMutatingAdapter writer("schema.writer.v1",
+                               "logical_adapter_rollback_items",
+                               false);
+    MdbxMutatingAdapter failing("schema.failing.v1",
+                                "logical_adapter_rollback_items",
+                                true);
+    registry.register_adapter(&writer);
+    registry.register_adapter(&failing);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(make_change("schema.writer.v1", 1));
+    changes.push_back(make_change("schema.failing.v1", 2));
+
+    mdbxc::Transaction txn =
+        conn->transaction(mdbxc::TransactionMode::WRITABLE);
+    const mdbxc::sync::LogicalApplyResult result =
+        registry.preflight_then_apply(txn.handle(), changes);
+    if (result.ok) {
+        throw std::runtime_error("failing logical apply succeeded");
+    }
+    txn.rollback();
+
+    MDBX_txn* raw_read = nullptr;
+    mdbxc::check_mdbx(mdbx_txn_begin(conn->env_handle(), nullptr,
+                                     MDBX_TXN_RDONLY, &raw_read),
+                      "logical adapter rollback read txn begin failed");
+    struct ReadGuard {
+        MDBX_txn* txn;
+        ~ReadGuard() { if (txn != nullptr) mdbx_txn_abort(txn); }
+    } read_guard = { raw_read };
+
+    MDBX_dbi dbi = 0;
+    const int open_rc = mdbx_dbi_open(
+        raw_read, "logical_adapter_rollback_items",
+        static_cast<MDBX_db_flags_t>(0), &dbi);
+    if (open_rc != MDBX_NOTFOUND) {
+        mdbxc::check_mdbx(open_rc,
+                          "logical adapter rollback DBI open failed");
+        const char key_bytes[] = "logical-key";
+        MDBX_val key = {
+            const_cast<char*>(key_bytes),
+            std::strlen(key_bytes)
+        };
+        MDBX_val value;
+        const int get_rc = mdbx_get(raw_read, dbi, &key, &value);
+        if (get_rc != MDBX_NOTFOUND) {
+            mdbxc::check_mdbx(get_rc,
+                              "logical adapter rollback read failed");
+            throw std::runtime_error(
+                "logical adapter partial MDBX mutation survived rollback");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 } // namespace
 
 int main() {
@@ -405,5 +525,6 @@ int main() {
     test_apply_failure_returns_failure_after_prior_apply();
     test_apply_exception_returns_failure_after_prior_apply();
     test_missing_adapter_fails_without_apply();
+    test_mdbx_mutation_rolls_back_when_later_apply_fails();
     return 0;
 }


### PR DESCRIPTION
## Summary
- add a real MDBX transaction regression for logical adapter apply failure
- verify a prior physical DBI mutation is not visible after the caller rolls back

## Validation
- ctest --test-dir tmp/build-pr193-cpp17 -R ^test_logical_table_adapter$ --output-on-failure
- ctest --test-dir tmp/build-pr193-cpp11 -R ^test_logical_table_adapter$ --output-on-failure