### PR TITLE
docs(sync): add key-value logical frame example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ All notable changes to this project will be documented in this file.
   adapter path. Malformed frame bytes return a failure result before adapter
   preflight or mutation, while apply-stage exceptions are reported separately
   from decode failures.
+- Added `sync_23_key_value_logical_frame.cpp` to demonstrate the explicit
+  `KeyValueTable` logical capture-session -> logical frame codec -> replica
+  apply workflow.
 - Added `ISyncCaptureSink::record_change_op(MDBX_txn*, const ChangeOp&)` as the
   preferred capture entry point. The previous raw-field callback remains the
   source-compatible abstract sink contract; new full-`ChangeOp` sinks can

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -209,6 +209,7 @@ cmake -S . -B tmp/build-ws-example `
 | `sync_20_observability.cpp` | Логи worker/transport observer-ов с trace IDs, progress и retry hints. | Продвинутый |
 | `sync_21_worker_guard_apply_hooks.cpp` | Жизненный цикл через `SyncNodeSession` и remote apply observer hooks. | Средний |
 | `sync_22_node_session_minimal.cpp` | Минимальный application-facing recipe для `SyncNodeSession`. | Начальный |
+| `sync_23_key_value_logical_frame.cpp` | Явный путь `KeyValueTable`: logical capture -> frame codec -> apply на реплике. | Продвинутый |
 
 ## Общие правила
 
@@ -238,6 +239,15 @@ cmake -S . -B tmp/build-ws-example `
   реплицируются как один локальный batch. Независимые вызовы без явной
   транзакции остаются независимыми локальными транзакциями и независимыми sync
   batches.
+- Logical capture через `KeyValueTableLogicalAdapter` сейчас является явным
+  opt-in путём. `LogicalChangeFrameCodec` может переносить такие typed logical
+  changes между компонентами приложения, а получатель применяет их через
+  `SyncEngine::apply_logical_frame_bytes()`. Обычные transport DTO
+  `PullRequest`, `PullResponse`, `PushRequest` и `PushResponse` остаются
+  raw-DBI only до появления negotiation для logical transport capabilities.
+  `LogicalChangeFrame` является payload-контейнером, а не протоколом доставки:
+  retrying transports всё ещё требуют внешний контракт для destination routing,
+  ordering и replay protection.
 - Чтение, поиск и range scans не запускают sync. Локальный commit также не
   обращается к другой ноде; `SyncWorker` или явный pull/push-код позже
   отправляет уже закоммиченные batches через `ISyncPeer`.

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -207,6 +207,7 @@ cmake -S . -B tmp/build-ws-example `
 | `sync_20_observability.cpp` | Worker and transport observer logs with trace IDs, progress, and retry hints. | Advanced |
 | `sync_21_worker_guard_apply_hooks.cpp` | `SyncNodeSession` lifecycle plus remote apply observer hooks. | Intermediate |
 | `sync_22_node_session_minimal.cpp` | Minimal application-facing `SyncNodeSession` recipe. | Beginner |
+| `sync_23_key_value_logical_frame.cpp` | Explicit `KeyValueTable` logical capture -> frame codec -> replica apply path. | Advanced |
 
 ## Common Rules
 
@@ -238,6 +239,15 @@ cmake -S . -B tmp/build-ws-example `
 - Sync is not triggered by reads, searches, or range scans. It also does not
   contact another node during the local commit; a `SyncWorker` or explicit
   pull/push code sends already committed batches later through an `ISyncPeer`.
+- `KeyValueTableLogicalAdapter` logical capture is currently an explicit opt-in
+  path. `LogicalChangeFrameCodec` can carry those typed logical changes between
+  application components, and the receiver applies them with
+  `SyncEngine::apply_logical_frame_bytes()`. The normal `PullRequest`,
+  `PullResponse`, `PushRequest`, and `PushResponse` transport DTOs remain
+  raw-DBI only until logical transport capability negotiation is added.
+  `LogicalChangeFrame` is a payload container, not a delivery protocol: retrying
+  transports still need an outer contract for destination routing, ordering, and
+  replay protection.
 - The minimal `SyncNodeSession` recipe uses `DirectSyncPeer` to stay
   dependency-free. A real HTTP node keeps the same session shape and replaces
   only the peer with a ready-made HTTP transport binding, for example

--- a/examples/sync_23_key_value_logical_frame.cpp
+++ b/examples/sync_23_key_value_logical_frame.cpp
@@ -1,0 +1,135 @@
+/**
+ * \ingroup mdbxc_examples
+ * \brief Explicit KeyValueTable logical frame replication.
+ *
+ * This example demonstrates the current opt-in logical sync path:
+ *   - source writes through KeyValueTableLogicalAdapter::LogicalCaptureSession;
+ *   - captured logical changes are encoded with LogicalChangeFrameCodec;
+ *   - replica decodes and applies the frame with SyncEngine.
+ *
+ * The normal pull/push transport DTOs remain raw-DBI only. Applications must
+ * opt into this logical frame path explicitly until transport capability
+ * negotiation is added.
+ *
+ * LogicalChangeFrame is only the payload container used here for a local
+ * handoff. It does not provide destination routing, delivery ordering, or
+ * replay protection for retrying transports; those belong to a separate
+ * delivery envelope or caller-owned protocol.
+ *
+ * Expected output:
+ *   [source] captured 3 logical change(s)
+ *   [wire] logical frame bytes=...
+ *   [replica] product 101=keyboard product 102 visible=no
+ *   OK: sync_23_key_value_logical_frame
+ */
+
+#include "sync_example_utils.hpp"
+
+#include <cstdio>
+#include <exception>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+typedef mdbxc::sync::KeyValueLogicalInt32Codec<int> IntKeyCodec;
+typedef mdbxc::sync::KeyValueLogicalStringCodec<std::string> StringValueCodec;
+typedef mdbxc::sync::KeyValueTableLogicalAdapter<
+    int, std::string, IntKeyCodec, StringValueCodec> ProductAdapter;
+
+} // namespace
+
+int main() {
+    const std::string source_path = "sync_23_source.mdbx";
+    const std::string replica_path = "sync_23_replica.mdbx";
+    const std::string dbi_name = "products";
+    const std::string schema_id = "app.products.kv.v1";
+
+    sync_example::cleanup(source_path);
+    sync_example::cleanup(replica_path);
+
+    std::shared_ptr<mdbxc::Connection> source_conn;
+    std::shared_ptr<mdbxc::Connection> replica_conn;
+
+    try {
+        const mdbxc::sync::NodeId source_node =
+            sync_example::make_node(0x41);
+        const mdbxc::sync::NodeId replica_node =
+            sync_example::make_node(0x42);
+        const mdbxc::sync::NodeId db_id =
+            sync_example::make_node(0xD3);
+
+        source_conn = sync_example::open(source_path);
+        replica_conn = sync_example::open(replica_path);
+
+        mdbxc::sync::SyncEngine source_engine(source_conn);
+        mdbxc::sync::SyncEngine replica_engine(replica_conn);
+        source_engine.initialize_local_identity(source_node, db_id);
+        replica_engine.initialize_local_identity(replica_node, db_id);
+
+        mdbxc::sync::LogicalSchemaRecord record;
+        record.dbi_name = dbi_name;
+        record.kind = mdbxc::sync::LogicalTableKind::KeyValue;
+        record.schema_version = 1;
+        record.dbi_names.push_back(dbi_name);
+        source_engine.register_logical_schema(schema_id, record);
+        replica_engine.register_logical_schema(schema_id, record);
+
+        mdbxc::KeyValueTable<int, std::string> source_products(
+            source_conn, dbi_name);
+        mdbxc::KeyValueTable<int, std::string> replica_products(
+            replica_conn, dbi_name);
+        ProductAdapter source_adapter(source_products, schema_id);
+        ProductAdapter replica_adapter(replica_products, schema_id);
+        replica_engine.register_logical_adapter(replica_adapter);
+
+        std::vector<mdbxc::sync::LogicalChange> captured;
+        {
+            std::unique_ptr<ProductAdapter::LogicalCaptureSession> session =
+                source_adapter.begin_capture_session();
+            session->insert_or_assign(101, "keyboard");
+            session->insert_or_assign(102, "mouse");
+            (void)session->erase(102);
+            session->commit(captured);
+        }
+
+        std::printf("[source] captured %zu logical change(s)\n",
+                    captured.size());
+
+        mdbxc::sync::LogicalChangeFrame frame;
+        frame.changes = captured;
+        const std::vector<std::uint8_t> wire =
+            mdbxc::sync::LogicalChangeFrameCodec::encode(frame);
+        std::printf("[wire] logical frame bytes=%zu\n", wire.size());
+
+        const mdbxc::sync::LogicalApplyResult applied =
+            replica_engine.apply_logical_frame_bytes(wire);
+        sync_example::require(applied.ok, applied.error);
+
+        const std::string product = sync_example::kv_or_throw(
+            replica_conn, replica_products, 101, "replica product 101");
+        const bool second_visible =
+            sync_example::kv_has(replica_conn, replica_products, 102);
+        sync_example::require(product == "keyboard",
+                              "replica product 101 mismatch");
+        sync_example::require(!second_visible,
+                              "deleted product 102 replicated as visible");
+
+        std::printf("[replica] product 101=%s product 102 visible=%s\n",
+                    product.c_str(), second_visible ? "yes" : "no");
+
+        sync_example::disconnect_and_cleanup(source_conn, source_path);
+        sync_example::disconnect_and_cleanup(replica_conn, replica_path);
+        std::puts("OK: sync_23_key_value_logical_frame");
+        return 0;
+    } catch (const std::exception& e) {
+        std::fprintf(stderr,
+                     "sync_23_key_value_logical_frame failed: %s\n",
+                     e.what());
+    }
+
+    sync_example::disconnect_and_cleanup(source_conn, source_path);
+    sync_example::disconnect_and_cleanup(replica_conn, replica_path);
+    return 1;
+}


### PR DESCRIPTION
## Summary
- add `sync_23_key_value_logical_frame.cpp` example
- document the explicit KeyValue logical capture -> frame codec -> replica apply workflow
- keep EN/RU sync example guides aligned

## Validation
- `cmake --build tmp\build-pr200-cpp17-mingw --target sync_23_key_value_logical_frame`
- `cmake --build tmp\build-pr200-cpp11-mingw --target sync_23_key_value_logical_frame`
- `tmp\build-pr200-cpp17-mingw\bin\examples\sync_23_key_value_logical_frame.exe`
- `tmp\build-pr200-cpp11-mingw\bin\examples\sync_23_key_value_logical_frame.exe`