### PR TITLE
ci: run archcheck on stacked pull requests

### DIFF
--- a/.github/workflows/archcheck.yml
+++ b/.github/workflows/archcheck.yml
@@ -2,7 +2,6 @@ name: Archcheck
 
 on:
   pull_request:
-    branches: [ main, stable ]
   workflow_dispatch:
     inputs:
       revspec:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 - Added a non-blocking `Archcheck` GitHub Actions workflow that runs
   `archcheck --diff` through a pinned official action as an advisory
-  architecture signal on pull requests and manual dispatch.
+  architecture signal on pull requests, including stacked PRs, and manual
+  dispatch.
 - Added a persistent sync schema registry store for future logical table
   adapters. The registry records logical schema ids, table kinds, schema
   versions, and canonical sorted unique owned DBI names without enabling

--- a/guides/build-and-test.md
+++ b/guides/build-and-test.md
@@ -179,9 +179,10 @@ sync_tick_hub_benchmark \
 - A separate Linux C++17 smoke job builds and runs `sync_tick_hub_benchmark`
   with `MDBXC_BUILD_BENCHMARKS=ON`.
 - The separate `Archcheck` workflow runs `archcheck --diff` as an advisory
-  architecture check on pull requests and manual dispatch. The action uses
-  `fail-on-gate: false`, so architecture findings are visible without blocking
-  merges, while configuration or tool execution failures still fail the job.
+  architecture check on pull requests, including stacked PRs, and manual
+  dispatch. The action uses `fail-on-gate: false`, so architecture findings are
+  visible without blocking merges, while configuration or tool execution
+  failures still fail the job.
 - The separate `Stress` workflow runs `ctest -L stress` on Linux C++17 when
   manually dispatched or triggered by its schedule.
 


### PR DESCRIPTION
## Summary

- Run the advisory Archcheck workflow for every pull request, including stacked PRs targeting feature branches.
- Document the stacked-PR policy in the build guide and changelog.

## Validation

- `git diff --check`