### PR TITLE
feat(sync): add logical delivery order status helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,10 @@ All notable changes to this project will be documented in this file.
   self-origin loopback envelopes as successful no-ops. Read-only marker
   inspection helpers expose marker counts and delivery identity metadata for
   diagnostics and future lifecycle work after validating persisted marker
-  key/value consistency. Ordering and marker retention remain external/future
-  lifecycle contracts.
+  key/value consistency. A stateless delivery order helper can classify an
+  envelope sequence against a caller-owned expected next sequence, but it does
+  not identify duplicates. Persisted ordering and marker retention remain
+  external/future lifecycle contracts.
 - Added `ISyncCaptureSink::record_change_op(MDBX_txn*, const ChangeOp&)` as the
   preferred capture entry point. The previous raw-field callback remains the
   source-compatible abstract sink contract; new full-`ChangeOp` sinks can

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -534,8 +534,14 @@ This delivery envelope provides routing validation and replay deduplication, but
 not ordered delivery. The receiver currently accepts envelopes from the same
 origin out of sequence, and it treats different `frame_id` values with the same
 `origin_sequence` as different delivery identities. Applications or transports
-that require ordered effects must serialize delivery externally until a later
-per-origin watermark/gap contract is added.
+that require ordered effects must serialize delivery externally.
+`check_logical_delivery_order()` provides a stateless helper for classifying an
+envelope against a caller-owned expected next sequence as in-order,
+behind the caller's watermark, or ahead with a sequence gap. It only classifies
+the numeric `origin_sequence`: it does not decide whether an envelope is an
+exact duplicate delivery identity, persist a watermark, buffer missing frames,
+or change `SyncEngine::apply_logical_delivery_envelope()` semantics. A future
+per-origin lifecycle PR should add persisted watermarks and pruning rules.
 
 `_mdbxc_logical_delivery` retention is currently permanent and unbounded. A
 future lifecycle PR should add an acknowledgement horizon or per-origin

--- a/include/mdbx_containers/sync/LogicalDeliveryEnvelope.hpp
+++ b/include/mdbx_containers/sync/LogicalDeliveryEnvelope.hpp
@@ -28,6 +28,45 @@ namespace sync {
         LogicalChangeFrame frame;         ///< Logical payload.
     };
 
+    /// \brief Result of an external per-origin delivery ordering check.
+    enum class LogicalDeliveryOrderStatus {
+        InOrder, ///< Observed sequence equals expected next sequence.
+        SequenceBehindWatermark, ///< Observed sequence is below the watermark.
+        SequenceGap ///< Observed sequence is above expected next sequence.
+    };
+
+    /// \brief External ordering check outcome for one delivery envelope.
+    /// \details This helper is intentionally stateless. It does not persist a
+    /// watermark, buffer gaps, or affect engine apply semantics.
+    struct LogicalDeliveryOrderResult {
+        LogicalDeliveryOrderStatus status =
+            LogicalDeliveryOrderStatus::SequenceGap;
+        std::uint64_t expected_sequence = 0;
+        std::uint64_t observed_sequence = 0;
+
+        bool can_apply_without_buffering() const {
+            return status == LogicalDeliveryOrderStatus::InOrder;
+        }
+    };
+
+    /// \brief Classifies \p envelope against a caller-owned next sequence.
+    inline LogicalDeliveryOrderResult check_logical_delivery_order(
+            const LogicalDeliveryEnvelope& envelope,
+            std::uint64_t expected_next_sequence) {
+        LogicalDeliveryOrderResult out;
+        out.expected_sequence = expected_next_sequence;
+        out.observed_sequence = envelope.origin_sequence;
+        if (envelope.origin_sequence == expected_next_sequence) {
+            out.status = LogicalDeliveryOrderStatus::InOrder;
+        } else if (envelope.origin_sequence < expected_next_sequence) {
+            out.status =
+                LogicalDeliveryOrderStatus::SequenceBehindWatermark;
+        } else {
+            out.status = LogicalDeliveryOrderStatus::SequenceGap;
+        }
+        return out;
+    }
+
     /// \brief Returns true when \p id is all zeros.
     inline bool is_zero_sync_id(const NodeId& id) {
         const NodeId zero{};

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -2046,6 +2046,38 @@ void test_key_value_logical_delivery_store_rejects_bad_marker_keys() {
         BadLogicalDeliveryMarkerKeyDigest, "digest");
 }
 
+void test_logical_delivery_order_status_helper() {
+    mdbxc::sync::LogicalDeliveryEnvelope envelope;
+    envelope.origin_sequence = 5;
+    envelope.frame_id = "frame-a";
+
+    mdbxc::sync::LogicalDeliveryOrderResult result =
+        mdbxc::sync::check_logical_delivery_order(envelope, 5);
+    MDBXC_TEST_ASSERT(
+        result.status == mdbxc::sync::LogicalDeliveryOrderStatus::InOrder);
+    MDBXC_TEST_ASSERT(result.expected_sequence == 5u);
+    MDBXC_TEST_ASSERT(result.observed_sequence == 5u);
+    MDBXC_TEST_ASSERT(result.can_apply_without_buffering());
+
+    result = mdbxc::sync::check_logical_delivery_order(envelope, 6);
+    MDBXC_TEST_ASSERT(
+        result.status ==
+        mdbxc::sync::LogicalDeliveryOrderStatus::SequenceBehindWatermark);
+    MDBXC_TEST_ASSERT(!result.can_apply_without_buffering());
+
+    envelope.frame_id = "frame-b";
+    result = mdbxc::sync::check_logical_delivery_order(envelope, 6);
+    MDBXC_TEST_ASSERT(
+        result.status ==
+        mdbxc::sync::LogicalDeliveryOrderStatus::SequenceBehindWatermark);
+    MDBXC_TEST_ASSERT(!result.can_apply_without_buffering());
+
+    result = mdbxc::sync::check_logical_delivery_order(envelope, 4);
+    MDBXC_TEST_ASSERT(
+        result.status == mdbxc::sync::LogicalDeliveryOrderStatus::SequenceGap);
+    MDBXC_TEST_ASSERT(!result.can_apply_without_buffering());
+}
+
 void test_key_value_logical_capture_session_discards_rollback() {
     const std::string path = "test_key_value_logical_adapter_session_rollback.mdbx";
     const std::string dbi_name = "logical_key_value_session_rollback";
@@ -2598,6 +2630,7 @@ int main() {
     test_key_value_logical_delivery_store_rejects_frame_id_bound();
     test_key_value_logical_delivery_store_lists_markers();
     test_key_value_logical_delivery_store_rejects_bad_marker_keys();
+    test_logical_delivery_order_status_helper();
     test_key_value_logical_capture_session_discards_rollback();
     test_key_value_logical_capture_session_requires_schema_marker();
     test_key_value_logical_capture_session_rejects_stale_marker();


### PR DESCRIPTION
## Summary
- add a stateless logical delivery order status helper
- classify in-order, sequence-behind-watermark, and sequence-gap envelopes against a caller-owned next sequence
- document that the helper does not identify duplicate delivery identity and that engine apply still does not persist watermarks or buffer gaps

## Validation
- git diff --check
- test_key_value_logical_adapter built and passed locally
- LogicalDeliveryEnvelope standalone header smoke built and passed locally