### PR TITLE
feat(sync): add logical change frame codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ All notable changes to this project will be documented in this file.
 - Added public `ChangeDomain`, `LogicalSchemaRef`, and `LogicalChange` model
   types for future logical table adapters. The current wire codec remains
   raw-DBI only.
+- Added `LogicalChangeFrame` and `LogicalChangeFrameCodec` as a strict
+  little-endian binary frame for explicit logical sync paths. The frame is a
+  payload container only: destination routing, origin ordering, and replay
+  protection remain the responsibility of an external delivery envelope or
+  caller-owned transport contract. Transport pull/push DTOs remain raw-DBI only
+  until a later capability-gated PR wires logical delivery into transport
+  exchange.
 - Added `ISyncCaptureSink::record_change_op(MDBX_txn*, const ChangeOp&)` as the
   preferred capture entry point. The previous raw-field callback remains the
   source-compatible abstract sink contract; new full-`ChangeOp` sinks can

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,6 +440,7 @@ if(MDBXC_BUILD_TESTS)
         mdbx_containers/sync/LogicalSchema.hpp
         mdbx_containers/sync/ChangeOp.hpp
         mdbx_containers/sync/LogicalChange.hpp
+        mdbx_containers/sync/LogicalChangeFrameCodec.hpp
         mdbx_containers/sync/LogicalTableAdapter.hpp
         mdbx_containers/sync/LogicalSchemaValidation.hpp
         mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -18,6 +18,7 @@
 #include "sync/LogicalSchema.hpp"
 #include "sync/ChangeOp.hpp"
 #include "sync/LogicalChange.hpp"
+#include "sync/LogicalChangeFrameCodec.hpp"
 #include "sync/LogicalTableAdapter.hpp"
 #include "sync/LogicalSchemaValidation.hpp"
 #include "sync/adapters/KeyValueTableLogicalAdapter.hpp"

--- a/include/mdbx_containers/sync/CodecBounds.hpp
+++ b/include/mdbx_containers/sync/CodecBounds.hpp
@@ -25,6 +25,7 @@ namespace sync {
         std::uint32_t max_cursor_origins       = 10000;               ///< Max origins in one transport cursor.
         std::uint32_t max_batches_per_message  = 10000;               ///< Max batches in one pull/push transport message.
         std::uint32_t max_error_len            = 16u * 1024u;         ///< Max transport error string bytes.
+        std::uint32_t max_logical_schema_id_len = 16u * 1024u;        ///< Max logical frame schema id bytes.
         std::uint32_t max_transport_message_bytes =
             128u * 1024u * 1024u; ///< Max encoded transport message bytes.
     };

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -500,6 +500,16 @@ The v0.1 `ChangeBatchCodec` still serializes raw DBI operations only. Adding
 the logical domain to the wire format requires an explicit codec version bump
 and compatibility tests.
 
+`LogicalChangeFrameCodec.hpp` defines the separate explicit logical frame
+boundary. It is a strict little-endian codec for ordered `LogicalChange`
+payloads, with its own magic/version/mandatory-flags header. This frame is not
+embedded into `TransportMessageCodec` yet; receivers must opt into logical
+apply explicitly and raw pull/push transports remain raw-DBI only. The frame is
+not a delivery envelope: it carries no destination database id, origin node id,
+monotonic sequence, frame id, or replay marker. Retrying transports must provide
+delivery routing, ordering, and replay protection outside this payload layer
+until a dedicated logical delivery envelope is used.
+
 `LogicalTableAdapter.hpp` reserves the apply-side extension point:
 
 - `ILogicalTableAdapter::preflight()` validates one logical change without

--- a/include/mdbx_containers/sync/LogicalChange.hpp
+++ b/include/mdbx_containers/sync/LogicalChange.hpp
@@ -63,6 +63,16 @@ namespace sync {
               payload(operation_payload) {}
     };
 
+    /// \brief Versioned logical change payload exchanged above raw DBI batches.
+    /// \details The transport pull/push DTOs remain raw-DBI only. This frame is
+    /// a payload container, not a delivery envelope: it does not carry
+    /// destination, origin, ordering, or replay identity. Callers that send
+    /// frames over retrying transports must provide those guarantees outside
+    /// this payload layer until a dedicated delivery envelope is used.
+    struct LogicalChangeFrame {
+        std::vector<LogicalChange> changes; ///< Ordered logical operations.
+    };
+
     /// \brief Returns true when \p ref names a concrete logical schema.
     inline bool is_logical_schema_ref_complete(const LogicalSchemaRef& ref) {
         return !ref.schema_id.empty() &&

--- a/include/mdbx_containers/sync/LogicalChangeFrameCodec.hpp
+++ b/include/mdbx_containers/sync/LogicalChangeFrameCodec.hpp
@@ -1,0 +1,378 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_CHANGE_FRAME_CODEC_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_CHANGE_FRAME_CODEC_HPP_INCLUDED
+
+/// \file LogicalChangeFrameCodec.hpp
+/// \brief Stable little-endian codec for explicit logical change frames.
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "CodecBounds.hpp"
+#include "LogicalChange.hpp"
+#include "common.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Stable binary codec for \c LogicalChangeFrame.
+    /// \details This is not yet embedded in \c TransportMessageCodec. It gives
+    /// explicit logical sync paths a strict fail-closed frame boundary while
+    /// raw pull/push transport DTOs remain unchanged. The frame is only a
+    /// payload boundary; routing, ordering, and replay protection belong to a
+    /// separate delivery envelope or caller-owned transport contract.
+    class LogicalChangeFrameCodec {
+    public:
+        /// \brief Encoded magic prefix (8 bytes, no NUL terminator).
+        static const std::uint8_t* magic() {
+            static const std::uint8_t m[8] =
+                { 'M','D','B','X','C','L','G','F' };
+            return m;
+        }
+
+        /// \brief Magic prefix length in bytes.
+        static std::size_t magic_size() { return 8; }
+
+        /// \brief Supported logical frame codec version.
+        static std::uint16_t codec_version() { return 1; }
+
+        /// \brief Encodes \p frame.
+        static std::vector<std::uint8_t> encode(
+                const LogicalChangeFrame& frame,
+                const CodecBounds* bounds = nullptr) {
+            bounds = effective_bounds(bounds);
+            if (frame.changes.size() > bounds->max_ops_per_batch) {
+                throw std::length_error(
+                    "logical changes exceed max_ops_per_batch");
+            }
+            std::vector<std::uint8_t> out;
+            out.reserve(64);
+            append_bytes(out, magic(), magic_size(), bounds);
+            append_u16_le(out, codec_version(), bounds);
+            append_u32_le(out, 0, bounds);
+            append_u32_size(out, frame.changes.size(), bounds,
+                            "logical change count exceeds u32");
+            for (std::size_t i = 0; i < frame.changes.size(); ++i) {
+                append_change(out, frame.changes[i], bounds);
+            }
+            validate_message_size(out, bounds);
+            return out;
+        }
+
+        /// \brief Strictly decodes \p data.
+        static LogicalChangeFrame decode(
+                const std::vector<std::uint8_t>& data,
+                const CodecBounds* bounds = nullptr) {
+            bounds = effective_bounds(bounds);
+            Cursor cur = make_cursor(data, bounds);
+            check_header(cur);
+            const std::uint32_t count = read_u32_le(cur);
+            if (count > bounds->max_ops_per_batch) {
+                throw std::length_error(
+                    "logical changes exceed max_ops_per_batch");
+            }
+            LogicalChangeFrame frame;
+            frame.changes.reserve(count);
+            for (std::uint32_t i = 0; i < count; ++i) {
+                frame.changes.push_back(read_change(cur, bounds));
+            }
+            check_consumed(cur);
+            return frame;
+        }
+
+    private:
+        struct Cursor {
+            const std::uint8_t* data;
+            std::size_t size;
+            std::size_t pos;
+        };
+
+        static const CodecBounds* effective_bounds(
+                const CodecBounds* bounds) {
+            static const CodecBounds defaults;
+            return bounds != nullptr ? bounds : &defaults;
+        }
+
+        static Cursor make_cursor(const std::vector<std::uint8_t>& data,
+                                  const CodecBounds* bounds) {
+            if (data.size() > bounds->max_transport_message_bytes) {
+                throw std::length_error(
+                    "logical frame exceeds max_transport_message_bytes");
+            }
+            Cursor cur;
+            cur.data = data.empty() ? nullptr : &data[0];
+            cur.size = data.size();
+            cur.pos = 0;
+            return cur;
+        }
+
+        static void check_header(Cursor& cur) {
+            check_bounds(cur, magic_size());
+            if (std::memcmp(cur.data + cur.pos, magic(), magic_size()) != 0) {
+                throw std::runtime_error("Logical frame magic mismatch");
+            }
+            cur.pos += magic_size();
+
+            const std::uint16_t version = read_u16_le(cur);
+            if (version != codec_version()) {
+                throw std::runtime_error(
+                    "Unsupported logical frame codec_version");
+            }
+            const std::uint32_t flags = read_u32_le(cur);
+            if (flags != 0) {
+                throw std::runtime_error(
+                    "Unknown mandatory logical frame flags");
+            }
+        }
+
+        static void check_consumed(const Cursor& cur) {
+            if (cur.pos != cur.size) {
+                throw std::runtime_error(
+                    "Trailing bytes after logical frame");
+            }
+        }
+
+        static void check_bounds(const Cursor& cur, std::size_t n) {
+            if (cur.pos > cur.size || n > cur.size - cur.pos) {
+                throw std::runtime_error(
+                    "Logical frame codec buffer underrun");
+            }
+        }
+
+        static void append_bytes(std::vector<std::uint8_t>& out,
+                                 const std::uint8_t* src,
+                                 std::size_t n,
+                                 const CodecBounds* bounds) {
+            if (n == 0) {
+                return;
+            }
+            const std::size_t base = out.size();
+            if (n > std::numeric_limits<std::size_t>::max() - base) {
+                throw std::length_error("logical frame size overflow");
+            }
+            if (base + n > bounds->max_transport_message_bytes) {
+                throw std::length_error(
+                    "logical frame exceeds max_transport_message_bytes");
+            }
+            out.resize(base + n);
+            std::memcpy(&out[base], src, n);
+        }
+
+        static void append_u16_le(std::vector<std::uint8_t>& out,
+                                  std::uint16_t value,
+                                  const CodecBounds* bounds) {
+            ensure_append_size(out, 2, bounds);
+            detail::append_u16_le(out, value);
+        }
+
+        static void append_u32_le(std::vector<std::uint8_t>& out,
+                                  std::uint32_t value,
+                                  const CodecBounds* bounds) {
+            ensure_append_size(out, 4, bounds);
+            detail::append_u32_le(out, value);
+        }
+
+        static void ensure_append_size(
+                const std::vector<std::uint8_t>& out,
+                std::size_t n,
+                const CodecBounds* bounds) {
+            if (n > std::numeric_limits<std::size_t>::max() - out.size()) {
+                throw std::length_error("logical frame size overflow");
+            }
+            if (out.size() + n > bounds->max_transport_message_bytes) {
+                throw std::length_error(
+                    "logical frame exceeds max_transport_message_bytes");
+            }
+        }
+
+        static void append_u32_size(std::vector<std::uint8_t>& out,
+                                    std::size_t value,
+                                    const CodecBounds* bounds,
+                                    const char* label) {
+            if (value > static_cast<std::size_t>(
+                    std::numeric_limits<std::uint32_t>::max())) {
+                throw std::length_error(label);
+            }
+            append_u32_le(out, static_cast<std::uint32_t>(value), bounds);
+        }
+
+        static void append_string(std::vector<std::uint8_t>& out,
+                                  const std::string& value,
+                                  const CodecBounds* bounds,
+                                  const char* label) {
+            if (value.empty()) {
+                throw std::runtime_error(label);
+            }
+            if (value.size() > bounds->max_logical_schema_id_len) {
+                throw std::length_error(
+                    "logical schema id exceeds max_logical_schema_id_len");
+            }
+            append_u32_size(out, value.size(), bounds,
+                            "string length exceeds u32");
+            append_bytes(out,
+                         reinterpret_cast<const std::uint8_t*>(value.data()),
+                         value.size(), bounds);
+        }
+
+        static void append_payload(std::vector<std::uint8_t>& out,
+                                   const std::vector<std::uint8_t>& payload,
+                                   const CodecBounds* bounds) {
+            if (payload.size() > bounds->max_value_len) {
+                throw std::length_error(
+                    "logical payload exceeds max_value_len");
+            }
+            append_u32_size(out, payload.size(), bounds,
+                            "logical payload length exceeds u32");
+            append_bytes(out, payload.empty() ? nullptr : &payload[0],
+                         payload.size(), bounds);
+        }
+
+        static void append_kind(std::vector<std::uint8_t>& out,
+                                LogicalTableKind kind,
+                                const CodecBounds* bounds) {
+            if (!is_known_logical_table_kind(kind)) {
+                throw std::logic_error(
+                    "LogicalChange has unknown table kind");
+            }
+            append_u16_le(out, static_cast<std::uint16_t>(kind),
+                          bounds);
+        }
+
+        static void append_change(std::vector<std::uint8_t>& out,
+                                  const LogicalChange& change,
+                                  const CodecBounds* bounds) {
+            if (!is_logical_schema_ref_complete(change.schema)) {
+                throw std::logic_error(
+                    "LogicalChange schema ref is incomplete");
+            }
+            if (change.flags != 0) {
+                throw std::logic_error(
+                    "LogicalChange flags are reserved and must be zero");
+            }
+            append_string(out, change.schema.schema_id, bounds,
+                          "LogicalChange schema id is empty");
+            append_kind(out, change.schema.kind, bounds);
+            append_u32_le(out, change.schema.schema_version, bounds);
+            append_u32_le(out, change.opcode, bounds);
+            append_u32_le(out, change.flags, bounds);
+            append_payload(out, change.payload, bounds);
+        }
+
+        static void validate_message_size(
+                const std::vector<std::uint8_t>& out,
+                const CodecBounds* bounds) {
+            if (out.size() > bounds->max_transport_message_bytes) {
+                throw std::length_error(
+                    "logical frame exceeds max_transport_message_bytes");
+            }
+        }
+
+        static std::uint16_t read_u16_le(Cursor& cur) {
+            check_bounds(cur, 2);
+            const std::uint16_t value =
+                detail::read_u16_le(cur.data + cur.pos);
+            cur.pos += 2;
+            return value;
+        }
+
+        static std::uint32_t read_u32_le(Cursor& cur) {
+            check_bounds(cur, 4);
+            const std::uint32_t value =
+                detail::read_u32_le(cur.data + cur.pos);
+            cur.pos += 4;
+            return value;
+        }
+
+        static const std::uint8_t* read_bytes(Cursor& cur, std::size_t n) {
+            check_bounds(cur, n);
+            if (n == 0) {
+                return nullptr;
+            }
+            const std::uint8_t* out = cur.data + cur.pos;
+            cur.pos += n;
+            return out;
+        }
+
+        static std::string read_string(Cursor& cur,
+                                       const CodecBounds* bounds,
+                                       const char* label) {
+            const std::uint32_t len = read_u32_le(cur);
+            if (len == 0) {
+                throw std::runtime_error(label);
+            }
+            if (len > bounds->max_logical_schema_id_len) {
+                throw std::length_error(
+                    "logical schema id exceeds max_logical_schema_id_len");
+            }
+            const std::uint8_t* bytes = read_bytes(cur, len);
+            return std::string(reinterpret_cast<const char*>(bytes), len);
+        }
+
+        static LogicalTableKind read_kind(Cursor& cur) {
+            const std::uint16_t value = read_u16_le(cur);
+            switch (value) {
+                case static_cast<std::uint16_t>(
+                        LogicalTableKind::AnyValue):
+                    return LogicalTableKind::AnyValue;
+                case static_cast<std::uint16_t>(
+                        LogicalTableKind::HashedKeyValue):
+                    return LogicalTableKind::HashedKeyValue;
+                case static_cast<std::uint16_t>(
+                        LogicalTableKind::KeyValue):
+                    return LogicalTableKind::KeyValue;
+                case static_cast<std::uint16_t>(
+                        LogicalTableKind::KeyMultiValue):
+                    return LogicalTableKind::KeyMultiValue;
+                case static_cast<std::uint16_t>(
+                        LogicalTableKind::KeyOrderedMultiValue):
+                    return LogicalTableKind::KeyOrderedMultiValue;
+            }
+            throw std::runtime_error("Invalid logical table kind");
+        }
+
+        static std::vector<std::uint8_t> read_payload(
+                Cursor& cur,
+                const CodecBounds* bounds) {
+            const std::uint32_t len = read_u32_le(cur);
+            if (len > bounds->max_value_len) {
+                throw std::length_error(
+                    "logical payload exceeds max_value_len");
+            }
+            const std::uint8_t* bytes = read_bytes(cur, len);
+            std::vector<std::uint8_t> payload(len);
+            if (len != 0u) {
+                std::memcpy(&payload[0], bytes, len);
+            }
+            return payload;
+        }
+
+        static LogicalChange read_change(Cursor& cur,
+                                         const CodecBounds* bounds) {
+            LogicalChange change;
+            change.schema.schema_id = read_string(
+                cur, bounds, "LogicalChange schema id is empty");
+            change.schema.kind = read_kind(cur);
+            change.schema.schema_version = read_u32_le(cur);
+            if (change.schema.schema_version == 0) {
+                throw std::runtime_error(
+                    "LogicalChange schema version is zero");
+            }
+            change.opcode = read_u32_le(cur);
+            change.flags = read_u32_le(cur);
+            if (change.flags != 0) {
+                throw std::runtime_error(
+                    "LogicalChange flags are reserved and must be zero");
+            }
+            change.payload = read_payload(cur, bounds);
+            return change;
+        }
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_CHANGE_FRAME_CODEC_HPP_INCLUDED

--- a/tests/test_logical_change_frame_codec.cpp
+++ b/tests/test_logical_change_frame_codec.cpp
@@ -1,0 +1,110 @@
+#include <mdbx_containers/sync.hpp>
+
+#include "test_assert.hpp"
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+mdbxc::sync::LogicalChange make_change(
+        const std::string& schema_id,
+        mdbxc::sync::LogicalTableKind kind,
+        std::uint32_t schema_version,
+        std::uint32_t opcode,
+        const std::vector<std::uint8_t>& payload) {
+    mdbxc::sync::LogicalSchemaRef ref;
+    ref.schema_id = schema_id;
+    ref.kind = kind;
+    ref.schema_version = schema_version;
+    return mdbxc::sync::LogicalChange(ref, opcode, 0, payload);
+}
+
+void test_logical_frame_roundtrip() {
+    mdbxc::sync::LogicalChangeFrame frame;
+    std::vector<std::uint8_t> first_payload;
+    first_payload.push_back(1);
+    first_payload.push_back(2);
+    first_payload.push_back(3);
+    frame.changes.push_back(make_change(
+        "app.logical.items.v1",
+        mdbxc::sync::LogicalTableKind::KeyValue,
+        1,
+        10,
+        first_payload));
+
+    std::vector<std::uint8_t> second_payload;
+    second_payload.push_back(0);
+    second_payload.push_back(255);
+    frame.changes.push_back(make_change(
+        "app.logical.items.v2",
+        mdbxc::sync::LogicalTableKind::KeyMultiValue,
+        2,
+        11,
+        second_payload));
+
+    const std::vector<std::uint8_t> encoded =
+        mdbxc::sync::LogicalChangeFrameCodec::encode(frame);
+    MDBXC_TEST_ASSERT(encoded.size() >
+                      mdbxc::sync::LogicalChangeFrameCodec::magic_size());
+
+    const mdbxc::sync::LogicalChangeFrame decoded =
+        mdbxc::sync::LogicalChangeFrameCodec::decode(encoded);
+    MDBXC_TEST_ASSERT(decoded.changes.size() == 2u);
+    MDBXC_TEST_ASSERT(decoded.changes[0].schema.schema_id ==
+                      "app.logical.items.v1");
+    MDBXC_TEST_ASSERT(decoded.changes[0].schema.kind ==
+                      mdbxc::sync::LogicalTableKind::KeyValue);
+    MDBXC_TEST_ASSERT(decoded.changes[0].schema.schema_version == 1u);
+    MDBXC_TEST_ASSERT(decoded.changes[0].opcode == 10u);
+    MDBXC_TEST_ASSERT(decoded.changes[0].flags == 0u);
+    MDBXC_TEST_ASSERT(decoded.changes[0].payload == first_payload);
+
+    MDBXC_TEST_ASSERT(decoded.changes[1].schema.schema_id ==
+                      "app.logical.items.v2");
+    MDBXC_TEST_ASSERT(decoded.changes[1].schema.kind ==
+                      mdbxc::sync::LogicalTableKind::KeyMultiValue);
+    MDBXC_TEST_ASSERT(decoded.changes[1].schema.schema_version == 2u);
+    MDBXC_TEST_ASSERT(decoded.changes[1].opcode == 11u);
+    MDBXC_TEST_ASSERT(decoded.changes[1].payload == second_payload);
+}
+
+void test_empty_logical_frame_roundtrip() {
+    mdbxc::sync::LogicalChangeFrame frame;
+    const std::vector<std::uint8_t> encoded =
+        mdbxc::sync::LogicalChangeFrameCodec::encode(frame);
+    const mdbxc::sync::LogicalChangeFrame decoded =
+        mdbxc::sync::LogicalChangeFrameCodec::decode(encoded);
+    MDBXC_TEST_ASSERT(decoded.changes.empty());
+}
+
+void test_logical_frame_encode_rejects_reserved_change_flags() {
+    mdbxc::sync::LogicalChangeFrame frame;
+    std::vector<std::uint8_t> payload;
+    frame.changes.push_back(make_change(
+        "app.logical.items.v1",
+        mdbxc::sync::LogicalTableKind::KeyValue,
+        1,
+        10,
+        payload));
+    frame.changes[0].flags = 1u;
+
+    bool caught = false;
+    try {
+        (void)mdbxc::sync::LogicalChangeFrameCodec::encode(frame);
+    } catch (const std::logic_error&) {
+        caught = true;
+    }
+    MDBXC_TEST_ASSERT(caught);
+}
+
+} // namespace
+
+int main() {
+    test_logical_frame_roundtrip();
+    test_empty_logical_frame_roundtrip();
+    test_logical_frame_encode_rejects_reserved_change_flags();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `LogicalChangeFrame` as an explicit logical operation frame
- add `LogicalChangeFrameCodec` with magic/version/mandatory-flags envelope
- expose the codec through `sync.hpp` and standalone header smoke list

## Validation
- `cmake --build tmp\build-pr200-cpp17-mingw --target test_logical_change_frame_codec header_sync_umbrella_test header_standalone_mdbx_containers_sync_LogicalChangeFrameCodec_hpp`
- `cmake --build tmp\build-pr200-cpp11-mingw --target test_logical_change_frame_codec header_sync_umbrella_test header_standalone_mdbx_containers_sync_LogicalChangeFrameCodec_hpp`
- `ctest --test-dir tmp\build-pr200-cpp17-mingw -R test_logical_change_frame_codec|header_sync_umbrella_test|header_standalone_mdbx_containers_sync_LogicalChangeFrameCodec_hpp --output-on-failure`
- `ctest --test-dir tmp\build-pr200-cpp11-mingw -R test_logical_change_frame_codec|header_sync_umbrella_test|header_standalone_mdbx_containers_sync_LogicalChangeFrameCodec_hpp --output-on-failure`