### PR TITLE
feat(sync): apply logical changes through engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,10 @@ All notable changes to this project will be documented in this file.
 - Added `ILogicalTableAdapter` and `LogicalTableRegistry` scaffolding for
   future two-phase logical table preflight/apply support. Apply exceptions are
   converted to failure results so the caller-owned transaction can be aborted.
-  `SyncEngine` still rejects unknown logical operations until a wire format and
-  registry integration are added.
+  `SyncEngine::apply_logical_changes()` now provides an explicit engine-owned
+  logical apply path; the transport pull/push wire format remains raw-DBI only.
 - Added `KeyValueTableLogicalAdapter` as the first concrete logical adapter
-  helper for explicit `LogicalTableRegistry::preflight_then_apply()` usage.
+  helper for explicit engine or registry logical apply usage.
   It covers typed upsert/delete/clear payloads for `KeyValueTable` with
   explicit key/value codec tags, including little-endian signed/unsigned
   integer wire codecs up to 64 bits, bool, and string codecs. Incoming logical

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,6 +441,7 @@ if(MDBXC_BUILD_TESTS)
         mdbx_containers/sync/ChangeOp.hpp
         mdbx_containers/sync/LogicalChange.hpp
         mdbx_containers/sync/LogicalTableAdapter.hpp
+        mdbx_containers/sync/LogicalSchemaValidation.hpp
         mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp
         mdbx_containers/sync/ChangeBatch.hpp
         mdbx_containers/sync/ChangeBatchCodec.hpp

--- a/README-RU.md
+++ b/README-RU.md
@@ -111,7 +111,8 @@
   `register_logical_schema()` для committed setup logical schema markers и
   `migrate_logical_schema()` для явной замены marker после exact preflight.
   `KeyValueTableLogicalAdapter` - первый concrete logical adapter helper для
-  явных вызовов `LogicalTableRegistry::preflight_then_apply()`. Его payload
+  явных вызовов `SyncEngine::apply_logical_changes()` или более низкоуровневого
+  `LogicalTableRegistry::preflight_then_apply()`. Его payload
   codec отделён от физического storage-формата таблицы и выбирается через
   явные key/value codec tags вроде `KeyValueLogicalInt64Codec<long>` и
   `KeyValueLogicalStringCodec<std::string>`. Codec tags являются частью
@@ -119,8 +120,8 @@
   schema-marker migration. Обычный вызов `register_logical_schema()` всё ещё
   отклоняет смену `schema_version` под уже зарегистрированным schema id.
   Integer payloads кодируются little-endian. Входящий logical apply подавляет
-  локальный raw capture для затронутой транзакции. Он ещё не подключён к
-  automatic sync pipeline.
+  локальный raw capture для затронутой транзакции. Это пока явный engine apply
+  path; transport pull/push pipeline остаётся raw-DBI only.
   `DirectSyncPeer` используется для in-process синхронизации в тестах и примерах,
   `HttpSyncPeer` задаёт HTTP-shaped adapter seam, `WebSocketSyncPeer` задаёт
   binary message seam, а `SyncWorker` запускает фоновой polling.

--- a/README-RU.md
+++ b/README-RU.md
@@ -119,9 +119,12 @@
   logical schema contract; их смена требует нового schema id или явной
   schema-marker migration. Обычный вызов `register_logical_schema()` всё ещё
   отклоняет смену `schema_version` под уже зарегистрированным schema id.
-  Integer payloads кодируются little-endian. Входящий logical apply подавляет
-  локальный raw capture для затронутой транзакции. Это пока явный engine apply
-  path; transport pull/push pipeline остаётся raw-DBI only.
+  `apply_logical_changes()` перепроверяет persistent marker для каждой schema
+  до adapter preflight, поэтому stale in-memory adapter не может применять
+  changes после schema-marker migration. Integer payloads кодируются
+  little-endian. Входящий logical apply подавляет локальный raw capture для
+  затронутой транзакции. Это пока явный engine apply path; transport pull/push
+  pipeline остаётся raw-DBI only.
   `DirectSyncPeer` используется для in-process синхронизации в тестах и примерах,
   `HttpSyncPeer` задаёт HTTP-shaped adapter seam, `WebSocketSyncPeer` задаёт
   binary message seam, а `SyncWorker` запускает фоновой polling.

--- a/README.md
+++ b/README.md
@@ -96,10 +96,12 @@
   logical schema contract; changing them requires a new schema id, or an
   explicit schema-marker migration. A plain `register_logical_schema()` call
   still rejects a changed `schema_version` under an already registered schema
-  id. Integer payloads are encoded little-endian. Incoming logical apply
-  suppresses local raw capture for the affected transaction. This is still an
-  explicit engine apply path; the transport pull/push pipeline remains
-  raw-DBI only.
+  id. `apply_logical_changes()` re-checks the persistent marker for each
+  schema before adapter preflight, so a stale in-memory adapter cannot apply
+  after marker migration. Integer payloads are encoded little-endian. Incoming
+  logical apply suppresses local raw capture for the affected transaction. This
+  is still an explicit engine apply path; the transport pull/push pipeline
+  remains raw-DBI only.
   `DirectSyncPeer` provides in-process sync for tests and examples,
   `HttpSyncPeer` defines an HTTP-shaped
   adapter seam, `WebSocketSyncPeer` defines a binary message seam, and

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@
   `migrate_logical_schema()` for explicit marker replacement after exact
   preflight.
   `KeyValueTableLogicalAdapter` is the first concrete logical adapter helper
-  for explicit `LogicalTableRegistry::preflight_then_apply()` calls. Its
+  for explicit `SyncEngine::apply_logical_changes()` or lower-level
+  `LogicalTableRegistry::preflight_then_apply()` calls. Its
   payload codec is separate from physical table storage and is selected through
   explicit key/value codec tags such as `KeyValueLogicalInt64Codec<long>` and
   `KeyValueLogicalStringCodec<std::string>`. Codec tags are part of the
@@ -96,8 +97,9 @@
   explicit schema-marker migration. A plain `register_logical_schema()` call
   still rejects a changed `schema_version` under an already registered schema
   id. Integer payloads are encoded little-endian. Incoming logical apply
-  suppresses local raw capture for the affected transaction. It is not wired
-  into the automatic sync pipeline yet.
+  suppresses local raw capture for the affected transaction. This is still an
+  explicit engine apply path; the transport pull/push pipeline remains
+  raw-DBI only.
   `DirectSyncPeer` provides in-process sync for tests and examples,
   `HttpSyncPeer` defines an HTTP-shaped
   adapter seam, `WebSocketSyncPeer` defines a binary message seam, and

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -90,12 +90,12 @@ The logical sync scaffolding is preparatory only:
 - `_mdbxc_sync_schema` is a persistent compatibility marker, not an apply path.
 - `LogicalChange` payloads are opaque and are not serialized by the current
   `ChangeBatchCodec`.
-- `LogicalTableRegistry` defines the future two-phase preflight/apply contract,
-  including full schema tuple validation before adapter callbacks, but
-  `SyncEngine` still applies raw DBI operations only.
-- Future `SyncEngine` integration must own the MDBX write transaction around
-  logical apply and abort it if an adapter reports failure or throws after any
-  mutation.
+- `LogicalTableRegistry` defines the two-phase preflight/apply contract,
+  including full schema tuple validation before adapter callbacks.
+- `SyncEngine::apply_logical_changes()` owns the MDBX write transaction around
+  explicit logical apply and aborts it if an adapter reports failure or throws
+  after any mutation. The transport `handle_push()` path still applies raw DBI
+  operations only.
 
 Until a causal context or another conflict model is implemented, future logical
 table support should document either one authoritative writer for the affected

--- a/include/mdbx_containers/common/Connection.hpp
+++ b/include/mdbx_containers/common/Connection.hpp
@@ -231,8 +231,8 @@ namespace mdbxc {
         /// stored generation with this value and rebuild when it changes.
         std::uint64_t sync_apply_generation() const;
 
-        /// \brief Registers a non-owning remote apply observer.
-        /// \details The observer is called after successful remote sync apply
+        /// \brief Registers a non-owning sync apply observer.
+        /// \details The observer is called after successful sync apply
         /// commits that changed user data. The pointer is non-owning; the
         /// observer must outlive the registration. Observer callbacks run
         /// after the connection apply/write barrier is released, and observer
@@ -243,7 +243,7 @@ namespace mdbxc {
         std::uint64_t add_sync_apply_observer(
             sync::ISyncApplyObserver* observer);
 
-        /// \brief Removes a previously registered remote apply observer.
+        /// \brief Removes a previously registered sync apply observer.
         /// \details When this returns \c true, no callback for \p token is
         /// still running or will start later. If this is called from that
         /// observer's own callback, it waits for other in-flight callbacks for

--- a/include/mdbx_containers/common/Connection.hpp
+++ b/include/mdbx_containers/common/Connection.hpp
@@ -345,7 +345,7 @@ namespace mdbxc {
             std::size_t applied_ops,
             const std::vector<std::string>& affected_dbi_names);
         void notify_sync_apply_observers(
-            const SyncApplyNotification& notification);
+            const SyncApplyNotification& notification) noexcept;
         void begin_sync_apply_observer_callback(
             const std::shared_ptr<SyncApplyObserverState>& state);
         void finish_sync_apply_observer_callback(

--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -389,22 +389,38 @@ namespace mdbxc {
         std::size_t applied_ops,
         const std::vector<std::string>& affected_dbi_names) {
         SyncApplyNotification notification;
+        try {
+            notification.affected_dbi_names = affected_dbi_names;
+        } catch (...) {
+            notification.affected_dbi_names.clear();
+        }
         std::lock_guard<std::mutex> locker(m_mdbx_mutex);
+        try {
+            notification.callbacks.reserve(m_sync_apply_observers.size());
+        } catch (...) {
+            ++m_sync_apply_generation;
+            notification.generation = m_sync_apply_generation;
+            notification.applied_batches = applied_batches;
+            notification.applied_ops = applied_ops;
+            return notification;
+        }
         ++m_sync_apply_generation;
         notification.generation = m_sync_apply_generation;
         notification.applied_batches = applied_batches;
         notification.applied_ops = applied_ops;
-        notification.affected_dbi_names = affected_dbi_names;
-        notification.callbacks.reserve(m_sync_apply_observers.size());
         for (std::size_t i = 0; i < m_sync_apply_observers.size(); ++i) {
             const std::shared_ptr<SyncApplyObserverState>& state =
                 m_sync_apply_observers[i];
             if (!state->removed && state->observer != nullptr) {
-                ++state->in_flight;
                 SyncApplyObserverCallback callback;
                 callback.state = state;
                 callback.observer = state->observer;
-                notification.callbacks.push_back(callback);
+                try {
+                    notification.callbacks.push_back(callback);
+                    ++state->in_flight;
+                } catch (...) {
+                    break;
+                }
             }
         }
         return notification;

--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -427,28 +427,39 @@ namespace mdbxc {
     }
 
     inline void Connection::notify_sync_apply_observers(
-        const SyncApplyNotification& notification) {
-        if (notification.callbacks.empty()) {
-            return;
-        }
-        sync::SyncApplyEvent event;
-        event.generation = notification.generation;
-        event.applied_batches = notification.applied_batches;
-        event.applied_ops = notification.applied_ops;
-        event.affected_dbi_names = notification.affected_dbi_names;
-        for (std::size_t i = 0; i < notification.callbacks.size(); ++i) {
-            try {
-                begin_sync_apply_observer_callback(
-                    notification.callbacks[i].state);
-                if (notification.callbacks[i].observer != nullptr) {
-                    notification.callbacks[i].observer
-                        ->on_sync_apply_committed(event);
-                }
-            } catch (...) {
-                // Remote apply has already committed; observers are best-effort.
+        const SyncApplyNotification& notification) noexcept {
+        try {
+            if (notification.callbacks.empty()) {
+                return;
             }
-            finish_sync_apply_observer_callback(
-                notification.callbacks[i].state);
+            sync::SyncApplyEvent event;
+            event.generation = notification.generation;
+            event.applied_batches = notification.applied_batches;
+            event.applied_ops = notification.applied_ops;
+            try {
+                event.affected_dbi_names = notification.affected_dbi_names;
+            } catch (...) {
+                event.affected_dbi_names.clear();
+            }
+            for (std::size_t i = 0; i < notification.callbacks.size(); ++i) {
+                try {
+                    begin_sync_apply_observer_callback(
+                        notification.callbacks[i].state);
+                    if (notification.callbacks[i].observer != nullptr) {
+                        notification.callbacks[i].observer
+                            ->on_sync_apply_committed(event);
+                    }
+                } catch (...) {
+                    // Sync apply has already committed; observers are best-effort.
+                }
+                try {
+                    finish_sync_apply_observer_callback(
+                        notification.callbacks[i].state);
+                } catch (...) {
+                }
+            }
+        } catch (...) {
+            // Sync apply has already committed; notification is best-effort.
         }
     }
 

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -19,6 +19,7 @@
 #include "sync/ChangeOp.hpp"
 #include "sync/LogicalChange.hpp"
 #include "sync/LogicalTableAdapter.hpp"
+#include "sync/LogicalSchemaValidation.hpp"
 #include "sync/adapters/KeyValueTableLogicalAdapter.hpp"
 #include "sync/CodecBounds.hpp"
 #include "sync/ChangeBatch.hpp"

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -547,6 +547,9 @@ for the transaction, commits only after the two-phase registry preflight/apply
 succeeds, and emits the normal sync apply observer event after commit.
 `SyncEngine::handle_push()` remains raw-DBI only. Unknown logical payloads and
 stale adapter/schema-marker combinations must not fall back to raw DBI apply.
+Until the adapter interface exposes an explicit primary DBI contract, generic
+logical apply accepts only single-DBI adapters and fails closed for multi-DBI
+adapters.
 
 Logical-table support therefore has a staged contract:
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -541,10 +541,12 @@ written through public table methods is not re-published as a local raw
 `ChangeOp`.
 
 `SyncEngine::apply_logical_changes()` owns the write transaction, routes the
-changes through its registered logical adapters, commits only after the
-two-phase registry preflight/apply succeeds, and emits the normal sync apply
-observer event after commit. `SyncEngine::handle_push()` remains raw-DBI only.
-Unknown logical payloads must not fall back to raw DBI apply.
+changes through its registered logical adapters, re-checks the persistent
+schema marker for each schema before adapter preflight, suppresses raw capture
+for the transaction, commits only after the two-phase registry preflight/apply
+succeeds, and emits the normal sync apply observer event after commit.
+`SyncEngine::handle_push()` remains raw-DBI only. Unknown logical payloads and
+stale adapter/schema-marker combinations must not fall back to raw DBI apply.
 
 Logical-table support therefore has a staged contract:
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -108,24 +108,26 @@ be non-empty and contain only ASCII letters, digits, `_`, and `-`; unsupported
 characters are rejected before internal DBI names are built. This prevents
 different logical collections from collapsing to the same physical DBI names.
 
-`Connection::sync_apply_generation()` is a coarse invalidation marker for
-remote sync apply. `SyncEngine::handle_push()` increments it after a successful
-commit that applied at least one incoming operation. `VectorStore` stores the
-last seen generation and rebuilds its in-memory index before index-dependent
-operations when the value changes. Applications and future cached wrappers may
-also register `ISyncApplyObserver` instances on the connection. Observers are
-called after the remote apply transaction commits and after the generation
-increments. The connection apply/write barrier is released before callbacks run,
-so observers may use table and cache-backed APIs on the same connection for
-invalidation. Observer exceptions are swallowed because the database state has
-already changed. Registrations are non-owning lifecycle hooks. A successful
+`Connection::sync_apply_generation()` is a coarse invalidation marker for sync
+apply commits. `SyncEngine::handle_push()` increments it after a successful
+commit that applied at least one incoming raw operation, and
+`SyncEngine::apply_logical_changes()` increments it after committed logical
+changes. `VectorStore` stores the last seen generation and rebuilds its
+in-memory index before index-dependent operations when the value changes.
+Applications and future cached wrappers may also register
+`ISyncApplyObserver` instances on the connection. Observers are called after
+the apply transaction commits and after the generation increments. The
+connection apply/write barrier is released before callbacks run, so observers
+may use table and cache-backed APIs on the same connection for invalidation.
+Observer exceptions are swallowed because the database state has already
+changed. Registrations are non-owning lifecycle hooks. A successful
 `remove_sync_apply_observer()` call is a callback drain barrier for that token,
 so the observer can be destroyed after removal returns. Apply events also carry
 the unique DBI names touched by applied operations in first-seen order. The
 names are local physical DBI names for invalidation; they are not transport
 identity, auth metadata, or a substitute for table-specific sync semantics.
 
-A connection-level apply/read barrier serializes remote apply commits with
+A connection-level apply/read barrier serializes sync apply commits with
 cache-backed `VectorStore` operations. C++17 builds use `std::shared_mutex` so
 different cache-backed readers can share the connection read side. Each
 `VectorStore` instance still serializes its own public operations with an
@@ -518,10 +520,10 @@ and compatibility tests.
 `adapters/KeyValueTableLogicalAdapter.hpp` provides the first concrete adapter
 helper. It translates typed `KeyValueTable` upsert/delete/clear operations into
 adapter-owned logical payloads and applies them through
+`SyncEngine::apply_logical_changes()` or
 `LogicalTableRegistry::preflight_then_apply()` inside a caller-owned write
-transaction. It is intentionally standalone: it proves the adapter contract and
-payload shape for a simple table, but it is not yet connected to the automatic
-pull/push wire pipeline.
+transaction. It proves the adapter contract and payload shape for a simple
+table, but it is not yet connected to the automatic pull/push wire pipeline.
 
 The adapter payload codec is not the table storage serializer. The initial
 codec surface is deliberately small and explicit: callers provide key/value
@@ -538,8 +540,11 @@ transaction-scoped sync-capture suppression guard so an incoming logical change
 written through public table methods is not re-published as a local raw
 `ChangeOp`.
 
-The current `SyncEngine` does not call this registry yet. Unknown logical
-payloads must not fall back to raw DBI apply.
+`SyncEngine::apply_logical_changes()` owns the write transaction, routes the
+changes through its registered logical adapters, commits only after the
+two-phase registry preflight/apply succeeds, and emits the normal sync apply
+observer event after commit. `SyncEngine::handle_push()` remains raw-DBI only.
+Unknown logical payloads must not fall back to raw DBI apply.
 
 Logical-table support therefore has a staged contract:
 

--- a/include/mdbx_containers/sync/LogicalSchemaValidation.hpp
+++ b/include/mdbx_containers/sync/LogicalSchemaValidation.hpp
@@ -1,0 +1,74 @@
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_SCHEMA_VALIDATION_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_SCHEMA_VALIDATION_HPP_INCLUDED
+
+/// \file LogicalSchemaValidation.hpp
+/// \brief Persistent marker validation helpers for logical sync adapters.
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include <mdbx.h>
+
+#include "LogicalTableAdapter.hpp"
+#include "stores/SchemaRegistryStore.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    inline bool canonical_logical_dbi_names(
+            const std::vector<std::string>& dbi_names,
+            std::vector<std::string>& out) {
+        out = dbi_names;
+        std::sort(out.begin(), out.end());
+        return std::unique(out.begin(), out.end()) == out.end();
+    }
+
+    inline LogicalApplyResult validate_logical_adapter_marker(
+            MDBX_txn* txn,
+            MDBX_env* env,
+            const ILogicalTableAdapter& adapter) {
+        const LogicalSchemaRef ref = adapter.schema_ref();
+        if (!is_logical_schema_ref_complete(ref)) {
+            return LogicalApplyResult::failure(
+                "Logical adapter schema ref is incomplete");
+        }
+
+        SchemaRegistryStore schemas(env);
+        LogicalSchemaRecord record;
+        if (!schemas.get(txn, ref.schema_id, record)) {
+            return LogicalApplyResult::failure(
+                "Persistent logical schema marker is missing");
+        }
+
+        if (record.kind != ref.kind ||
+            record.schema_version != ref.schema_version) {
+            return LogicalApplyResult::failure(
+                "Persistent logical schema marker does not match adapter");
+        }
+
+        std::vector<std::string> adapter_dbis;
+        std::vector<std::string> marker_dbis;
+        if (!canonical_logical_dbi_names(adapter.affected_dbis(),
+                                         adapter_dbis) ||
+            !canonical_logical_dbi_names(record.dbi_names, marker_dbis) ||
+            adapter_dbis.empty() ||
+            marker_dbis.empty() ||
+            adapter_dbis != marker_dbis) {
+            return LogicalApplyResult::failure(
+                "Persistent logical schema marker DBI set does not match adapter");
+        }
+
+        if (adapter_dbis.size() == 1u &&
+            record.dbi_name != adapter_dbis[0]) {
+            return LogicalApplyResult::failure(
+                "Persistent logical schema marker primary DBI does not match adapter");
+        }
+
+        return LogicalApplyResult::success();
+    }
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_SCHEMA_VALIDATION_HPP_INCLUDED

--- a/include/mdbx_containers/sync/LogicalSchemaValidation.hpp
+++ b/include/mdbx_containers/sync/LogicalSchemaValidation.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_SCHEMA_VALIDATION_HPP_INCLUDED
 #define MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_SCHEMA_VALIDATION_HPP_INCLUDED
 
@@ -47,10 +48,16 @@ namespace sync {
                 "Persistent logical schema marker does not match adapter");
         }
 
+        const std::vector<std::string> affected_dbis =
+            adapter.affected_dbis();
+        if (affected_dbis.size() != 1u) {
+            return LogicalApplyResult::failure(
+                "Logical adapter multi-DBI primary contract is not supported");
+        }
+
         std::vector<std::string> adapter_dbis;
         std::vector<std::string> marker_dbis;
-        if (!canonical_logical_dbi_names(adapter.affected_dbis(),
-                                         adapter_dbis) ||
+        if (!canonical_logical_dbi_names(affected_dbis, adapter_dbis) ||
             !canonical_logical_dbi_names(record.dbi_names, marker_dbis) ||
             adapter_dbis.empty() ||
             marker_dbis.empty() ||

--- a/include/mdbx_containers/sync/SyncApplyObserver.hpp
+++ b/include/mdbx_containers/sync/SyncApplyObserver.hpp
@@ -3,7 +3,7 @@
 #define MDBX_CONTAINERS_HEADER_SYNC_SYNC_APPLY_OBSERVER_HPP_INCLUDED
 
 /// \file SyncApplyObserver.hpp
-/// \brief Observer hook for successful remote sync apply commits.
+/// \brief Observer hook for successful sync apply commits.
 
 #include <cstddef>
 #include <cstdint>
@@ -13,10 +13,11 @@
 namespace mdbxc {
 namespace sync {
 
-    /// \brief Summary of one committed remote sync apply.
+    /// \brief Summary of one committed sync apply.
     /// \details Emitted after \c SyncEngine::handle_push() commits at least
-    /// one non-empty incoming batch, after the connection apply generation
-    /// has been incremented, and after the connection apply/write barrier has
+    /// one non-empty incoming batch or \c SyncEngine::apply_logical_changes()
+    /// commits logical changes, after the connection apply generation has
+    /// been incremented, and after the connection apply/write barrier has
     /// been released.
     struct SyncApplyEvent {
         std::uint64_t generation = 0;       ///< New connection apply generation.
@@ -28,10 +29,10 @@ namespace sync {
         std::vector<std::string> affected_dbi_names;
     };
 
-    /// \brief Non-owning observer for successful remote sync apply commits.
+    /// \brief Non-owning observer for successful sync apply commits.
     /// \details Register through \c Connection::add_sync_apply_observer().
     /// Implementations are intended for cache invalidation, metrics, and
-    /// structured logging. Callbacks run after the remote apply write barrier
+    /// structured logging. Callbacks run after the apply write barrier
     /// is released, so an observer may use table and cache-backed APIs on the
     /// same connection. Exceptions thrown by observers are swallowed by the
     /// connection so they cannot roll back an already committed sync apply.
@@ -39,7 +40,7 @@ namespace sync {
     public:
         virtual ~ISyncApplyObserver() = default;
 
-        /// \brief Called after a remote sync apply commit changes user data.
+        /// \brief Called after a sync apply commit changes user data.
         virtual void on_sync_apply_committed(
             const SyncApplyEvent& event) = 0;
     };

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -260,16 +260,26 @@ namespace sync {
                 const Connection::SyncApplyWriteGuard sync_apply_guard =
                     m_conn->sync_apply_write_guard();
                 auto txn = m_conn->transaction(TransactionMode::WRITABLE);
-                result = m_logical_registry.preflight_then_apply(
+                result = validate_logical_schema_markers(
                     txn.handle(), changes);
+                if (result.ok) {
+                    Connection::SyncCaptureSuppressionScope suppress_capture(
+                        *m_conn, txn.handle());
+                    result = m_logical_registry.preflight_then_apply(
+                        txn.handle(), changes);
+                }
                 if (!result.ok) {
                     txn.rollback();
                     return result;
                 }
                 txn.commit();
-                notification =
-                    m_conn->mark_sync_apply_committed(
-                        1u, changes.size(), affected_dbi_names);
+                try {
+                    notification =
+                        m_conn->mark_sync_apply_committed(
+                            1u, changes.size(), affected_dbi_names);
+                } catch (...) {
+                    return result;
+                }
             }
             m_conn->notify_sync_apply_observers(notification);
             return result;
@@ -690,6 +700,71 @@ namespace sync {
                     add_unique_dbi_name(names, dbis[j]);
                 }
             }
+        }
+
+        static std::vector<std::string> canonical_dbi_names(
+                const std::vector<std::string>& dbi_names) {
+            std::vector<std::string> out = dbi_names;
+            std::sort(out.begin(), out.end());
+            if (std::unique(out.begin(), out.end()) != out.end()) {
+                return std::vector<std::string>();
+            }
+            return out;
+        }
+
+        LogicalApplyResult validate_logical_schema_markers(
+                MDBX_txn* txn,
+                const std::vector<LogicalChange>& changes) const {
+            SchemaRegistryStore schemas(m_conn->env_handle());
+            std::vector<std::string> checked_schema_ids;
+
+            for (std::size_t i = 0; i < changes.size(); ++i) {
+                const std::string& schema_id = changes[i].schema.schema_id;
+                bool already_checked = false;
+                for (std::size_t j = 0; j < checked_schema_ids.size(); ++j) {
+                    if (checked_schema_ids[j] == schema_id) {
+                        already_checked = true;
+                        break;
+                    }
+                }
+                if (already_checked) {
+                    continue;
+                }
+
+                ILogicalTableAdapter* adapter =
+                    m_logical_registry.find(schema_id);
+                if (adapter == nullptr) {
+                    return LogicalApplyResult::failure(
+                        "No logical adapter registered for schema id");
+                }
+
+                LogicalSchemaRecord record;
+                if (!schemas.get(txn, schema_id, record)) {
+                    return LogicalApplyResult::failure(
+                        "Persistent logical schema marker is missing");
+                }
+
+                const LogicalSchemaRef ref = adapter->schema_ref();
+                if (record.kind != ref.kind ||
+                    record.schema_version != ref.schema_version) {
+                    return LogicalApplyResult::failure(
+                        "Persistent logical schema marker does not match adapter");
+                }
+
+                const std::vector<std::string> adapter_dbis =
+                    canonical_dbi_names(adapter->affected_dbis());
+                const std::vector<std::string> marker_dbis =
+                    canonical_dbi_names(record.dbi_names);
+                if (adapter_dbis.empty() || marker_dbis.empty() ||
+                    adapter_dbis != marker_dbis) {
+                    return LogicalApplyResult::failure(
+                        "Persistent logical schema marker DBI set does not match adapter");
+                }
+
+                checked_schema_ids.push_back(schema_id);
+            }
+
+            return LogicalApplyResult::success();
         }
 
         static std::uint32_t persistent_dbi_flags_mask() {

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -41,6 +41,7 @@
 #include "ChangeBatch.hpp"
 #include "ChangeBatchCodec.hpp"
 #include "ChangeOp.hpp"
+#include "LogicalTableAdapter.hpp"
 #include "protocol.hpp"
 #include "SyncCursor.hpp"
 #include "stores/AppliedStore.hpp"
@@ -219,6 +220,59 @@ namespace sync {
             schemas.migrate_or_verify(txn.handle(), schema_id,
                                       expected_existing, replacement);
             txn.commit();
+        }
+
+        /// \brief Registers a logical table adapter for engine-owned apply.
+        /// \details Registration is a lifecycle operation and is not
+        /// synchronized with concurrent \c apply_logical_changes() calls.
+        void register_logical_adapter(ILogicalTableAdapter& adapter) {
+            m_logical_registry.register_adapter(&adapter);
+        }
+
+        /// \brief Removes a logical table adapter by schema id.
+        bool unregister_logical_adapter(const std::string& schema_id) {
+            return m_logical_registry.unregister_adapter(schema_id);
+        }
+
+        /// \brief Returns the number of registered logical table adapters.
+        std::size_t logical_adapter_count() const {
+            return m_logical_registry.size();
+        }
+
+        /// \brief Applies logical table changes in an engine-owned write txn.
+        /// \details This is the first engine integration point for
+        /// \c LogicalTableRegistry. It does not change the transport wire
+        /// format and is not called by \c handle_push() yet. Unknown schemas
+        /// fail closed, all adapter preflights run before any apply, and any
+        /// failure rolls back the transaction.
+        LogicalApplyResult apply_logical_changes(
+                const std::vector<LogicalChange>& changes) {
+            if (changes.empty()) {
+                return LogicalApplyResult::success();
+            }
+
+            std::vector<std::string> affected_dbi_names;
+            collect_logical_affected_dbis(changes, affected_dbi_names);
+
+            Connection::SyncApplyNotification notification;
+            LogicalApplyResult result;
+            {
+                const Connection::SyncApplyWriteGuard sync_apply_guard =
+                    m_conn->sync_apply_write_guard();
+                auto txn = m_conn->transaction(TransactionMode::WRITABLE);
+                result = m_logical_registry.preflight_then_apply(
+                    txn.handle(), changes);
+                if (!result.ok) {
+                    txn.rollback();
+                    return result;
+                }
+                txn.commit();
+                notification =
+                    m_conn->mark_sync_apply_committed(
+                        1u, changes.size(), affected_dbi_names);
+            }
+            m_conn->notify_sync_apply_observers(notification);
+            return result;
         }
 
         /// \brief Applies a single \c ChangeBatch to local DBIs inside \p txn.
@@ -619,6 +673,23 @@ namespace sync {
                 }
             }
             names.push_back(dbi_name);
+        }
+
+        void collect_logical_affected_dbis(
+                const std::vector<LogicalChange>& changes,
+                std::vector<std::string>& names) const {
+            for (std::size_t i = 0; i < changes.size(); ++i) {
+                ILogicalTableAdapter* adapter =
+                    m_logical_registry.find(changes[i].schema.schema_id);
+                if (adapter == nullptr) {
+                    continue;
+                }
+                const std::vector<std::string> dbis =
+                    adapter->affected_dbis();
+                for (std::size_t j = 0; j < dbis.size(); ++j) {
+                    add_unique_dbi_name(names, dbis[j]);
+                }
+            }
         }
 
         static std::uint32_t persistent_dbi_flags_mask() {
@@ -1164,6 +1235,7 @@ namespace sync {
 
         std::shared_ptr<Connection> m_conn;
         ConflictPolicy              m_policy;
+        LogicalTableRegistry        m_logical_registry;
     };
 
 } // namespace sync

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -42,6 +42,7 @@
 #include "ChangeBatchCodec.hpp"
 #include "ChangeOp.hpp"
 #include "LogicalTableAdapter.hpp"
+#include "LogicalSchemaValidation.hpp"
 #include "protocol.hpp"
 #include "SyncCursor.hpp"
 #include "stores/AppliedStore.hpp"
@@ -702,20 +703,9 @@ namespace sync {
             }
         }
 
-        static std::vector<std::string> canonical_dbi_names(
-                const std::vector<std::string>& dbi_names) {
-            std::vector<std::string> out = dbi_names;
-            std::sort(out.begin(), out.end());
-            if (std::unique(out.begin(), out.end()) != out.end()) {
-                return std::vector<std::string>();
-            }
-            return out;
-        }
-
         LogicalApplyResult validate_logical_schema_markers(
                 MDBX_txn* txn,
                 const std::vector<LogicalChange>& changes) const {
-            SchemaRegistryStore schemas(m_conn->env_handle());
             std::vector<std::string> checked_schema_ids;
 
             for (std::size_t i = 0; i < changes.size(); ++i) {
@@ -738,28 +728,10 @@ namespace sync {
                         "No logical adapter registered for schema id");
                 }
 
-                LogicalSchemaRecord record;
-                if (!schemas.get(txn, schema_id, record)) {
-                    return LogicalApplyResult::failure(
-                        "Persistent logical schema marker is missing");
-                }
-
-                const LogicalSchemaRef ref = adapter->schema_ref();
-                if (record.kind != ref.kind ||
-                    record.schema_version != ref.schema_version) {
-                    return LogicalApplyResult::failure(
-                        "Persistent logical schema marker does not match adapter");
-                }
-
-                const std::vector<std::string> adapter_dbis =
-                    canonical_dbi_names(adapter->affected_dbis());
-                const std::vector<std::string> marker_dbis =
-                    canonical_dbi_names(record.dbi_names);
-                if (adapter_dbis.empty() || marker_dbis.empty() ||
-                    adapter_dbis != marker_dbis) {
-                    return LogicalApplyResult::failure(
-                        "Persistent logical schema marker DBI set does not match adapter");
-                }
+                const LogicalApplyResult marker_result =
+                    validate_logical_adapter_marker(
+                        txn, m_conn->env_handle(), *adapter);
+                if (!marker_result.ok) return marker_result;
 
                 checked_schema_ids.push_back(schema_id);
             }

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -47,11 +47,12 @@ mdbxc::sync::NodeId make_node(std::uint8_t seed) {
     return n;
 }
 
-mdbxc::sync::LogicalSchemaRecord make_record(const std::string& dbi_name) {
+mdbxc::sync::LogicalSchemaRecord make_record(const std::string& dbi_name,
+                                             std::uint32_t version = 1) {
     mdbxc::sync::LogicalSchemaRecord record;
     record.dbi_name = dbi_name;
     record.kind = mdbxc::sync::LogicalTableKind::KeyValue;
-    record.schema_version = 1;
+    record.schema_version = version;
     record.dbi_names.push_back(dbi_name);
     return record;
 }
@@ -75,6 +76,52 @@ public:
     std::size_t applied_batches;
     std::size_t applied_ops;
     std::vector<std::string> affected_dbi_names;
+};
+
+class RawWritingLogicalAdapter : public mdbxc::sync::ILogicalTableAdapter {
+public:
+    RawWritingLogicalAdapter(
+            mdbxc::KeyValueTable<int, std::string>& table,
+            const std::string& schema_id)
+        : m_table(table),
+          m_schema_id(schema_id) {}
+
+    mdbxc::sync::LogicalSchemaRef schema_ref() const override {
+        mdbxc::sync::LogicalSchemaRef ref;
+        ref.schema_id = m_schema_id;
+        ref.kind = mdbxc::sync::LogicalTableKind::KeyValue;
+        ref.schema_version = 1;
+        return ref;
+    }
+
+    std::vector<std::string> affected_dbis() const override {
+        std::vector<std::string> out;
+        out.push_back(m_table.dbi_name());
+        return out;
+    }
+
+    mdbxc::sync::LogicalApplyResult preflight(
+            MDBX_txn* txn,
+            const mdbxc::sync::LogicalChange& change) const override {
+        (void)txn;
+        if (change.schema.schema_id != m_schema_id) {
+            return mdbxc::sync::LogicalApplyResult::failure(
+                "unexpected schema id");
+        }
+        return mdbxc::sync::LogicalApplyResult::success();
+    }
+
+    mdbxc::sync::LogicalApplyResult apply(
+            MDBX_txn* txn,
+            const mdbxc::sync::LogicalChange& change) override {
+        (void)change;
+        m_table.insert_or_assign(30, "thirty", txn);
+        return mdbxc::sync::LogicalApplyResult::success();
+    }
+
+private:
+    mdbxc::KeyValueTable<int, std::string>& m_table;
+    std::string m_schema_id;
 };
 
 void test_key_value_logical_adapter_applies_basic_ops() {
@@ -222,6 +269,161 @@ void test_key_value_logical_adapter_engine_rejects_unknown_schema() {
     MDBXC_TEST_ASSERT(result.error.find("No logical adapter") !=
                       std::string::npos);
     MDBXC_TEST_ASSERT(!table.contains(5));
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_value_logical_engine_rejects_missing_schema_marker() {
+    const std::string path = "test_key_value_logical_adapter_missing_marker.mdbx";
+    const std::string dbi_name = "logical_key_value_missing_marker";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x1A), make_node(0xAA));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    IntStringAdapter adapter(table, "app.logical_kv_missing_marker.v1");
+    engine.register_logical_adapter(adapter);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(adapter.make_upsert(6, "six"));
+    const mdbxc::sync::LogicalApplyResult result =
+        engine.apply_logical_changes(changes);
+    MDBXC_TEST_ASSERT(!result.ok);
+    MDBXC_TEST_ASSERT(result.error.find("schema marker") !=
+                      std::string::npos);
+    MDBXC_TEST_ASSERT(!table.contains(6));
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_value_logical_engine_rejects_stale_schema_marker() {
+    const std::string path = "test_key_value_logical_adapter_stale_marker.mdbx";
+    const std::string dbi_name = "logical_key_value_stale_marker";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x1B), make_node(0xAB));
+    engine.register_logical_schema("app.logical_kv_stale_marker.v1",
+                                   make_record(dbi_name, 1));
+    engine.migrate_logical_schema("app.logical_kv_stale_marker.v1",
+                                  make_record(dbi_name, 1),
+                                  make_record(dbi_name, 2));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    IntStringAdapter adapter(table, "app.logical_kv_stale_marker.v1", 1);
+    engine.register_logical_adapter(adapter);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(adapter.make_upsert(7, "seven"));
+    const mdbxc::sync::LogicalApplyResult result =
+        engine.apply_logical_changes(changes);
+    MDBXC_TEST_ASSERT(!result.ok);
+    MDBXC_TEST_ASSERT(result.error.find("schema marker") !=
+                      std::string::npos);
+    MDBXC_TEST_ASSERT(!table.contains(7));
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_value_logical_engine_rejects_marker_dbi_mismatch() {
+    const std::string path = "test_key_value_logical_adapter_dbi_marker.mdbx";
+    const std::string dbi_name = "logical_key_value_dbi_marker";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x1C), make_node(0xAC));
+    engine.register_logical_schema("app.logical_kv_dbi_marker.v1",
+                                   make_record(dbi_name + "_other"));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    IntStringAdapter adapter(table, "app.logical_kv_dbi_marker.v1");
+    engine.register_logical_adapter(adapter);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(adapter.make_upsert(8, "eight"));
+    const mdbxc::sync::LogicalApplyResult result =
+        engine.apply_logical_changes(changes);
+    MDBXC_TEST_ASSERT(!result.ok);
+    MDBXC_TEST_ASSERT(result.error.find("DBI set") !=
+                      std::string::npos);
+    MDBXC_TEST_ASSERT(!table.contains(8));
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_value_logical_engine_suppresses_generic_raw_capture() {
+    const std::string path = "test_key_value_logical_adapter_engine_capture.mdbx";
+    const std::string dbi_name = "logical_key_value_engine_capture";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId node = make_node(0x1D);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(node, make_node(0xAD));
+    engine.register_logical_schema("app.logical_kv_engine_capture.v1",
+                                   make_record(dbi_name));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    RawWritingLogicalAdapter adapter(
+        table, "app.logical_kv_engine_capture.v1");
+    engine.register_logical_adapter(adapter);
+
+    mdbxc::sync::ThreadLocalChangeAccumulator capture(conn);
+    conn->attach_sync_capture(&capture);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    mdbxc::sync::LogicalChange change;
+    change.schema = adapter.schema_ref();
+    change.opcode = mdbxc::sync::KeyValueLogicalUpsert;
+    changes.push_back(change);
+    const mdbxc::sync::LogicalApplyResult result =
+        engine.apply_logical_changes(changes);
+    conn->detach_sync_capture();
+    MDBXC_TEST_ASSERT(result.ok);
+
+    const std::pair<bool, std::string> found = table.find_compat(30);
+    MDBXC_TEST_ASSERT(found.first);
+    MDBXC_TEST_ASSERT(found.second == "thirty");
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        mdbxc::sync::ChangeLogStore changelog(conn->env_handle());
+        changelog.open(txn.handle());
+        MDBXC_TEST_ASSERT(!changelog.contains(txn.handle(), node, 1));
+    }
 
     conn->disconnect();
     cleanup(path);
@@ -472,6 +674,10 @@ int main() {
     test_key_value_logical_adapter_applies_basic_ops();
     test_key_value_logical_adapter_applies_through_sync_engine();
     test_key_value_logical_adapter_engine_rejects_unknown_schema();
+    test_key_value_logical_engine_rejects_missing_schema_marker();
+    test_key_value_logical_engine_rejects_stale_schema_marker();
+    test_key_value_logical_engine_rejects_marker_dbi_mismatch();
+    test_key_value_logical_engine_suppresses_generic_raw_capture();
     test_key_value_logical_adapter_rejects_malformed_payload();
     test_key_value_logical_adapter_uses_stable_payload();
     test_key_value_logical_adapter_decodes_literal_little_endian_payload();

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -124,6 +124,53 @@ private:
     std::string m_schema_id;
 };
 
+class MultiDbiLogicalAdapter : public mdbxc::sync::ILogicalTableAdapter {
+public:
+    MultiDbiLogicalAdapter(
+            mdbxc::KeyValueTable<int, std::string>& table,
+            const std::string& secondary_dbi_name,
+            const std::string& schema_id)
+        : m_table(table),
+          m_secondary_dbi_name(secondary_dbi_name),
+          m_schema_id(schema_id) {}
+
+    mdbxc::sync::LogicalSchemaRef schema_ref() const override {
+        mdbxc::sync::LogicalSchemaRef ref;
+        ref.schema_id = m_schema_id;
+        ref.kind = mdbxc::sync::LogicalTableKind::KeyValue;
+        ref.schema_version = 1;
+        return ref;
+    }
+
+    std::vector<std::string> affected_dbis() const override {
+        std::vector<std::string> out;
+        out.push_back(m_table.dbi_name());
+        out.push_back(m_secondary_dbi_name);
+        return out;
+    }
+
+    mdbxc::sync::LogicalApplyResult preflight(
+            MDBX_txn* txn,
+            const mdbxc::sync::LogicalChange& change) const override {
+        (void)txn;
+        (void)change;
+        return mdbxc::sync::LogicalApplyResult::success();
+    }
+
+    mdbxc::sync::LogicalApplyResult apply(
+            MDBX_txn* txn,
+            const mdbxc::sync::LogicalChange& change) override {
+        (void)change;
+        m_table.insert_or_assign(31, "thirty-one", txn);
+        return mdbxc::sync::LogicalApplyResult::success();
+    }
+
+private:
+    mdbxc::KeyValueTable<int, std::string>& m_table;
+    std::string m_secondary_dbi_name;
+    std::string m_schema_id;
+};
+
 void test_key_value_logical_adapter_applies_basic_ops() {
     const std::string path = "test_key_value_logical_adapter_basic.mdbx";
     const std::string dbi_name = "logical_key_value_items";
@@ -372,6 +419,46 @@ void test_key_value_logical_engine_rejects_marker_dbi_mismatch() {
     MDBXC_TEST_ASSERT(result.error.find("DBI set") !=
                       std::string::npos);
     MDBXC_TEST_ASSERT(!table.contains(8));
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_value_logical_engine_rejects_multi_dbi_adapter_until_primary_contract() {
+    const std::string path = "test_key_value_logical_adapter_multi_dbi.mdbx";
+    const std::string dbi_name = "logical_key_value_multi_dbi";
+    const std::string secondary_dbi_name = dbi_name + "_index";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x1E), make_node(0xAE));
+    mdbxc::sync::LogicalSchemaRecord record = make_record(dbi_name);
+    record.dbi_names.push_back(secondary_dbi_name);
+    engine.register_logical_schema("app.logical_kv_multi_dbi.v1", record);
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    MultiDbiLogicalAdapter adapter(
+        table, secondary_dbi_name, "app.logical_kv_multi_dbi.v1");
+    engine.register_logical_adapter(adapter);
+
+    mdbxc::sync::LogicalChange change;
+    change.schema = adapter.schema_ref();
+    change.opcode = mdbxc::sync::KeyValueLogicalUpsert;
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(change);
+    const mdbxc::sync::LogicalApplyResult result =
+        engine.apply_logical_changes(changes);
+    MDBXC_TEST_ASSERT(!result.ok);
+    MDBXC_TEST_ASSERT(result.error.find("multi-DBI") !=
+                      std::string::npos);
+    MDBXC_TEST_ASSERT(!table.contains(31));
 
     conn->disconnect();
     cleanup(path);
@@ -677,6 +764,7 @@ int main() {
     test_key_value_logical_engine_rejects_missing_schema_marker();
     test_key_value_logical_engine_rejects_stale_schema_marker();
     test_key_value_logical_engine_rejects_marker_dbi_mismatch();
+    test_key_value_logical_engine_rejects_multi_dbi_adapter_until_primary_contract();
     test_key_value_logical_engine_suppresses_generic_raw_capture();
     test_key_value_logical_adapter_rejects_malformed_payload();
     test_key_value_logical_adapter_uses_stable_payload();

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -56,6 +56,27 @@ mdbxc::sync::LogicalSchemaRecord make_record(const std::string& dbi_name) {
     return record;
 }
 
+class CountingApplyObserver : public mdbxc::sync::ISyncApplyObserver {
+public:
+    CountingApplyObserver()
+        : calls(0), generation(0), applied_batches(0), applied_ops(0) {}
+
+    void on_sync_apply_committed(
+        const mdbxc::sync::SyncApplyEvent& event) override {
+        ++calls;
+        generation = event.generation;
+        applied_batches = event.applied_batches;
+        applied_ops = event.applied_ops;
+        affected_dbi_names = event.affected_dbi_names;
+    }
+
+    std::size_t calls;
+    std::uint64_t generation;
+    std::size_t applied_batches;
+    std::size_t applied_ops;
+    std::vector<std::string> affected_dbi_names;
+};
+
 void test_key_value_logical_adapter_applies_basic_ops() {
     const std::string path = "test_key_value_logical_adapter_basic.mdbx";
     const std::string dbi_name = "logical_key_value_items";
@@ -114,6 +135,93 @@ void test_key_value_logical_adapter_applies_basic_ops() {
         txn.commit();
     }
     MDBXC_TEST_ASSERT(table.count() == 0u);
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_value_logical_adapter_applies_through_sync_engine() {
+    const std::string path = "test_key_value_logical_adapter_engine.mdbx";
+    const std::string dbi_name = "logical_key_value_engine";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x16), make_node(0xA6));
+    engine.register_logical_schema("app.logical_kv_engine.v1",
+                                   make_record(dbi_name));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    IntStringAdapter adapter(table, "app.logical_kv_engine.v1");
+    engine.register_logical_adapter(adapter);
+    MDBXC_TEST_ASSERT(engine.logical_adapter_count() == 1u);
+
+    CountingApplyObserver observer;
+    const std::uint64_t token =
+        conn->add_sync_apply_observer(&observer);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(adapter.make_upsert(11, "eleven"));
+    changes.push_back(adapter.make_upsert(12, "twelve"));
+    changes.push_back(adapter.make_delete(12));
+
+    const mdbxc::sync::LogicalApplyResult result =
+        engine.apply_logical_changes(changes);
+    MDBXC_TEST_ASSERT(result.ok);
+
+    const std::pair<bool, std::string> found = table.find_compat(11);
+    MDBXC_TEST_ASSERT(found.first);
+    MDBXC_TEST_ASSERT(found.second == "eleven");
+    MDBXC_TEST_ASSERT(!table.contains(12));
+    MDBXC_TEST_ASSERT(observer.calls == 1u);
+    MDBXC_TEST_ASSERT(observer.generation == conn->sync_apply_generation());
+    MDBXC_TEST_ASSERT(observer.applied_batches == 1u);
+    MDBXC_TEST_ASSERT(observer.applied_ops == changes.size());
+    MDBXC_TEST_ASSERT(observer.affected_dbi_names.size() == 1u);
+    MDBXC_TEST_ASSERT(observer.affected_dbi_names[0] == dbi_name);
+
+    MDBXC_TEST_ASSERT(conn->remove_sync_apply_observer(token));
+    MDBXC_TEST_ASSERT(engine.unregister_logical_adapter(
+        "app.logical_kv_engine.v1"));
+    MDBXC_TEST_ASSERT(engine.logical_adapter_count() == 0u);
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_value_logical_adapter_engine_rejects_unknown_schema() {
+    const std::string path = "test_key_value_logical_adapter_unknown.mdbx";
+    const std::string dbi_name = "logical_key_value_unknown";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x17), make_node(0xA7));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    IntStringAdapter adapter(table, "app.logical_kv_unknown.v1");
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(adapter.make_upsert(5, "five"));
+
+    const mdbxc::sync::LogicalApplyResult result =
+        engine.apply_logical_changes(changes);
+    MDBXC_TEST_ASSERT(!result.ok);
+    MDBXC_TEST_ASSERT(result.error.find("No logical adapter") !=
+                      std::string::npos);
+    MDBXC_TEST_ASSERT(!table.contains(5));
 
     conn->disconnect();
     cleanup(path);
@@ -362,6 +470,8 @@ void test_key_value_logical_apply_does_not_recapture_incoming_change() {
 
 int main() {
     test_key_value_logical_adapter_applies_basic_ops();
+    test_key_value_logical_adapter_applies_through_sync_engine();
+    test_key_value_logical_adapter_engine_rejects_unknown_schema();
     test_key_value_logical_adapter_rejects_malformed_payload();
     test_key_value_logical_adapter_uses_stable_payload();
     test_key_value_logical_adapter_decodes_literal_little_endian_payload();


### PR DESCRIPTION
## Summary
- add SyncEngine lifecycle registration for logical table adapters
- add apply_logical_changes() with engine-owned write transaction, rollback on registry failure, and post-commit apply observers
- document that this is explicit engine apply; transport pull/push remains raw-DBI only

## Validation
- git diff --check
- C++11: test_key_value_logical_adapter, test_logical_table_adapter, header_sync_umbrella_test
- C++17: test_key_value_logical_adapter, test_logical_table_adapter, header_sync_umbrella_test