### PR TITLE
feat(sync): add logical schema marker migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
   versions, and canonical sorted unique owned DBI names without enabling
   logical replication yet. `SyncEngine::register_logical_schema()` is the
   normal committed setup entry point for application schema markers.
+  `SyncEngine::migrate_logical_schema()` provides an explicit exact-preflight
+  marker replacement lifecycle without migrating user data or old changelog
+  entries.
 - Added public `ChangeDomain`, `LogicalSchemaRef`, and `LogicalChange` model
   types for future logical table adapters. The current wire codec remains
   raw-DBI only.

--- a/README-RU.md
+++ b/README-RU.md
@@ -107,19 +107,20 @@
   Caller-created raw read-only transactions остаются допустимыми для
   read/search snapshot operations. Любое исключение из capture recording или
   flush делает transaction rollback-only; повторный `commit()` отклоняется.
-- `SyncEngine` предоставляет pull/push/apply primitives и
-  `register_logical_schema()` для committed setup logical schema markers.
+- `SyncEngine` предоставляет pull/push/apply primitives,
+  `register_logical_schema()` для committed setup logical schema markers и
+  `migrate_logical_schema()` для явной замены marker после exact preflight.
   `KeyValueTableLogicalAdapter` - первый concrete logical adapter helper для
   явных вызовов `LogicalTableRegistry::preflight_then_apply()`. Его payload
   codec отделён от физического storage-формата таблицы и выбирается через
   явные key/value codec tags вроде `KeyValueLogicalInt64Codec<long>` и
   `KeyValueLogicalStringCodec<std::string>`. Codec tags являются частью
   logical schema contract; их смена требует нового schema id или явной
-  schema-marker migration. Смена `schema_version` под уже зарегистрированным
-  schema id отклоняется текущим immutable registry. Integer payloads
-  кодируются little-endian. Входящий logical apply подавляет локальный raw
-  capture для затронутой транзакции. Он ещё не подключён к automatic sync
-  pipeline.
+  schema-marker migration. Обычный вызов `register_logical_schema()` всё ещё
+  отклоняет смену `schema_version` под уже зарегистрированным schema id.
+  Integer payloads кодируются little-endian. Входящий logical apply подавляет
+  локальный raw capture для затронутой транзакции. Он ещё не подключён к
+  automatic sync pipeline.
   `DirectSyncPeer` используется для in-process синхронизации в тестах и примерах,
   `HttpSyncPeer` задаёт HTTP-shaped adapter seam, `WebSocketSyncPeer` задаёт
   binary message seam, а `SyncWorker` запускает фоновой polling.

--- a/README.md
+++ b/README.md
@@ -84,18 +84,20 @@
   flushing makes that transaction rollback-only; retrying `commit()` is
   rejected.
 - `SyncEngine` exposes pull/push/apply primitives and
-  `register_logical_schema()` for committed logical schema marker setup.
+  `register_logical_schema()` for committed logical schema marker setup, plus
+  `migrate_logical_schema()` for explicit marker replacement after exact
+  preflight.
   `KeyValueTableLogicalAdapter` is the first concrete logical adapter helper
   for explicit `LogicalTableRegistry::preflight_then_apply()` calls. Its
   payload codec is separate from physical table storage and is selected through
   explicit key/value codec tags such as `KeyValueLogicalInt64Codec<long>` and
   `KeyValueLogicalStringCodec<std::string>`. Codec tags are part of the
   logical schema contract; changing them requires a new schema id, or an
-  explicit schema-marker migration. Changing `schema_version` under an already
-  registered schema id is rejected by the current immutable registry. Integer
-  payloads are encoded little-endian. Incoming logical apply suppresses local
-  raw capture for the affected transaction. It is not wired into the automatic
-  sync pipeline yet.
+  explicit schema-marker migration. A plain `register_logical_schema()` call
+  still rejects a changed `schema_version` under an already registered schema
+  id. Integer payloads are encoded little-endian. Incoming logical apply
+  suppresses local raw capture for the affected transaction. It is not wired
+  into the automatic sync pipeline yet.
   `DirectSyncPeer` provides in-process sync for tests and examples,
   `HttpSyncPeer` defines an HTTP-shaped
   adapter seam, `WebSocketSyncPeer` defines a binary message seam, and

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -464,6 +464,13 @@ or repair tools. Both paths ensure that an existing database was opened with
 the same logical table kind, application schema version, and owned physical DBI
 set.
 
+Schema marker evolution is explicit. `register_or_verify()` creates or checks
+an exact immutable marker; it does not update an existing record.
+`SchemaRegistryStore::migrate_or_verify()` and
+`SyncEngine::migrate_logical_schema()` replace a marker only when the current
+record first matches an expected old record exactly. This marker operation does
+not migrate user table contents or old changelog entries.
+
 `SyncEngine::initialize_local_identity()` creates this DBI together with the
 required sync metadata stores in a committed setup transaction. Standalone
 maintenance code may still use `SchemaRegistryStore` directly; public store
@@ -523,10 +530,10 @@ codec tags such as `KeyValueLogicalInt64Codec<long>` and
 source spelling, defines the logical wire type; for example, local `long` may
 be mapped to signed 64-bit wire integers and range-checked on decode. Codec
 tags are part of the logical schema contract, so changing them requires a new
-schema id, or an explicit schema-marker migration. The current registry is
-immutable: changing `schema_version` under an already registered schema id is
-detected as a mismatch. Integer logical payload bytes are little-endian,
-matching the project-wide payload integer rule above. Apply uses a
+schema id, or an explicit schema-marker migration. A plain registration call
+still detects `schema_version` changes under an already registered schema id as
+a mismatch. Integer logical payload bytes are little-endian, matching the
+project-wide payload integer rule above. Apply uses a
 transaction-scoped sync-capture suppression guard so an incoming logical change
 written through public table methods is not re-published as a local raw
 `ChangeOp`.
@@ -1203,10 +1210,8 @@ When HLC or similar lands in v0.2, it goes in as opaque bytes inside
 
 - `meta_schema_version()` currently returns 1; bump rule + migration
   procedure not defined.
-- Logical schema-marker migration API. The current `_mdbxc_sync_schema`
-  registry is immutable and only creates or verifies exact records; changing a
-  codec tag for an existing logical table requires a new schema id until an
-  explicit marker migration lifecycle is designed.
+- Logical data migration policy for existing logical table contents and
+  retained changelog entries after a schema-marker migration.
 - Public sync API stability after the first external transport adapter.
 - `PeerRegistry` for multi-peer fan-out — single peer per sync invocation
   in v0.1.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -452,7 +452,7 @@ Real removal is explicit via `erase()`.
 | | |
 |---|---|
 | Key | application-defined logical schema id string |
-| Value | `schema_id` repeated in the versioned value envelope, followed by `LogicalSchemaRecord { kind, schema_version, flags, dbi_name, dbi_names[] }`; owned `dbi_names[]` are stored as a sorted unique set |
+| Value | `schema_id` repeated in the versioned value envelope, followed by `LogicalSchemaRecord { kind, schema_version, flags, dbi_name, dbi_names[] }`; owned `dbi_names[]` are stored as a sorted unique set and must include the primary `dbi_name` |
 
 This store is a persistent compatibility marker for future logical table
 adapters. It does not enable logical sync by itself. Normal application setup

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -204,6 +204,23 @@ namespace sync {
             txn.commit();
         }
 
+        /// \brief Migrates an existing persistent logical table schema marker.
+        /// \details This is an explicit marker lifecycle operation. It does
+        /// not migrate user table contents or changelog data. The current
+        /// marker must match \p expected_existing exactly unless it already
+        /// equals \p replacement, making retries idempotent.
+        void migrate_logical_schema(
+                const std::string& schema_id,
+                const LogicalSchemaRecord& expected_existing,
+                const LogicalSchemaRecord& replacement) {
+            auto txn = m_conn->transaction(TransactionMode::WRITABLE);
+            initialize_system_stores(txn.handle());
+            SchemaRegistryStore schemas(m_conn->env_handle());
+            schemas.migrate_or_verify(txn.handle(), schema_id,
+                                      expected_existing, replacement);
+            txn.commit();
+        }
+
         /// \brief Applies a single \c ChangeBatch to local DBIs inside \p txn.
         /// \details See class-level docs for the seq / apply rules. The
         /// caller commits the transaction. User DBIs are opened lazily by

--- a/include/mdbx_containers/sync/stores/SchemaRegistryStore.hpp
+++ b/include/mdbx_containers/sync/stores/SchemaRegistryStore.hpp
@@ -211,11 +211,19 @@ namespace sync {
             if (record.dbi_name.empty()) {
                 throw std::invalid_argument("Logical schema DBI name must not be empty");
             }
+            bool primary_dbi_listed = false;
             for (std::size_t i = 0; i < record.dbi_names.size(); ++i) {
                 if (record.dbi_names[i].empty()) {
                     throw std::invalid_argument(
                         "Logical schema owned DBI name must not be empty");
                 }
+                if (record.dbi_names[i] == record.dbi_name) {
+                    primary_dbi_listed = true;
+                }
+            }
+            if (!primary_dbi_listed) {
+                throw std::invalid_argument(
+                    "Logical schema primary DBI must be listed in owned DBIs");
             }
             if (!is_known_logical_table_kind(record.kind)) {
                 throw std::invalid_argument("Logical schema kind must be known");

--- a/include/mdbx_containers/sync/stores/SchemaRegistryStore.hpp
+++ b/include/mdbx_containers/sync/stores/SchemaRegistryStore.hpp
@@ -90,6 +90,50 @@ namespace sync {
                        "SchemaRegistryStore put failed");
         }
 
+        /// \brief Replaces an existing schema record after exact preflight.
+        /// \details This is a marker migration primitive, not a data
+        /// migration. The current record must equal \p expected_existing
+        /// exactly after canonicalization, unless it already equals
+        /// \p replacement. This makes retries idempotent while rejecting
+        /// silent overwrites of an unexpected marker.
+        /// \throws std::runtime_error when the current marker is missing or
+        /// differs from \p expected_existing and \p replacement.
+        void migrate_or_verify(MDBX_txn* txn,
+                               const std::string& schema_id,
+                               const LogicalSchemaRecord& expected_existing,
+                               const LogicalSchemaRecord& replacement) {
+            txn = checked_txn(txn, "SchemaRegistryStore::migrate_or_verify");
+            validate_record(schema_id, expected_existing);
+            validate_record(schema_id, replacement);
+            open(txn);
+
+            LogicalSchemaRecord existing;
+            if (!get(txn, schema_id, existing)) {
+                throw std::runtime_error(
+                    "Logical sync schema registry migration source missing");
+            }
+            if (records_equal(existing, replacement)) {
+                return;
+            }
+            if (!records_equal(existing, expected_existing)) {
+                throw std::runtime_error(
+                    "Logical sync schema registry migration preflight mismatch");
+            }
+
+            std::vector<std::uint8_t> value;
+            encode_record(schema_id, replacement, value);
+            MDBX_val key = {
+                const_cast<char*>(schema_id.data()),
+                schema_id.size()
+            };
+            MDBX_val val = {
+                value.empty() ? nullptr : &value[0],
+                value.size()
+            };
+            check_mdbx(mdbx_put(txn, m_dbi, &key, &val, MDBX_UPSERT),
+                       "SchemaRegistryStore migration put failed");
+        }
+
         /// \brief Reads a schema record.
         /// \return true when present, false when absent.
         bool get(MDBX_txn* txn,

--- a/tests/test_sync_stores.cpp
+++ b/tests/test_sync_stores.cpp
@@ -700,6 +700,7 @@ void test_schema_registry_store() {
     vector_like.dbi_name = "vectors";
     vector_like.kind = LogicalTableKind::HashedKeyValue;
     vector_like.schema_version = 3;
+    vector_like.dbi_names.push_back("vectors");
     vector_like.dbi_names.push_back("vectors.ids");
     vector_like.dbi_names.push_back("vectors.payload");
 
@@ -751,6 +752,23 @@ void test_schema_registry_store() {
         }
         if (!caught) {
             throw std::runtime_error("duplicate owned DBI was accepted");
+        }
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        SchemaRegistryStore store(conn->env_handle());
+        LogicalSchemaRecord missing_primary = ordered;
+        missing_primary.dbi_name = "events_primary";
+        bool caught = false;
+        try {
+            store.register_or_verify(
+                txn.handle(), "app.missing_primary.v1", missing_primary);
+        } catch (const std::invalid_argument&) {
+            caught = true;
+        }
+        if (!caught) {
+            throw std::runtime_error("missing primary owned DBI was accepted");
         }
     }
 

--- a/tests/test_sync_stores.cpp
+++ b/tests/test_sync_stores.cpp
@@ -855,6 +855,85 @@ void test_schema_registry_open_after_aborted_create() {
     cleanup(p);
 }
 
+void test_schema_registry_migrates_marker_explicitly() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_schema_migration.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    LogicalSchemaRecord v1;
+    v1.dbi_name = "items";
+    v1.kind = LogicalTableKind::KeyValue;
+    v1.schema_version = 1;
+    v1.dbi_names.push_back("items");
+
+    LogicalSchemaRecord v2 = v1;
+    v2.schema_version = 2;
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        SchemaRegistryStore store(conn->env_handle());
+        store.register_or_verify(txn.handle(), "app.items", v1);
+        store.migrate_or_verify(txn.handle(), "app.items", v1, v2);
+        store.migrate_or_verify(txn.handle(), "app.items", v1, v2);
+        txn.commit();
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        SchemaRegistryStore store(conn->env_handle());
+        LogicalSchemaRecord out;
+        if (!store.get(txn.handle(), "app.items", out) ||
+            out.schema_version != 2u) {
+            throw std::runtime_error(
+                "schema registry migration did not persist replacement");
+        }
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        SchemaRegistryStore store(conn->env_handle());
+        bool caught = false;
+        try {
+            store.migrate_or_verify(txn.handle(), "app.missing", v1, v2);
+        } catch (const std::runtime_error&) {
+            caught = true;
+        }
+        if (!caught) {
+            throw std::runtime_error(
+                "schema registry migration accepted missing source");
+        }
+    }
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        SchemaRegistryStore store(conn->env_handle());
+        LogicalSchemaRecord wrong_expected = v1;
+        wrong_expected.kind = LogicalTableKind::KeyMultiValue;
+        LogicalSchemaRecord v3 = v2;
+        v3.schema_version = 3;
+        bool caught = false;
+        try {
+            store.migrate_or_verify(txn.handle(), "app.items",
+                                    wrong_expected, v3);
+        } catch (const std::runtime_error&) {
+            caught = true;
+        }
+        if (!caught) {
+            throw std::runtime_error(
+                "schema registry migration accepted wrong expected marker");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 void test_schema_registry_created_by_sync_engine_init() {
     using namespace mdbxc::sync;
     const std::string p = "test_sync_stores_schema_engine_init.mdbx";
@@ -944,6 +1023,61 @@ void test_sync_engine_registers_logical_schema_marker() {
             throw std::runtime_error(
                 "mismatched logical schema marker rewrote existing record");
         }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_sync_engine_migrates_logical_schema_marker() {
+    using namespace mdbxc::sync;
+    const std::string p = "test_sync_stores_schema_engine_migrate.mdbx";
+    cleanup(p);
+
+    mdbxc::Config cfg;
+    cfg.pathname = p;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    auto conn = mdbxc::Connection::create(cfg);
+
+    SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x14), make_node(0x25));
+
+    LogicalSchemaRecord v1;
+    v1.dbi_name = "items";
+    v1.kind = LogicalTableKind::KeyValue;
+    v1.schema_version = 1;
+    v1.dbi_names.push_back("items");
+
+    LogicalSchemaRecord v2 = v1;
+    v2.schema_version = 2;
+
+    engine.register_logical_schema("app.items", v1);
+    engine.migrate_logical_schema("app.items", v1, v2);
+    engine.migrate_logical_schema("app.items", v1, v2);
+
+    {
+        auto txn = conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        SchemaRegistryStore store(conn->env_handle());
+        LogicalSchemaRecord out;
+        if (!store.get(txn.handle(), "app.items", out) ||
+            out.schema_version != 2u) {
+            throw std::runtime_error(
+                "SyncEngine logical schema migration was not persisted");
+        }
+    }
+
+    LogicalSchemaRecord v3 = v2;
+    v3.schema_version = 3;
+    bool caught = false;
+    try {
+        engine.migrate_logical_schema("app.items", v1, v3);
+    } catch (const std::runtime_error&) {
+        caught = true;
+    }
+    if (!caught) {
+        throw std::runtime_error(
+            "SyncEngine accepted logical schema migration with stale expected marker");
     }
 
     conn->disconnect();
@@ -1209,9 +1343,11 @@ int main() {
     test_changelog_prune_does_not_touch_other_origin();
     test_identity_key_collision();
     test_schema_registry_store();
+    test_schema_registry_migrates_marker_explicitly();
     test_schema_registry_open_after_aborted_create();
     test_schema_registry_created_by_sync_engine_init();
     test_sync_engine_registers_logical_schema_marker();
+    test_sync_engine_migrates_logical_schema_marker();
     test_sync_engine_registers_logical_schema_without_identity_init();
     test_schema_registry_rejects_malformed_records();
     test_stores_require_open();


### PR DESCRIPTION
## Summary
- add explicit schema marker migration APIs to SchemaRegistryStore and SyncEngine
- require exact old-marker preflight before replacing a marker, while allowing idempotent retries
- document that marker migration does not migrate user data or retained changelog entries

## Validation
- git diff --check
- C++11: test_sync_stores, header_sync_umbrella_test
- C++17: test_sync_stores, header_sync_umbrella_test