### PR TITLE
feat(sync): add logical schema marker setup API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file.
 - Added a persistent sync schema registry store for future logical table
   adapters. The registry records logical schema ids, table kinds, schema
   versions, and canonical sorted unique owned DBI names without enabling
-  logical replication yet.
+  logical replication yet. `SyncEngine::register_logical_schema()` is the
+  normal committed setup entry point for application schema markers.
 - Added public `ChangeDomain`, `LogicalSchemaRef`, and `LogicalChange` model
   types for future logical table adapters. The current wire codec remains
   raw-DBI only.

--- a/README-RU.md
+++ b/README-RU.md
@@ -107,8 +107,9 @@
   Caller-created raw read-only transactions остаются допустимыми для
   read/search snapshot operations. Любое исключение из capture recording или
   flush делает transaction rollback-only; повторный `commit()` отклоняется.
-- `SyncEngine` предоставляет pull/push/apply primitives, `DirectSyncPeer`
-  используется для in-process синхронизации в тестах и примерах,
+- `SyncEngine` предоставляет pull/push/apply primitives и
+  `register_logical_schema()` для committed setup logical schema markers.
+  `DirectSyncPeer` используется для in-process синхронизации в тестах и примерах,
   `HttpSyncPeer` задаёт HTTP-shaped adapter seam, `WebSocketSyncPeer` задаёт
   binary message seam, а `SyncWorker` запускает фоновой polling.
   `mdbx_containers/sync/transport.hpp` - umbrella header транспортного слоя.

--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@
   read/search snapshot operations. Any exception from capture recording or
   flushing makes that transaction rollback-only; retrying `commit()` is
   rejected.
-- `SyncEngine` exposes pull/push/apply primitives, `DirectSyncPeer` provides
-  in-process sync for tests and examples, `HttpSyncPeer` defines an HTTP-shaped
+- `SyncEngine` exposes pull/push/apply primitives and
+  `register_logical_schema()` for committed logical schema marker setup.
+  `DirectSyncPeer` provides in-process sync for tests and examples,
+  `HttpSyncPeer` defines an HTTP-shaped
   adapter seam, `WebSocketSyncPeer` defines a binary message seam, and
   `SyncWorker` is the background polling driver. `mdbx_containers/sync/transport.hpp`
   is the transport-layer umbrella. Optional ready-made Simple-Web

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -455,10 +455,14 @@ Real removal is explicit via `erase()`.
 | Value | `schema_id` repeated in the versioned value envelope, followed by `LogicalSchemaRecord { kind, schema_version, flags, dbi_name, dbi_names[] }`; owned `dbi_names[]` are stored as a sorted unique set |
 
 This store is a persistent compatibility marker for future logical table
-adapters. It does not enable logical sync by itself. A wrapper or adapter may
-call `register_or_verify(schema_id, record)` during lifecycle setup to ensure
-that an existing database was opened with the same logical table kind,
-application schema version, and owned physical DBI set.
+adapters. It does not enable logical sync by itself. Normal application setup
+should call `SyncEngine::register_logical_schema(schema_id, record)` so the
+marker is written through a committed sync-system lifecycle transaction. A
+wrapper or adapter may call `SchemaRegistryStore::register_or_verify()` only
+when it already owns the setup transaction, for example in tests, migrations,
+or repair tools. Both paths ensure that an existing database was opened with
+the same logical table kind, application schema version, and owned physical DBI
+set.
 
 `SyncEngine::initialize_local_identity()` creates this DBI together with the
 required sync metadata stores in a committed setup transaction. Standalone

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -189,6 +189,21 @@ namespace sync {
         /// \brief Returns the conflict resolution policy.
         ConflictPolicy policy() const noexcept { return m_policy; }
 
+        /// \brief Registers or verifies a persistent logical table schema.
+        /// \details This is the normal lifecycle entry point for application
+        /// logical schema markers. It opens the sync system DBIs and commits
+        /// the schema registry update atomically. Direct
+        /// \c SchemaRegistryStore usage remains available for tests,
+        /// migrations, and repair utilities that already own a transaction.
+        void register_logical_schema(const std::string& schema_id,
+                                     const LogicalSchemaRecord& record) {
+            auto txn = m_conn->transaction(TransactionMode::WRITABLE);
+            initialize_system_stores(txn.handle());
+            SchemaRegistryStore schemas(m_conn->env_handle());
+            schemas.register_or_verify(txn.handle(), schema_id, record);
+            txn.commit();
+        }
+
         /// \brief Applies a single \c ChangeBatch to local DBIs inside \p txn.
         /// \details See class-level docs for the seq / apply rules. The
         /// caller commits the transaction. User DBIs are opened lazily by

--- a/tests/test_sync_stores.cpp
+++ b/tests/test_sync_stores.cpp
@@ -846,6 +846,60 @@ void test_schema_registry_created_by_sync_engine_init() {
     cleanup(p);
 }
 
+void test_sync_engine_registers_logical_schema_marker() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_schema_engine_register.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x12), make_node(0x23));
+
+    LogicalSchemaRecord record;
+    record.dbi_name = "items";
+    record.kind = LogicalTableKind::KeyMultiValue;
+    record.schema_version = 1;
+    record.dbi_names.push_back("items");
+
+    engine.register_logical_schema("app.items.v1", record);
+    engine.register_logical_schema("app.items.v1", record);
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        SchemaRegistryStore store(conn->env_handle());
+        LogicalSchemaRecord out;
+        if (!store.get(txn.handle(), "app.items.v1", out) ||
+            out.dbi_name != record.dbi_name ||
+            out.kind != record.kind ||
+            out.schema_version != record.schema_version ||
+            out.dbi_names != record.dbi_names) {
+            throw std::runtime_error(
+                "SyncEngine logical schema marker was not persisted");
+        }
+    }
+
+    LogicalSchemaRecord mismatch = record;
+    mismatch.schema_version = 2;
+    bool caught = false;
+    try {
+        engine.register_logical_schema("app.items.v1", mismatch);
+    } catch (const std::runtime_error&) {
+        caught = true;
+    }
+    if (!caught) {
+        throw std::runtime_error(
+            "SyncEngine accepted mismatched logical schema marker");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 void expect_schema_get_failure(const std::string& label,
                                mdbxc::sync::SchemaRegistryStore& store,
                                MDBX_txn* txn,
@@ -1068,6 +1122,7 @@ int main() {
     test_schema_registry_store();
     test_schema_registry_open_after_aborted_create();
     test_schema_registry_created_by_sync_engine_init();
+    test_sync_engine_registers_logical_schema_marker();
     test_schema_registry_rejects_malformed_records();
     test_stores_require_open();
     return 0;

--- a/tests/test_sync_stores.cpp
+++ b/tests/test_sync_stores.cpp
@@ -896,6 +896,59 @@ void test_sync_engine_registers_logical_schema_marker() {
             "SyncEngine accepted mismatched logical schema marker");
     }
 
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        SchemaRegistryStore store(conn->env_handle());
+        LogicalSchemaRecord out;
+        if (!store.get(txn.handle(), "app.items.v1", out) ||
+            out.dbi_name != record.dbi_name ||
+            out.kind != record.kind ||
+            out.schema_version != record.schema_version ||
+            out.dbi_names != record.dbi_names) {
+            throw std::runtime_error(
+                "mismatched logical schema marker rewrote existing record");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_sync_engine_registers_logical_schema_without_identity_init() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_schema_engine_register_fresh.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    SyncEngine engine(conn);
+
+    LogicalSchemaRecord record;
+    record.dbi_name = "fresh_items";
+    record.kind = LogicalTableKind::KeyValue;
+    record.schema_version = 1;
+    record.dbi_names.push_back("fresh_items");
+
+    engine.register_logical_schema("app.fresh_items.v1", record);
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        SchemaRegistryStore store(conn->env_handle());
+        LogicalSchemaRecord out;
+        if (!store.get(txn.handle(), "app.fresh_items.v1", out) ||
+            out.dbi_name != record.dbi_name ||
+            out.kind != record.kind ||
+            out.schema_version != record.schema_version ||
+            out.dbi_names != record.dbi_names) {
+            throw std::runtime_error(
+                "fresh SyncEngine logical schema marker was not persisted");
+        }
+    }
+
     conn->disconnect();
     cleanup(p);
 }
@@ -1123,6 +1176,7 @@ int main() {
     test_schema_registry_open_after_aborted_create();
     test_schema_registry_created_by_sync_engine_init();
     test_sync_engine_registers_logical_schema_marker();
+    test_sync_engine_registers_logical_schema_without_identity_init();
     test_schema_registry_rejects_malformed_records();
     test_stores_require_open();
     return 0;

--- a/tests/test_sync_stores.cpp
+++ b/tests/test_sync_stores.cpp
@@ -929,7 +929,7 @@ void test_sync_engine_registers_logical_schema_without_identity_init() {
 
     LogicalSchemaRecord record;
     record.dbi_name = "fresh_items";
-    record.kind = LogicalTableKind::KeyValue;
+    record.kind = LogicalTableKind::KeyMultiValue;
     record.schema_version = 1;
     record.dbi_names.push_back("fresh_items");
 


### PR DESCRIPTION
## Summary
- add SyncEngine::register_logical_schema() as the committed setup path for schema markers
- verify idempotent marker registration and mismatch rejection through SyncEngine
- document the normal engine lifecycle vs direct SchemaRegistryStore usage

## Validation
- ctest --test-dir tmp/build-pr193-cpp17 -R ^(test_sync_stores|header_sync_umbrella_test)$ --output-on-failure
- ctest --test-dir tmp/build-pr193-cpp11 -R ^(test_sync_stores|header_sync_umbrella_test)$ --output-on-failure