### PR TITLE
feat(sync): add KeyTable logical capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Added an opt-in typed `LogicalCaptureSession` to
+  `KeyTableLogicalAdapter`. It owns one writable transaction, suppresses raw
+  capture, emits logical insert/delete changes only for successful local
+  membership mutations, records explicit clear requests, and publishes pending
+  changes only after commit.
 - Added a non-blocking `Archcheck` GitHub Actions workflow that runs
   `archcheck --diff` through a pinned official action as an advisory
   architecture signal on pull requests, including stacked PRs, and manual

--- a/guides/sync-table-coverage.md
+++ b/guides/sync-table-coverage.md
@@ -51,9 +51,8 @@ has three separate pieces that must not be treated as support by themselves:
   the full schema tuple plus reserved flags before invoking adapters.
 
 `KeyValueTableLogicalAdapter` and `KeyTableLogicalAdapter` are the current
-explicit logical apply helpers. They are not connected to the transport
-pull/push path, and `KeyTableLogicalAdapter` does not yet provide a typed local
-capture session.
+explicit logical apply helpers with opt-in typed capture sessions. They are not
+connected to the transport pull/push path; callers own logical frame delivery.
 
 Until a wrapper has a codec extension, a registered adapter, capture tests, and
 round-trip tests, it must remain in the deferred rows below and must not emit

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -97,9 +97,8 @@ The logical sync scaffolding is preparatory only:
   after any mutation. The transport `handle_push()` path still applies raw DBI
   operations only.
 - `KeyValueTableLogicalAdapter` and `KeyTableLogicalAdapter` are explicit
-  apply helpers only. `KeyValueTableLogicalAdapter` also has an opt-in typed
-  capture session; `KeyTableLogicalAdapter` does not yet capture local typed
-  writes.
+  apply helpers with opt-in typed capture sessions. Neither is connected to
+  the transport pull/push path yet; callers own logical frame delivery.
 
 Until a causal context or another conflict model is implemented, future logical
 table support should document either one authoritative writer for the affected

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -583,16 +583,17 @@ payloads and apply them through
 transaction. These helpers prove the adapter contract and payload shape for
 simple tables, but they are not yet connected to the automatic pull/push wire
 pipeline.
-`KeyValueTableLogicalAdapter` supports upsert/delete/clear and exposes an
-opt-in `LogicalCaptureSession`. The session owns a writable transaction,
-suppresses raw capture for its typed writes, buffers logical changes privately,
-and copies them to the caller only from `commit(out)`. Rollback, destruction,
-or commit failure discards the pending logical changes. Session construction
-validates the adapter against the persistent schema marker in the same writable
-transaction, before any local mutation can be performed.
-`KeyTableLogicalAdapter` currently supports apply-side insert/delete/clear
-only; a typed local capture session for key-only tables is deferred until the
-logical capture API is generalized beyond `KeyValueTable`.
+`KeyValueTableLogicalAdapter` supports upsert/delete/clear and
+`KeyTableLogicalAdapter` supports insert/delete/clear. Both expose an opt-in
+`LogicalCaptureSession`. The session owns a writable transaction, suppresses
+raw capture for its typed writes, buffers logical changes privately, and copies
+them to the caller only from `commit(out)`. Rollback, destruction, or commit
+failure discards the pending logical changes. Session construction validates
+the adapter against the persistent schema marker in the same writable
+transaction, before any local mutation can be performed. For `KeyTable`, only
+successful membership changes are captured: inserting an existing key or
+erasing an absent key leaves the pending logical frame unchanged; an explicit
+clear request is captured even when the table is already empty.
 
 The adapter payload codec is not the table storage serializer. The initial
 codec surface is deliberately small and explicit: callers provide key/value

--- a/include/mdbx_containers/sync/adapters/KeyTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyTableLogicalAdapter.hpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -28,8 +29,7 @@ namespace sync {
 
     /// \brief Logical adapter for typed \c KeyTable insert/delete/clear ops.
     /// \details The adapter reuses the explicit key codec tags used by
-    /// \c KeyValueTableLogicalAdapter. It is an apply-side helper only; local
-    /// capture sessions for key-only tables can be layered on top later.
+    /// \c KeyValueTableLogicalAdapter.
     template<class KeyT,
              class KeyCodec,
              class Options = DefaultTableOptions>
@@ -100,6 +100,147 @@ namespace sync {
             change.schema = schema_ref();
             change.opcode = KeyTableLogicalClear;
             return change;
+        }
+
+        /// \brief Transaction-bound typed logical capture session.
+        /// \details The session owns a writable transaction. Successful local
+        /// writes are buffered as logical changes and raw capture is
+        /// suppressed for the transaction. Pending changes are copied to the
+        /// caller only by \c commit(out), after the session has prepared the
+        /// destination vector and before the native commit. If commit fails,
+        /// the appended tail is erased and the destructor rolls back the
+        /// transaction. The adapter, table, and connection referenced by the
+        /// adapter must outlive the session.
+        class LogicalCaptureSession {
+        public:
+            explicit LogicalCaptureSession(
+                    const KeyTableLogicalAdapter& adapter)
+                : m_adapter(adapter),
+                  m_txn(adapter.m_table.connection()->transaction(
+                      TransactionMode::WRITABLE)),
+                  m_active(true) {
+                const LogicalApplyResult marker_result =
+                    validate_logical_adapter_marker(
+                        m_txn.handle(),
+                        adapter.m_table.connection()->env_handle(),
+                        adapter);
+                if (!marker_result.ok) {
+                    throw std::runtime_error(marker_result.error);
+                }
+            }
+
+            ~LogicalCaptureSession() noexcept {
+                rollback();
+            }
+
+            LogicalCaptureSession(const LogicalCaptureSession&) = delete;
+            LogicalCaptureSession& operator=(
+                    const LogicalCaptureSession&) = delete;
+
+            bool insert(const KeyT& key) {
+                ensure_active();
+                const LogicalChange change = m_adapter.make_insert(key);
+                const std::size_t previous_size = m_pending.size();
+                m_pending.push_back(change);
+                try {
+                    Connection::SyncCaptureSuppressionScope suppress_capture(
+                        *m_adapter.m_table.connection(), m_txn.handle());
+                    const bool inserted =
+                        m_adapter.m_table.insert(key, m_txn.handle());
+                    if (!inserted) {
+                        m_pending.resize(previous_size);
+                    }
+                    return inserted;
+                } catch (...) {
+                    m_pending.resize(previous_size);
+                    throw;
+                }
+            }
+
+            bool erase(const KeyT& key) {
+                ensure_active();
+                const LogicalChange change = m_adapter.make_delete(key);
+                const std::size_t previous_size = m_pending.size();
+                m_pending.push_back(change);
+                try {
+                    Connection::SyncCaptureSuppressionScope suppress_capture(
+                        *m_adapter.m_table.connection(), m_txn.handle());
+                    const bool removed =
+                        m_adapter.m_table.erase(key, m_txn.handle());
+                    if (!removed) {
+                        m_pending.resize(previous_size);
+                    }
+                    return removed;
+                } catch (...) {
+                    m_pending.resize(previous_size);
+                    throw;
+                }
+            }
+
+            void clear() {
+                ensure_active();
+                const LogicalChange change = m_adapter.make_clear();
+                const std::size_t previous_size = m_pending.size();
+                m_pending.push_back(change);
+                try {
+                    Connection::SyncCaptureSuppressionScope suppress_capture(
+                        *m_adapter.m_table.connection(), m_txn.handle());
+                    m_adapter.m_table.clear(m_txn.handle());
+                } catch (...) {
+                    m_pending.resize(previous_size);
+                    throw;
+                }
+            }
+
+            void commit(std::vector<LogicalChange>& out) {
+                ensure_active();
+                const std::size_t old_size = out.size();
+                out.insert(out.end(), m_pending.begin(), m_pending.end());
+                try {
+                    m_txn.commit();
+                } catch (...) {
+                    out.erase(out.begin() +
+                              static_cast<std::ptrdiff_t>(old_size),
+                              out.end());
+                    throw;
+                }
+                m_pending.clear();
+                m_active = false;
+            }
+
+            void rollback() noexcept {
+                if (!m_active) {
+                    return;
+                }
+                try {
+                    m_pending.clear();
+                    m_txn.rollback();
+                } catch (...) {
+                }
+                m_active = false;
+            }
+
+            std::size_t pending_size() const {
+                return m_pending.size();
+            }
+
+        private:
+            void ensure_active() const {
+                if (!m_active) {
+                    throw std::logic_error(
+                        "KeyTable logical capture session is not active");
+                }
+            }
+
+            const KeyTableLogicalAdapter& m_adapter;
+            Transaction m_txn;
+            std::vector<LogicalChange> m_pending;
+            bool m_active;
+        };
+
+        std::unique_ptr<LogicalCaptureSession> begin_capture_session() const {
+            return std::unique_ptr<LogicalCaptureSession>(
+                new LogicalCaptureSession(*this));
         }
 
         LogicalApplyResult preflight(

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -757,6 +757,67 @@ void test_key_table_logical_adapter_rejects_malformed_payload() {
     cleanup(path);
 }
 
+void test_key_table_logical_capture_session_commits_typed_local_writes() {
+    const std::string path =
+        "test_key_table_logical_adapter_session.mdbx";
+    const std::string dbi_name = "logical_key_table_session";
+    const std::string schema_id = "app.logical_key_table_session.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId node = make_node(0x4A);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(node, make_node(0xD3));
+    engine.register_logical_schema(
+        schema_id, make_key_table_record(dbi_name));
+
+    mdbxc::KeyTable<int> table(conn, dbi_name);
+    IntKeyTableAdapter adapter(table, schema_id);
+    mdbxc::sync::ThreadLocalChangeAccumulator raw_capture(conn);
+    conn->attach_sync_capture(&raw_capture);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    {
+        std::unique_ptr<IntKeyTableAdapter::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        MDBXC_TEST_ASSERT(session->insert(1));
+        MDBXC_TEST_ASSERT(!session->insert(1));
+        MDBXC_TEST_ASSERT(session->insert(2));
+        MDBXC_TEST_ASSERT(session->erase(1));
+        MDBXC_TEST_ASSERT(!session->erase(9));
+        MDBXC_TEST_ASSERT(session->pending_size() == 3u);
+        session->commit(changes);
+    }
+    conn->detach_sync_capture();
+
+    MDBXC_TEST_ASSERT(changes.size() == 3u);
+    MDBXC_TEST_ASSERT(changes[0].opcode ==
+                      mdbxc::sync::KeyTableLogicalInsert);
+    MDBXC_TEST_ASSERT(changes[1].opcode ==
+                      mdbxc::sync::KeyTableLogicalInsert);
+    MDBXC_TEST_ASSERT(changes[2].opcode ==
+                      mdbxc::sync::KeyTableLogicalDelete);
+    MDBXC_TEST_ASSERT(!table.contains(1));
+    MDBXC_TEST_ASSERT(table.contains(2));
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        mdbxc::sync::ChangeLogStore changelog(conn->env_handle());
+        changelog.open(txn.handle());
+        MDBXC_TEST_ASSERT(!changelog.contains(txn.handle(), node, 1));
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 void test_key_value_logical_adapter_engine_rejects_unknown_schema() {
     const std::string path = "test_key_value_logical_adapter_unknown.mdbx";
     const std::string dbi_name = "logical_key_value_unknown";
@@ -2699,6 +2760,7 @@ int main() {
     test_key_value_logical_adapter_applies_through_sync_engine();
     test_key_table_logical_adapter_applies_through_sync_engine();
     test_key_table_logical_adapter_rejects_malformed_payload();
+    test_key_table_logical_capture_session_commits_typed_local_writes();
     test_key_value_logical_adapter_engine_rejects_unknown_schema();
     test_key_value_logical_engine_rejects_missing_schema_marker();
     test_key_value_logical_engine_rejects_stale_schema_marker();


### PR DESCRIPTION
## What changed

Adds an opt-in typed `LogicalCaptureSession` to `KeyTableLogicalAdapter`.

## Why

Applications can now record successful key-only insert/delete operations as logical changes while the session owns the same writable transaction as the local table mutations.

## Behavior

- Raw capture is suppressed for session-owned writes.
- Failed insert/erase membership operations are omitted from the logical frame.
- Explicit clear requests are retained.
- Pending changes are published only after transaction commit.
- Session creation validates the persistent logical schema marker before mutation.

## Validation

- `test_key_value_logical_adapter` passed with MinGW C++11.
- `test_key_value_logical_adapter` passed with MinGW C++17.
