### PR TITLE
feat(sync): add KeyValueTable logical adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ All notable changes to this project will be documented in this file.
   converted to failure results so the caller-owned transaction can be aborted.
   `SyncEngine` still rejects unknown logical operations until a wire format and
   registry integration are added.
+- Added `KeyValueTableLogicalAdapter` as the first concrete logical adapter
+  helper for explicit `LogicalTableRegistry::preflight_then_apply()` usage.
+  It covers typed upsert/delete/clear payloads for `KeyValueTable` without
+  enabling automatic logical replication in `SyncEngine`.
 - Documented the staged logical sync contract: schema marker, logical wire
   frame, adapter preflight/apply, then capture. Deferred logical tables still
   require single-writer or application-serialized conflicting writes until a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,11 @@ All notable changes to this project will be documented in this file.
   registry integration are added.
 - Added `KeyValueTableLogicalAdapter` as the first concrete logical adapter
   helper for explicit `LogicalTableRegistry::preflight_then_apply()` usage.
-  It covers typed upsert/delete/clear payloads for `KeyValueTable` without
-  enabling automatic logical replication in `SyncEngine`.
+  It covers typed upsert/delete/clear payloads for `KeyValueTable` with a
+  stable logical codec for `std::string`, `bool`, and integral values up to
+  64 bits. Incoming logical apply suppresses local raw capture for the affected
+  transaction and does not enable automatic logical replication in
+  `SyncEngine`.
 - Documented the staged logical sync contract: schema marker, logical wire
   frame, adapter preflight/apply, then capture. Deferred logical tables still
   require single-writer or application-serialized conflicting writes until a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,11 @@ All notable changes to this project will be documented in this file.
   registry integration are added.
 - Added `KeyValueTableLogicalAdapter` as the first concrete logical adapter
   helper for explicit `LogicalTableRegistry::preflight_then_apply()` usage.
-  It covers typed upsert/delete/clear payloads for `KeyValueTable` with a
-  stable logical codec for `std::string`, `bool`, and fixed-width integer
-  aliases up to 64 bits. Plain character and platform-sized source spellings
-  such as `long` and `size_t` are not portable logical schema fields. Incoming
-  logical apply suppresses local raw capture for the affected transaction and
-  does not enable automatic logical replication in `SyncEngine`.
+  It covers typed upsert/delete/clear payloads for `KeyValueTable` with
+  explicit key/value codec tags, including little-endian signed/unsigned
+  integer wire codecs up to 64 bits, bool, and string codecs. Incoming logical
+  apply suppresses local raw capture for the affected transaction and does not
+  enable automatic logical replication in `SyncEngine`.
 - Documented the staged logical sync contract: schema marker, logical wire
   frame, adapter preflight/apply, then capture. Deferred logical tables still
   require single-writer or application-serialized conflicting writes until a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,11 @@ All notable changes to this project will be documented in this file.
 - Added `KeyValueTableLogicalAdapter` as the first concrete logical adapter
   helper for explicit `LogicalTableRegistry::preflight_then_apply()` usage.
   It covers typed upsert/delete/clear payloads for `KeyValueTable` with a
-  stable logical codec for `std::string`, `bool`, and integral values up to
-  64 bits. Incoming logical apply suppresses local raw capture for the affected
-  transaction and does not enable automatic logical replication in
-  `SyncEngine`.
+  stable logical codec for `std::string`, `bool`, and fixed-width integer
+  aliases up to 64 bits. Plain character and platform-sized source spellings
+  such as `long` and `size_t` are not portable logical schema fields. Incoming
+  logical apply suppresses local raw capture for the affected transaction and
+  does not enable automatic logical replication in `SyncEngine`.
 - Documented the staged logical sync contract: schema marker, logical wire
   frame, adapter preflight/apply, then capture. Deferred logical tables still
   require single-writer or application-serialized conflicting writes until a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,6 +441,7 @@ if(MDBXC_BUILD_TESTS)
         mdbx_containers/sync/ChangeOp.hpp
         mdbx_containers/sync/LogicalChange.hpp
         mdbx_containers/sync/LogicalTableAdapter.hpp
+        mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp
         mdbx_containers/sync/ChangeBatch.hpp
         mdbx_containers/sync/ChangeBatchCodec.hpp
         mdbx_containers/sync/SyncApplyObserver.hpp

--- a/README-RU.md
+++ b/README-RU.md
@@ -112,9 +112,11 @@
   `KeyValueTableLogicalAdapter` - первый concrete logical adapter helper для
   явных вызовов `LogicalTableRegistry::preflight_then_apply()`. Его payload
   codec отделён от физического storage-формата таблицы и сейчас поддерживает
-  `std::string`, `bool` и integral values до 64 бит; входящий logical apply
-  подавляет локальный raw capture для затронутой транзакции. Он ещё не
-  подключён к automatic sync pipeline.
+  `std::string`, `bool` и fixed-width integer aliases до 64 бит; не используйте
+  plain character или platform-sized spellings вроде `long` и `size_t` как
+  переносимые поля logical schema. Входящий logical apply подавляет локальный
+  raw capture для затронутой транзакции. Он ещё не подключён к automatic sync
+  pipeline.
   `DirectSyncPeer` используется для in-process синхронизации в тестах и примерах,
   `HttpSyncPeer` задаёт HTTP-shaped adapter seam, `WebSocketSyncPeer` задаёт
   binary message seam, а `SyncWorker` запускает фоновой polling.

--- a/README-RU.md
+++ b/README-RU.md
@@ -111,11 +111,14 @@
   `register_logical_schema()` для committed setup logical schema markers.
   `KeyValueTableLogicalAdapter` - первый concrete logical adapter helper для
   явных вызовов `LogicalTableRegistry::preflight_then_apply()`. Его payload
-  codec отделён от физического storage-формата таблицы и сейчас поддерживает
-  `std::string`, `bool` и fixed-width integer aliases до 64 бит; не используйте
-  plain character или platform-sized spellings вроде `long` и `size_t` как
-  переносимые поля logical schema. Входящий logical apply подавляет локальный
-  raw capture для затронутой транзакции. Он ещё не подключён к automatic sync
+  codec отделён от физического storage-формата таблицы и выбирается через
+  явные key/value codec tags вроде `KeyValueLogicalInt64Codec<long>` и
+  `KeyValueLogicalStringCodec<std::string>`. Codec tags являются частью
+  logical schema contract; их смена требует нового schema id или явной
+  schema-marker migration. Смена `schema_version` под уже зарегистрированным
+  schema id отклоняется текущим immutable registry. Integer payloads
+  кодируются little-endian. Входящий logical apply подавляет локальный raw
+  capture для затронутой транзакции. Он ещё не подключён к automatic sync
   pipeline.
   `DirectSyncPeer` используется для in-process синхронизации в тестах и примерах,
   `HttpSyncPeer` задаёт HTTP-shaped adapter seam, `WebSocketSyncPeer` задаёт

--- a/README-RU.md
+++ b/README-RU.md
@@ -109,6 +109,9 @@
   flush делает transaction rollback-only; повторный `commit()` отклоняется.
 - `SyncEngine` предоставляет pull/push/apply primitives и
   `register_logical_schema()` для committed setup logical schema markers.
+  `KeyValueTableLogicalAdapter` - первый concrete logical adapter helper для
+  явных вызовов `LogicalTableRegistry::preflight_then_apply()`; он ещё не
+  подключён к automatic sync pipeline.
   `DirectSyncPeer` используется для in-process синхронизации в тестах и примерах,
   `HttpSyncPeer` задаёт HTTP-shaped adapter seam, `WebSocketSyncPeer` задаёт
   binary message seam, а `SyncWorker` запускает фоновой polling.

--- a/README-RU.md
+++ b/README-RU.md
@@ -110,7 +110,10 @@
 - `SyncEngine` предоставляет pull/push/apply primitives и
   `register_logical_schema()` для committed setup logical schema markers.
   `KeyValueTableLogicalAdapter` - первый concrete logical adapter helper для
-  явных вызовов `LogicalTableRegistry::preflight_then_apply()`; он ещё не
+  явных вызовов `LogicalTableRegistry::preflight_then_apply()`. Его payload
+  codec отделён от физического storage-формата таблицы и сейчас поддерживает
+  `std::string`, `bool` и integral values до 64 бит; входящий logical apply
+  подавляет локальный raw capture для затронутой транзакции. Он ещё не
   подключён к automatic sync pipeline.
   `DirectSyncPeer` используется для in-process синхронизации в тестах и примерах,
   `HttpSyncPeer` задаёт HTTP-shaped adapter seam, `WebSocketSyncPeer` задаёт

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@
   rejected.
 - `SyncEngine` exposes pull/push/apply primitives and
   `register_logical_schema()` for committed logical schema marker setup.
+  `KeyValueTableLogicalAdapter` is the first concrete logical adapter helper
+  for explicit `LogicalTableRegistry::preflight_then_apply()` calls; it is not
+  wired into the automatic sync pipeline yet.
   `DirectSyncPeer` provides in-process sync for tests and examples,
   `HttpSyncPeer` defines an HTTP-shaped
   adapter seam, `WebSocketSyncPeer` defines a binary message seam, and

--- a/README.md
+++ b/README.md
@@ -87,10 +87,13 @@
   `register_logical_schema()` for committed logical schema marker setup.
   `KeyValueTableLogicalAdapter` is the first concrete logical adapter helper
   for explicit `LogicalTableRegistry::preflight_then_apply()` calls. Its
-  payload codec is separate from physical table storage and currently covers
-  `std::string`, `bool`, and fixed-width integer aliases up to 64 bits; do not
-  use plain character or platform-sized spellings such as `long` and `size_t`
-  as portable logical schema fields. Incoming logical apply suppresses local
+  payload codec is separate from physical table storage and is selected through
+  explicit key/value codec tags such as `KeyValueLogicalInt64Codec<long>` and
+  `KeyValueLogicalStringCodec<std::string>`. Codec tags are part of the
+  logical schema contract; changing them requires a new schema id, or an
+  explicit schema-marker migration. Changing `schema_version` under an already
+  registered schema id is rejected by the current immutable registry. Integer
+  payloads are encoded little-endian. Incoming logical apply suppresses local
   raw capture for the affected transaction. It is not wired into the automatic
   sync pipeline yet.
   `DirectSyncPeer` provides in-process sync for tests and examples,

--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@
 - `SyncEngine` exposes pull/push/apply primitives and
   `register_logical_schema()` for committed logical schema marker setup.
   `KeyValueTableLogicalAdapter` is the first concrete logical adapter helper
-  for explicit `LogicalTableRegistry::preflight_then_apply()` calls; it is not
+  for explicit `LogicalTableRegistry::preflight_then_apply()` calls. Its
+  payload codec is separate from physical table storage and currently covers
+  `std::string`, `bool`, and integral values up to 64 bits; incoming logical
+  apply suppresses local raw capture for the affected transaction. It is not
   wired into the automatic sync pipeline yet.
   `DirectSyncPeer` provides in-process sync for tests and examples,
   `HttpSyncPeer` defines an HTTP-shaped

--- a/README.md
+++ b/README.md
@@ -88,9 +88,11 @@
   `KeyValueTableLogicalAdapter` is the first concrete logical adapter helper
   for explicit `LogicalTableRegistry::preflight_then_apply()` calls. Its
   payload codec is separate from physical table storage and currently covers
-  `std::string`, `bool`, and integral values up to 64 bits; incoming logical
-  apply suppresses local raw capture for the affected transaction. It is not
-  wired into the automatic sync pipeline yet.
+  `std::string`, `bool`, and fixed-width integer aliases up to 64 bits; do not
+  use plain character or platform-sized spellings such as `long` and `size_t`
+  as portable logical schema fields. Incoming logical apply suppresses local
+  raw capture for the affected transaction. It is not wired into the automatic
+  sync pipeline yet.
   `DirectSyncPeer` provides in-process sync for tests and examples,
   `HttpSyncPeer` defines an HTTP-shaped
   adapter seam, `WebSocketSyncPeer` defines a binary message seam, and

--- a/include/mdbx_containers/common/Connection.hpp
+++ b/include/mdbx_containers/common/Connection.hpp
@@ -28,6 +28,7 @@
 #include "Transaction.hpp"
 
 namespace mdbxc {
+    class BaseTable;
     class VectorStore;
 
     namespace sync {
@@ -200,6 +201,29 @@ namespace mdbxc {
         /// \brief Returns the currently attached \c ISyncCaptureSink or \c nullptr.
         sync::ISyncCaptureSink* sync_capture() const;
 
+        /// \brief Temporarily suppresses sync capture for one writable transaction.
+        /// \details Intended for incoming logical sync apply paths that must
+        /// write through public table wrappers without re-publishing the same
+        /// incoming change as a local raw \c ChangeOp.
+        class SyncCaptureSuppressionScope {
+        public:
+            SyncCaptureSuppressionScope(Connection& connection, MDBX_txn* txn);
+            ~SyncCaptureSuppressionScope() noexcept;
+
+            SyncCaptureSuppressionScope(
+                const SyncCaptureSuppressionScope&) = delete;
+            SyncCaptureSuppressionScope& operator=(
+                const SyncCaptureSuppressionScope&) = delete;
+            SyncCaptureSuppressionScope(
+                SyncCaptureSuppressionScope&&) = delete;
+            SyncCaptureSuppressionScope& operator=(
+                SyncCaptureSuppressionScope&&) = delete;
+
+        private:
+            Connection* m_connection;
+            MDBX_txn* m_txn;
+        };
+
         /// \brief Returns the remote sync-apply invalidation generation.
         /// \details The value increments after a successful
         /// \c SyncEngine::handle_push() commit that applied at least one
@@ -259,6 +283,7 @@ namespace mdbxc {
         void sync_to_disk(bool force = true, bool nonblock = false);
 
     private:
+        friend class BaseTable;
         friend class Transaction;
 
         MDBX_env *m_env = nullptr;          ///< Pointer to the MDBX environment handle.
@@ -295,6 +320,9 @@ namespace mdbxc {
         void mark_sync_capture_failed(MDBX_txn* txn) noexcept;
         bool sync_capture_failed(MDBX_txn* txn) const noexcept;
         void clear_sync_capture_failed(MDBX_txn* txn) noexcept;
+        void begin_sync_capture_suppression(MDBX_txn* txn);
+        void end_sync_capture_suppression(MDBX_txn* txn) noexcept;
+        bool sync_capture_suppressed(MDBX_txn* txn) const;
         void ensure_sync_capture_txn_supported(MDBX_txn* txn,
                                                const char* context) const;
         struct SyncApplyObserverState;
@@ -349,6 +377,7 @@ namespace mdbxc {
         std::uint64_t m_sync_capture_token = 0;
         std::uint64_t m_next_sync_capture_token = 0;
         MDBX_txn* m_sync_capture_failed_txn = nullptr;
+        std::vector<MDBX_txn*> m_sync_capture_suppressed_txns;
         mutable std::mutex m_sync_capture_failure_mutex;
         std::uint64_t m_next_sync_apply_observer_token = 0;
         std::uint64_t m_sync_apply_generation = 0;

--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -187,6 +187,20 @@ namespace mdbxc {
         return m_sync_capture;
     }
 
+    inline Connection::SyncCaptureSuppressionScope::
+    SyncCaptureSuppressionScope(Connection& connection, MDBX_txn* txn)
+        : m_connection(&connection),
+          m_txn(txn) {
+        m_connection->begin_sync_capture_suppression(m_txn);
+    }
+
+    inline Connection::SyncCaptureSuppressionScope::
+    ~SyncCaptureSuppressionScope() noexcept {
+        if (m_connection != nullptr) {
+            m_connection->end_sync_capture_suppression(m_txn);
+        }
+    }
+
     inline std::uint64_t Connection::sync_apply_generation() const {
         std::lock_guard<std::mutex> locker(m_mdbx_mutex);
         return m_sync_apply_generation;
@@ -298,6 +312,51 @@ namespace mdbxc {
         if (m_sync_capture_failed_txn == txn) {
             m_sync_capture_failed_txn = nullptr;
         }
+    }
+
+    inline void Connection::begin_sync_capture_suppression(MDBX_txn* txn) {
+        if (txn == nullptr) {
+            throw std::invalid_argument(
+                "Connection::SyncCaptureSuppressionScope transaction cannot be null");
+        }
+        checked_txn_env(txn, m_env,
+                        "Connection::SyncCaptureSuppressionScope");
+        std::lock_guard<std::mutex> locker(m_mdbx_mutex);
+        m_sync_capture_suppressed_txns.push_back(txn);
+    }
+
+    inline void Connection::end_sync_capture_suppression(
+            MDBX_txn* txn) noexcept {
+        if (txn == nullptr) {
+            return;
+        }
+        try {
+            std::lock_guard<std::mutex> locker(m_mdbx_mutex);
+            for (std::vector<MDBX_txn*>::iterator it =
+                     m_sync_capture_suppressed_txns.begin();
+                 it != m_sync_capture_suppressed_txns.end(); ++it) {
+                if (*it == txn) {
+                    m_sync_capture_suppressed_txns.erase(it);
+                    return;
+                }
+            }
+        } catch (...) {
+            // Destructors must not throw; a missing suppression entry is benign.
+        }
+    }
+
+    inline bool Connection::sync_capture_suppressed(MDBX_txn* txn) const {
+        if (txn == nullptr) {
+            return false;
+        }
+        std::lock_guard<std::mutex> locker(m_mdbx_mutex);
+        for (std::size_t i = 0; i < m_sync_capture_suppressed_txns.size();
+             ++i) {
+            if (m_sync_capture_suppressed_txns[i] == txn) {
+                return true;
+            }
+        }
+        return false;
     }
 
     inline void Connection::ensure_sync_capture_txn_supported(

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -127,6 +127,16 @@ namespace mdbxc {
             }
         }
 
+        /// \brief Returns the MDBX DBI name used by this table wrapper.
+        const std::string& dbi_name() const noexcept {
+            return m_name;
+        }
+
+        /// \brief Returns the shared MDBX connection used by this table wrapper.
+        std::shared_ptr<Connection> connection() const {
+            return m_connection;
+        }
+
     protected:
         struct CursorGuard {
             MDBX_cursor* cursor;
@@ -210,6 +220,7 @@ namespace mdbxc {
                        const std::vector<std::uint8_t>& storage_key,
                        const std::vector<std::uint8_t>& value) const {
             if (m_connection->is_read_only()) return;
+            if (m_connection->sync_capture_suppressed(txn)) return;
             sync::ISyncCaptureSink* sink = m_connection->sync_capture();
             if (sink == nullptr) return;
             sync::ChangeOp op;

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -19,6 +19,7 @@
 #include "sync/ChangeOp.hpp"
 #include "sync/LogicalChange.hpp"
 #include "sync/LogicalTableAdapter.hpp"
+#include "sync/adapters/KeyValueTableLogicalAdapter.hpp"
 #include "sync/CodecBounds.hpp"
 #include "sync/ChangeBatch.hpp"
 #include "sync/ChangeBatchCodec.hpp"

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -517,13 +517,19 @@ payload shape for a simple table, but it is not yet connected to the automatic
 pull/push wire pipeline.
 
 The adapter payload codec is not the table storage serializer. The initial
-codec surface is deliberately small and stable: `std::string`, `bool`, and
-fixed-width integer aliases whose width is at most 64 bits. Plain character
-types are rejected. Platform-sized source spellings such as `long`, `size_t`,
-and `ptrdiff_t` must not be used as portable logical schema fields; use explicit
-fixed-width schema types instead. Apply uses a transaction-scoped sync-capture
-suppression guard so an incoming logical change written through public table
-methods is not re-published as a local raw `ChangeOp`.
+codec surface is deliberately small and explicit: callers provide key/value
+codec tags such as `KeyValueLogicalInt64Codec<long>` and
+`KeyValueLogicalStringCodec<std::string>`. The codec tag, not the native C++
+source spelling, defines the logical wire type; for example, local `long` may
+be mapped to signed 64-bit wire integers and range-checked on decode. Codec
+tags are part of the logical schema contract, so changing them requires a new
+schema id, or an explicit schema-marker migration. The current registry is
+immutable: changing `schema_version` under an already registered schema id is
+detected as a mismatch. Integer logical payload bytes are little-endian,
+matching the project-wide payload integer rule above. Apply uses a
+transaction-scoped sync-capture suppression guard so an incoming logical change
+written through public table methods is not re-published as a local raw
+`ChangeOp`.
 
 The current `SyncEngine` does not call this registry yet. Unknown logical
 payloads must not fall back to raw DBI apply.
@@ -1197,6 +1203,10 @@ When HLC or similar lands in v0.2, it goes in as opaque bytes inside
 
 - `meta_schema_version()` currently returns 1; bump rule + migration
   procedure not defined.
+- Logical schema-marker migration API. The current `_mdbxc_sync_schema`
+  registry is immutable and only creates or verifies exact records; changing a
+  codec tag for an existing logical table requires a new schema id until an
+  explicit marker migration lifecycle is designed.
 - Public sync API stability after the first external transport adapter.
 - `PeerRegistry` for multi-peer fan-out — single peer per sync invocation
   in v0.1.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -508,6 +508,14 @@ and compatibility tests.
   must abort that transaction; the registry cannot roll back a transaction it
   does not own.
 
+`adapters/KeyValueTableLogicalAdapter.hpp` provides the first concrete adapter
+helper. It translates typed `KeyValueTable` upsert/delete/clear operations into
+adapter-owned logical payloads and applies them through
+`LogicalTableRegistry::preflight_then_apply()` inside a caller-owned write
+transaction. It is intentionally standalone: it proves the adapter contract and
+payload shape for a simple table, but it is not yet connected to the automatic
+pull/push wire pipeline.
+
 The current `SyncEngine` does not call this registry yet. Unknown logical
 payloads must not fall back to raw DBI apply.
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -516,6 +516,12 @@ transaction. It is intentionally standalone: it proves the adapter contract and
 payload shape for a simple table, but it is not yet connected to the automatic
 pull/push wire pipeline.
 
+The adapter payload codec is not the table storage serializer. The initial
+codec surface is deliberately small and stable: `std::string`, `bool`, and
+integral values whose width is at most 64 bits. Apply uses a transaction-scoped
+sync-capture suppression guard so an incoming logical change written through
+public table methods is not re-published as a local raw `ChangeOp`.
+
 The current `SyncEngine` does not call this registry yet. Unknown logical
 payloads must not fall back to raw DBI apply.
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -518,9 +518,12 @@ pull/push wire pipeline.
 
 The adapter payload codec is not the table storage serializer. The initial
 codec surface is deliberately small and stable: `std::string`, `bool`, and
-integral values whose width is at most 64 bits. Apply uses a transaction-scoped
-sync-capture suppression guard so an incoming logical change written through
-public table methods is not re-published as a local raw `ChangeOp`.
+fixed-width integer aliases whose width is at most 64 bits. Plain character
+types are rejected. Platform-sized source spellings such as `long`, `size_t`,
+and `ptrdiff_t` must not be used as portable logical schema fields; use explicit
+fixed-width schema types instead. Apply uses a transaction-scoped sync-capture
+suppression guard so an incoming logical change written through public table
+methods is not re-published as a local raw `ChangeOp`.
 
 The current `SyncEngine` does not call this registry yet. Unknown logical
 payloads must not fall back to raw DBI apply.

--- a/include/mdbx_containers/sync/LogicalSchema.hpp
+++ b/include/mdbx_containers/sync/LogicalSchema.hpp
@@ -17,6 +17,7 @@ namespace sync {
         KeyOrderedMultiValue = 2, ///< Key-to-multiple-values table with presentation order.
         AnyValue             = 3, ///< Dynamically typed value table.
         HashedKeyValue       = 4, ///< Hashed key-value store.
+        KeyValue             = 5, ///< One value per key table.
     };
 
     /// \brief Returns true when \p kind is a supported logical table kind.
@@ -26,6 +27,7 @@ namespace sync {
             case LogicalTableKind::KeyOrderedMultiValue:
             case LogicalTableKind::AnyValue:
             case LogicalTableKind::HashedKeyValue:
+            case LogicalTableKind::KeyValue:
                 return true;
             case LogicalTableKind::Unknown:
                 return false;

--- a/include/mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp
@@ -9,6 +9,8 @@
 #include <limits>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "../../KeyValueTable.hpp"
@@ -25,10 +27,121 @@ namespace sync {
         KeyValueLogicalClear  = 3
     };
 
+namespace detail {
+
+    template<class T, class Enable = void>
+    struct KeyValueLogicalCodec;
+
+    template<class T>
+    struct KeyValueLogicalCodec<
+        T,
+        typename std::enable_if<
+            std::is_integral<T>::value && !std::is_same<T, bool>::value
+        >::type> {
+        static std::vector<std::uint8_t> encode(T value) {
+            static_assert(sizeof(T) <= 8,
+                          "KeyValue logical integral codec supports up to 64 bits");
+            std::uint64_t raw = 0;
+            if (std::numeric_limits<T>::is_signed) {
+                const std::int64_t signed_value =
+                    static_cast<std::int64_t>(value);
+                raw = static_cast<std::uint64_t>(signed_value);
+            } else {
+                raw = static_cast<std::uint64_t>(value);
+            }
+            std::vector<std::uint8_t> out(8);
+            for (int i = 7; i >= 0; --i) {
+                out[static_cast<std::size_t>(i)] =
+                    static_cast<std::uint8_t>(raw & 0xFFu);
+                raw >>= 8;
+            }
+            return out;
+        }
+
+        static T decode(const std::vector<std::uint8_t>& bytes) {
+            if (bytes.size() != 8u) {
+                throw std::runtime_error(
+                    "KeyValue logical integral payload must be 8 bytes");
+            }
+            std::uint64_t raw = 0;
+            for (std::size_t i = 0; i < bytes.size(); ++i) {
+                raw = (raw << 8) | bytes[i];
+            }
+            if (std::numeric_limits<T>::is_signed) {
+                std::int64_t signed_value = 0;
+                if (raw <= static_cast<std::uint64_t>(
+                        std::numeric_limits<std::int64_t>::max())) {
+                    signed_value = static_cast<std::int64_t>(raw);
+                } else {
+                    const std::uint64_t magnitude = (~raw) + 1u;
+                    const std::uint64_t min_magnitude =
+                        static_cast<std::uint64_t>(
+                            std::numeric_limits<std::int64_t>::max()) + 1u;
+                    if (magnitude == min_magnitude) {
+                        signed_value =
+                            (std::numeric_limits<std::int64_t>::min)();
+                    } else {
+                        signed_value =
+                            -static_cast<std::int64_t>(magnitude);
+                    }
+                }
+                if (signed_value <
+                        static_cast<std::int64_t>(
+                            (std::numeric_limits<T>::min)()) ||
+                    signed_value >
+                        static_cast<std::int64_t>(
+                            (std::numeric_limits<T>::max)())) {
+                    throw std::out_of_range(
+                        "KeyValue logical integral payload is out of range");
+                }
+                return static_cast<T>(signed_value);
+            }
+            if (raw > static_cast<std::uint64_t>(
+                    (std::numeric_limits<T>::max)())) {
+                throw std::out_of_range(
+                    "KeyValue logical unsigned payload is out of range");
+            }
+            return static_cast<T>(raw);
+        }
+    };
+
+    template<>
+    struct KeyValueLogicalCodec<bool, void> {
+        static std::vector<std::uint8_t> encode(bool value) {
+            std::vector<std::uint8_t> out(1);
+            out[0] = value ? 1u : 0u;
+            return out;
+        }
+
+        static bool decode(const std::vector<std::uint8_t>& bytes) {
+            if (bytes.size() != 1u || bytes[0] > 1u) {
+                throw std::runtime_error(
+                    "KeyValue logical bool payload is invalid");
+            }
+            return bytes[0] != 0u;
+        }
+    };
+
+    template<>
+    struct KeyValueLogicalCodec<std::string, void> {
+        static std::vector<std::uint8_t> encode(const std::string& value) {
+            return std::vector<std::uint8_t>(value.begin(), value.end());
+        }
+
+        static std::string decode(const std::vector<std::uint8_t>& bytes) {
+            return std::string(bytes.begin(), bytes.end());
+        }
+    };
+
+} // namespace detail
+
     /// \brief First concrete logical adapter for simple one-value-per-key tables.
     /// \details The payload format is adapter-owned and intentionally separate
-    /// from the raw DBI wire codec. It is used only when a caller explicitly
-    /// invokes \c LogicalTableRegistry::preflight_then_apply().
+    /// from the raw DBI wire codec. The initial stable codec supports
+    /// \c std::string, \c bool, and integral types up to 64 bits. Incoming
+    /// logical apply suppresses local raw capture for the supplied transaction.
+    /// It is used only when a caller explicitly invokes
+    /// \c LogicalTableRegistry::preflight_then_apply().
     template<class KeyT, class ValueT, class Options = DefaultTableOptions>
     class KeyValueTableLogicalAdapter : public ILogicalTableAdapter {
     public:
@@ -36,17 +149,15 @@ namespace sync {
 
         KeyValueTableLogicalAdapter(table_type& table,
                                     const std::string& schema_id,
-                                    const std::string& dbi_name,
                                     std::uint32_t schema_version = 1)
             : m_table(table),
               m_schema_id(schema_id),
-              m_dbi_name(dbi_name),
               m_schema_version(schema_version) {
             if (m_schema_id.empty()) {
                 throw std::invalid_argument(
                     "KeyValueTableLogicalAdapter schema id is empty");
             }
-            if (m_dbi_name.empty()) {
+            if (m_table.dbi_name().empty()) {
                 throw std::invalid_argument(
                     "KeyValueTableLogicalAdapter DBI name is empty");
             }
@@ -66,7 +177,7 @@ namespace sync {
 
         std::vector<std::string> affected_dbis() const override {
             std::vector<std::string> out;
-            out.push_back(m_dbi_name);
+            out.push_back(m_table.dbi_name());
             return out;
         }
 
@@ -107,16 +218,17 @@ namespace sync {
             if (!validation.ok) return validation;
 
             try {
+                Connection::SyncCaptureSuppressionScope suppress_capture(
+                    *m_table.connection(), txn);
                 if (change.opcode == KeyValueLogicalUpsert) {
-                    KeyT key;
-                    ValueT value;
-                    decode_upsert(change.payload, key, value);
-                    m_table.insert_or_assign(key, value, txn);
+                    const std::pair<KeyT, ValueT> decoded =
+                        decode_upsert(change.payload);
+                    m_table.insert_or_assign(
+                        decoded.first, decoded.second, txn);
                     return LogicalApplyResult::success();
                 }
                 if (change.opcode == KeyValueLogicalDelete) {
-                    KeyT key;
-                    decode_key_only(change.payload, key);
+                    const KeyT key = decode_key_only(change.payload);
                     (void)m_table.erase(key, txn);
                     return LogicalApplyResult::success();
                 }
@@ -151,35 +263,31 @@ namespace sync {
             }
         }
 
-        static void append_blob(std::vector<std::uint8_t>& out,
-                                const MDBX_val& value) {
-            if (value.iov_len >
+        static void append_blob(
+                std::vector<std::uint8_t>& out,
+                const std::vector<std::uint8_t>& value) {
+            if (value.size() >
                 static_cast<std::size_t>(
                     std::numeric_limits<std::uint32_t>::max())) {
                 throw std::length_error(
                     "KeyValue logical payload blob is too large");
             }
             detail::append_u32_le(out,
-                static_cast<std::uint32_t>(value.iov_len));
-            if (value.iov_len == 0) {
-                return;
-            }
-            const std::uint8_t* bytes =
-                static_cast<const std::uint8_t*>(value.iov_base);
-            out.insert(out.end(), bytes, bytes + value.iov_len);
+                static_cast<std::uint32_t>(value.size()));
+            out.insert(out.end(), value.begin(), value.end());
         }
 
-        static MDBX_val read_blob(PayloadCursor& cursor) {
+        static std::vector<std::uint8_t> read_blob(PayloadCursor& cursor) {
             require(cursor, 4);
             const std::uint32_t size =
                 detail::read_u32_le(cursor.data + cursor.pos);
             cursor.pos += 4;
             require(cursor, size);
-            MDBX_val out = {
-                size == 0 ? nullptr :
-                    const_cast<std::uint8_t*>(cursor.data + cursor.pos),
-                size
-            };
+            std::vector<std::uint8_t> out;
+            if (size != 0u) {
+                out.assign(cursor.data + cursor.pos,
+                           cursor.data + cursor.pos + size);
+            }
             cursor.pos += size;
             return out;
         }
@@ -203,58 +311,52 @@ namespace sync {
 
         static void encode_key_only(const KeyT& key,
                                     std::vector<std::uint8_t>& out) {
-            SerializeScratch key_scratch;
             out.clear();
-            const MDBX_val encoded_key =
-                serialize_key<Options::safe_integer_key>(key, key_scratch);
+            const std::vector<std::uint8_t> encoded_key =
+                detail::KeyValueLogicalCodec<KeyT>::encode(key);
             append_blob(out, encoded_key);
         }
 
         static void encode_upsert(const KeyT& key,
                                   const ValueT& value,
                                   std::vector<std::uint8_t>& out) {
-            SerializeScratch key_scratch;
-            SerializeScratch value_scratch;
             out.clear();
-            const MDBX_val encoded_key =
-                serialize_key<Options::safe_integer_key>(key, key_scratch);
-            const MDBX_val encoded_value =
-                serialize_value(value, value_scratch);
+            const std::vector<std::uint8_t> encoded_key =
+                detail::KeyValueLogicalCodec<KeyT>::encode(key);
+            const std::vector<std::uint8_t> encoded_value =
+                detail::KeyValueLogicalCodec<ValueT>::encode(value);
             append_blob(out, encoded_key);
             append_blob(out, encoded_value);
         }
 
-        static void decode_key_only(const std::vector<std::uint8_t>& payload,
-                                    KeyT& key) {
+        static KeyT decode_key_only(
+                const std::vector<std::uint8_t>& payload) {
             PayloadCursor cursor = make_cursor(payload);
-            const MDBX_val encoded_key = read_blob(cursor);
+            const std::vector<std::uint8_t> encoded_key = read_blob(cursor);
             ensure_end(cursor);
-            key = deserialize_key<KeyT>(encoded_key);
+            return detail::KeyValueLogicalCodec<KeyT>::decode(encoded_key);
         }
 
-        static void decode_upsert(const std::vector<std::uint8_t>& payload,
-                                  KeyT& key,
-                                  ValueT& value) {
+        static std::pair<KeyT, ValueT> decode_upsert(
+                const std::vector<std::uint8_t>& payload) {
             PayloadCursor cursor = make_cursor(payload);
-            const MDBX_val encoded_key = read_blob(cursor);
-            const MDBX_val encoded_value = read_blob(cursor);
+            const std::vector<std::uint8_t> encoded_key = read_blob(cursor);
+            const std::vector<std::uint8_t> encoded_value = read_blob(cursor);
             ensure_end(cursor);
-            key = deserialize_key<KeyT>(encoded_key);
-            value = deserialize_value<ValueT>(encoded_value);
+            return std::make_pair(
+                detail::KeyValueLogicalCodec<KeyT>::decode(encoded_key),
+                detail::KeyValueLogicalCodec<ValueT>::decode(encoded_value));
         }
 
         LogicalApplyResult validate_payload(
                 const LogicalChange& change) const {
             try {
                 if (change.opcode == KeyValueLogicalUpsert) {
-                    KeyT key;
-                    ValueT value;
-                    decode_upsert(change.payload, key, value);
+                    (void)decode_upsert(change.payload);
                     return LogicalApplyResult::success();
                 }
                 if (change.opcode == KeyValueLogicalDelete) {
-                    KeyT key;
-                    decode_key_only(change.payload, key);
+                    (void)decode_key_only(change.payload);
                     return LogicalApplyResult::success();
                 }
                 if (change.opcode == KeyValueLogicalClear) {
@@ -278,7 +380,6 @@ namespace sync {
 
         table_type& m_table;
         std::string m_schema_id;
-        std::string m_dbi_name;
         std::uint32_t m_schema_version;
     };
 

--- a/include/mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp
@@ -29,6 +29,40 @@ namespace sync {
 
 namespace detail {
 
+    template<class T>
+    struct KeyValueLogicalPlainCharType {
+        typedef typename std::remove_cv<T>::type value_type;
+        static const bool value =
+            std::is_same<value_type, char>::value ||
+            std::is_same<value_type, wchar_t>::value ||
+            std::is_same<value_type, char16_t>::value ||
+            std::is_same<value_type, char32_t>::value;
+    };
+
+    template<class T>
+    struct KeyValueLogicalFixedIntegralType {
+        typedef typename std::remove_cv<T>::type value_type;
+        static const bool value =
+            !KeyValueLogicalPlainCharType<value_type>::value &&
+            (std::is_same<value_type, std::int8_t>::value ||
+             std::is_same<value_type, std::uint8_t>::value ||
+             std::is_same<value_type, std::int16_t>::value ||
+             std::is_same<value_type, std::uint16_t>::value ||
+             std::is_same<value_type, std::int32_t>::value ||
+             std::is_same<value_type, std::uint32_t>::value ||
+             std::is_same<value_type, std::int64_t>::value ||
+             std::is_same<value_type, std::uint64_t>::value);
+    };
+
+    template<class T>
+    struct KeyValueLogicalCodecSupported {
+        typedef typename std::remove_cv<T>::type value_type;
+        static const bool value =
+            KeyValueLogicalFixedIntegralType<value_type>::value ||
+            std::is_same<value_type, bool>::value ||
+            std::is_same<value_type, std::string>::value;
+    };
+
     template<class T, class Enable = void>
     struct KeyValueLogicalCodec;
 
@@ -36,7 +70,7 @@ namespace detail {
     struct KeyValueLogicalCodec<
         T,
         typename std::enable_if<
-            std::is_integral<T>::value && !std::is_same<T, bool>::value
+            KeyValueLogicalFixedIntegralType<T>::value
         >::type> {
         static std::vector<std::uint8_t> encode(T value) {
             static_assert(sizeof(T) <= 8,
@@ -138,14 +172,21 @@ namespace detail {
     /// \brief First concrete logical adapter for simple one-value-per-key tables.
     /// \details The payload format is adapter-owned and intentionally separate
     /// from the raw DBI wire codec. The initial stable codec supports
-    /// \c std::string, \c bool, and integral types up to 64 bits. Incoming
-    /// logical apply suppresses local raw capture for the supplied transaction.
-    /// It is used only when a caller explicitly invokes
+    /// \c std::string, \c bool, and fixed-width integral aliases up to 64 bits.
+    /// Plain character types are rejected; platform-sized source spellings such
+    /// as \c long and \c size_t should not be used for portable logical schemas.
+    /// Incoming logical apply suppresses local raw capture for the supplied
+    /// transaction. It is used only when a caller explicitly invokes
     /// \c LogicalTableRegistry::preflight_then_apply().
     template<class KeyT, class ValueT, class Options = DefaultTableOptions>
     class KeyValueTableLogicalAdapter : public ILogicalTableAdapter {
     public:
         typedef KeyValueTable<KeyT, ValueT, Options> table_type;
+
+        static_assert(detail::KeyValueLogicalCodecSupported<KeyT>::value,
+                      "KeyValueTableLogicalAdapter key type is not supported by the stable logical codec");
+        static_assert(detail::KeyValueLogicalCodecSupported<ValueT>::value,
+                      "KeyValueTableLogicalAdapter value type is not supported by the stable logical codec");
 
         KeyValueTableLogicalAdapter(table_type& table,
                                     const std::string& schema_id,

--- a/include/mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp
@@ -40,107 +40,238 @@ namespace detail {
     };
 
     template<class T>
-    struct KeyValueLogicalFixedIntegralType {
+    struct KeyValueLogicalIntegerLocalSupported {
         typedef typename std::remove_cv<T>::type value_type;
         static const bool value =
+            std::is_integral<value_type>::value &&
+            !std::is_same<value_type, bool>::value &&
             !KeyValueLogicalPlainCharType<value_type>::value &&
-            (std::is_same<value_type, std::int8_t>::value ||
-             std::is_same<value_type, std::uint8_t>::value ||
-             std::is_same<value_type, std::int16_t>::value ||
-             std::is_same<value_type, std::uint16_t>::value ||
-             std::is_same<value_type, std::int32_t>::value ||
-             std::is_same<value_type, std::uint32_t>::value ||
-             std::is_same<value_type, std::int64_t>::value ||
-             std::is_same<value_type, std::uint64_t>::value);
+            sizeof(value_type) <= 8;
     };
 
-    template<class T>
-    struct KeyValueLogicalCodecSupported {
-        typedef typename std::remove_cv<T>::type value_type;
-        static const bool value =
-            KeyValueLogicalFixedIntegralType<value_type>::value ||
-            std::is_same<value_type, bool>::value ||
-            std::is_same<value_type, std::string>::value;
-    };
+    template<class LocalT, class WireT>
+    struct KeyValueLogicalIntegerCodecBase {
+        typedef LocalT value_type;
+        typedef WireT wire_type;
 
-    template<class T, class Enable = void>
-    struct KeyValueLogicalCodec;
+        static_assert(KeyValueLogicalIntegerLocalSupported<LocalT>::value,
+                      "KeyValue logical integer codec requires a non-character integral local type up to 64 bits");
+        static_assert(std::is_integral<WireT>::value &&
+                      !std::is_same<WireT, bool>::value &&
+                      sizeof(WireT) <= 8,
+                      "KeyValue logical integer wire type must be an integer up to 64 bits");
 
-    template<class T>
-    struct KeyValueLogicalCodec<
-        T,
-        typename std::enable_if<
-            KeyValueLogicalFixedIntegralType<T>::value
-        >::type> {
-        static std::vector<std::uint8_t> encode(T value) {
-            static_assert(sizeof(T) <= 8,
-                          "KeyValue logical integral codec supports up to 64 bits");
-            std::uint64_t raw = 0;
-            if (std::numeric_limits<T>::is_signed) {
-                const std::int64_t signed_value =
-                    static_cast<std::int64_t>(value);
-                raw = static_cast<std::uint64_t>(signed_value);
-            } else {
-                raw = static_cast<std::uint64_t>(value);
-            }
-            std::vector<std::uint8_t> out(8);
-            for (int i = 7; i >= 0; --i) {
-                out[static_cast<std::size_t>(i)] =
-                    static_cast<std::uint8_t>(raw & 0xFFu);
-                raw >>= 8;
-            }
+        static std::vector<std::uint8_t> encode(LocalT value) {
+            const std::uint64_t raw = encode_raw(value);
+            std::vector<std::uint8_t> out;
+            ::mdbxc::sync::detail::append_u64_le(out, raw);
+            out.resize(sizeof(WireT));
             return out;
         }
 
-        static T decode(const std::vector<std::uint8_t>& bytes) {
-            if (bytes.size() != 8u) {
+        static LocalT decode(const std::vector<std::uint8_t>& bytes) {
+            if (bytes.size() != sizeof(WireT)) {
                 throw std::runtime_error(
-                    "KeyValue logical integral payload must be 8 bytes");
+                    "KeyValue logical integer payload has unexpected width");
             }
-            std::uint64_t raw = 0;
+            std::uint8_t storage[8] = {};
             for (std::size_t i = 0; i < bytes.size(); ++i) {
-                raw = (raw << 8) | bytes[i];
+                storage[i] = bytes[i];
             }
-            if (std::numeric_limits<T>::is_signed) {
+            const std::uint64_t raw =
+                ::mdbxc::sync::detail::read_u64_le(storage);
+            return decode_raw(raw);
+        }
+
+    private:
+        static std::uint64_t bit_mask() {
+            return sizeof(WireT) == 8u
+                ? (std::numeric_limits<std::uint64_t>::max)()
+                : ((static_cast<std::uint64_t>(1) <<
+                    (sizeof(WireT) * 8u)) - 1u);
+        }
+
+        static std::int64_t wire_min() {
+            if (!std::numeric_limits<WireT>::is_signed) {
+                return 0;
+            }
+            if (sizeof(WireT) == 8u) {
+                return (std::numeric_limits<std::int64_t>::min)();
+            }
+            return -static_cast<std::int64_t>(
+                static_cast<std::uint64_t>(1) <<
+                (sizeof(WireT) * 8u - 1u));
+        }
+
+        static std::uint64_t wire_unsigned_max() {
+            return bit_mask();
+        }
+
+        static std::int64_t wire_signed_max() {
+            if (sizeof(WireT) == 8u) {
+                return (std::numeric_limits<std::int64_t>::max)();
+            }
+            return static_cast<std::int64_t>(
+                (static_cast<std::uint64_t>(1) <<
+                 (sizeof(WireT) * 8u - 1u)) - 1u);
+        }
+
+        static std::uint64_t signed_raw(std::int64_t value) {
+            if (value >= 0) {
+                return static_cast<std::uint64_t>(value) & bit_mask();
+            }
+            std::uint64_t magnitude = 0;
+            if (value == (std::numeric_limits<std::int64_t>::min)()) {
+                magnitude = static_cast<std::uint64_t>(1) << 63u;
+            } else {
+                magnitude = static_cast<std::uint64_t>(-value);
+            }
+            return ((~magnitude) + 1u) & bit_mask();
+        }
+
+        static std::uint64_t encode_raw(LocalT value) {
+            if (std::numeric_limits<WireT>::is_signed) {
                 std::int64_t signed_value = 0;
-                if (raw <= static_cast<std::uint64_t>(
-                        std::numeric_limits<std::int64_t>::max())) {
-                    signed_value = static_cast<std::int64_t>(raw);
+                if (std::numeric_limits<LocalT>::is_signed) {
+                    signed_value = static_cast<std::int64_t>(value);
                 } else {
-                    const std::uint64_t magnitude = (~raw) + 1u;
-                    const std::uint64_t min_magnitude =
+                    const std::uint64_t unsigned_value =
+                        static_cast<std::uint64_t>(value);
+                    if (unsigned_value >
                         static_cast<std::uint64_t>(
-                            std::numeric_limits<std::int64_t>::max()) + 1u;
-                    if (magnitude == min_magnitude) {
-                        signed_value =
-                            (std::numeric_limits<std::int64_t>::min)();
-                    } else {
-                        signed_value =
-                            -static_cast<std::int64_t>(magnitude);
+                            (std::numeric_limits<std::int64_t>::max)())) {
+                        throw std::out_of_range(
+                            "KeyValue logical integer value exceeds signed wire range");
                     }
+                    signed_value = static_cast<std::int64_t>(unsigned_value);
                 }
-                if (signed_value <
-                        static_cast<std::int64_t>(
-                            (std::numeric_limits<T>::min)()) ||
-                    signed_value >
-                        static_cast<std::int64_t>(
-                            (std::numeric_limits<T>::max)())) {
+                if (signed_value < wire_min() ||
+                    signed_value > wire_signed_max()) {
                     throw std::out_of_range(
-                        "KeyValue logical integral payload is out of range");
+                        "KeyValue logical integer value is out of wire range");
                 }
-                return static_cast<T>(signed_value);
+                return signed_raw(signed_value);
             }
-            if (raw > static_cast<std::uint64_t>(
-                    (std::numeric_limits<T>::max)())) {
+            if (std::numeric_limits<LocalT>::is_signed && value < 0) {
                 throw std::out_of_range(
-                    "KeyValue logical unsigned payload is out of range");
+                    "KeyValue logical integer value is negative for unsigned wire");
             }
-            return static_cast<T>(raw);
+            const std::uint64_t unsigned_value =
+                static_cast<std::uint64_t>(value);
+            if (unsigned_value > wire_unsigned_max()) {
+                throw std::out_of_range(
+                    "KeyValue logical integer value is out of wire range");
+            }
+            return unsigned_value;
+        }
+
+        static std::int64_t decode_signed_raw(std::uint64_t raw) {
+            raw &= bit_mask();
+            const std::size_t bits = sizeof(WireT) * 8u;
+            const std::uint64_t sign_bit =
+                static_cast<std::uint64_t>(1) << (bits - 1u);
+            if ((raw & sign_bit) == 0u) {
+                return static_cast<std::int64_t>(raw);
+            }
+            const std::uint64_t magnitude = ((~raw) & bit_mask()) + 1u;
+            if (magnitude ==
+                (static_cast<std::uint64_t>(1) << 63u)) {
+                return (std::numeric_limits<std::int64_t>::min)();
+            }
+            return -static_cast<std::int64_t>(magnitude);
+        }
+
+        static LocalT decode_raw(std::uint64_t raw) {
+            if (std::numeric_limits<WireT>::is_signed) {
+                const std::int64_t signed_value = decode_signed_raw(raw);
+                if (std::numeric_limits<LocalT>::is_signed) {
+                    if (signed_value <
+                            static_cast<std::int64_t>(
+                                (std::numeric_limits<LocalT>::min)()) ||
+                        signed_value >
+                            static_cast<std::int64_t>(
+                                (std::numeric_limits<LocalT>::max)())) {
+                        throw std::out_of_range(
+                            "KeyValue logical integer payload is out of local range");
+                    }
+                    return static_cast<LocalT>(signed_value);
+                }
+                if (signed_value < 0) {
+                    throw std::out_of_range(
+                        "KeyValue logical integer payload is negative for unsigned local type");
+                }
+                const std::uint64_t unsigned_value =
+                    static_cast<std::uint64_t>(signed_value);
+                if (unsigned_value >
+                    static_cast<std::uint64_t>(
+                        (std::numeric_limits<LocalT>::max)())) {
+                    throw std::out_of_range(
+                        "KeyValue logical integer payload is out of local range");
+                }
+                return static_cast<LocalT>(unsigned_value);
+            }
+
+            if (std::numeric_limits<LocalT>::is_signed) {
+                if (raw >
+                    static_cast<std::uint64_t>(
+                        (std::numeric_limits<LocalT>::max)())) {
+                    throw std::out_of_range(
+                        "KeyValue logical integer payload is out of local range");
+                }
+                return static_cast<LocalT>(raw);
+            }
+            if (raw >
+                static_cast<std::uint64_t>(
+                    (std::numeric_limits<LocalT>::max)())) {
+                throw std::out_of_range(
+                    "KeyValue logical integer payload is out of local range");
+            }
+            return static_cast<LocalT>(raw);
         }
     };
 
-    template<>
-    struct KeyValueLogicalCodec<bool, void> {
+} // namespace detail
+
+    template<class LocalT>
+    struct KeyValueLogicalInt8Codec
+        : detail::KeyValueLogicalIntegerCodecBase<LocalT, std::int8_t> {};
+
+    template<class LocalT>
+    struct KeyValueLogicalUInt8Codec
+        : detail::KeyValueLogicalIntegerCodecBase<LocalT, std::uint8_t> {};
+
+    template<class LocalT>
+    struct KeyValueLogicalInt16Codec
+        : detail::KeyValueLogicalIntegerCodecBase<LocalT, std::int16_t> {};
+
+    template<class LocalT>
+    struct KeyValueLogicalUInt16Codec
+        : detail::KeyValueLogicalIntegerCodecBase<LocalT, std::uint16_t> {};
+
+    template<class LocalT>
+    struct KeyValueLogicalInt32Codec
+        : detail::KeyValueLogicalIntegerCodecBase<LocalT, std::int32_t> {};
+
+    template<class LocalT>
+    struct KeyValueLogicalUInt32Codec
+        : detail::KeyValueLogicalIntegerCodecBase<LocalT, std::uint32_t> {};
+
+    template<class LocalT>
+    struct KeyValueLogicalInt64Codec
+        : detail::KeyValueLogicalIntegerCodecBase<LocalT, std::int64_t> {};
+
+    template<class LocalT>
+    struct KeyValueLogicalUInt64Codec
+        : detail::KeyValueLogicalIntegerCodecBase<LocalT, std::uint64_t> {};
+
+    template<class LocalT>
+    struct KeyValueLogicalBoolCodec {
+        typedef LocalT value_type;
+        static_assert(std::is_same<
+                          typename std::remove_cv<LocalT>::type,
+                          bool>::value,
+                      "KeyValue logical bool codec requires bool local type");
+
         static std::vector<std::uint8_t> encode(bool value) {
             std::vector<std::uint8_t> out(1);
             out[0] = value ? 1u : 0u;
@@ -156,8 +287,14 @@ namespace detail {
         }
     };
 
-    template<>
-    struct KeyValueLogicalCodec<std::string, void> {
+    template<class LocalT>
+    struct KeyValueLogicalStringCodec {
+        typedef LocalT value_type;
+        static_assert(std::is_same<
+                          typename std::remove_cv<LocalT>::type,
+                          std::string>::value,
+                      "KeyValue logical string codec requires std::string local type");
+
         static std::vector<std::uint8_t> encode(const std::string& value) {
             return std::vector<std::uint8_t>(value.begin(), value.end());
         }
@@ -167,26 +304,29 @@ namespace detail {
         }
     };
 
-} // namespace detail
-
     /// \brief First concrete logical adapter for simple one-value-per-key tables.
     /// \details The payload format is adapter-owned and intentionally separate
-    /// from the raw DBI wire codec. The initial stable codec supports
-    /// \c std::string, \c bool, and fixed-width integral aliases up to 64 bits.
-    /// Plain character types are rejected; platform-sized source spellings such
-    /// as \c long and \c size_t should not be used for portable logical schemas.
+    /// from the raw DBI wire codec. The caller supplies explicit key/value
+    /// codec tags, so local C++ storage types such as \c long can be mapped to
+    /// a named logical wire type such as \c KeyValueLogicalInt64Codec<long>.
+    /// Codec tags are part of the logical schema contract; changing them
+    /// requires a new schema id, or an explicit schema-marker migration.
     /// Incoming logical apply suppresses local raw capture for the supplied
     /// transaction. It is used only when a caller explicitly invokes
     /// \c LogicalTableRegistry::preflight_then_apply().
-    template<class KeyT, class ValueT, class Options = DefaultTableOptions>
+    template<class KeyT, class ValueT,
+             class KeyCodec, class ValueCodec,
+             class Options = DefaultTableOptions>
     class KeyValueTableLogicalAdapter : public ILogicalTableAdapter {
     public:
         typedef KeyValueTable<KeyT, ValueT, Options> table_type;
 
-        static_assert(detail::KeyValueLogicalCodecSupported<KeyT>::value,
-                      "KeyValueTableLogicalAdapter key type is not supported by the stable logical codec");
-        static_assert(detail::KeyValueLogicalCodecSupported<ValueT>::value,
-                      "KeyValueTableLogicalAdapter value type is not supported by the stable logical codec");
+        static_assert(std::is_same<typename KeyCodec::value_type,
+                                   KeyT>::value,
+                      "KeyValueTableLogicalAdapter key codec local type must match KeyT");
+        static_assert(std::is_same<typename ValueCodec::value_type,
+                                   ValueT>::value,
+                      "KeyValueTableLogicalAdapter value codec local type must match ValueT");
 
         KeyValueTableLogicalAdapter(table_type& table,
                                     const std::string& schema_id,
@@ -354,7 +494,7 @@ namespace detail {
                                     std::vector<std::uint8_t>& out) {
             out.clear();
             const std::vector<std::uint8_t> encoded_key =
-                detail::KeyValueLogicalCodec<KeyT>::encode(key);
+                KeyCodec::encode(key);
             append_blob(out, encoded_key);
         }
 
@@ -363,9 +503,9 @@ namespace detail {
                                   std::vector<std::uint8_t>& out) {
             out.clear();
             const std::vector<std::uint8_t> encoded_key =
-                detail::KeyValueLogicalCodec<KeyT>::encode(key);
+                KeyCodec::encode(key);
             const std::vector<std::uint8_t> encoded_value =
-                detail::KeyValueLogicalCodec<ValueT>::encode(value);
+                ValueCodec::encode(value);
             append_blob(out, encoded_key);
             append_blob(out, encoded_value);
         }
@@ -375,7 +515,7 @@ namespace detail {
             PayloadCursor cursor = make_cursor(payload);
             const std::vector<std::uint8_t> encoded_key = read_blob(cursor);
             ensure_end(cursor);
-            return detail::KeyValueLogicalCodec<KeyT>::decode(encoded_key);
+            return KeyCodec::decode(encoded_key);
         }
 
         static std::pair<KeyT, ValueT> decode_upsert(
@@ -385,8 +525,8 @@ namespace detail {
             const std::vector<std::uint8_t> encoded_value = read_blob(cursor);
             ensure_end(cursor);
             return std::make_pair(
-                detail::KeyValueLogicalCodec<KeyT>::decode(encoded_key),
-                detail::KeyValueLogicalCodec<ValueT>::decode(encoded_value));
+                KeyCodec::decode(encoded_key),
+                ValueCodec::decode(encoded_value));
         }
 
         LogicalApplyResult validate_payload(

--- a/include/mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp
@@ -1,0 +1,288 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_ADAPTERS_KEY_VALUE_TABLE_LOGICAL_ADAPTER_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_ADAPTERS_KEY_VALUE_TABLE_LOGICAL_ADAPTER_HPP_INCLUDED
+
+/// \file KeyValueTableLogicalAdapter.hpp
+/// \brief Minimal logical adapter for \c KeyValueTable.
+
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "../../KeyValueTable.hpp"
+#include "../LogicalTableAdapter.hpp"
+#include "../common.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Opcodes understood by \c KeyValueTableLogicalAdapter.
+    enum KeyValueTableLogicalOpcode {
+        KeyValueLogicalUpsert = 1,
+        KeyValueLogicalDelete = 2,
+        KeyValueLogicalClear  = 3
+    };
+
+    /// \brief First concrete logical adapter for simple one-value-per-key tables.
+    /// \details The payload format is adapter-owned and intentionally separate
+    /// from the raw DBI wire codec. It is used only when a caller explicitly
+    /// invokes \c LogicalTableRegistry::preflight_then_apply().
+    template<class KeyT, class ValueT, class Options = DefaultTableOptions>
+    class KeyValueTableLogicalAdapter : public ILogicalTableAdapter {
+    public:
+        typedef KeyValueTable<KeyT, ValueT, Options> table_type;
+
+        KeyValueTableLogicalAdapter(table_type& table,
+                                    const std::string& schema_id,
+                                    const std::string& dbi_name,
+                                    std::uint32_t schema_version = 1)
+            : m_table(table),
+              m_schema_id(schema_id),
+              m_dbi_name(dbi_name),
+              m_schema_version(schema_version) {
+            if (m_schema_id.empty()) {
+                throw std::invalid_argument(
+                    "KeyValueTableLogicalAdapter schema id is empty");
+            }
+            if (m_dbi_name.empty()) {
+                throw std::invalid_argument(
+                    "KeyValueTableLogicalAdapter DBI name is empty");
+            }
+            if (m_schema_version == 0) {
+                throw std::invalid_argument(
+                    "KeyValueTableLogicalAdapter schema version is zero");
+            }
+        }
+
+        LogicalSchemaRef schema_ref() const override {
+            LogicalSchemaRef ref;
+            ref.schema_id = m_schema_id;
+            ref.kind = LogicalTableKind::KeyValue;
+            ref.schema_version = m_schema_version;
+            return ref;
+        }
+
+        std::vector<std::string> affected_dbis() const override {
+            std::vector<std::string> out;
+            out.push_back(m_dbi_name);
+            return out;
+        }
+
+        LogicalChange make_upsert(const KeyT& key, const ValueT& value) const {
+            LogicalChange change;
+            change.schema = schema_ref();
+            change.opcode = KeyValueLogicalUpsert;
+            encode_upsert(key, value, change.payload);
+            return change;
+        }
+
+        LogicalChange make_delete(const KeyT& key) const {
+            LogicalChange change;
+            change.schema = schema_ref();
+            change.opcode = KeyValueLogicalDelete;
+            encode_key_only(key, change.payload);
+            return change;
+        }
+
+        LogicalChange make_clear() const {
+            LogicalChange change;
+            change.schema = schema_ref();
+            change.opcode = KeyValueLogicalClear;
+            return change;
+        }
+
+        LogicalApplyResult preflight(
+                MDBX_txn* txn,
+                const LogicalChange& change) const override {
+            (void)txn;
+            return validate_payload(change);
+        }
+
+        LogicalApplyResult apply(
+                MDBX_txn* txn,
+                const LogicalChange& change) override {
+            const LogicalApplyResult validation = validate_payload(change);
+            if (!validation.ok) return validation;
+
+            try {
+                if (change.opcode == KeyValueLogicalUpsert) {
+                    KeyT key;
+                    ValueT value;
+                    decode_upsert(change.payload, key, value);
+                    m_table.insert_or_assign(key, value, txn);
+                    return LogicalApplyResult::success();
+                }
+                if (change.opcode == KeyValueLogicalDelete) {
+                    KeyT key;
+                    decode_key_only(change.payload, key);
+                    (void)m_table.erase(key, txn);
+                    return LogicalApplyResult::success();
+                }
+                if (change.opcode == KeyValueLogicalClear) {
+                    m_table.clear(txn);
+                    return LogicalApplyResult::success();
+                }
+            } catch (const std::exception& e) {
+                return LogicalApplyResult::failure(
+                    std::string("KeyValue logical adapter apply failed: ") +
+                    e.what());
+            } catch (...) {
+                return LogicalApplyResult::failure(
+                    "KeyValue logical adapter apply failed");
+            }
+            return LogicalApplyResult::failure(
+                "KeyValue logical adapter opcode is unsupported");
+        }
+
+    private:
+        struct PayloadCursor {
+            const std::uint8_t* data;
+            std::size_t size;
+            std::size_t pos;
+        };
+
+        static void require(PayloadCursor& cursor, std::size_t size) {
+            if (cursor.pos > cursor.size ||
+                size > cursor.size - cursor.pos) {
+                throw std::runtime_error(
+                    "KeyValue logical payload underrun");
+            }
+        }
+
+        static void append_blob(std::vector<std::uint8_t>& out,
+                                const MDBX_val& value) {
+            if (value.iov_len >
+                static_cast<std::size_t>(
+                    std::numeric_limits<std::uint32_t>::max())) {
+                throw std::length_error(
+                    "KeyValue logical payload blob is too large");
+            }
+            detail::append_u32_le(out,
+                static_cast<std::uint32_t>(value.iov_len));
+            if (value.iov_len == 0) {
+                return;
+            }
+            const std::uint8_t* bytes =
+                static_cast<const std::uint8_t*>(value.iov_base);
+            out.insert(out.end(), bytes, bytes + value.iov_len);
+        }
+
+        static MDBX_val read_blob(PayloadCursor& cursor) {
+            require(cursor, 4);
+            const std::uint32_t size =
+                detail::read_u32_le(cursor.data + cursor.pos);
+            cursor.pos += 4;
+            require(cursor, size);
+            MDBX_val out = {
+                size == 0 ? nullptr :
+                    const_cast<std::uint8_t*>(cursor.data + cursor.pos),
+                size
+            };
+            cursor.pos += size;
+            return out;
+        }
+
+        static PayloadCursor make_cursor(
+                const std::vector<std::uint8_t>& payload) {
+            PayloadCursor cursor = {
+                payload.empty() ? nullptr : &payload[0],
+                payload.size(),
+                0
+            };
+            return cursor;
+        }
+
+        static void ensure_end(const PayloadCursor& cursor) {
+            if (cursor.pos != cursor.size) {
+                throw std::runtime_error(
+                    "KeyValue logical payload has trailing bytes");
+            }
+        }
+
+        static void encode_key_only(const KeyT& key,
+                                    std::vector<std::uint8_t>& out) {
+            SerializeScratch key_scratch;
+            out.clear();
+            const MDBX_val encoded_key =
+                serialize_key<Options::safe_integer_key>(key, key_scratch);
+            append_blob(out, encoded_key);
+        }
+
+        static void encode_upsert(const KeyT& key,
+                                  const ValueT& value,
+                                  std::vector<std::uint8_t>& out) {
+            SerializeScratch key_scratch;
+            SerializeScratch value_scratch;
+            out.clear();
+            const MDBX_val encoded_key =
+                serialize_key<Options::safe_integer_key>(key, key_scratch);
+            const MDBX_val encoded_value =
+                serialize_value(value, value_scratch);
+            append_blob(out, encoded_key);
+            append_blob(out, encoded_value);
+        }
+
+        static void decode_key_only(const std::vector<std::uint8_t>& payload,
+                                    KeyT& key) {
+            PayloadCursor cursor = make_cursor(payload);
+            const MDBX_val encoded_key = read_blob(cursor);
+            ensure_end(cursor);
+            key = deserialize_key<KeyT>(encoded_key);
+        }
+
+        static void decode_upsert(const std::vector<std::uint8_t>& payload,
+                                  KeyT& key,
+                                  ValueT& value) {
+            PayloadCursor cursor = make_cursor(payload);
+            const MDBX_val encoded_key = read_blob(cursor);
+            const MDBX_val encoded_value = read_blob(cursor);
+            ensure_end(cursor);
+            key = deserialize_key<KeyT>(encoded_key);
+            value = deserialize_value<ValueT>(encoded_value);
+        }
+
+        LogicalApplyResult validate_payload(
+                const LogicalChange& change) const {
+            try {
+                if (change.opcode == KeyValueLogicalUpsert) {
+                    KeyT key;
+                    ValueT value;
+                    decode_upsert(change.payload, key, value);
+                    return LogicalApplyResult::success();
+                }
+                if (change.opcode == KeyValueLogicalDelete) {
+                    KeyT key;
+                    decode_key_only(change.payload, key);
+                    return LogicalApplyResult::success();
+                }
+                if (change.opcode == KeyValueLogicalClear) {
+                    if (!change.payload.empty()) {
+                        return LogicalApplyResult::failure(
+                            "KeyValue clear payload must be empty");
+                    }
+                    return LogicalApplyResult::success();
+                }
+            } catch (const std::exception& e) {
+                return LogicalApplyResult::failure(
+                    std::string("KeyValue logical payload is invalid: ") +
+                    e.what());
+            } catch (...) {
+                return LogicalApplyResult::failure(
+                    "KeyValue logical payload is invalid");
+            }
+            return LogicalApplyResult::failure(
+                "KeyValue logical adapter opcode is unsupported");
+        }
+
+        table_type& m_table;
+        std::string m_schema_id;
+        std::string m_dbi_name;
+        std::uint32_t m_schema_version;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_ADAPTERS_KEY_VALUE_TABLE_LOGICAL_ADAPTER_HPP_INCLUDED

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -11,24 +11,29 @@
 
 namespace {
 
-static_assert(mdbxc::sync::detail::KeyValueLogicalCodecSupported<
+typedef mdbxc::sync::KeyValueLogicalInt32Codec<int> IntKeyCodec;
+typedef mdbxc::sync::KeyValueLogicalStringCodec<std::string> StringValueCodec;
+typedef mdbxc::sync::KeyValueTableLogicalAdapter<
+    int, std::string, IntKeyCodec, StringValueCodec> IntStringAdapter;
+
+static_assert(mdbxc::sync::detail::KeyValueLogicalIntegerLocalSupported<
                   std::int32_t>::value,
-              "int32_t must be supported by KeyValue logical codec");
-static_assert(mdbxc::sync::detail::KeyValueLogicalCodecSupported<
-                  std::uint64_t>::value,
-              "uint64_t must be supported by KeyValue logical codec");
-static_assert(!mdbxc::sync::detail::KeyValueLogicalCodecSupported<
+              "int32_t local type must be supported by integer codec");
+static_assert(mdbxc::sync::detail::KeyValueLogicalIntegerLocalSupported<
+                  long>::value,
+              "long can be used only with an explicit integer codec tag");
+static_assert(!mdbxc::sync::detail::KeyValueLogicalIntegerLocalSupported<
                   char>::value,
-              "plain char must not be supported by KeyValue logical codec");
-static_assert(!mdbxc::sync::detail::KeyValueLogicalCodecSupported<
+              "plain char must not be supported by integer codec");
+static_assert(!mdbxc::sync::detail::KeyValueLogicalIntegerLocalSupported<
                   wchar_t>::value,
-              "wchar_t must not be supported by KeyValue logical codec");
-static_assert(!mdbxc::sync::detail::KeyValueLogicalCodecSupported<
+              "wchar_t must not be supported by integer codec");
+static_assert(!mdbxc::sync::detail::KeyValueLogicalIntegerLocalSupported<
                   char16_t>::value,
-              "char16_t must not be supported by KeyValue logical codec");
-static_assert(!mdbxc::sync::detail::KeyValueLogicalCodecSupported<
+              "char16_t must not be supported by integer codec");
+static_assert(!mdbxc::sync::detail::KeyValueLogicalIntegerLocalSupported<
                   char32_t>::value,
-              "char32_t must not be supported by KeyValue logical codec");
+              "char32_t must not be supported by integer codec");
 
 void cleanup(const std::string& p) {
     std::remove(p.c_str());
@@ -68,8 +73,7 @@ void test_key_value_logical_adapter_applies_basic_ops() {
                                    make_record(dbi_name));
 
     mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
-    mdbxc::sync::KeyValueTableLogicalAdapter<int, std::string> adapter(
-        table, "app.logical_kv.v1");
+    IntStringAdapter adapter(table, "app.logical_kv.v1");
     MDBXC_TEST_ASSERT(adapter.affected_dbis().size() == 1u);
     MDBXC_TEST_ASSERT(adapter.affected_dbis()[0] == dbi_name);
     mdbxc::sync::LogicalTableRegistry registry;
@@ -127,8 +131,7 @@ void test_key_value_logical_adapter_rejects_malformed_payload() {
     std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
 
     mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
-    mdbxc::sync::KeyValueTableLogicalAdapter<int, std::string> adapter(
-        table, "app.logical_kv_malformed.v1");
+    IntStringAdapter adapter(table, "app.logical_kv_malformed.v1");
     mdbxc::sync::LogicalTableRegistry registry;
     registry.register_adapter(&adapter);
 
@@ -165,14 +168,12 @@ void test_key_value_logical_adapter_uses_stable_payload() {
     std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
 
     mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
-    mdbxc::sync::KeyValueTableLogicalAdapter<int, std::string> adapter(
-        table, "app.logical_kv_payload.v1");
+    IntStringAdapter adapter(table, "app.logical_kv_payload.v1");
 
     const mdbxc::sync::LogicalChange change =
         adapter.make_upsert(-1, "one");
     const std::uint8_t expected_raw[] = {
-        8, 0, 0, 0,
-        0xFF, 0xFF, 0xFF, 0xFF,
+        4, 0, 0, 0,
         0xFF, 0xFF, 0xFF, 0xFF,
         3, 0, 0, 0,
         static_cast<std::uint8_t>('o'),
@@ -186,17 +187,22 @@ void test_key_value_logical_adapter_uses_stable_payload() {
 
     mdbxc::KeyValueTable<std::int32_t, std::uint64_t> fixed_table(
         conn, "logical_key_value_payload_fixed");
-    mdbxc::sync::KeyValueTableLogicalAdapter<
-        std::int32_t, std::uint64_t> fixed_adapter(
-            fixed_table, "app.logical_kv_payload_fixed.v1");
+    typedef mdbxc::sync::KeyValueLogicalInt32Codec<std::int32_t>
+        FixedInt32Codec;
+    typedef mdbxc::sync::KeyValueLogicalUInt64Codec<std::uint64_t>
+        FixedUInt64Codec;
+    typedef mdbxc::sync::KeyValueTableLogicalAdapter<
+        std::int32_t, std::uint64_t,
+        FixedInt32Codec, FixedUInt64Codec> FixedAdapter;
+    FixedAdapter fixed_adapter(
+        fixed_table, "app.logical_kv_payload_fixed.v1");
     const mdbxc::sync::LogicalChange fixed_change =
         fixed_adapter.make_upsert(
             (std::numeric_limits<std::int32_t>::min)(),
             (std::numeric_limits<std::uint64_t>::max)());
     const std::uint8_t expected_fixed_raw[] = {
-        8, 0, 0, 0,
-        0xFF, 0xFF, 0xFF, 0xFF,
-        0x80, 0x00, 0x00, 0x00,
+        4, 0, 0, 0,
+        0x00, 0x00, 0x00, 0x80,
         8, 0, 0, 0,
         0xFF, 0xFF, 0xFF, 0xFF,
         0xFF, 0xFF, 0xFF, 0xFF
@@ -206,6 +212,86 @@ void test_key_value_logical_adapter_uses_stable_payload() {
         expected_fixed_raw + sizeof(expected_fixed_raw) /
             sizeof(expected_fixed_raw[0]));
     MDBXC_TEST_ASSERT(fixed_change.payload == expected_fixed);
+
+    mdbxc::KeyValueTable<long, std::string> long_table(
+        conn, "logical_key_value_payload_long");
+    typedef mdbxc::sync::KeyValueLogicalInt64Codec<long> LongInt64Codec;
+    typedef mdbxc::sync::KeyValueTableLogicalAdapter<
+        long, std::string, LongInt64Codec, StringValueCodec> LongAdapter;
+    LongAdapter long_adapter(
+        long_table, "app.logical_kv_payload_long.v1");
+    const mdbxc::sync::LogicalChange long_change =
+        long_adapter.make_upsert(42L, "forty-two");
+    const std::uint8_t expected_long_raw[] = {
+        8, 0, 0, 0,
+        42, 0, 0, 0, 0, 0, 0, 0,
+        9, 0, 0, 0,
+        static_cast<std::uint8_t>('f'),
+        static_cast<std::uint8_t>('o'),
+        static_cast<std::uint8_t>('r'),
+        static_cast<std::uint8_t>('t'),
+        static_cast<std::uint8_t>('y'),
+        static_cast<std::uint8_t>('-'),
+        static_cast<std::uint8_t>('t'),
+        static_cast<std::uint8_t>('w'),
+        static_cast<std::uint8_t>('o')
+    };
+    const std::vector<std::uint8_t> expected_long(
+        expected_long_raw,
+        expected_long_raw + sizeof(expected_long_raw) /
+            sizeof(expected_long_raw[0]));
+    MDBXC_TEST_ASSERT(long_change.payload == expected_long);
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_value_logical_adapter_decodes_literal_little_endian_payload() {
+    const std::string path = "test_key_value_logical_adapter_literal.mdbx";
+    const std::string dbi_name = "logical_key_value_literal";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    IntStringAdapter adapter(table, "app.logical_kv_literal.v1");
+    mdbxc::sync::LogicalTableRegistry registry;
+    registry.register_adapter(&adapter);
+
+    mdbxc::sync::LogicalChange literal;
+    literal.schema = adapter.schema_ref();
+    literal.opcode = mdbxc::sync::KeyValueLogicalUpsert;
+    const std::uint8_t literal_payload[] = {
+        4, 0, 0, 0,
+        1, 0, 0, 0,
+        3, 0, 0, 0,
+        static_cast<std::uint8_t>('u'),
+        static_cast<std::uint8_t>('n'),
+        static_cast<std::uint8_t>('o')
+    };
+    literal.payload.assign(
+        literal_payload,
+        literal_payload + sizeof(literal_payload) /
+            sizeof(literal_payload[0]));
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        std::vector<mdbxc::sync::LogicalChange> changes;
+        changes.push_back(literal);
+        const mdbxc::sync::LogicalApplyResult result =
+            registry.preflight_then_apply(txn.handle(), changes);
+        MDBXC_TEST_ASSERT(result.ok);
+        txn.commit();
+    }
+
+    const std::pair<bool, std::string> found = table.find_compat(1);
+    MDBXC_TEST_ASSERT(found.first);
+    MDBXC_TEST_ASSERT(found.second == "uno");
 
     conn->disconnect();
     cleanup(path);
@@ -227,8 +313,7 @@ void test_key_value_logical_apply_does_not_recapture_incoming_change() {
     engine.initialize_local_identity(node, make_node(0x55));
 
     mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
-    mdbxc::sync::KeyValueTableLogicalAdapter<int, std::string> adapter(
-        table, "app.logical_kv_capture.v1");
+    IntStringAdapter adapter(table, "app.logical_kv_capture.v1");
     mdbxc::sync::LogicalTableRegistry registry;
     registry.register_adapter(&adapter);
 
@@ -279,6 +364,7 @@ int main() {
     test_key_value_logical_adapter_applies_basic_ops();
     test_key_value_logical_adapter_rejects_malformed_payload();
     test_key_value_logical_adapter_uses_stable_payload();
+    test_key_value_logical_adapter_decodes_literal_little_endian_payload();
     test_key_value_logical_apply_does_not_recapture_incoming_change();
     return 0;
 }

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -4,11 +4,31 @@
 
 #include <cstdio>
 #include <cstdint>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 namespace {
+
+static_assert(mdbxc::sync::detail::KeyValueLogicalCodecSupported<
+                  std::int32_t>::value,
+              "int32_t must be supported by KeyValue logical codec");
+static_assert(mdbxc::sync::detail::KeyValueLogicalCodecSupported<
+                  std::uint64_t>::value,
+              "uint64_t must be supported by KeyValue logical codec");
+static_assert(!mdbxc::sync::detail::KeyValueLogicalCodecSupported<
+                  char>::value,
+              "plain char must not be supported by KeyValue logical codec");
+static_assert(!mdbxc::sync::detail::KeyValueLogicalCodecSupported<
+                  wchar_t>::value,
+              "wchar_t must not be supported by KeyValue logical codec");
+static_assert(!mdbxc::sync::detail::KeyValueLogicalCodecSupported<
+                  char16_t>::value,
+              "char16_t must not be supported by KeyValue logical codec");
+static_assert(!mdbxc::sync::detail::KeyValueLogicalCodecSupported<
+                  char32_t>::value,
+              "char32_t must not be supported by KeyValue logical codec");
 
 void cleanup(const std::string& p) {
     std::remove(p.c_str());
@@ -163,6 +183,29 @@ void test_key_value_logical_adapter_uses_stable_payload() {
         expected_raw,
         expected_raw + sizeof(expected_raw) / sizeof(expected_raw[0]));
     MDBXC_TEST_ASSERT(change.payload == expected);
+
+    mdbxc::KeyValueTable<std::int32_t, std::uint64_t> fixed_table(
+        conn, "logical_key_value_payload_fixed");
+    mdbxc::sync::KeyValueTableLogicalAdapter<
+        std::int32_t, std::uint64_t> fixed_adapter(
+            fixed_table, "app.logical_kv_payload_fixed.v1");
+    const mdbxc::sync::LogicalChange fixed_change =
+        fixed_adapter.make_upsert(
+            (std::numeric_limits<std::int32_t>::min)(),
+            (std::numeric_limits<std::uint64_t>::max)());
+    const std::uint8_t expected_fixed_raw[] = {
+        8, 0, 0, 0,
+        0xFF, 0xFF, 0xFF, 0xFF,
+        0x80, 0x00, 0x00, 0x00,
+        8, 0, 0, 0,
+        0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF
+    };
+    const std::vector<std::uint8_t> expected_fixed(
+        expected_fixed_raw,
+        expected_fixed_raw + sizeof(expected_fixed_raw) /
+            sizeof(expected_fixed_raw[0]));
+    MDBXC_TEST_ASSERT(fixed_change.payload == expected_fixed);
 
     conn->disconnect();
     cleanup(path);

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -1,0 +1,139 @@
+#include <mdbx_containers/sync.hpp>
+
+#include "test_assert.hpp"
+
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+void cleanup(const std::string& p) {
+    std::remove(p.c_str());
+}
+
+mdbxc::sync::NodeId make_node(std::uint8_t seed) {
+    mdbxc::sync::NodeId n{};
+    for (int i = 0; i < 16; ++i) {
+        n[i] = static_cast<std::uint8_t>(seed + i);
+    }
+    return n;
+}
+
+mdbxc::sync::LogicalSchemaRecord make_record(const std::string& dbi_name) {
+    mdbxc::sync::LogicalSchemaRecord record;
+    record.dbi_name = dbi_name;
+    record.kind = mdbxc::sync::LogicalTableKind::KeyValue;
+    record.schema_version = 1;
+    record.dbi_names.push_back(dbi_name);
+    return record;
+}
+
+void test_key_value_logical_adapter_applies_basic_ops() {
+    const std::string path = "test_key_value_logical_adapter_basic.mdbx";
+    const std::string dbi_name = "logical_key_value_items";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x10), make_node(0xA0));
+    engine.register_logical_schema("app.logical_kv.v1",
+                                   make_record(dbi_name));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    mdbxc::sync::KeyValueTableLogicalAdapter<int, std::string> adapter(
+        table, "app.logical_kv.v1", dbi_name);
+    mdbxc::sync::LogicalTableRegistry registry;
+    registry.register_adapter(&adapter);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(adapter.make_upsert(1, "one"));
+    changes.push_back(adapter.make_upsert(2, "two"));
+    changes.push_back(adapter.make_upsert(3, ""));
+    changes.push_back(adapter.make_delete(1));
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        const mdbxc::sync::LogicalApplyResult result =
+            registry.preflight_then_apply(txn.handle(), changes);
+        MDBXC_TEST_ASSERT(result.ok);
+        txn.commit();
+    }
+
+    MDBXC_TEST_ASSERT(!table.contains(1));
+    const std::pair<bool, std::string> found = table.find_compat(2);
+    MDBXC_TEST_ASSERT(found.first);
+    MDBXC_TEST_ASSERT(found.second == "two");
+    const std::pair<bool, std::string> empty_found = table.find_compat(3);
+    MDBXC_TEST_ASSERT(empty_found.first);
+    MDBXC_TEST_ASSERT(empty_found.second.empty());
+    MDBXC_TEST_ASSERT(table.count() == 2u);
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        std::vector<mdbxc::sync::LogicalChange> clear_changes;
+        clear_changes.push_back(adapter.make_clear());
+        const mdbxc::sync::LogicalApplyResult result =
+            registry.preflight_then_apply(txn.handle(), clear_changes);
+        MDBXC_TEST_ASSERT(result.ok);
+        txn.commit();
+    }
+    MDBXC_TEST_ASSERT(table.count() == 0u);
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_value_logical_adapter_rejects_malformed_payload() {
+    const std::string path = "test_key_value_logical_adapter_malformed.mdbx";
+    const std::string dbi_name = "logical_key_value_malformed";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    mdbxc::sync::KeyValueTableLogicalAdapter<int, std::string> adapter(
+        table, "app.logical_kv_malformed.v1", dbi_name);
+    mdbxc::sync::LogicalTableRegistry registry;
+    registry.register_adapter(&adapter);
+
+    mdbxc::sync::LogicalChange malformed = adapter.make_upsert(7, "seven");
+    malformed.payload.pop_back();
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        std::vector<mdbxc::sync::LogicalChange> changes;
+        changes.push_back(malformed);
+        const mdbxc::sync::LogicalApplyResult result =
+            registry.preflight_then_apply(txn.handle(), changes);
+        MDBXC_TEST_ASSERT(!result.ok);
+        MDBXC_TEST_ASSERT(result.error.find("payload") != std::string::npos);
+        txn.rollback();
+    }
+
+    MDBXC_TEST_ASSERT(table.count() == 0u);
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+} // namespace
+
+int main() {
+    test_key_value_logical_adapter_applies_basic_ops();
+    test_key_value_logical_adapter_rejects_malformed_payload();
+    return 0;
+}

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -3,6 +3,7 @@
 #include "test_assert.hpp"
 
 #include <cstdio>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -48,7 +49,9 @@ void test_key_value_logical_adapter_applies_basic_ops() {
 
     mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
     mdbxc::sync::KeyValueTableLogicalAdapter<int, std::string> adapter(
-        table, "app.logical_kv.v1", dbi_name);
+        table, "app.logical_kv.v1");
+    MDBXC_TEST_ASSERT(adapter.affected_dbis().size() == 1u);
+    MDBXC_TEST_ASSERT(adapter.affected_dbis()[0] == dbi_name);
     mdbxc::sync::LogicalTableRegistry registry;
     registry.register_adapter(&adapter);
 
@@ -105,7 +108,7 @@ void test_key_value_logical_adapter_rejects_malformed_payload() {
 
     mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
     mdbxc::sync::KeyValueTableLogicalAdapter<int, std::string> adapter(
-        table, "app.logical_kv_malformed.v1", dbi_name);
+        table, "app.logical_kv_malformed.v1");
     mdbxc::sync::LogicalTableRegistry registry;
     registry.register_adapter(&adapter);
 
@@ -130,10 +133,109 @@ void test_key_value_logical_adapter_rejects_malformed_payload() {
     cleanup(path);
 }
 
+void test_key_value_logical_adapter_uses_stable_payload() {
+    const std::string path = "test_key_value_logical_adapter_payload.mdbx";
+    const std::string dbi_name = "logical_key_value_payload";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    mdbxc::sync::KeyValueTableLogicalAdapter<int, std::string> adapter(
+        table, "app.logical_kv_payload.v1");
+
+    const mdbxc::sync::LogicalChange change =
+        adapter.make_upsert(-1, "one");
+    const std::uint8_t expected_raw[] = {
+        8, 0, 0, 0,
+        0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF,
+        3, 0, 0, 0,
+        static_cast<std::uint8_t>('o'),
+        static_cast<std::uint8_t>('n'),
+        static_cast<std::uint8_t>('e')
+    };
+    const std::vector<std::uint8_t> expected(
+        expected_raw,
+        expected_raw + sizeof(expected_raw) / sizeof(expected_raw[0]));
+    MDBXC_TEST_ASSERT(change.payload == expected);
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_value_logical_apply_does_not_recapture_incoming_change() {
+    const std::string path = "test_key_value_logical_adapter_capture.mdbx";
+    const std::string dbi_name = "logical_key_value_capture";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId node = make_node(0x44);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(node, make_node(0x55));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    mdbxc::sync::KeyValueTableLogicalAdapter<int, std::string> adapter(
+        table, "app.logical_kv_capture.v1");
+    mdbxc::sync::LogicalTableRegistry registry;
+    registry.register_adapter(&adapter);
+
+    mdbxc::sync::ThreadLocalChangeAccumulator capture(conn);
+    conn->attach_sync_capture(&capture);
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        std::vector<mdbxc::sync::LogicalChange> changes;
+        changes.push_back(adapter.make_upsert(10, "ten"));
+        const mdbxc::sync::LogicalApplyResult result =
+            registry.preflight_then_apply(txn.handle(), changes);
+        MDBXC_TEST_ASSERT(result.ok);
+        txn.commit();
+    }
+
+    table.insert_or_assign(11, "eleven");
+    conn->detach_sync_capture();
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        mdbxc::sync::ChangeLogStore changelog(conn->env_handle());
+        changelog.open(txn.handle());
+        std::vector<std::uint8_t> raw;
+        MDBXC_TEST_ASSERT(changelog.get(txn.handle(), node, 1, raw));
+        MDBXC_TEST_ASSERT(!changelog.contains(txn.handle(), node, 2));
+        const mdbxc::sync::ChangeBatch batch =
+            mdbxc::sync::ChangeBatchCodec::decode(raw);
+        MDBXC_TEST_ASSERT(batch.ops.size() == 1u);
+        MDBXC_TEST_ASSERT(batch.ops[0].dbi_name == dbi_name);
+        const std::string captured_value(
+            batch.ops[0].value.begin(), batch.ops[0].value.end());
+        MDBXC_TEST_ASSERT(captured_value == "eleven");
+    }
+
+    const std::pair<bool, std::string> logical_found = table.find_compat(10);
+    MDBXC_TEST_ASSERT(logical_found.first);
+    MDBXC_TEST_ASSERT(logical_found.second == "ten");
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 } // namespace
 
 int main() {
     test_key_value_logical_adapter_applies_basic_ops();
     test_key_value_logical_adapter_rejects_malformed_payload();
+    test_key_value_logical_adapter_uses_stable_payload();
+    test_key_value_logical_apply_does_not_recapture_incoming_change();
     return 0;
 }

--- a/tests/test_sync_stores.cpp
+++ b/tests/test_sync_stores.cpp
@@ -770,6 +770,42 @@ void test_schema_registry_store() {
         }
     }
 
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        SchemaRegistryStore store(conn->env_handle());
+        LogicalSchemaRecord bumped = ordered;
+        bumped.schema_version = 2;
+        bool caught = false;
+        try {
+            store.register_or_verify(txn.handle(), "app.events.v1", bumped);
+        } catch (const std::runtime_error&) {
+            caught = true;
+        }
+        if (!caught) {
+            throw std::runtime_error(
+                "schema registry accepted version change under existing id");
+        }
+
+        store.register_or_verify(txn.handle(), "app.events.v2", bumped);
+        txn.commit();
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        SchemaRegistryStore store(conn->env_handle());
+        LogicalSchemaRecord v1;
+        LogicalSchemaRecord v2;
+        if (!store.get(txn.handle(), "app.events.v1", v1) ||
+            !store.get(txn.handle(), "app.events.v2", v2)) {
+            throw std::runtime_error(
+                "schema registry versioned ids were not preserved");
+        }
+        if (v1.schema_version != 1u || v2.schema_version != 2u) {
+            throw std::runtime_error(
+                "schema registry versioned id records mismatch");
+        }
+    }
+
     conn->disconnect();
     cleanup(p);
 }


### PR DESCRIPTION
## Summary
- add KeyValueTableLogicalAdapter as the first concrete logical adapter helper
- add KeyValue logical table kind and expose the adapter through sync umbrella and standalone header smoke
- cover typed upsert/delete/clear plus fail-closed malformed payload handling

## Validation
- ctest --test-dir tmp/build-pr193-cpp17 -R ^(test_key_value_logical_adapter|header_sync_umbrella_test|header_standalone_mdbx_containers_sync_adapters_KeyValueTableLogicalAdapter_hpp)$ --output-on-failure
- ctest --test-dir tmp/build-pr193-cpp11 -R ^(test_key_value_logical_adapter|header_sync_umbrella_test|header_standalone_mdbx_containers_sync_adapters_KeyValueTableLogicalAdapter_hpp)$ --output-on-failure
- git diff --check