### PR TITLE
ci: add archcheck advisory workflow

### DIFF
--- a/.github/workflows/archcheck.yml
+++ b/.github/workflows/archcheck.yml
@@ -1,0 +1,39 @@
+name: Archcheck
+
+on:
+  pull_request:
+    branches: [ main, stable ]
+  workflow_dispatch:
+    inputs:
+      revspec:
+        description: "Two-dot diff range for manual runs, for example origin/main..HEAD."
+        required: true
+        default: "origin/main..HEAD"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  archcheck:
+    name: Archcheck advisory
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run archcheck diff advisory
+        uses: blurman-ai/archcheck-action@55d36f4a884912b747bbdb9809ace08baea26fcc
+        with:
+          version: "0.1.5"
+          path: "."
+          revspec: ${{ github.event_name == 'workflow_dispatch' && inputs.revspec || '' }}
+          sticky-comment: "false"
+          fail-on-gate: "false"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Added a non-blocking `Archcheck` GitHub Actions workflow that runs
+  `archcheck --diff` through a pinned official action as an advisory
+  architecture signal on pull requests and manual dispatch.
 - Added a persistent sync schema registry store for future logical table
   adapters. The registry records logical schema ids, table kinds, schema
   versions, and canonical sorted unique owned DBI names without enabling

--- a/guides/build-and-test.md
+++ b/guides/build-and-test.md
@@ -178,6 +178,10 @@ sync_tick_hub_benchmark \
 - CI uses CMake with Ninja and runs `ctest --output-on-failure`.
 - A separate Linux C++17 smoke job builds and runs `sync_tick_hub_benchmark`
   with `MDBXC_BUILD_BENCHMARKS=ON`.
+- The separate `Archcheck` workflow runs `archcheck --diff` as an advisory
+  architecture check on pull requests and manual dispatch. The action uses
+  `fail-on-gate: false`, so architecture findings are visible without blocking
+  merges, while configuration or tool execution failures still fail the job.
 - The separate `Stress` workflow runs `ctest -L stress` on Linux C++17 when
   manually dispatched or triggered by its schedule.
 


### PR DESCRIPTION
## Summary
- add a separate non-blocking Archcheck workflow
- run `archcheck --diff` on pull requests and manual dispatch
- document that the check is advisory and does not block merges

## Validation
- `git diff --check`
