### PR TITLE
feat(sync): add KeyTable logical adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,11 @@ All notable changes to this project will be documented in this file.
   validates the persistent schema marker before local mutation, buffers typed
   local changes, and publishes them only after successful commit. Transport
   pull/push remains raw-DBI only.
+- Added `KeyTableLogicalAdapter` for explicit apply-side logical
+  insert/delete/clear operations on `KeyTable`. It reuses the existing explicit
+  key codec tags and validates the persistent single-DBI schema marker through
+  the normal engine logical apply path. Typed local capture for key-only tables
+  remains future work.
 - Documented the staged logical sync contract: schema marker, logical wire
   frame, adapter preflight/apply, then capture. Deferred logical tables still
   require single-writer or application-serialized conflicting writes until a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,6 +446,7 @@ if(MDBXC_BUILD_TESTS)
         mdbx_containers/sync/LogicalTableAdapter.hpp
         mdbx_containers/sync/LogicalSchemaValidation.hpp
         mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp
+        mdbx_containers/sync/adapters/KeyTableLogicalAdapter.hpp
         mdbx_containers/sync/ChangeBatch.hpp
         mdbx_containers/sync/ChangeBatchCodec.hpp
         mdbx_containers/sync/SyncApplyObserver.hpp

--- a/README-RU.md
+++ b/README-RU.md
@@ -110,11 +110,12 @@
 - `SyncEngine` предоставляет pull/push/apply primitives,
   `register_logical_schema()` для committed setup logical schema markers и
   `migrate_logical_schema()` для явной замены marker после exact preflight.
-  `KeyValueTableLogicalAdapter` - первый concrete logical adapter helper для
-  явных вызовов `SyncEngine::apply_logical_changes()` или более низкоуровневого
-  `LogicalTableRegistry::preflight_then_apply()`. Его payload
-  codec отделён от физического storage-формата таблицы и выбирается через
-  явные key/value codec tags вроде `KeyValueLogicalInt64Codec<long>` и
+  `KeyValueTableLogicalAdapter` и `KeyTableLogicalAdapter` - первые concrete
+  logical adapter helpers для явных вызовов
+  `SyncEngine::apply_logical_changes()` или более низкоуровневого
+  `LogicalTableRegistry::preflight_then_apply()`. Их payload codecs отделены
+  от физического storage-формата таблиц и выбираются через явные codec tags
+  вроде `KeyValueLogicalInt64Codec<long>` и
   `KeyValueLogicalStringCodec<std::string>`. Codec tags являются частью
   logical schema contract; их смена требует нового schema id или явной
   schema-marker migration. Обычный вызов `register_logical_schema()` всё ещё

--- a/README.md
+++ b/README.md
@@ -87,11 +87,12 @@
   `register_logical_schema()` for committed logical schema marker setup, plus
   `migrate_logical_schema()` for explicit marker replacement after exact
   preflight.
-  `KeyValueTableLogicalAdapter` is the first concrete logical adapter helper
-  for explicit `SyncEngine::apply_logical_changes()` or lower-level
-  `LogicalTableRegistry::preflight_then_apply()` calls. Its
-  payload codec is separate from physical table storage and is selected through
-  explicit key/value codec tags such as `KeyValueLogicalInt64Codec<long>` and
+  `KeyValueTableLogicalAdapter` and `KeyTableLogicalAdapter` are the first
+  concrete logical adapter helpers for explicit
+  `SyncEngine::apply_logical_changes()` or lower-level
+  `LogicalTableRegistry::preflight_then_apply()` calls. Their
+  payload codecs are separate from physical table storage and are selected
+  through explicit codec tags such as `KeyValueLogicalInt64Codec<long>` and
   `KeyValueLogicalStringCodec<std::string>`. Codec tags are part of the
   logical schema contract; changing them requires a new schema id, or an
   explicit schema-marker migration. A plain `register_logical_schema()` call

--- a/guides/sync-table-coverage.md
+++ b/guides/sync-table-coverage.md
@@ -50,6 +50,11 @@ has three separate pieces that must not be treated as support by themselves:
 - `LogicalTableRegistry` reserves a two-phase preflight/apply path and validates
   the full schema tuple plus reserved flags before invoking adapters.
 
+`KeyValueTableLogicalAdapter` and `KeyTableLogicalAdapter` are the current
+explicit logical apply helpers. They are not connected to the transport
+pull/push path, and `KeyTableLogicalAdapter` does not yet provide a typed local
+capture session.
+
 Until a wrapper has a codec extension, a registered adapter, capture tests, and
 round-trip tests, it must remain in the deferred rows below and must not emit
 logical or raw `ChangeOp` records.

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -96,6 +96,10 @@ The logical sync scaffolding is preparatory only:
   explicit logical apply and aborts it if an adapter reports failure or throws
   after any mutation. The transport `handle_push()` path still applies raw DBI
   operations only.
+- `KeyValueTableLogicalAdapter` and `KeyTableLogicalAdapter` are explicit
+  apply helpers only. `KeyValueTableLogicalAdapter` also has an opt-in typed
+  capture session; `KeyTableLogicalAdapter` does not yet capture local typed
+  writes.
 
 Until a causal context or another conflict model is implemented, future logical
 table support should document either one authoritative writer for the affected

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -23,6 +23,7 @@
 #include "sync/LogicalTableAdapter.hpp"
 #include "sync/LogicalSchemaValidation.hpp"
 #include "sync/adapters/KeyValueTableLogicalAdapter.hpp"
+#include "sync/adapters/KeyTableLogicalAdapter.hpp"
 #include "sync/CodecBounds.hpp"
 #include "sync/ChangeBatch.hpp"
 #include "sync/ChangeBatchCodec.hpp"

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -574,20 +574,25 @@ define a retention policy and must not be used as a standalone pruning signal.
   must abort that transaction; the registry cannot roll back a transaction it
   does not own.
 
-`adapters/KeyValueTableLogicalAdapter.hpp` provides the first concrete adapter
-helper. It translates typed `KeyValueTable` upsert/delete/clear operations into
-adapter-owned logical payloads and applies them through
+`adapters/KeyValueTableLogicalAdapter.hpp` and
+`adapters/KeyTableLogicalAdapter.hpp` provide the first concrete adapter
+helpers. They translate typed table operations into adapter-owned logical
+payloads and apply them through
 `SyncEngine::apply_logical_changes()` or
 `LogicalTableRegistry::preflight_then_apply()` inside a caller-owned write
-transaction. It proves the adapter contract and payload shape for a simple
-table, but it is not yet connected to the automatic pull/push wire pipeline.
-The adapter also exposes an opt-in `LogicalCaptureSession`. The session owns a
-writable transaction, suppresses raw capture for its typed writes, buffers
-logical changes privately, and copies them to the caller only from
-`commit(out)`. Rollback, destruction, or commit failure discards the pending
-logical changes. Session construction validates the adapter against the
-persistent schema marker in the same writable transaction, before any local
-mutation can be performed.
+transaction. These helpers prove the adapter contract and payload shape for
+simple tables, but they are not yet connected to the automatic pull/push wire
+pipeline.
+`KeyValueTableLogicalAdapter` supports upsert/delete/clear and exposes an
+opt-in `LogicalCaptureSession`. The session owns a writable transaction,
+suppresses raw capture for its typed writes, buffers logical changes privately,
+and copies them to the caller only from `commit(out)`. Rollback, destruction,
+or commit failure discards the pending logical changes. Session construction
+validates the adapter against the persistent schema marker in the same writable
+transaction, before any local mutation can be performed.
+`KeyTableLogicalAdapter` currently supports apply-side insert/delete/clear
+only; a typed local capture session for key-only tables is deferred until the
+logical capture API is generalized beyond `KeyValueTable`.
 
 The adapter payload codec is not the table storage serializer. The initial
 codec surface is deliberately small and explicit: callers provide key/value

--- a/include/mdbx_containers/sync/LogicalChangeFrameCodec.hpp
+++ b/include/mdbx_containers/sync/LogicalChangeFrameCodec.hpp
@@ -325,6 +325,9 @@ namespace sync {
                         LogicalTableKind::KeyValue):
                     return LogicalTableKind::KeyValue;
                 case static_cast<std::uint16_t>(
+                        LogicalTableKind::KeyTable):
+                    return LogicalTableKind::KeyTable;
+                case static_cast<std::uint16_t>(
                         LogicalTableKind::KeyMultiValue):
                     return LogicalTableKind::KeyMultiValue;
                 case static_cast<std::uint16_t>(

--- a/include/mdbx_containers/sync/LogicalSchema.hpp
+++ b/include/mdbx_containers/sync/LogicalSchema.hpp
@@ -18,6 +18,7 @@ namespace sync {
         AnyValue             = 3, ///< Dynamically typed value table.
         HashedKeyValue       = 4, ///< Hashed key-value store.
         KeyValue             = 5, ///< One value per key table.
+        KeyTable             = 6, ///< Key-only set table.
     };
 
     /// \brief Returns true when \p kind is a supported logical table kind.
@@ -28,6 +29,7 @@ namespace sync {
             case LogicalTableKind::AnyValue:
             case LogicalTableKind::HashedKeyValue:
             case LogicalTableKind::KeyValue:
+            case LogicalTableKind::KeyTable:
                 return true;
             case LogicalTableKind::Unknown:
                 return false;

--- a/include/mdbx_containers/sync/adapters/KeyTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyTableLogicalAdapter.hpp
@@ -1,0 +1,258 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_ADAPTERS_KEY_TABLE_LOGICAL_ADAPTER_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_ADAPTERS_KEY_TABLE_LOGICAL_ADAPTER_HPP_INCLUDED
+
+/// \file KeyTableLogicalAdapter.hpp
+/// \brief Minimal logical adapter for \c KeyTable.
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "../../KeyTable.hpp"
+#include "KeyValueTableLogicalAdapter.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Opcodes understood by \c KeyTableLogicalAdapter.
+    enum KeyTableLogicalOpcode {
+        KeyTableLogicalInsert = 1,
+        KeyTableLogicalDelete = 2,
+        KeyTableLogicalClear  = 3
+    };
+
+    /// \brief Logical adapter for typed \c KeyTable insert/delete/clear ops.
+    /// \details The adapter reuses the explicit key codec tags used by
+    /// \c KeyValueTableLogicalAdapter. It is an apply-side helper only; local
+    /// capture sessions for key-only tables can be layered on top later.
+    template<class KeyT,
+             class KeyCodec,
+             class Options = DefaultTableOptions>
+    class KeyTableLogicalAdapter : public ILogicalTableAdapter {
+    public:
+        typedef KeyTable<KeyT, Options> table_type;
+
+        static_assert(std::is_same<typename KeyCodec::value_type,
+                                   KeyT>::value,
+                      "KeyTableLogicalAdapter key codec local type must match KeyT");
+
+        KeyTableLogicalAdapter(table_type& table,
+                               const std::string& schema_id,
+                               std::uint32_t schema_version = 1)
+            : m_table(table),
+              m_schema_id(schema_id),
+              m_schema_version(schema_version) {
+            if (m_schema_id.empty()) {
+                throw std::invalid_argument(
+                    "KeyTableLogicalAdapter schema id is empty");
+            }
+            if (m_table.dbi_name().empty()) {
+                throw std::invalid_argument(
+                    "KeyTableLogicalAdapter DBI name is empty");
+            }
+            if (m_schema_version == 0) {
+                throw std::invalid_argument(
+                    "KeyTableLogicalAdapter schema version is zero");
+            }
+        }
+
+        LogicalSchemaRef schema_ref() const override {
+            LogicalSchemaRef ref;
+            ref.schema_id = m_schema_id;
+            ref.kind = LogicalTableKind::KeyTable;
+            ref.schema_version = m_schema_version;
+            return ref;
+        }
+
+        std::string primary_dbi() const override {
+            return m_table.dbi_name();
+        }
+
+        std::vector<std::string> affected_dbis() const override {
+            std::vector<std::string> out;
+            out.push_back(m_table.dbi_name());
+            return out;
+        }
+
+        LogicalChange make_insert(const KeyT& key) const {
+            LogicalChange change;
+            change.schema = schema_ref();
+            change.opcode = KeyTableLogicalInsert;
+            encode_key_only(key, change.payload);
+            return change;
+        }
+
+        LogicalChange make_delete(const KeyT& key) const {
+            LogicalChange change;
+            change.schema = schema_ref();
+            change.opcode = KeyTableLogicalDelete;
+            encode_key_only(key, change.payload);
+            return change;
+        }
+
+        LogicalChange make_clear() const {
+            LogicalChange change;
+            change.schema = schema_ref();
+            change.opcode = KeyTableLogicalClear;
+            return change;
+        }
+
+        LogicalApplyResult preflight(
+                MDBX_txn* txn,
+                const LogicalChange& change) const override {
+            (void)txn;
+            return validate_payload(change);
+        }
+
+        LogicalApplyResult apply(
+                MDBX_txn* txn,
+                const LogicalChange& change) override {
+            const LogicalApplyResult validation = validate_payload(change);
+            if (!validation.ok) return validation;
+
+            try {
+                Connection::SyncCaptureSuppressionScope suppress_capture(
+                    *m_table.connection(), txn);
+                if (change.opcode == KeyTableLogicalInsert) {
+                    const KeyT key = decode_key_only(change.payload);
+                    (void)m_table.insert(key, txn);
+                    return LogicalApplyResult::success();
+                }
+                if (change.opcode == KeyTableLogicalDelete) {
+                    const KeyT key = decode_key_only(change.payload);
+                    (void)m_table.erase(key, txn);
+                    return LogicalApplyResult::success();
+                }
+                if (change.opcode == KeyTableLogicalClear) {
+                    m_table.clear(txn);
+                    return LogicalApplyResult::success();
+                }
+            } catch (const std::exception& e) {
+                return LogicalApplyResult::failure(
+                    std::string("KeyTable logical adapter apply failed: ") +
+                    e.what());
+            } catch (...) {
+                return LogicalApplyResult::failure(
+                    "KeyTable logical adapter apply failed");
+            }
+            return LogicalApplyResult::failure(
+                "KeyTable logical adapter opcode is unsupported");
+        }
+
+    private:
+        struct PayloadCursor {
+            const std::uint8_t* data;
+            std::size_t size;
+            std::size_t pos;
+        };
+
+        static void require(PayloadCursor& cursor, std::size_t size) {
+            if (cursor.pos > cursor.size ||
+                size > cursor.size - cursor.pos) {
+                throw std::runtime_error(
+                    "KeyTable logical payload underrun");
+            }
+        }
+
+        static void append_blob(std::vector<std::uint8_t>& out,
+                                const std::vector<std::uint8_t>& value) {
+            if (value.size() >
+                static_cast<std::size_t>(
+                    std::numeric_limits<std::uint32_t>::max())) {
+                throw std::length_error(
+                    "KeyTable logical payload blob is too large");
+            }
+            detail::append_u32_le(out,
+                static_cast<std::uint32_t>(value.size()));
+            out.insert(out.end(), value.begin(), value.end());
+        }
+
+        static std::vector<std::uint8_t> read_blob(PayloadCursor& cursor) {
+            require(cursor, 4u);
+            const std::uint32_t size =
+                detail::read_u32_le(cursor.data + cursor.pos);
+            cursor.pos += 4u;
+            require(cursor, size);
+            std::vector<std::uint8_t> out;
+            if (size != 0u) {
+                out.assign(cursor.data + cursor.pos,
+                           cursor.data + cursor.pos + size);
+            }
+            cursor.pos += size;
+            return out;
+        }
+
+        static PayloadCursor make_cursor(
+                const std::vector<std::uint8_t>& payload) {
+            PayloadCursor cursor = {
+                payload.empty() ? nullptr : &payload[0],
+                payload.size(),
+                0u
+            };
+            return cursor;
+        }
+
+        static void ensure_end(const PayloadCursor& cursor) {
+            if (cursor.pos != cursor.size) {
+                throw std::runtime_error(
+                    "KeyTable logical payload has trailing bytes");
+            }
+        }
+
+        static void encode_key_only(const KeyT& key,
+                                    std::vector<std::uint8_t>& out) {
+            out.clear();
+            const std::vector<std::uint8_t> encoded_key =
+                KeyCodec::encode(key);
+            append_blob(out, encoded_key);
+        }
+
+        static KeyT decode_key_only(
+                const std::vector<std::uint8_t>& payload) {
+            PayloadCursor cursor = make_cursor(payload);
+            const std::vector<std::uint8_t> encoded_key = read_blob(cursor);
+            ensure_end(cursor);
+            return KeyCodec::decode(encoded_key);
+        }
+
+        LogicalApplyResult validate_payload(
+                const LogicalChange& change) const {
+            try {
+                if (change.opcode == KeyTableLogicalInsert ||
+                    change.opcode == KeyTableLogicalDelete) {
+                    (void)decode_key_only(change.payload);
+                    return LogicalApplyResult::success();
+                }
+                if (change.opcode == KeyTableLogicalClear) {
+                    if (!change.payload.empty()) {
+                        return LogicalApplyResult::failure(
+                            "KeyTable clear payload must be empty");
+                    }
+                    return LogicalApplyResult::success();
+                }
+            } catch (const std::exception& e) {
+                return LogicalApplyResult::failure(
+                    std::string("KeyTable logical payload is invalid: ") +
+                    e.what());
+            } catch (...) {
+                return LogicalApplyResult::failure(
+                    "KeyTable logical payload is invalid");
+            }
+            return LogicalApplyResult::failure(
+                "KeyTable logical adapter opcode is unsupported");
+        }
+
+        table_type& m_table;
+        std::string m_schema_id;
+        std::uint32_t m_schema_version;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_ADAPTERS_KEY_TABLE_LOGICAL_ADAPTER_HPP_INCLUDED

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -21,6 +21,8 @@ typedef mdbxc::sync::KeyValueTableLogicalAdapter<
     std::string,
     mdbxc::sync::KeyValueLogicalInt32Codec<long long>,
     StringValueCodec> LongLongInt32StringAdapter;
+typedef mdbxc::sync::KeyTableLogicalAdapter<int, IntKeyCodec>
+    IntKeyTableAdapter;
 
 static_assert(mdbxc::sync::detail::KeyValueLogicalIntegerLocalSupported<
                   std::int32_t>::value,
@@ -105,6 +107,17 @@ mdbxc::sync::LogicalSchemaRecord make_record(const std::string& dbi_name,
     mdbxc::sync::LogicalSchemaRecord record;
     record.dbi_name = dbi_name;
     record.kind = mdbxc::sync::LogicalTableKind::KeyValue;
+    record.schema_version = version;
+    record.dbi_names.push_back(dbi_name);
+    return record;
+}
+
+mdbxc::sync::LogicalSchemaRecord make_key_table_record(
+        const std::string& dbi_name,
+        std::uint32_t version = 1) {
+    mdbxc::sync::LogicalSchemaRecord record;
+    record.dbi_name = dbi_name;
+    record.kind = mdbxc::sync::LogicalTableKind::KeyTable;
     record.schema_version = version;
     record.dbi_names.push_back(dbi_name);
     return record;
@@ -658,6 +671,87 @@ void test_key_value_logical_adapter_applies_through_sync_engine() {
     MDBXC_TEST_ASSERT(engine.unregister_logical_adapter(
         "app.logical_kv_engine.v1"));
     MDBXC_TEST_ASSERT(engine.logical_adapter_count() == 0u);
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_table_logical_adapter_applies_through_sync_engine() {
+    const std::string path = "test_key_table_logical_adapter_engine.mdbx";
+    const std::string dbi_name = "logical_key_table_engine";
+    const std::string schema_id = "app.logical_key_table_engine.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x48), make_node(0xD1));
+    engine.register_logical_schema(
+        schema_id, make_key_table_record(dbi_name));
+
+    mdbxc::KeyTable<int> table(conn, dbi_name);
+    IntKeyTableAdapter adapter(table, schema_id);
+    engine.register_logical_adapter(adapter);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(adapter.make_insert(11));
+    changes.push_back(adapter.make_insert(12));
+    changes.push_back(adapter.make_delete(11));
+
+    mdbxc::sync::LogicalApplyResult result =
+        engine.apply_logical_changes(changes);
+    MDBXC_TEST_ASSERT(result.ok);
+    MDBXC_TEST_ASSERT(!table.contains(11));
+    MDBXC_TEST_ASSERT(table.contains(12));
+    MDBXC_TEST_ASSERT(table.count() == 1u);
+
+    changes.clear();
+    changes.push_back(adapter.make_clear());
+    result = engine.apply_logical_changes(changes);
+    MDBXC_TEST_ASSERT(result.ok);
+    MDBXC_TEST_ASSERT(table.count() == 0u);
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_table_logical_adapter_rejects_malformed_payload() {
+    const std::string path = "test_key_table_logical_adapter_malformed.mdbx";
+    const std::string dbi_name = "logical_key_table_malformed";
+    const std::string schema_id = "app.logical_key_table_malformed.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x49), make_node(0xD2));
+    engine.register_logical_schema(
+        schema_id, make_key_table_record(dbi_name));
+
+    mdbxc::KeyTable<int> table(conn, dbi_name);
+    IntKeyTableAdapter adapter(table, schema_id);
+    engine.register_logical_adapter(adapter);
+
+    mdbxc::sync::LogicalChange malformed = adapter.make_insert(5);
+    malformed.payload.push_back(0xffu);
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(malformed);
+
+    const mdbxc::sync::LogicalApplyResult result =
+        engine.apply_logical_changes(changes);
+    MDBXC_TEST_ASSERT(!result.ok);
+    MDBXC_TEST_ASSERT(result.error.find("payload") != std::string::npos);
+    MDBXC_TEST_ASSERT(!table.contains(5));
 
     conn->disconnect();
     cleanup(path);
@@ -2603,6 +2697,8 @@ void test_key_value_logical_apply_does_not_recapture_incoming_change() {
 int main() {
     test_key_value_logical_adapter_applies_basic_ops();
     test_key_value_logical_adapter_applies_through_sync_engine();
+    test_key_table_logical_adapter_applies_through_sync_engine();
+    test_key_table_logical_adapter_rejects_malformed_payload();
     test_key_value_logical_adapter_engine_rejects_unknown_schema();
     test_key_value_logical_engine_rejects_missing_schema_marker();
     test_key_value_logical_engine_rejects_stale_schema_marker();

--- a/tests/test_logical_change_frame_codec.cpp
+++ b/tests/test_logical_change_frame_codec.cpp
@@ -153,6 +153,27 @@ void test_logical_frame_roundtrip() {
     MDBXC_TEST_ASSERT(decoded.changes[1].payload == second_payload);
 }
 
+void test_logical_frame_accepts_key_table_kind() {
+    mdbxc::sync::LogicalChangeFrame frame;
+    std::vector<std::uint8_t> payload;
+    payload.push_back(7);
+    frame.changes.push_back(make_change(
+        "app.logical.keys.v1",
+        mdbxc::sync::LogicalTableKind::KeyTable,
+        1,
+        1,
+        payload));
+
+    const std::vector<std::uint8_t> encoded =
+        mdbxc::sync::LogicalChangeFrameCodec::encode(frame);
+    const mdbxc::sync::LogicalChangeFrame decoded =
+        mdbxc::sync::LogicalChangeFrameCodec::decode(encoded);
+    MDBXC_TEST_ASSERT(decoded.changes.size() == 1u);
+    MDBXC_TEST_ASSERT(decoded.changes[0].schema.kind ==
+                      mdbxc::sync::LogicalTableKind::KeyTable);
+    MDBXC_TEST_ASSERT(decoded.changes[0].payload == payload);
+}
+
 void test_logical_frame_matches_golden_vector() {
     mdbxc::sync::LogicalChangeFrame frame;
     std::vector<std::uint8_t> payload;
@@ -405,6 +426,7 @@ void test_logical_frame_decode_rejects_payload_length_overflow() {
 
 int main() {
     test_logical_frame_roundtrip();
+    test_logical_frame_accepts_key_table_kind();
     test_logical_frame_matches_golden_vector();
     test_empty_logical_frame_roundtrip();
     test_logical_frame_encode_rejects_too_many_changes();


### PR DESCRIPTION
## Summary
- add KeyTableLogicalAdapter for explicit logical insert/delete/clear apply
- add KeyTable logical schema kind support in the frame codec
- cover engine apply, malformed payload rejection, standalone header, and docs

## Validation
- git diff --check
- CMake configure in build_codex_mingw
- test_key_value_logical_adapter passed locally
- test_logical_change_frame_codec passed locally
- KeyTableLogicalAdapter standalone header smoke passed locally
- header_sync_umbrella_test passed locally