### PR TITLE
feat(sync): add logical delivery envelope dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,15 @@ All notable changes to this project will be documented in this file.
 - Added `sync_23_key_value_logical_frame.cpp` to demonstrate the explicit
   `KeyValueTable` logical capture-session -> logical frame codec -> replica
   apply workflow.
+- Added `LogicalDeliveryEnvelope`, `LogicalDeliveryEnvelopeCodec`, and the
+  `_mdbxc_logical_delivery` replay marker store. `SyncEngine` can now apply a
+  delivery envelope with destination db uuid validation and atomic persisted
+  deduplication in the same transaction as logical adapter mutations. Replay
+  markers use fixed-size MDBX keys, bind the full delivery identity to
+  canonical nested frame bytes, reject identity collisions with different
+  payloads, preserve caller codec bounds during marker creation, and skip
+  self-origin loopback envelopes as successful no-ops. Ordering and marker
+  retention remain external/future lifecycle contracts.
 - Added `ISyncCaptureSink::record_change_op(MDBX_txn*, const ChangeOp&)` as the
   preferred capture entry point. The previous raw-field callback remains the
   source-compatible abstract sink contract; new full-`ChangeOp` sinks can

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,6 +441,8 @@ if(MDBXC_BUILD_TESTS)
         mdbx_containers/sync/ChangeOp.hpp
         mdbx_containers/sync/LogicalChange.hpp
         mdbx_containers/sync/LogicalChangeFrameCodec.hpp
+        mdbx_containers/sync/LogicalDeliveryEnvelope.hpp
+        mdbx_containers/sync/LogicalDeliveryEnvelopeCodec.hpp
         mdbx_containers/sync/LogicalTableAdapter.hpp
         mdbx_containers/sync/LogicalSchemaValidation.hpp
         mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp
@@ -449,6 +451,7 @@ if(MDBXC_BUILD_TESTS)
         mdbx_containers/sync/SyncApplyObserver.hpp
         mdbx_containers/sync/SyncNodeSession.hpp
         mdbx_containers/sync/SyncWorkerGuard.hpp
+        mdbx_containers/sync/stores/LogicalDeliveryStore.hpp
         mdbx_containers/sync/stores/SchemaRegistryStore.hpp
         mdbx_containers/sync/TransportMessageCodec.hpp
     )

--- a/examples/README-sync-RU.md
+++ b/examples/README-sync-RU.md
@@ -246,8 +246,8 @@ cmake -S . -B tmp/build-ws-example `
   `PullRequest`, `PullResponse`, `PushRequest` и `PushResponse` остаются
   raw-DBI only до появления negotiation для logical transport capabilities.
   `LogicalChangeFrame` является payload-контейнером, а не протоколом доставки:
-  retrying transports всё ещё требуют внешний контракт для destination routing,
-  ordering и replay protection.
+  retrying transports должны оборачивать его в `LogicalDeliveryEnvelope`, где
+  есть destination identity и persistent replay protection.
 - Чтение, поиск и range scans не запускают sync. Локальный commit также не
   обращается к другой ноде; `SyncWorker` или явный pull/push-код позже
   отправляет уже закоммиченные batches через `ISyncPeer`.

--- a/examples/README-sync.md
+++ b/examples/README-sync.md
@@ -246,8 +246,8 @@ cmake -S . -B tmp/build-ws-example `
   `PullResponse`, `PushRequest`, and `PushResponse` transport DTOs remain
   raw-DBI only until logical transport capability negotiation is added.
   `LogicalChangeFrame` is a payload container, not a delivery protocol: retrying
-  transports still need an outer contract for destination routing, ordering, and
-  replay protection.
+  transports should wrap it in `LogicalDeliveryEnvelope`, which adds destination
+  routing identity and persisted replay protection.
 - The minimal `SyncNodeSession` recipe uses `DirectSyncPeer` to stay
   dependency-free. A real HTTP node keeps the same session shape and replaces
   only the peer with a ready-made HTTP transport binding, for example

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -19,6 +19,7 @@
 #include "sync/ChangeOp.hpp"
 #include "sync/LogicalChange.hpp"
 #include "sync/LogicalChangeFrameCodec.hpp"
+#include "sync/LogicalDeliveryEnvelopeCodec.hpp"
 #include "sync/LogicalTableAdapter.hpp"
 #include "sync/LogicalSchemaValidation.hpp"
 #include "sync/adapters/KeyValueTableLogicalAdapter.hpp"
@@ -49,6 +50,7 @@
 #include "sync/stores/ChangeLogStore.hpp"
 #include "sync/stores/AppliedStore.hpp"
 #include "sync/stores/IdentityIndexStore.hpp"
+#include "sync/stores/LogicalDeliveryStore.hpp"
 #include "sync/stores/SchemaRegistryStore.hpp"
 #endif
 

--- a/include/mdbx_containers/sync/CodecBounds.hpp
+++ b/include/mdbx_containers/sync/CodecBounds.hpp
@@ -26,6 +26,8 @@ namespace sync {
         std::uint32_t max_batches_per_message  = 10000;               ///< Max batches in one pull/push transport message.
         std::uint32_t max_error_len            = 16u * 1024u;         ///< Max transport error string bytes.
         std::uint32_t max_logical_schema_id_len = 16u * 1024u;        ///< Max logical frame schema id bytes.
+        std::uint32_t max_logical_delivery_frame_id_len =
+            16u * 1024u; ///< Max logical delivery frame id bytes.
         std::uint32_t max_transport_message_bytes =
             128u * 1024u * 1024u; ///< Max encoded transport message bytes.
     };

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -510,6 +510,38 @@ monotonic sequence, frame id, or replay marker. Retrying transports must provide
 delivery routing, ordering, and replay protection outside this payload layer
 until a dedicated logical delivery envelope is used.
 
+`LogicalDeliveryEnvelopeCodec.hpp` defines that outer retry-safe layer for
+explicit logical frame delivery. The envelope carries the destination database
+uuid, origin node id, origin sequence, stable frame id, and nested
+`LogicalChangeFrame`. `SyncEngine::apply_logical_delivery_envelope()` validates
+the destination against local sync metadata, inserts a persistent marker into
+`_mdbxc_logical_delivery` with `MDBX_NOOVERWRITE`, and applies adapter mutations
+in the same writable transaction. If the transaction rolls back, both user data
+and the replay marker roll back. If the same delivery key is seen again after a
+committed apply, the engine treats it as a successful no-op and does not invoke
+adapters again. Envelopes whose origin is the local node are also treated as
+successful no-ops before marker insertion, matching the raw sync self-origin
+guard.
+
+The marker key is fixed-size: origin node id, origin sequence, and a stable
+digest of `frame_id`. The marker value stores the full delivery identity,
+destination database id, and canonical encoded nested frame bytes; reusing the
+same delivery key with different frame content is an explicit identity conflict.
+When `apply_logical_delivery_envelope_bytes()` receives custom `CodecBounds`,
+the same bounds are used for decode and marker frame fingerprinting.
+
+This delivery envelope provides routing validation and replay deduplication, but
+not ordered delivery. The receiver currently accepts envelopes from the same
+origin out of sequence, and it treats different `frame_id` values with the same
+`origin_sequence` as different delivery identities. Applications or transports
+that require ordered effects must serialize delivery externally until a later
+per-origin watermark/gap contract is added.
+
+`_mdbxc_logical_delivery` retention is currently permanent and unbounded. A
+future lifecycle PR should add an acknowledgement horizon or per-origin
+watermark before old replay markers can be pruned safely; deleting markers by
+time alone would re-open the exact late-retry problem the store prevents.
+
 `LogicalTableAdapter.hpp` reserves the apply-side extension point:
 
 - `ILogicalTableAdapter::preflight()` validates one logical change without

--- a/include/mdbx_containers/sync/LogicalDeliveryEnvelope.hpp
+++ b/include/mdbx_containers/sync/LogicalDeliveryEnvelope.hpp
@@ -1,0 +1,74 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_DELIVERY_ENVELOPE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_DELIVERY_ENVELOPE_HPP_INCLUDED
+
+/// \file LogicalDeliveryEnvelope.hpp
+/// \brief Retry-safe delivery metadata for logical change frames.
+
+#include <cstdint>
+#include <string>
+
+#include "CodecBounds.hpp"
+#include "LogicalChange.hpp"
+#include "common.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Logical frame plus delivery identity.
+    /// \details This envelope is the replay-safe layer above
+    /// \c LogicalChangeFrame. The frame remains an adapter payload container;
+    /// the envelope supplies destination routing and stable origin identity
+    /// that receivers can persist atomically with logical mutations.
+    struct LogicalDeliveryEnvelope {
+        DbId destination_db_uuid{};       ///< Expected receiver database id.
+        NodeId origin_node_id{};          ///< Stable sender node id.
+        std::uint64_t origin_sequence = 0;///< Sender-side sequence component.
+        std::string frame_id;             ///< Stable sender frame id.
+        LogicalChangeFrame frame;         ///< Logical payload.
+    };
+
+    /// \brief Returns true when \p id is all zeros.
+    inline bool is_zero_sync_id(const NodeId& id) {
+        const NodeId zero{};
+        return compare_node_id(id, zero) == 0;
+    }
+
+    /// \brief Returns true when \p envelope has required delivery identity.
+    inline bool is_logical_delivery_envelope_complete(
+            const LogicalDeliveryEnvelope& envelope) {
+        return !is_zero_sync_id(envelope.destination_db_uuid) &&
+               !is_zero_sync_id(envelope.origin_node_id) &&
+               envelope.origin_sequence != 0 &&
+               !envelope.frame_id.empty();
+    }
+
+    /// \brief Returns effective delivery envelope codec bounds.
+    inline const CodecBounds& logical_delivery_effective_bounds(
+            const CodecBounds* bounds) {
+        static const CodecBounds defaults;
+        return bounds != nullptr ? *bounds : defaults;
+    }
+
+    /// \brief Throws when delivery identity violates structural bounds.
+    inline void validate_logical_delivery_envelope(
+            const LogicalDeliveryEnvelope& envelope,
+            const CodecBounds* bounds = nullptr) {
+        const CodecBounds& effective =
+            logical_delivery_effective_bounds(bounds);
+        if (!is_logical_delivery_envelope_complete(envelope)) {
+            throw std::runtime_error(
+                "Logical delivery envelope identity is incomplete");
+        }
+        if (envelope.frame_id.size() >
+            effective.max_logical_delivery_frame_id_len) {
+            throw std::length_error(
+                "logical delivery frame id exceeds "
+                "max_logical_delivery_frame_id_len");
+        }
+    }
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_DELIVERY_ENVELOPE_HPP_INCLUDED

--- a/include/mdbx_containers/sync/LogicalDeliveryEnvelopeCodec.hpp
+++ b/include/mdbx_containers/sync/LogicalDeliveryEnvelopeCodec.hpp
@@ -1,0 +1,301 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_DELIVERY_ENVELOPE_CODEC_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_DELIVERY_ENVELOPE_CODEC_HPP_INCLUDED
+
+/// \file LogicalDeliveryEnvelopeCodec.hpp
+/// \brief Stable little-endian codec for logical delivery envelopes.
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "CodecBounds.hpp"
+#include "LogicalChangeFrameCodec.hpp"
+#include "LogicalDeliveryEnvelope.hpp"
+#include "common.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Stable binary codec for \c LogicalDeliveryEnvelope.
+    /// \details The envelope supplies routing and replay identity around a
+    /// nested \c LogicalChangeFrame. The nested frame is decoded with the same
+    /// bounds so malformed payloads fail before adapter preflight.
+    class LogicalDeliveryEnvelopeCodec {
+    public:
+        /// \brief Encoded magic prefix (8 bytes, no NUL terminator).
+        static const std::uint8_t* magic() {
+            static const std::uint8_t m[8] =
+                { 'M','D','B','X','C','L','D','E' };
+            return m;
+        }
+
+        /// \brief Magic prefix length in bytes.
+        static std::size_t magic_size() { return 8; }
+
+        /// \brief Supported delivery envelope codec version.
+        static std::uint16_t codec_version() { return 1; }
+
+        /// \brief Encodes \p envelope.
+        static std::vector<std::uint8_t> encode(
+                const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds = nullptr) {
+            bounds = effective_bounds(bounds);
+            validate_envelope(envelope, bounds);
+            const std::vector<std::uint8_t> frame_bytes =
+                LogicalChangeFrameCodec::encode(envelope.frame, bounds);
+
+            std::vector<std::uint8_t> out;
+            out.reserve(128);
+            append_bytes(out, magic(), magic_size(), bounds);
+            append_u16_le(out, codec_version(), bounds);
+            append_u32_le(out, 0, bounds);
+            append_bytes(out, envelope.destination_db_uuid.data(),
+                         envelope.destination_db_uuid.size(), bounds);
+            append_bytes(out, envelope.origin_node_id.data(),
+                         envelope.origin_node_id.size(), bounds);
+            append_u64_le(out, envelope.origin_sequence, bounds);
+            append_string(out, envelope.frame_id, bounds);
+            append_u32_size(out, frame_bytes.size(), bounds,
+                            "logical delivery frame length exceeds u32");
+            append_bytes(out,
+                         frame_bytes.empty() ? nullptr : &frame_bytes[0],
+                         frame_bytes.size(), bounds);
+            return out;
+        }
+
+        /// \brief Strictly decodes \p data.
+        static LogicalDeliveryEnvelope decode(
+                const std::vector<std::uint8_t>& data,
+                const CodecBounds* bounds = nullptr) {
+            bounds = effective_bounds(bounds);
+            Cursor cur = make_cursor(data, bounds);
+            check_header(cur);
+
+            LogicalDeliveryEnvelope envelope;
+            read_id(cur, envelope.destination_db_uuid);
+            read_id(cur, envelope.origin_node_id);
+            envelope.origin_sequence = read_u64_le(cur);
+            envelope.frame_id = read_string(cur, bounds);
+            const std::uint32_t frame_size = read_u32_le(cur);
+            const std::uint8_t* frame_bytes = read_bytes(cur, frame_size);
+            std::vector<std::uint8_t> nested(frame_size);
+            if (frame_size != 0u) {
+                std::memcpy(&nested[0], frame_bytes, frame_size);
+            }
+            envelope.frame = LogicalChangeFrameCodec::decode(nested, bounds);
+            validate_envelope(envelope, bounds);
+            check_consumed(cur);
+            return envelope;
+        }
+
+    private:
+        struct Cursor {
+            const std::uint8_t* data;
+            std::size_t size;
+            std::size_t pos;
+        };
+
+        static const CodecBounds* effective_bounds(
+                const CodecBounds* bounds) {
+            static const CodecBounds defaults;
+            return bounds != nullptr ? bounds : &defaults;
+        }
+
+        static void validate_envelope(
+                const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds) {
+            validate_logical_delivery_envelope(envelope, bounds);
+        }
+
+        static Cursor make_cursor(const std::vector<std::uint8_t>& data,
+                                  const CodecBounds* bounds) {
+            if (data.size() > bounds->max_transport_message_bytes) {
+                throw std::length_error(
+                    "logical delivery envelope exceeds "
+                    "max_transport_message_bytes");
+            }
+            Cursor cur;
+            cur.data = data.empty() ? nullptr : &data[0];
+            cur.size = data.size();
+            cur.pos = 0;
+            return cur;
+        }
+
+        static void check_header(Cursor& cur) {
+            check_bounds(cur, magic_size());
+            if (std::memcmp(cur.data + cur.pos, magic(), magic_size()) != 0) {
+                throw std::runtime_error(
+                    "Logical delivery envelope magic mismatch");
+            }
+            cur.pos += magic_size();
+
+            const std::uint16_t version = read_u16_le(cur);
+            if (version != codec_version()) {
+                throw std::runtime_error(
+                    "Unsupported logical delivery envelope codec_version");
+            }
+            const std::uint32_t flags = read_u32_le(cur);
+            if (flags != 0) {
+                throw std::runtime_error(
+                    "Unknown mandatory logical delivery envelope flags");
+            }
+        }
+
+        static void check_consumed(const Cursor& cur) {
+            if (cur.pos != cur.size) {
+                throw std::runtime_error(
+                    "Trailing bytes after logical delivery envelope");
+            }
+        }
+
+        static void check_bounds(const Cursor& cur, std::size_t n) {
+            if (cur.pos > cur.size || n > cur.size - cur.pos) {
+                throw std::runtime_error(
+                    "Logical delivery envelope codec buffer underrun");
+            }
+        }
+
+        static void ensure_append_size(
+                const std::vector<std::uint8_t>& out,
+                std::size_t n,
+                const CodecBounds* bounds) {
+            if (n > std::numeric_limits<std::size_t>::max() - out.size()) {
+                throw std::length_error(
+                    "logical delivery envelope size overflow");
+            }
+            if (out.size() + n > bounds->max_transport_message_bytes) {
+                throw std::length_error(
+                    "logical delivery envelope exceeds "
+                    "max_transport_message_bytes");
+            }
+        }
+
+        static void append_bytes(std::vector<std::uint8_t>& out,
+                                 const std::uint8_t* src,
+                                 std::size_t n,
+                                 const CodecBounds* bounds) {
+            if (n == 0) {
+                return;
+            }
+            ensure_append_size(out, n, bounds);
+            const std::size_t base = out.size();
+            out.resize(base + n);
+            std::memcpy(&out[base], src, n);
+        }
+
+        static void append_u16_le(std::vector<std::uint8_t>& out,
+                                  std::uint16_t value,
+                                  const CodecBounds* bounds) {
+            ensure_append_size(out, 2, bounds);
+            detail::append_u16_le(out, value);
+        }
+
+        static void append_u32_le(std::vector<std::uint8_t>& out,
+                                  std::uint32_t value,
+                                  const CodecBounds* bounds) {
+            ensure_append_size(out, 4, bounds);
+            detail::append_u32_le(out, value);
+        }
+
+        static void append_u64_le(std::vector<std::uint8_t>& out,
+                                  std::uint64_t value,
+                                  const CodecBounds* bounds) {
+            ensure_append_size(out, 8, bounds);
+            detail::append_u64_le(out, value);
+        }
+
+        static void append_u32_size(std::vector<std::uint8_t>& out,
+                                    std::size_t value,
+                                    const CodecBounds* bounds,
+                                    const char* label) {
+            if (value > static_cast<std::size_t>(
+                    std::numeric_limits<std::uint32_t>::max())) {
+                throw std::length_error(label);
+            }
+            append_u32_le(out, static_cast<std::uint32_t>(value), bounds);
+        }
+
+        static void append_string(std::vector<std::uint8_t>& out,
+                                  const std::string& value,
+                                  const CodecBounds* bounds) {
+            if (value.empty()) {
+                throw std::runtime_error(
+                    "Logical delivery envelope frame id is empty");
+            }
+            if (value.size() >
+                bounds->max_logical_delivery_frame_id_len) {
+                throw std::length_error(
+                    "logical delivery frame id exceeds "
+                    "max_logical_delivery_frame_id_len");
+            }
+            append_u32_size(out, value.size(), bounds,
+                            "logical delivery frame id length exceeds u32");
+            append_bytes(out,
+                         reinterpret_cast<const std::uint8_t*>(value.data()),
+                         value.size(), bounds);
+        }
+
+        static std::uint16_t read_u16_le(Cursor& cur) {
+            check_bounds(cur, 2);
+            const std::uint16_t value =
+                detail::read_u16_le(cur.data + cur.pos);
+            cur.pos += 2;
+            return value;
+        }
+
+        static std::uint32_t read_u32_le(Cursor& cur) {
+            check_bounds(cur, 4);
+            const std::uint32_t value =
+                detail::read_u32_le(cur.data + cur.pos);
+            cur.pos += 4;
+            return value;
+        }
+
+        static std::uint64_t read_u64_le(Cursor& cur) {
+            check_bounds(cur, 8);
+            const std::uint64_t value =
+                detail::read_u64_le(cur.data + cur.pos);
+            cur.pos += 8;
+            return value;
+        }
+
+        static const std::uint8_t* read_bytes(Cursor& cur, std::size_t n) {
+            check_bounds(cur, n);
+            if (n == 0) {
+                return nullptr;
+            }
+            const std::uint8_t* out = cur.data + cur.pos;
+            cur.pos += n;
+            return out;
+        }
+
+        static void read_id(Cursor& cur, NodeId& out) {
+            const std::uint8_t* bytes = read_bytes(cur, out.size());
+            std::memcpy(out.data(), bytes, out.size());
+        }
+
+        static std::string read_string(Cursor& cur,
+                                       const CodecBounds* bounds) {
+            const std::uint32_t len = read_u32_le(cur);
+            if (len == 0) {
+                throw std::runtime_error(
+                    "Logical delivery envelope frame id is empty");
+            }
+            if (len > bounds->max_logical_delivery_frame_id_len) {
+                throw std::length_error(
+                    "logical delivery frame id exceeds "
+                    "max_logical_delivery_frame_id_len");
+            }
+            const std::uint8_t* bytes = read_bytes(cur, len);
+            return std::string(reinterpret_cast<const char*>(bytes), len);
+        }
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_DELIVERY_ENVELOPE_CODEC_HPP_INCLUDED

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -41,6 +41,7 @@
 #include "ChangeBatch.hpp"
 #include "ChangeBatchCodec.hpp"
 #include "ChangeOp.hpp"
+#include "LogicalDeliveryEnvelopeCodec.hpp"
 #include "LogicalChangeFrameCodec.hpp"
 #include "LogicalTableAdapter.hpp"
 #include "LogicalSchemaValidation.hpp"
@@ -48,6 +49,7 @@
 #include "SyncCursor.hpp"
 #include "stores/AppliedStore.hpp"
 #include "stores/ChangeLogStore.hpp"
+#include "stores/LogicalDeliveryStore.hpp"
 #include "stores/MetaStore.hpp"
 #include "stores/OriginIndexStore.hpp"
 #include "stores/SchemaRegistryStore.hpp"
@@ -322,6 +324,130 @@ namespace sync {
             } catch (...) {
                 return LogicalApplyResult::failure(
                     "Logical change frame apply failed");
+            }
+        }
+
+        /// \brief Applies a logical delivery envelope with atomic replay dedup.
+        /// \details The envelope destination must match this engine's
+        /// \c db_uuid. Envelopes whose origin is this engine's local
+        /// \c node_id are treated as successful loopback no-ops before marker
+        /// insertion. The delivery marker is written in the same MDBX write
+        /// transaction as adapter mutations, so a failed apply rolls back both
+        /// data and replay identity. Re-delivery of an already committed
+        /// envelope is treated as a successful no-op.
+        LogicalApplyResult apply_logical_delivery_envelope(
+                const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds = nullptr) {
+            try {
+                validate_logical_delivery_envelope(envelope, bounds);
+            } catch (const std::exception& e) {
+                return LogicalApplyResult::failure(
+                    e.what());
+            } catch (...) {
+                return LogicalApplyResult::failure(
+                    "Logical delivery envelope validation failed");
+            }
+
+            const std::vector<LogicalChange>& changes =
+                envelope.frame.changes;
+            std::vector<std::string> affected_dbi_names;
+
+            Connection::SyncApplyNotification notification;
+            LogicalApplyResult result;
+            bool notify = false;
+            {
+                const Connection::SyncApplyWriteGuard sync_apply_guard =
+                    m_conn->sync_apply_write_guard();
+                auto txn = m_conn->transaction(TransactionMode::WRITABLE);
+
+                MetaStore meta(m_conn->env_handle());
+                LogicalDeliveryStore delivery(m_conn->env_handle());
+                meta.open(txn.handle());
+                delivery.open(txn.handle());
+
+                const DbId local_db_uuid = meta.get_db_uuid(txn.handle());
+                const NodeId local_node_id = meta.get_node_id(txn.handle());
+                if (compare_node_id(local_db_uuid,
+                                    envelope.destination_db_uuid) != 0) {
+                    txn.rollback();
+                    return LogicalApplyResult::failure(
+                        "Logical delivery envelope destination db_uuid "
+                        "mismatch");
+                }
+                if (compare_node_id(local_node_id,
+                                    envelope.origin_node_id) == 0) {
+                    txn.rollback();
+                    return LogicalApplyResult::success();
+                }
+
+                if (!delivery.try_mark_applied(
+                        txn.handle(), envelope, bounds)) {
+                    txn.rollback();
+                    return LogicalApplyResult::success();
+                }
+
+                collect_logical_affected_dbis(
+                    changes, affected_dbi_names);
+
+                result = validate_logical_schema_markers(
+                    txn.handle(), changes);
+                if (result.ok) {
+                    Connection::SyncCaptureSuppressionScope suppress_capture(
+                        *m_conn, txn.handle());
+                    result = m_logical_registry.preflight_then_apply(
+                        txn.handle(), changes);
+                }
+                if (!result.ok) {
+                    txn.rollback();
+                    return result;
+                }
+
+                txn.commit();
+                if (!changes.empty()) {
+                    try {
+                        notification =
+                            m_conn->mark_sync_apply_committed(
+                                1u, changes.size(), affected_dbi_names);
+                        notify = true;
+                    } catch (...) {
+                        return result;
+                    }
+                }
+            }
+            if (notify) {
+                m_conn->notify_sync_apply_observers(notification);
+            }
+            return result;
+        }
+
+        /// \brief Decodes and applies a logical delivery envelope.
+        LogicalApplyResult apply_logical_delivery_envelope_bytes(
+                const std::vector<std::uint8_t>& encoded,
+                const CodecBounds* bounds = nullptr) {
+            LogicalDeliveryEnvelope envelope;
+            try {
+                envelope =
+                    LogicalDeliveryEnvelopeCodec::decode(encoded, bounds);
+            } catch (const std::exception& e) {
+                return LogicalApplyResult::failure(
+                    std::string(
+                        "Logical delivery envelope decode failed: ") +
+                    e.what());
+            } catch (...) {
+                return LogicalApplyResult::failure(
+                    "Logical delivery envelope decode failed");
+            }
+
+            try {
+                return apply_logical_delivery_envelope(envelope, bounds);
+            } catch (const std::exception& e) {
+                return LogicalApplyResult::failure(
+                    std::string(
+                        "Logical delivery envelope apply failed: ") +
+                    e.what());
+            } catch (...) {
+                return LogicalApplyResult::failure(
+                    "Logical delivery envelope apply failed");
             }
         }
 
@@ -658,10 +784,12 @@ namespace sync {
             ChangeLogStore change_log(m_conn->env_handle());
             AppliedStore applied(m_conn->env_handle());
             SchemaRegistryStore schemas(m_conn->env_handle());
+            LogicalDeliveryStore logical_delivery(m_conn->env_handle());
             meta.open(txn);
             change_log.open(txn);
             applied.open(txn);
             schemas.open(txn);
+            logical_delivery.open(txn);
         }
 
         static ApplyOutcome make_apply_outcome(ApplyResult result,

--- a/include/mdbx_containers/sync/stores/LogicalDeliveryStore.hpp
+++ b/include/mdbx_containers/sync/stores/LogicalDeliveryStore.hpp
@@ -1,0 +1,257 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_STORES_LOGICAL_DELIVERY_STORE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_STORES_LOGICAL_DELIVERY_STORE_HPP_INCLUDED
+
+/// \file LogicalDeliveryStore.hpp
+/// \brief Persistent replay marker store for logical delivery envelopes.
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mdbx.h>
+
+#include "../../common/MdbxException.hpp"
+#include "../../detail/utils.hpp"
+#include "../LogicalChangeFrameCodec.hpp"
+#include "../LogicalDeliveryEnvelope.hpp"
+#include "../common.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Tracks applied logical delivery envelopes.
+    /// \details Key = fixed-size origin node id + origin sequence + frame id
+    /// digest. Value = full delivery identity, destination database id, and
+    /// canonical encoded logical frame bytes.
+    /// The caller writes this marker in the same MDBX transaction that applies
+    /// the logical mutations, making duplicate delivery detection atomic with
+    /// apply rollback/commit. Reusing the same delivery key with different
+    /// frame content fails closed as an identity conflict.
+    class LogicalDeliveryStore {
+    public:
+        explicit LogicalDeliveryStore(
+                MDBX_env* env,
+                const std::string& dbi_name = "_mdbxc_logical_delivery")
+            : m_env(env), m_dbi_name(dbi_name), m_dbi(0), m_open(false) {}
+
+        /// \brief Opens the store DBI inside the supplied transaction.
+        void open(MDBX_txn* txn) {
+            txn = checked_txn(txn, "LogicalDeliveryStore::open");
+            open_checked(txn);
+        }
+
+        bool is_open() const { return m_open; }
+
+        MDBX_dbi handle(MDBX_txn* txn) const {
+            txn = checked_txn(txn, "LogicalDeliveryStore::handle");
+            open_checked(txn);
+            return m_dbi;
+        }
+
+        void reset_open() { m_open = false; }
+
+        void ensure_open() const {
+            if (!m_open) {
+                throw std::logic_error("LogicalDeliveryStore is not open");
+            }
+        }
+
+        /// \brief Returns true when \p envelope already has an applied marker.
+        bool contains(MDBX_txn* txn,
+                      const LogicalDeliveryEnvelope& envelope,
+                      const CodecBounds* bounds = nullptr) const {
+            txn = checked_txn(txn, "LogicalDeliveryStore::contains");
+            open_const(txn);
+            const std::vector<std::uint8_t> key =
+                make_key(envelope, bounds);
+            MDBX_val k = {
+                const_cast<std::uint8_t*>(key.empty() ? nullptr : &key[0]),
+                key.size()
+            };
+            MDBX_val v;
+            const int rc = mdbx_get(txn, m_dbi, &k, &v);
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "LogicalDeliveryStore read failed");
+            assert_marker_value_matches(envelope, v, bounds);
+            return true;
+        }
+
+        /// \brief Inserts an applied marker.
+        /// \return false when the exact delivery key already exists.
+        bool try_mark_applied(MDBX_txn* txn,
+                              const LogicalDeliveryEnvelope& envelope,
+                              const CodecBounds* bounds = nullptr) {
+            txn = checked_txn(txn, "LogicalDeliveryStore::try_mark_applied");
+            open(txn);
+            const std::vector<std::uint8_t> key =
+                make_key(envelope, bounds);
+            MDBX_val k = {
+                const_cast<std::uint8_t*>(key.empty() ? nullptr : &key[0]),
+                key.size()
+            };
+            const std::vector<std::uint8_t> value =
+                make_marker_value(envelope, bounds);
+            MDBX_val v = {
+                const_cast<std::uint8_t*>(
+                    value.empty() ? nullptr : &value[0]),
+                value.size()
+            };
+            const int rc = mdbx_put(txn, m_dbi, &k, &v, MDBX_NOOVERWRITE);
+            if (rc == MDBX_KEYEXIST) {
+                MDBX_val existing;
+                check_mdbx(mdbx_get(txn, m_dbi, &k, &existing),
+                           "LogicalDeliveryStore duplicate read failed");
+                assert_marker_value_matches(envelope, existing, bounds);
+                return false;
+            }
+            check_mdbx(rc, "LogicalDeliveryStore write failed");
+            return true;
+        }
+
+    private:
+        MDBX_txn* checked_txn(MDBX_txn* txn, const char* context) const {
+            return checked_txn_env(txn, m_env, context);
+        }
+
+        void open_const(MDBX_txn* txn) const {
+            txn = checked_txn(txn, "LogicalDeliveryStore::open");
+            open_checked(txn);
+        }
+
+        void open_checked(MDBX_txn* txn) const {
+            int rc = mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE, &m_dbi);
+            if (rc == MDBX_EACCESS) {
+                rc = mdbx_dbi_open(txn, m_dbi_name.c_str(),
+                                   static_cast<MDBX_db_flags_t>(0), &m_dbi);
+            }
+            check_mdbx(rc, "Failed to open LogicalDeliveryStore DBI");
+            m_open = true;
+        }
+
+        static std::vector<std::uint8_t> make_key(
+                const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds) {
+            validate_logical_delivery_envelope(envelope, bounds);
+            if (envelope.frame_id.size() >
+                static_cast<std::size_t>(
+                    (std::numeric_limits<std::uint32_t>::max)())) {
+                throw std::length_error(
+                    "Logical delivery frame id length exceeds u32");
+            }
+            const std::vector<std::uint8_t> frame_id_digest =
+                make_frame_id_digest(envelope.frame_id);
+            std::vector<std::uint8_t> key;
+            key.reserve(2u + envelope.origin_node_id.size() + 8u +
+                        frame_id_digest.size());
+            detail::append_u16_le(key, marker_key_version());
+            key.insert(key.end(),
+                       envelope.origin_node_id.begin(),
+                       envelope.origin_node_id.end());
+            detail::append_u64_le(key, envelope.origin_sequence);
+            key.insert(key.end(), frame_id_digest.begin(),
+                       frame_id_digest.end());
+            return key;
+        }
+
+        static std::vector<std::uint8_t> make_marker_value(
+                const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds) {
+            validate_logical_delivery_envelope(envelope, bounds);
+            const std::vector<std::uint8_t> frame_bytes =
+                LogicalChangeFrameCodec::encode(envelope.frame, bounds);
+            if (frame_bytes.size() >
+                static_cast<std::size_t>(
+                    (std::numeric_limits<std::uint32_t>::max)())) {
+                throw std::length_error(
+                    "Logical delivery frame bytes exceed u32");
+            }
+            if (envelope.frame_id.size() >
+                static_cast<std::size_t>(
+                    (std::numeric_limits<std::uint32_t>::max)())) {
+                throw std::length_error(
+                    "Logical delivery frame id length exceeds u32");
+            }
+            std::vector<std::uint8_t> out;
+            out.reserve(2u + envelope.destination_db_uuid.size() +
+                        envelope.origin_node_id.size() + 8u + 4u +
+                        envelope.frame_id.size() + 2u + 4u +
+                        frame_bytes.size());
+            detail::append_u16_le(out, marker_value_version());
+            out.insert(out.end(),
+                       envelope.destination_db_uuid.begin(),
+                       envelope.destination_db_uuid.end());
+            out.insert(out.end(),
+                       envelope.origin_node_id.begin(),
+                       envelope.origin_node_id.end());
+            detail::append_u64_le(out, envelope.origin_sequence);
+            detail::append_u32_le(
+                out, static_cast<std::uint32_t>(envelope.frame_id.size()));
+            out.insert(out.end(),
+                       envelope.frame_id.begin(),
+                       envelope.frame_id.end());
+            detail::append_u16_le(
+                out, LogicalChangeFrameCodec::codec_version());
+            detail::append_u32_le(
+                out, static_cast<std::uint32_t>(frame_bytes.size()));
+            out.insert(out.end(), frame_bytes.begin(), frame_bytes.end());
+            return out;
+        }
+
+        static void assert_marker_value_matches(
+                const LogicalDeliveryEnvelope& envelope,
+                const MDBX_val& value,
+                const CodecBounds* bounds) {
+            const std::vector<std::uint8_t> expected =
+                make_marker_value(envelope, bounds);
+            if (value.iov_len != expected.size()) {
+                throw std::runtime_error(
+                    "LogicalDeliveryStore delivery identity conflict");
+            }
+            if (expected.empty()) {
+                return;
+            }
+            if (std::memcmp(value.iov_base, &expected[0],
+                            expected.size()) != 0) {
+                throw std::runtime_error(
+                    "LogicalDeliveryStore delivery identity conflict");
+            }
+        }
+
+        static std::vector<std::uint8_t> make_frame_id_digest(
+                const std::string& frame_id) {
+            std::uint64_t h0 = UINT64_C(0xcbf29ce484222325);
+            std::uint64_t h1 = UINT64_C(0x9ae16a3b2f90404f);
+            for (std::size_t i = 0; i < frame_id.size(); ++i) {
+                const std::uint8_t b =
+                    static_cast<std::uint8_t>(frame_id[i]);
+                h0 ^= static_cast<std::uint64_t>(b);
+                h0 *= UINT64_C(0x100000001b3);
+                h1 ^= static_cast<std::uint64_t>(b) +
+                      static_cast<std::uint64_t>(i & 0xffu);
+                h1 *= UINT64_C(0x100000001b3);
+            }
+            std::vector<std::uint8_t> out;
+            out.reserve(16u);
+            detail::append_u64_le(out, h0);
+            detail::append_u64_le(out, h1);
+            return out;
+        }
+
+        static std::uint16_t marker_key_version() { return 1; }
+
+        static std::uint16_t marker_value_version() { return 1; }
+
+        MDBX_env*   m_env;
+        std::string m_dbi_name;
+        mutable MDBX_dbi m_dbi;
+        mutable bool     m_open;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_STORES_LOGICAL_DELIVERY_STORE_HPP_INCLUDED

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -351,6 +351,130 @@ private:
     std::string m_schema_id;
 };
 
+class CountingDeliveryLogicalAdapter
+        : public mdbxc::sync::ILogicalTableAdapter {
+public:
+    CountingDeliveryLogicalAdapter(
+            mdbxc::KeyValueTable<int, std::string>& table,
+            const std::string& schema_id,
+            int& calls,
+            bool* preflight_should_fail = nullptr,
+            bool* affected_should_fail = nullptr,
+            int* affected_calls = nullptr)
+        : m_table(table),
+          m_schema_id(schema_id),
+          m_calls(calls),
+          m_preflight_should_fail(preflight_should_fail),
+          m_affected_should_fail(affected_should_fail),
+          m_affected_calls(affected_calls) {}
+
+    mdbxc::sync::LogicalSchemaRef schema_ref() const override {
+        mdbxc::sync::LogicalSchemaRef ref;
+        ref.schema_id = m_schema_id;
+        ref.kind = mdbxc::sync::LogicalTableKind::KeyValue;
+        ref.schema_version = 1;
+        return ref;
+    }
+
+    std::string primary_dbi() const override {
+        return m_table.dbi_name();
+    }
+
+    std::vector<std::string> affected_dbis() const override {
+        if (m_affected_calls != nullptr) {
+            ++(*m_affected_calls);
+        }
+        if (m_affected_should_fail != nullptr &&
+                *m_affected_should_fail) {
+            throw std::runtime_error("forced logical delivery affected_dbis failure");
+        }
+        std::vector<std::string> out;
+        out.push_back(m_table.dbi_name());
+        return out;
+    }
+
+    mdbxc::sync::LogicalApplyResult preflight(
+            MDBX_txn* txn,
+            const mdbxc::sync::LogicalChange& change) const override {
+        (void)txn;
+        (void)change;
+        if (m_preflight_should_fail != nullptr &&
+                *m_preflight_should_fail) {
+            return mdbxc::sync::LogicalApplyResult::failure(
+                "forced logical delivery preflight failure");
+        }
+        return mdbxc::sync::LogicalApplyResult::success();
+    }
+
+    mdbxc::sync::LogicalApplyResult apply(
+            MDBX_txn* txn,
+            const mdbxc::sync::LogicalChange& change) override {
+        (void)change;
+        ++m_calls;
+        m_table.insert_or_assign(90, std::to_string(m_calls), txn);
+        return mdbxc::sync::LogicalApplyResult::success();
+    }
+
+private:
+    mdbxc::KeyValueTable<int, std::string>& m_table;
+    std::string m_schema_id;
+    int& m_calls;
+    bool* m_preflight_should_fail;
+    bool* m_affected_should_fail;
+    int* m_affected_calls;
+};
+
+class CountingOnlyDeliveryLogicalAdapter
+        : public mdbxc::sync::ILogicalTableAdapter {
+public:
+    CountingOnlyDeliveryLogicalAdapter(const std::string& dbi_name,
+                                       const std::string& schema_id,
+                                       int& calls)
+        : m_dbi_name(dbi_name),
+          m_schema_id(schema_id),
+          m_calls(calls) {}
+
+    mdbxc::sync::LogicalSchemaRef schema_ref() const override {
+        mdbxc::sync::LogicalSchemaRef ref;
+        ref.schema_id = m_schema_id;
+        ref.kind = mdbxc::sync::LogicalTableKind::KeyValue;
+        ref.schema_version = 1;
+        return ref;
+    }
+
+    std::string primary_dbi() const override {
+        return m_dbi_name;
+    }
+
+    std::vector<std::string> affected_dbis() const override {
+        std::vector<std::string> out;
+        out.push_back(m_dbi_name);
+        return out;
+    }
+
+    mdbxc::sync::LogicalApplyResult preflight(
+            MDBX_txn* txn,
+            const mdbxc::sync::LogicalChange& change) const override {
+        (void)txn;
+        (void)change;
+        return mdbxc::sync::LogicalApplyResult::success();
+    }
+
+    mdbxc::sync::LogicalApplyResult apply(
+            MDBX_txn* txn,
+            const mdbxc::sync::LogicalChange& change) override {
+        (void)txn;
+        (void)change;
+        ++m_calls;
+        return mdbxc::sync::LogicalApplyResult::success();
+    }
+
+private:
+    std::string m_dbi_name;
+    std::string m_schema_id;
+    int& m_calls;
+};
+
 class ThrowingFlushSink : public mdbxc::sync::ISyncCaptureSink {
 public:
     void record_change(MDBX_txn* txn,
@@ -1179,6 +1303,521 @@ void test_key_value_logical_frame_reports_apply_stage_exception() {
     cleanup(path);
 }
 
+void test_key_value_logical_delivery_envelope_deduplicates_after_reopen() {
+    const std::string path =
+        "test_key_value_logical_delivery_dedup.mdbx";
+    const std::string dbi_name = "logical_key_value_delivery_dedup";
+    const std::string schema_id = "app.logical_kv_delivery_dedup.v1";
+    cleanup(path);
+
+    const mdbxc::sync::NodeId local_node = make_node(0x36);
+    const mdbxc::sync::NodeId origin_node = make_node(0x37);
+    const mdbxc::sync::NodeId db_uuid = make_node(0xC6);
+
+    mdbxc::sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = db_uuid;
+    envelope.origin_node_id = origin_node;
+    envelope.origin_sequence = 1;
+    envelope.frame_id = "frame-0001";
+    {
+        mdbxc::sync::LogicalSchemaRef ref;
+        ref.schema_id = schema_id;
+        ref.kind = mdbxc::sync::LogicalTableKind::KeyValue;
+        ref.schema_version = 1;
+        std::vector<std::uint8_t> payload;
+        envelope.frame.changes.push_back(
+            mdbxc::sync::LogicalChange(ref, 1u, 0u, payload));
+    }
+    const std::vector<std::uint8_t> encoded =
+        mdbxc::sync::LogicalDeliveryEnvelopeCodec::encode(envelope);
+
+    {
+        mdbxc::Config cfg;
+        cfg.pathname = path;
+        cfg.max_dbs = 16;
+        cfg.no_subdir = true;
+        std::shared_ptr<mdbxc::Connection> conn =
+            mdbxc::Connection::create(cfg);
+
+        mdbxc::sync::SyncEngine engine(conn);
+        engine.initialize_local_identity(local_node, db_uuid);
+        engine.register_logical_schema(schema_id, make_record(dbi_name));
+
+        mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+        int apply_calls = 0;
+        CountingDeliveryLogicalAdapter adapter(
+            table, schema_id, apply_calls);
+        engine.register_logical_adapter(adapter);
+
+        const mdbxc::sync::LogicalApplyResult first =
+            engine.apply_logical_delivery_envelope_bytes(encoded);
+        MDBXC_TEST_ASSERT(first.ok);
+        MDBXC_TEST_ASSERT(apply_calls == 1);
+        const std::pair<bool, std::string> found = table.find_compat(90);
+        MDBXC_TEST_ASSERT(found.first);
+        MDBXC_TEST_ASSERT(found.second == "1");
+
+        conn->disconnect();
+    }
+
+    {
+        mdbxc::Config cfg;
+        cfg.pathname = path;
+        cfg.max_dbs = 16;
+        cfg.no_subdir = true;
+        std::shared_ptr<mdbxc::Connection> conn =
+            mdbxc::Connection::create(cfg);
+
+        mdbxc::sync::SyncEngine engine(conn);
+        engine.initialize_local_identity(local_node, db_uuid);
+        engine.register_logical_schema(schema_id, make_record(dbi_name));
+
+        mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+        int apply_calls = 0;
+        bool affected_should_fail = true;
+        int affected_calls = 0;
+        CountingDeliveryLogicalAdapter adapter(
+            table, schema_id, apply_calls, nullptr,
+            &affected_should_fail, &affected_calls);
+        engine.register_logical_adapter(adapter);
+
+        const mdbxc::sync::LogicalApplyResult duplicate =
+            engine.apply_logical_delivery_envelope_bytes(encoded);
+        MDBXC_TEST_ASSERT(duplicate.ok);
+        MDBXC_TEST_ASSERT(apply_calls == 0);
+        MDBXC_TEST_ASSERT(affected_calls == 0);
+        const std::pair<bool, std::string> found = table.find_compat(90);
+        MDBXC_TEST_ASSERT(found.first);
+        MDBXC_TEST_ASSERT(found.second == "1");
+
+        conn->disconnect();
+    }
+
+    cleanup(path);
+}
+
+void test_key_value_logical_delivery_envelope_rejects_wrong_destination() {
+    const std::string path =
+        "test_key_value_logical_delivery_wrong_destination.mdbx";
+    const std::string dbi_name = "logical_key_value_delivery_wrong_dest";
+    const std::string schema_id = "app.logical_kv_delivery_wrong_dest.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId db_uuid = make_node(0xC7);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x38), db_uuid);
+    engine.register_logical_schema(schema_id, make_record(dbi_name));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    int apply_calls = 0;
+    bool affected_should_fail = true;
+    int affected_calls = 0;
+    CountingDeliveryLogicalAdapter adapter(
+        table, schema_id, apply_calls, nullptr,
+        &affected_should_fail, &affected_calls);
+    engine.register_logical_adapter(adapter);
+
+    mdbxc::sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = make_node(0xC8);
+    envelope.origin_node_id = make_node(0x39);
+    envelope.origin_sequence = 1;
+    envelope.frame_id = "wrong-destination";
+    envelope.frame.changes.push_back(mdbxc::sync::LogicalChange(
+        adapter.schema_ref(), 1u, 0u, std::vector<std::uint8_t>()));
+
+    const mdbxc::sync::LogicalApplyResult result =
+        engine.apply_logical_delivery_envelope(envelope);
+    MDBXC_TEST_ASSERT(!result.ok);
+    MDBXC_TEST_ASSERT(result.error.find("destination") !=
+                      std::string::npos);
+    MDBXC_TEST_ASSERT(apply_calls == 0);
+    MDBXC_TEST_ASSERT(affected_calls == 0);
+    MDBXC_TEST_ASSERT(!table.contains(90));
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_value_logical_delivery_envelope_rejects_identity_collision() {
+    const std::string path =
+        "test_key_value_logical_delivery_identity_collision.mdbx";
+    const std::string dbi_name = "logical_key_value_delivery_collision";
+    const std::string schema_id = "app.logical_kv_delivery_collision.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId db_uuid = make_node(0xC9);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x3A), db_uuid);
+    engine.register_logical_schema(schema_id, make_record(dbi_name));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    int apply_calls = 0;
+    bool affected_should_fail = false;
+    int affected_calls = 0;
+    CountingDeliveryLogicalAdapter adapter(
+        table, schema_id, apply_calls, nullptr,
+        &affected_should_fail, &affected_calls);
+    engine.register_logical_adapter(adapter);
+
+    mdbxc::sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = db_uuid;
+    envelope.origin_node_id = make_node(0x3B);
+    envelope.origin_sequence = 7;
+    envelope.frame_id = "identity-collision";
+    envelope.frame.changes.push_back(mdbxc::sync::LogicalChange(
+        adapter.schema_ref(), 1u, 0u, std::vector<std::uint8_t>()));
+
+    const mdbxc::sync::LogicalApplyResult first =
+        engine.apply_logical_delivery_envelope_bytes(
+            mdbxc::sync::LogicalDeliveryEnvelopeCodec::encode(envelope));
+    MDBXC_TEST_ASSERT(first.ok);
+    MDBXC_TEST_ASSERT(apply_calls == 1);
+    std::pair<bool, std::string> found = table.find_compat(90);
+    MDBXC_TEST_ASSERT(found.first);
+    MDBXC_TEST_ASSERT(found.second == "1");
+
+    mdbxc::sync::LogicalDeliveryEnvelope collision = envelope;
+    std::vector<std::uint8_t> payload;
+    payload.push_back(0x42u);
+    collision.frame.changes[0] = mdbxc::sync::LogicalChange(
+        adapter.schema_ref(), 1u, 0u, payload);
+    affected_should_fail = true;
+
+    const mdbxc::sync::LogicalApplyResult second =
+        engine.apply_logical_delivery_envelope_bytes(
+            mdbxc::sync::LogicalDeliveryEnvelopeCodec::encode(collision));
+    MDBXC_TEST_ASSERT(!second.ok);
+    MDBXC_TEST_ASSERT(second.error.find("identity conflict") !=
+                      std::string::npos);
+    MDBXC_TEST_ASSERT(apply_calls == 1);
+    found = table.find_compat(90);
+    MDBXC_TEST_ASSERT(found.first);
+    MDBXC_TEST_ASSERT(found.second == "1");
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_value_logical_delivery_marker_rolls_back_after_apply_failure() {
+    const std::string path =
+        "test_key_value_logical_delivery_marker_rollback.mdbx";
+    const std::string dbi_name = "logical_key_value_delivery_rollback";
+    const std::string schema_id = "app.logical_kv_delivery_rollback.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId db_uuid = make_node(0xCA);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x3C), db_uuid);
+    engine.register_logical_schema(schema_id, make_record(dbi_name));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    int apply_calls = 0;
+    bool fail_preflight = true;
+    CountingDeliveryLogicalAdapter adapter(
+        table, schema_id, apply_calls, &fail_preflight);
+    engine.register_logical_adapter(adapter);
+
+    mdbxc::sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = db_uuid;
+    envelope.origin_node_id = make_node(0x3D);
+    envelope.origin_sequence = 8;
+    envelope.frame_id = "marker-rollback";
+    envelope.frame.changes.push_back(mdbxc::sync::LogicalChange(
+        adapter.schema_ref(), 1u, 0u, std::vector<std::uint8_t>()));
+    const std::vector<std::uint8_t> encoded =
+        mdbxc::sync::LogicalDeliveryEnvelopeCodec::encode(envelope);
+
+    const mdbxc::sync::LogicalApplyResult failed =
+        engine.apply_logical_delivery_envelope_bytes(encoded);
+    MDBXC_TEST_ASSERT(!failed.ok);
+    MDBXC_TEST_ASSERT(failed.error.find(
+                          "forced logical delivery preflight failure") !=
+                      std::string::npos);
+    MDBXC_TEST_ASSERT(apply_calls == 0);
+    MDBXC_TEST_ASSERT(!table.contains(90));
+
+    fail_preflight = false;
+    const mdbxc::sync::LogicalApplyResult retried =
+        engine.apply_logical_delivery_envelope_bytes(encoded);
+    MDBXC_TEST_ASSERT(retried.ok);
+    MDBXC_TEST_ASSERT(apply_calls == 1);
+    const std::pair<bool, std::string> found = table.find_compat(90);
+    MDBXC_TEST_ASSERT(found.first);
+    MDBXC_TEST_ASSERT(found.second == "1");
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_value_logical_delivery_envelope_skips_self_origin() {
+    const std::string path =
+        "test_key_value_logical_delivery_self_origin.mdbx";
+    const std::string dbi_name = "logical_key_value_delivery_self_origin";
+    const std::string schema_id = "app.logical_kv_delivery_self_origin.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId local_node = make_node(0x3E);
+    const mdbxc::sync::NodeId db_uuid = make_node(0xCB);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(local_node, db_uuid);
+    engine.register_logical_schema(schema_id, make_record(dbi_name));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    int apply_calls = 0;
+    bool affected_should_fail = true;
+    int affected_calls = 0;
+    CountingDeliveryLogicalAdapter adapter(
+        table, schema_id, apply_calls, nullptr,
+        &affected_should_fail, &affected_calls);
+    engine.register_logical_adapter(adapter);
+
+    mdbxc::sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = db_uuid;
+    envelope.origin_node_id = local_node;
+    envelope.origin_sequence = 9;
+    envelope.frame_id = "self-origin";
+    envelope.frame.changes.push_back(mdbxc::sync::LogicalChange(
+        adapter.schema_ref(), 1u, 0u, std::vector<std::uint8_t>()));
+
+    const mdbxc::sync::LogicalApplyResult result =
+        engine.apply_logical_delivery_envelope_bytes(
+            mdbxc::sync::LogicalDeliveryEnvelopeCodec::encode(envelope));
+    MDBXC_TEST_ASSERT(result.ok);
+    MDBXC_TEST_ASSERT(apply_calls == 0);
+    MDBXC_TEST_ASSERT(affected_calls == 0);
+    MDBXC_TEST_ASSERT(!table.contains(90));
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_value_logical_delivery_envelope_accepts_long_frame_id() {
+    const std::string path =
+        "test_key_value_logical_delivery_long_frame_id.mdbx";
+    const std::string dbi_name = "logical_key_value_delivery_long_frame";
+    const std::string schema_id = "app.logical_kv_delivery_long_frame.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId db_uuid = make_node(0xCC);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x3F), db_uuid);
+    engine.register_logical_schema(schema_id, make_record(dbi_name));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    int apply_calls = 0;
+    CountingDeliveryLogicalAdapter adapter(table, schema_id, apply_calls);
+    engine.register_logical_adapter(adapter);
+
+    mdbxc::sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = db_uuid;
+    envelope.origin_node_id = make_node(0x40);
+    envelope.origin_sequence = 10;
+    envelope.frame_id = std::string(3000u, 'f');
+    envelope.frame.changes.push_back(mdbxc::sync::LogicalChange(
+        adapter.schema_ref(), 1u, 0u, std::vector<std::uint8_t>()));
+
+    const mdbxc::sync::LogicalApplyResult result =
+        engine.apply_logical_delivery_envelope_bytes(
+            mdbxc::sync::LogicalDeliveryEnvelopeCodec::encode(envelope));
+    MDBXC_TEST_ASSERT(result.ok);
+    MDBXC_TEST_ASSERT(apply_calls == 1);
+    const std::pair<bool, std::string> found = table.find_compat(90);
+    MDBXC_TEST_ASSERT(found.first);
+    MDBXC_TEST_ASSERT(found.second == "1");
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_value_logical_delivery_envelope_keeps_custom_bounds() {
+    const std::string path =
+        "test_key_value_logical_delivery_custom_bounds.mdbx";
+    const std::string dbi_name = "logical_key_value_delivery_bounds";
+    const std::string schema_id = "app.logical_kv_delivery_bounds.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId db_uuid = make_node(0xCD);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x41), db_uuid);
+    engine.register_logical_schema(schema_id, make_record(dbi_name));
+
+    int apply_calls = 0;
+    CountingOnlyDeliveryLogicalAdapter adapter(
+        dbi_name, schema_id, apply_calls);
+    engine.register_logical_adapter(adapter);
+
+    mdbxc::sync::CodecBounds bounds;
+    bounds.max_ops_per_batch = 10001u;
+
+    mdbxc::sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = db_uuid;
+    envelope.origin_node_id = make_node(0x42);
+    envelope.origin_sequence = 11;
+    envelope.frame_id = "custom-bounds";
+    const mdbxc::sync::LogicalSchemaRef schema = adapter.schema_ref();
+    envelope.frame.changes.reserve(bounds.max_ops_per_batch);
+    for (std::uint32_t i = 0; i < bounds.max_ops_per_batch; ++i) {
+        (void)i;
+        envelope.frame.changes.push_back(mdbxc::sync::LogicalChange(
+            schema, 1u, 0u, std::vector<std::uint8_t>()));
+    }
+
+    const std::vector<std::uint8_t> encoded =
+        mdbxc::sync::LogicalDeliveryEnvelopeCodec::encode(
+            envelope, &bounds);
+    const mdbxc::sync::LogicalApplyResult result =
+        engine.apply_logical_delivery_envelope_bytes(encoded, &bounds);
+    MDBXC_TEST_ASSERT(result.ok);
+    MDBXC_TEST_ASSERT(apply_calls ==
+                      static_cast<int>(bounds.max_ops_per_batch));
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_value_logical_delivery_object_api_rejects_frame_id_bound() {
+    const std::string path =
+        "test_key_value_logical_delivery_object_bound.mdbx";
+    const std::string dbi_name = "logical_key_value_delivery_object_bound";
+    const std::string schema_id = "app.logical_kv_delivery_object_bound.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId db_uuid = make_node(0xCE);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x43), db_uuid);
+    engine.register_logical_schema(schema_id, make_record(dbi_name));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    int apply_calls = 0;
+    bool affected_should_fail = true;
+    int affected_calls = 0;
+    CountingDeliveryLogicalAdapter adapter(
+        table, schema_id, apply_calls, nullptr,
+        &affected_should_fail, &affected_calls);
+    engine.register_logical_adapter(adapter);
+
+    mdbxc::sync::CodecBounds bounds;
+    bounds.max_logical_delivery_frame_id_len = 8u;
+
+    mdbxc::sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = db_uuid;
+    envelope.origin_node_id = make_node(0x44);
+    envelope.origin_sequence = 12;
+    envelope.frame_id = "123456789";
+    envelope.frame.changes.push_back(mdbxc::sync::LogicalChange(
+        adapter.schema_ref(), 1u, 0u, std::vector<std::uint8_t>()));
+
+    const mdbxc::sync::LogicalApplyResult result =
+        engine.apply_logical_delivery_envelope(envelope, &bounds);
+    MDBXC_TEST_ASSERT(!result.ok);
+    MDBXC_TEST_ASSERT(result.error.find(
+                          "max_logical_delivery_frame_id_len") !=
+                      std::string::npos);
+    MDBXC_TEST_ASSERT(apply_calls == 0);
+    MDBXC_TEST_ASSERT(affected_calls == 0);
+    MDBXC_TEST_ASSERT(!table.contains(90));
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_value_logical_delivery_store_rejects_frame_id_bound() {
+    const std::string path =
+        "test_key_value_logical_delivery_store_bound.mdbx";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    mdbxc::sync::CodecBounds bounds;
+    bounds.max_logical_delivery_frame_id_len = 8u;
+
+    mdbxc::sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = make_node(0xCF);
+    envelope.origin_node_id = make_node(0x45);
+    envelope.origin_sequence = 13;
+    envelope.frame_id = "123456789";
+    mdbxc::sync::LogicalSchemaRef ref;
+    ref.schema_id = "app.logical_kv_delivery_store_bound.v1";
+    ref.kind = mdbxc::sync::LogicalTableKind::KeyValue;
+    ref.schema_version = 1;
+    envelope.frame.changes.push_back(mdbxc::sync::LogicalChange(
+        ref, 1u, 0u, std::vector<std::uint8_t>()));
+
+    bool threw = false;
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        mdbxc::sync::LogicalDeliveryStore store(conn->env_handle());
+        store.open(txn.handle());
+        try {
+            store.try_mark_applied(txn.handle(), envelope, &bounds);
+        } catch (const std::length_error& e) {
+            threw = std::string(e.what()).find(
+                        "max_logical_delivery_frame_id_len") !=
+                    std::string::npos;
+        }
+        txn.rollback();
+    }
+    MDBXC_TEST_ASSERT(threw);
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 void test_key_value_logical_capture_session_discards_rollback() {
     const std::string path = "test_key_value_logical_adapter_session_rollback.mdbx";
     const std::string dbi_name = "logical_key_value_session_rollback";
@@ -1720,6 +2359,15 @@ int main() {
     test_key_value_logical_frame_replicates_capture_session();
     test_key_value_logical_frame_rejects_malformed_bytes_before_apply();
     test_key_value_logical_frame_reports_apply_stage_exception();
+    test_key_value_logical_delivery_envelope_deduplicates_after_reopen();
+    test_key_value_logical_delivery_envelope_rejects_wrong_destination();
+    test_key_value_logical_delivery_envelope_rejects_identity_collision();
+    test_key_value_logical_delivery_marker_rolls_back_after_apply_failure();
+    test_key_value_logical_delivery_envelope_skips_self_origin();
+    test_key_value_logical_delivery_envelope_accepts_long_frame_id();
+    test_key_value_logical_delivery_envelope_keeps_custom_bounds();
+    test_key_value_logical_delivery_object_api_rejects_frame_id_bound();
+    test_key_value_logical_delivery_store_rejects_frame_id_bound();
     test_key_value_logical_capture_session_discards_rollback();
     test_key_value_logical_capture_session_requires_schema_marker();
     test_key_value_logical_capture_session_rejects_stale_marker();


### PR DESCRIPTION
﻿## Summary
- add `LogicalDeliveryEnvelope` and `LogicalDeliveryEnvelopeCodec` around logical frames
- add `_mdbxc_logical_delivery` persisted replay markers with atomic `MDBX_NOOVERWRITE` dedup
- add `SyncEngine::apply_logical_delivery_envelope(_bytes)` with destination db uuid validation
- cover duplicate delivery after reopen and wrong-destination rejection

## Validation
- `cmake -S . -B tmp\build-pr200-cpp17-mingw`
- `cmake --build tmp\build-pr200-cpp17-mingw --target test_key_value_logical_adapter header_sync_umbrella_test header_standalone_mdbx_containers_sync_LogicalDeliveryEnvelope_hpp header_standalone_mdbx_containers_sync_LogicalDeliveryEnvelopeCodec_hpp header_standalone_mdbx_containers_sync_stores_LogicalDeliveryStore_hpp`
- `ctest --test-dir tmp\build-pr200-cpp17-mingw --output-on-failure -R "test_key_value_logical_adapter|header_sync_umbrella_test|header_standalone_mdbx_containers_sync_LogicalDeliveryEnvelope_hpp|header_standalone_mdbx_containers_sync_LogicalDeliveryEnvelopeCodec_hpp|header_standalone_mdbx_containers_sync_stores_LogicalDeliveryStore_hpp"`
- `cmake -S . -B tmp\build-pr200-cpp11-mingw`
- `cmake --build tmp\build-pr200-cpp11-mingw --target test_key_value_logical_adapter header_sync_umbrella_test header_standalone_mdbx_containers_sync_LogicalDeliveryEnvelope_hpp header_standalone_mdbx_containers_sync_LogicalDeliveryEnvelopeCodec_hpp header_standalone_mdbx_containers_sync_stores_LogicalDeliveryStore_hpp`
- `ctest --test-dir tmp\build-pr200-cpp11-mingw --output-on-failure -R "test_key_value_logical_adapter|header_sync_umbrella_test|header_standalone_mdbx_containers_sync_LogicalDeliveryEnvelope_hpp|header_standalone_mdbx_containers_sync_LogicalDeliveryEnvelopeCodec_hpp|header_standalone_mdbx_containers_sync_stores_LogicalDeliveryStore_hpp"`
