### PR TITLE
feat(sync): expose logical delivery marker inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,11 @@ All notable changes to this project will be documented in this file.
   markers use fixed-size MDBX keys, bind the full delivery identity to
   canonical nested frame bytes, reject identity collisions with different
   payloads, preserve caller codec bounds during marker creation, and skip
-  self-origin loopback envelopes as successful no-ops. Ordering and marker
-  retention remain external/future lifecycle contracts.
+  self-origin loopback envelopes as successful no-ops. Read-only marker
+  inspection helpers expose marker counts and delivery identity metadata for
+  diagnostics and future lifecycle work after validating persisted marker
+  key/value consistency. Ordering and marker retention remain external/future
+  lifecycle contracts.
 - Added `ISyncCaptureSink::record_change_op(MDBX_txn*, const ChangeOp&)` as the
   preferred capture entry point. The previous raw-field callback remains the
   source-compatible abstract sink contract; new full-`ChangeOp` sinks can

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -541,6 +541,11 @@ per-origin watermark/gap contract is added.
 future lifecycle PR should add an acknowledgement horizon or per-origin
 watermark before old replay markers can be pruned safely; deleting markers by
 time alone would re-open the exact late-retry problem the store prevents.
+`LogicalDeliveryStore::count()` and `list_markers()` are read-only inspection
+helpers for diagnostics, repair tooling, and future lifecycle work. They expose
+delivery identity and stored frame metadata after validating that the persisted
+marker key matches the marker value identity and `frame_id` digest. They do not
+define a retention policy and must not be used as a standalone pruning signal.
 
 `LogicalTableAdapter.hpp` reserves the apply-side extension point:
 

--- a/include/mdbx_containers/sync/stores/LogicalDeliveryStore.hpp
+++ b/include/mdbx_containers/sync/stores/LogicalDeliveryStore.hpp
@@ -6,6 +6,7 @@
 /// \brief Persistent replay marker store for logical delivery envelopes.
 
 #include <cstdint>
+#include <cstddef>
 #include <cstring>
 #include <limits>
 #include <stdexcept>
@@ -22,6 +23,19 @@
 
 namespace mdbxc {
 namespace sync {
+
+    /// \brief Read-only metadata decoded from an applied delivery marker.
+    /// \details The inspection record intentionally exposes only delivery
+    /// identity and stored frame metadata. It is not a pruning contract and
+    /// does not expose or decode the nested logical frame payload.
+    struct LogicalDeliveryMarkerInfo {
+        DbId destination_db_uuid{};        ///< Destination database id.
+        NodeId origin_node_id{};           ///< Delivery origin node.
+        std::uint64_t origin_sequence = 0; ///< Origin delivery sequence.
+        std::string frame_id;              ///< Stable sender frame id.
+        std::uint16_t frame_codec_version = 0; ///< Nested frame codec version.
+        std::uint32_t frame_bytes_size = 0;    ///< Stored nested frame bytes.
+    };
 
     /// \brief Tracks applied logical delivery envelopes.
     /// \details Key = fixed-size origin node id + origin sequence + frame id
@@ -58,6 +72,67 @@ namespace sync {
             if (!m_open) {
                 throw std::logic_error("LogicalDeliveryStore is not open");
             }
+        }
+
+        /// \brief Counts persisted logical delivery markers.
+        std::size_t count(MDBX_txn* txn) const {
+            txn = checked_txn(txn, "LogicalDeliveryStore::count");
+            open_const(txn);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "LogicalDeliveryStore cursor open failed");
+            std::size_t out = 0;
+            try {
+                MDBX_val key;
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    (void)decode_and_validate_marker(key, value);
+                    ++out;
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "LogicalDeliveryStore cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return out;
+        }
+
+        /// \brief Lists persisted logical delivery marker identities.
+        /// \param limit Maximum number of markers to return, or zero for all.
+        std::vector<LogicalDeliveryMarkerInfo> list_markers(
+                MDBX_txn* txn,
+                std::size_t limit = 0) const {
+            txn = checked_txn(txn, "LogicalDeliveryStore::list_markers");
+            open_const(txn);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "LogicalDeliveryStore cursor open failed");
+            std::vector<LogicalDeliveryMarkerInfo> out;
+            try {
+                MDBX_val key;
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    out.push_back(decode_and_validate_marker(key, value));
+                    if (limit != 0 && out.size() >= limit) {
+                        break;
+                    }
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND && (limit == 0 || out.size() < limit)) {
+                    check_mdbx(rc, "LogicalDeliveryStore cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return out;
         }
 
         /// \brief Returns true when \p envelope already has an applied marker.
@@ -244,6 +319,153 @@ namespace sync {
         static std::uint16_t marker_key_version() { return 1; }
 
         static std::uint16_t marker_value_version() { return 1; }
+
+        struct ValueCursor {
+            const std::uint8_t* data;
+            std::size_t size;
+            std::size_t pos;
+        };
+
+        struct MarkerKeyInfo {
+            NodeId origin_node_id{};
+            std::uint64_t origin_sequence = 0;
+            std::vector<std::uint8_t> frame_id_digest;
+        };
+
+        static void require_bytes(ValueCursor& cur,
+                                  std::size_t n,
+                                  const char* context) {
+            if (n > cur.size || cur.pos > cur.size - n) {
+                throw std::runtime_error(context);
+            }
+        }
+
+        static std::uint16_t read_marker_u16(ValueCursor& cur) {
+            require_bytes(cur, 2u,
+                          "LogicalDeliveryStore marker value underrun");
+            const std::uint16_t out = detail::read_u16_le(cur.data + cur.pos);
+            cur.pos += 2u;
+            return out;
+        }
+
+        static std::uint32_t read_marker_u32(ValueCursor& cur) {
+            require_bytes(cur, 4u,
+                          "LogicalDeliveryStore marker value underrun");
+            const std::uint32_t out = detail::read_u32_le(cur.data + cur.pos);
+            cur.pos += 4u;
+            return out;
+        }
+
+        static std::uint64_t read_marker_u64(ValueCursor& cur) {
+            require_bytes(cur, 8u,
+                          "LogicalDeliveryStore marker value underrun");
+            const std::uint64_t out = detail::read_u64_le(cur.data + cur.pos);
+            cur.pos += 8u;
+            return out;
+        }
+
+        static void read_marker_id(ValueCursor& cur, NodeId& out) {
+            require_bytes(cur, out.size(),
+                          "LogicalDeliveryStore marker value underrun");
+            for (std::size_t i = 0; i < out.size(); ++i) {
+                out[i] = cur.data[cur.pos + i];
+            }
+            cur.pos += out.size();
+        }
+
+        static std::string read_marker_string(ValueCursor& cur,
+                                              std::uint32_t len) {
+            require_bytes(cur, len,
+                          "LogicalDeliveryStore marker value underrun");
+            const char* begin =
+                reinterpret_cast<const char*>(cur.data + cur.pos);
+            cur.pos += len;
+            return std::string(begin, begin + len);
+        }
+
+        static LogicalDeliveryMarkerInfo decode_marker_value(
+                const MDBX_val& value) {
+            ValueCursor cur = {
+                static_cast<const std::uint8_t*>(value.iov_base),
+                value.iov_len,
+                0u
+            };
+            LogicalDeliveryMarkerInfo out;
+            const std::uint16_t version = read_marker_u16(cur);
+            if (version != marker_value_version()) {
+                throw std::runtime_error(
+                    "Unsupported LogicalDeliveryStore marker value version");
+            }
+            read_marker_id(cur, out.destination_db_uuid);
+            read_marker_id(cur, out.origin_node_id);
+            out.origin_sequence = read_marker_u64(cur);
+            const std::uint32_t frame_id_len = read_marker_u32(cur);
+            out.frame_id = read_marker_string(cur, frame_id_len);
+            out.frame_codec_version = read_marker_u16(cur);
+            out.frame_bytes_size = read_marker_u32(cur);
+            require_bytes(cur, out.frame_bytes_size,
+                          "LogicalDeliveryStore marker value underrun");
+            cur.pos += out.frame_bytes_size;
+            if (cur.pos != cur.size) {
+                throw std::runtime_error(
+                    "Trailing bytes after LogicalDeliveryStore marker value");
+            }
+            return out;
+        }
+
+        static MarkerKeyInfo decode_marker_key(const MDBX_val& key) {
+            ValueCursor cur = {
+                static_cast<const std::uint8_t*>(key.iov_base),
+                key.iov_len,
+                0u
+            };
+            const std::size_t digest_size = 16u;
+            const std::size_t expected_size =
+                2u + NodeId().size() + 8u + digest_size;
+            if (cur.size != expected_size) {
+                throw std::runtime_error(
+                    "LogicalDeliveryStore marker key has unexpected size");
+            }
+            const std::uint16_t version = read_marker_u16(cur);
+            if (version != marker_key_version()) {
+                throw std::runtime_error(
+                    "Unsupported LogicalDeliveryStore marker key version");
+            }
+            MarkerKeyInfo out;
+            read_marker_id(cur, out.origin_node_id);
+            out.origin_sequence = read_marker_u64(cur);
+            require_bytes(cur, digest_size,
+                          "LogicalDeliveryStore marker key underrun");
+            out.frame_id_digest.assign(cur.data + cur.pos,
+                                       cur.data + cur.pos + digest_size);
+            cur.pos += digest_size;
+            if (cur.pos != cur.size) {
+                throw std::runtime_error(
+                    "Trailing bytes after LogicalDeliveryStore marker key");
+            }
+            return out;
+        }
+
+        static LogicalDeliveryMarkerInfo decode_and_validate_marker(
+                const MDBX_val& key,
+                const MDBX_val& value) {
+            const MarkerKeyInfo key_info = decode_marker_key(key);
+            const LogicalDeliveryMarkerInfo info =
+                decode_marker_value(value);
+            if (compare_node_id(key_info.origin_node_id,
+                                info.origin_node_id) != 0 ||
+                key_info.origin_sequence != info.origin_sequence) {
+                throw std::runtime_error(
+                    "LogicalDeliveryStore marker key/value identity mismatch");
+            }
+            const std::vector<std::uint8_t> expected_digest =
+                make_frame_id_digest(info.frame_id);
+            if (key_info.frame_id_digest != expected_digest) {
+                throw std::runtime_error(
+                    "LogicalDeliveryStore marker key/value frame id mismatch");
+            }
+            return info;
+        }
 
         MDBX_env*   m_env;
         std::string m_dbi_name;

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -53,6 +53,53 @@ mdbxc::sync::NodeId make_node(std::uint8_t seed) {
     return n;
 }
 
+enum BadLogicalDeliveryMarkerKeyCase {
+    BadLogicalDeliveryMarkerKeySize,
+    BadLogicalDeliveryMarkerKeyVersion,
+    BadLogicalDeliveryMarkerKeyOrigin,
+    BadLogicalDeliveryMarkerKeySequence,
+    BadLogicalDeliveryMarkerKeyDigest
+};
+
+void copy_first_logical_delivery_marker(
+        MDBX_txn* txn,
+        mdbxc::sync::LogicalDeliveryStore& store,
+        std::vector<std::uint8_t>& key,
+        std::vector<std::uint8_t>& value) {
+    MDBX_cursor* cursor = nullptr;
+    MDBXC_TEST_ASSERT(
+        mdbx_cursor_open(txn, store.handle(txn), &cursor) == MDBX_SUCCESS);
+    MDBX_val raw_key;
+    MDBX_val raw_value;
+    const int rc = mdbx_cursor_get(cursor, &raw_key, &raw_value, MDBX_FIRST);
+    MDBXC_TEST_ASSERT(rc == MDBX_SUCCESS);
+    const std::uint8_t* key_begin =
+        static_cast<const std::uint8_t*>(raw_key.iov_base);
+    const std::uint8_t* value_begin =
+        static_cast<const std::uint8_t*>(raw_value.iov_base);
+    key.assign(key_begin, key_begin + raw_key.iov_len);
+    value.assign(value_begin, value_begin + raw_value.iov_len);
+    mdbx_cursor_close(cursor);
+}
+
+void put_raw_logical_delivery_marker(
+        MDBX_txn* txn,
+        mdbxc::sync::LogicalDeliveryStore& store,
+        const std::vector<std::uint8_t>& key,
+        const std::vector<std::uint8_t>& value) {
+    MDBX_val raw_key = {
+        const_cast<std::uint8_t*>(key.empty() ? nullptr : &key[0]),
+        key.size()
+    };
+    MDBX_val raw_value = {
+        const_cast<std::uint8_t*>(value.empty() ? nullptr : &value[0]),
+        value.size()
+    };
+    MDBXC_TEST_ASSERT(
+        mdbx_put(txn, store.handle(txn), &raw_key, &raw_value,
+                 MDBX_NOOVERWRITE) == MDBX_SUCCESS);
+}
+
 mdbxc::sync::LogicalSchemaRecord make_record(const std::string& dbi_name,
                                              std::uint32_t version = 1) {
     mdbxc::sync::LogicalSchemaRecord record;
@@ -1818,6 +1865,187 @@ void test_key_value_logical_delivery_store_rejects_frame_id_bound() {
     cleanup(path);
 }
 
+void test_key_value_logical_delivery_store_lists_markers() {
+    const std::string path =
+        "test_key_value_logical_delivery_store_list.mdbx";
+    const std::string dbi_name = "logical_key_value_delivery_store_list";
+    const std::string schema_id = "app.logical_kv_delivery_store_list.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId db_uuid = make_node(0xD0);
+    const mdbxc::sync::NodeId origin = make_node(0x46);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x47), db_uuid);
+    engine.register_logical_schema(schema_id, make_record(dbi_name));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    int apply_calls = 0;
+    CountingDeliveryLogicalAdapter adapter(table, schema_id, apply_calls);
+    engine.register_logical_adapter(adapter);
+
+    for (int i = 0; i < 2; ++i) {
+        mdbxc::sync::LogicalDeliveryEnvelope envelope;
+        envelope.destination_db_uuid = db_uuid;
+        envelope.origin_node_id = origin;
+        envelope.origin_sequence = static_cast<std::uint64_t>(30 + i);
+        envelope.frame_id = i == 0 ? "inspect-a" : "inspect-b";
+        envelope.frame.changes.push_back(mdbxc::sync::LogicalChange(
+            adapter.schema_ref(), 1u, 0u, std::vector<std::uint8_t>()));
+        const mdbxc::sync::LogicalApplyResult result =
+            engine.apply_logical_delivery_envelope(envelope);
+        MDBXC_TEST_ASSERT(result.ok);
+    }
+    MDBXC_TEST_ASSERT(apply_calls == 2);
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        mdbxc::sync::LogicalDeliveryStore store(conn->env_handle());
+        store.open(txn.handle());
+        MDBXC_TEST_ASSERT(store.count(txn.handle()) == 2u);
+        const std::vector<mdbxc::sync::LogicalDeliveryMarkerInfo> one =
+            store.list_markers(txn.handle(), 1u);
+        MDBXC_TEST_ASSERT(one.size() == 1u);
+
+        const std::vector<mdbxc::sync::LogicalDeliveryMarkerInfo> all =
+            store.list_markers(txn.handle());
+        MDBXC_TEST_ASSERT(all.size() == 2u);
+        bool saw_a = false;
+        bool saw_b = false;
+        for (std::size_t i = 0; i < all.size(); ++i) {
+            MDBXC_TEST_ASSERT(
+                mdbxc::sync::compare_node_id(
+                    all[i].destination_db_uuid, db_uuid) == 0);
+            MDBXC_TEST_ASSERT(
+                mdbxc::sync::compare_node_id(
+                    all[i].origin_node_id, origin) == 0);
+            MDBXC_TEST_ASSERT(
+                all[i].frame_codec_version ==
+                mdbxc::sync::LogicalChangeFrameCodec::codec_version());
+            MDBXC_TEST_ASSERT(all[i].frame_bytes_size > 0u);
+            if (all[i].frame_id == "inspect-a") {
+                saw_a = all[i].origin_sequence == 30u;
+            } else if (all[i].frame_id == "inspect-b") {
+                saw_b = all[i].origin_sequence == 31u;
+            }
+        }
+        MDBXC_TEST_ASSERT(saw_a);
+        MDBXC_TEST_ASSERT(saw_b);
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void run_logical_delivery_store_bad_marker_key_case(
+        BadLogicalDeliveryMarkerKeyCase marker_case,
+        const std::string& suffix) {
+    const std::string path =
+        "test_key_value_logical_delivery_bad_marker_" + suffix + ".mdbx";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    mdbxc::sync::LogicalSchemaRef ref;
+    ref.schema_id = "app.logical_kv_delivery_bad_marker.v1";
+    ref.kind = mdbxc::sync::LogicalTableKind::KeyValue;
+    ref.schema_version = 1;
+
+    mdbxc::sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = make_node(0xD3);
+    envelope.origin_node_id = make_node(0x4A);
+    envelope.origin_sequence = 40;
+    envelope.frame_id = "bad-marker-key";
+    envelope.frame.changes.push_back(mdbxc::sync::LogicalChange(
+        ref, 1u, 0u, std::vector<std::uint8_t>()));
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        mdbxc::sync::LogicalDeliveryStore store(conn->env_handle());
+        store.open(txn.handle());
+        MDBXC_TEST_ASSERT(
+            store.try_mark_applied(txn.handle(), envelope));
+
+        std::vector<std::uint8_t> key;
+        std::vector<std::uint8_t> value;
+        copy_first_logical_delivery_marker(
+            txn.handle(), store, key, value);
+        MDBXC_TEST_ASSERT(key.size() > 40u);
+
+        switch (marker_case) {
+            case BadLogicalDeliveryMarkerKeySize:
+                key.pop_back();
+                break;
+            case BadLogicalDeliveryMarkerKeyVersion:
+                key[0] ^= 0x80u;
+                break;
+            case BadLogicalDeliveryMarkerKeyOrigin:
+                key[2] ^= 0x80u;
+                break;
+            case BadLogicalDeliveryMarkerKeySequence:
+                key[18] ^= 0x01u;
+                break;
+            case BadLogicalDeliveryMarkerKeyDigest:
+                key[key.size() - 1u] ^= 0x01u;
+                break;
+        }
+        put_raw_logical_delivery_marker(
+            txn.handle(), store, key, value);
+        txn.commit();
+    }
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        mdbxc::sync::LogicalDeliveryStore store(conn->env_handle());
+        store.open(txn.handle());
+        bool count_threw = false;
+        try {
+            (void)store.count(txn.handle());
+        } catch (const std::runtime_error&) {
+            count_threw = true;
+        }
+        MDBXC_TEST_ASSERT(count_threw);
+
+        bool list_threw = false;
+        try {
+            (void)store.list_markers(txn.handle());
+        } catch (const std::runtime_error&) {
+            list_threw = true;
+        }
+        MDBXC_TEST_ASSERT(list_threw);
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_value_logical_delivery_store_rejects_bad_marker_keys() {
+    run_logical_delivery_store_bad_marker_key_case(
+        BadLogicalDeliveryMarkerKeySize, "size");
+    run_logical_delivery_store_bad_marker_key_case(
+        BadLogicalDeliveryMarkerKeyVersion, "version");
+    run_logical_delivery_store_bad_marker_key_case(
+        BadLogicalDeliveryMarkerKeyOrigin, "origin");
+    run_logical_delivery_store_bad_marker_key_case(
+        BadLogicalDeliveryMarkerKeySequence, "sequence");
+    run_logical_delivery_store_bad_marker_key_case(
+        BadLogicalDeliveryMarkerKeyDigest, "digest");
+}
+
 void test_key_value_logical_capture_session_discards_rollback() {
     const std::string path = "test_key_value_logical_adapter_session_rollback.mdbx";
     const std::string dbi_name = "logical_key_value_session_rollback";
@@ -2368,6 +2596,8 @@ int main() {
     test_key_value_logical_delivery_envelope_keeps_custom_bounds();
     test_key_value_logical_delivery_object_api_rejects_frame_id_bound();
     test_key_value_logical_delivery_store_rejects_frame_id_bound();
+    test_key_value_logical_delivery_store_lists_markers();
+    test_key_value_logical_delivery_store_rejects_bad_marker_keys();
     test_key_value_logical_capture_session_discards_rollback();
     test_key_value_logical_capture_session_requires_schema_marker();
     test_key_value_logical_capture_session_rejects_stale_marker();


### PR DESCRIPTION
## Summary
- add read-only logical delivery marker count/list inspection helpers
- decode marker identity metadata with fail-closed value parsing
- document marker inspection as diagnostics/lifecycle groundwork, not pruning

## Validation
- git diff --check
- test_key_value_logical_adapter built and passed locally
- LogicalDeliveryStore standalone header smoke built and passed locally