### PR TITLE
feat(sync): prune logical delivery markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Added explicit logical-delivery replay-marker pruning with persistent
+  per-origin watermarks. `SyncEngine::prune_logical_delivery_markers()` removes
+  acknowledged markers atomically and turns later replay at or below the saved
+  boundary into a stale no-op; callers remain responsible for deriving a safe
+  boundary from their own delivery/acknowledgement protocol.
 - Added an opt-in typed `LogicalCaptureSession` to
   `KeyTableLogicalAdapter`. It owns one writable transaction, suppresses raw
   capture, emits logical insert/delete changes only for successful local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 - Added explicit logical-delivery replay-marker pruning with persistent
-  per-origin watermarks. `SyncEngine::prune_logical_delivery_markers()` removes
-  acknowledged markers atomically and turns later replay at or below the saved
-  boundary into a stale no-op; callers remain responsible for deriving a safe
-  boundary from their own delivery/acknowledgement protocol.
+  per-origin watermarks. `SyncEngine::prune_logical_delivery_markers()` lazily
+  creates its watermark DBI, removes acknowledged markers atomically, and turns
+  later replay at or below the saved boundary into a stale no-op. Deployments
+  that use pruning need one additional `Config::max_dbs` slot; callers remain
+  responsible for deriving a safe boundary from their own
+  delivery/acknowledgement protocol.
 - Added an opt-in typed `LogicalCaptureSession` to
   `KeyTableLogicalAdapter`. It owns one writable transaction, suppresses raw
   capture, emits logical insert/delete changes only for successful local

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -99,6 +99,10 @@ The logical sync scaffolding is preparatory only:
 - `KeyValueTableLogicalAdapter` and `KeyTableLogicalAdapter` are explicit
   apply helpers with opt-in typed capture sessions. Neither is connected to
   the transport pull/push path yet; callers own logical frame delivery.
+- Logical delivery replay markers can be pruned through a persisted per-origin
+  watermark. Callers must advance it only from an external delivery/acknowledge
+  protocol that rules out later unseen frames at or below the boundary; the
+  engine does not supply ordering, buffering, or acknowledgements itself.
 
 Until a causal context or another conflict model is implemented, future logical
 table support should document either one authoritative writer for the affected

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -100,6 +100,9 @@ The logical sync scaffolding is preparatory only:
   apply helpers with opt-in typed capture sessions. Neither is connected to
   the transport pull/push path yet; callers own logical frame delivery.
 - Logical delivery replay markers can be pruned through a persisted per-origin
+  watermark. The watermark DBI is created lazily on the first pruning call, so
+  deployments that use pruning must reserve one additional named-DBI slot in
+  `Config::max_dbs`; older layouts without it remain readable with a zero
   watermark. Callers must advance it only from an external delivery/acknowledge
   protocol that rules out later unseen frames at or below the boundary; the
   engine does not supply ordering, buffering, or acknowledgements itself.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -542,9 +542,14 @@ the numeric `origin_sequence`: it does not decide whether an envelope is an
 exact duplicate delivery identity, persist a watermark, buffer missing frames,
 or decide whether it is safe to advance one.
 
-`LogicalDeliveryStore` persists one monotonic per-origin watermark in
-`_mdbxc_logical_delivery_watermarks`. A caller may advance it through
-`SyncEngine::prune_logical_delivery_markers(origin, safe_through_sequence)`;
+`LogicalDeliveryStore` persists one monotonic per-origin watermark in the
+optional `_mdbxc_logical_delivery_watermarks` DBI. The DBI is created lazily by
+the first `SyncEngine::prune_logical_delivery_markers()` call; normal logical
+delivery and read-only inspection work with older layouts where it is absent
+and report a zero watermark. Environments that use pruning must reserve one
+additional named-DBI slot through `Config::max_dbs`. A caller may advance it
+through `SyncEngine::prune_logical_delivery_markers(origin,
+safe_through_sequence)`;
 the operation atomically deletes the matching replay markers through that
 sequence and persists the new boundary. Replays at or below the boundary become
 successful stale no-ops without adapter callbacks, even after restart. This is
@@ -557,7 +562,10 @@ helpers for diagnostics, repair tooling, and future lifecycle work. They expose
 delivery identity and stored frame metadata after validating that the persisted
 marker key matches the marker value identity and `frame_id` digest. They do not
 define an acknowledgement horizon and must not be used as a standalone pruning
-signal.
+signal. `LogicalDeliveryStore::contains()` likewise reports only the presence
+of an exact physical marker; it does not treat a delivery below a watermark as
+present. `try_mark_applied()` applies the watermark when deciding whether a
+delivery is a stale no-op.
 
 `LogicalTableAdapter.hpp` reserves the apply-side extension point:
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -540,18 +540,24 @@ envelope against a caller-owned expected next sequence as in-order,
 behind the caller's watermark, or ahead with a sequence gap. It only classifies
 the numeric `origin_sequence`: it does not decide whether an envelope is an
 exact duplicate delivery identity, persist a watermark, buffer missing frames,
-or change `SyncEngine::apply_logical_delivery_envelope()` semantics. A future
-per-origin lifecycle PR should add persisted watermarks and pruning rules.
+or decide whether it is safe to advance one.
 
-`_mdbxc_logical_delivery` retention is currently permanent and unbounded. A
-future lifecycle PR should add an acknowledgement horizon or per-origin
-watermark before old replay markers can be pruned safely; deleting markers by
-time alone would re-open the exact late-retry problem the store prevents.
+`LogicalDeliveryStore` persists one monotonic per-origin watermark in
+`_mdbxc_logical_delivery_watermarks`. A caller may advance it through
+`SyncEngine::prune_logical_delivery_markers(origin, safe_through_sequence)`;
+the operation atomically deletes the matching replay markers through that
+sequence and persists the new boundary. Replays at or below the boundary become
+successful stale no-ops without adapter callbacks, even after restart. This is
+not an ordering, buffering, or acknowledgement protocol: the caller must
+advance the watermark only after its external delivery protocol has established
+that no unseen envelope at or below the boundary can arrive later. Time-based
+deletion remains unsafe.
 `LogicalDeliveryStore::count()` and `list_markers()` are read-only inspection
 helpers for diagnostics, repair tooling, and future lifecycle work. They expose
 delivery identity and stored frame metadata after validating that the persisted
 marker key matches the marker value identity and `frame_id` digest. They do not
-define a retention policy and must not be used as a standalone pruning signal.
+define an acknowledgement horizon and must not be used as a standalone pruning
+signal.
 
 `LogicalTableAdapter.hpp` reserves the apply-side extension point:
 

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -451,6 +451,28 @@ namespace sync {
             }
         }
 
+        /// \brief Prunes acknowledged logical delivery replay markers.
+        /// \details Persists a per-origin watermark and removes markers whose
+        /// sequence is at or below \p safe_through_sequence in one write
+        /// transaction. The caller must supply this boundary only after its
+        /// delivery/acknowledgement protocol guarantees that no unseen
+        /// envelope at or below it can arrive later. Future replay at or below
+        /// the persisted watermark is a successful stale no-op.
+        /// \return Number of removed replay markers.
+        std::size_t prune_logical_delivery_markers(
+                const NodeId& origin,
+                std::uint64_t safe_through_sequence) {
+            const Connection::SyncApplyWriteGuard sync_apply_guard =
+                m_conn->sync_apply_write_guard();
+            auto txn = m_conn->transaction(TransactionMode::WRITABLE);
+            initialize_system_stores(txn.handle());
+            LogicalDeliveryStore delivery(m_conn->env_handle());
+            const std::size_t removed = delivery.prune_up_to(
+                txn.handle(), origin, safe_through_sequence);
+            txn.commit();
+            return removed;
+        }
+
         /// \brief Applies a single \c ChangeBatch to local DBIs inside \p txn.
         /// \details See class-level docs for the seq / apply rules. The
         /// caller commits the transaction. User DBIs are opened lazily by

--- a/include/mdbx_containers/sync/stores/LogicalDeliveryStore.hpp
+++ b/include/mdbx_containers/sync/stores/LogicalDeliveryStore.hpp
@@ -55,26 +55,30 @@ namespace sync {
               m_watermark_dbi_name(dbi_name + "_watermarks"),
               m_dbi(0),
               m_watermark_dbi(0),
-              m_open(false) {}
+              m_marker_open(false),
+              m_watermark_open(false) {}
 
         /// \brief Opens the store DBI inside the supplied transaction.
         void open(MDBX_txn* txn) {
             txn = checked_txn(txn, "LogicalDeliveryStore::open");
-            open_checked(txn);
+            open_marker_checked(txn);
         }
 
-        bool is_open() const { return m_open; }
+        bool is_open() const { return m_marker_open; }
 
         MDBX_dbi handle(MDBX_txn* txn) const {
             txn = checked_txn(txn, "LogicalDeliveryStore::handle");
-            open_checked(txn);
+            open_marker_checked(txn);
             return m_dbi;
         }
 
-        void reset_open() { m_open = false; }
+        void reset_open() {
+            m_marker_open = false;
+            m_watermark_open = false;
+        }
 
         void ensure_open() const {
-            if (!m_open) {
+            if (!m_marker_open) {
                 throw std::logic_error("LogicalDeliveryStore is not open");
             }
         }
@@ -141,11 +145,11 @@ namespace sync {
         }
 
         /// \brief Returns the persisted replay-pruning watermark for \p origin.
-        /// \return Zero when no markers for \p origin have been pruned.
+        /// \return Zero when no markers for \p origin have been pruned or
+        /// the optional watermark DBI has not been created yet.
         std::uint64_t watermark(MDBX_txn* txn,
                                 const NodeId& origin) const {
             txn = checked_txn(txn, "LogicalDeliveryStore::watermark");
-            open_const(txn);
             return read_watermark(txn, origin);
         }
 
@@ -156,6 +160,8 @@ namespace sync {
         /// successful no-ops. The caller must advance this boundary only after
         /// its delivery protocol guarantees that no unseen envelope at or
         /// below the boundary can arrive later.
+        /// The first call creates the optional watermark DBI and therefore
+        /// requires one additional named-DBI slot in the MDBX environment.
         /// \return Number of removed delivery markers.
         std::size_t prune_up_to(MDBX_txn* txn,
                                 const NodeId& origin,
@@ -169,7 +175,8 @@ namespace sync {
                 throw std::invalid_argument(
                     "LogicalDeliveryStore prune watermark is zero");
             }
-            open(txn);
+            open_marker_checked(txn);
+            open_watermark_for_write(txn);
             const std::uint64_t previous = read_watermark(txn, origin);
             if (safe_through_sequence < previous) {
                 throw std::invalid_argument(
@@ -211,16 +218,17 @@ namespace sync {
             return removed;
         }
 
-        /// \brief Returns true when \p envelope already has an applied marker.
+        /// \brief Returns true when \p envelope has an exact applied marker.
+        /// \details A persisted replay watermark is intentionally not included
+        /// in this inspection result. Use \c watermark() to inspect the
+        /// pruning boundary; \c try_mark_applied() applies that boundary when
+        /// deciding whether a delivery may mutate local data.
         bool contains(MDBX_txn* txn,
                       const LogicalDeliveryEnvelope& envelope,
                       const CodecBounds* bounds = nullptr) const {
             txn = checked_txn(txn, "LogicalDeliveryStore::contains");
             open_const(txn);
             validate_logical_delivery_envelope(envelope, bounds);
-            if (is_at_or_below_watermark(txn, envelope)) {
-                return true;
-            }
             const std::vector<std::uint8_t> key =
                 make_key(envelope, bounds);
             MDBX_val k = {
@@ -241,7 +249,7 @@ namespace sync {
                               const LogicalDeliveryEnvelope& envelope,
                               const CodecBounds* bounds = nullptr) {
             txn = checked_txn(txn, "LogicalDeliveryStore::try_mark_applied");
-            open(txn);
+            open_marker_checked(txn);
             validate_logical_delivery_envelope(envelope, bounds);
             if (is_at_or_below_watermark(txn, envelope)) {
                 return false;
@@ -278,13 +286,35 @@ namespace sync {
 
         void open_const(MDBX_txn* txn) const {
             txn = checked_txn(txn, "LogicalDeliveryStore::open");
-            open_checked(txn);
+            open_marker_checked(txn);
         }
 
-        void open_checked(MDBX_txn* txn) const {
+        void open_marker_checked(MDBX_txn* txn) const {
             open_dbi_checked(txn, m_dbi_name, m_dbi);
+            m_marker_open = true;
+        }
+
+        bool open_watermark_if_exists(MDBX_txn* txn) const {
+            if (m_watermark_open) {
+                return true;
+            }
+            const int rc = mdbx_dbi_open(
+                txn, m_watermark_dbi_name.c_str(),
+                static_cast<MDBX_db_flags_t>(0), &m_watermark_dbi);
+            if (rc == MDBX_NOTFOUND) {
+                return false;
+            }
+            check_mdbx(rc, "Failed to open LogicalDeliveryStore watermark DBI");
+            m_watermark_open = true;
+            return true;
+        }
+
+        void open_watermark_for_write(MDBX_txn* txn) const {
+            if (m_watermark_open) {
+                return;
+            }
             open_dbi_checked(txn, m_watermark_dbi_name, m_watermark_dbi);
-            m_open = true;
+            m_watermark_open = true;
         }
 
         static void open_dbi_checked(MDBX_txn* txn,
@@ -300,6 +330,9 @@ namespace sync {
 
         std::uint64_t read_watermark(MDBX_txn* txn,
                                      const NodeId& origin) const {
+            if (!open_watermark_if_exists(txn)) {
+                return 0u;
+            }
             MDBX_val key = {
                 const_cast<std::uint8_t*>(&origin[0]),
                 origin.size()
@@ -316,6 +349,7 @@ namespace sync {
         void write_watermark(MDBX_txn* txn,
                              const NodeId& origin,
                              std::uint64_t sequence) const {
+            open_watermark_for_write(txn);
             MDBX_val key = {
                 const_cast<std::uint8_t*>(&origin[0]),
                 origin.size()
@@ -634,7 +668,8 @@ namespace sync {
         std::string m_watermark_dbi_name;
         mutable MDBX_dbi m_dbi;
         mutable MDBX_dbi m_watermark_dbi;
-        mutable bool     m_open;
+        mutable bool     m_marker_open;
+        mutable bool     m_watermark_open;
     };
 
 } // namespace sync

--- a/include/mdbx_containers/sync/stores/LogicalDeliveryStore.hpp
+++ b/include/mdbx_containers/sync/stores/LogicalDeliveryStore.hpp
@@ -55,8 +55,7 @@ namespace sync {
               m_watermark_dbi_name(dbi_name + "_watermarks"),
               m_dbi(0),
               m_watermark_dbi(0),
-              m_marker_open(false),
-              m_watermark_open(false) {}
+              m_marker_open(false) {}
 
         /// \brief Opens the store DBI inside the supplied transaction.
         void open(MDBX_txn* txn) {
@@ -74,7 +73,6 @@ namespace sync {
 
         void reset_open() {
             m_marker_open = false;
-            m_watermark_open = false;
         }
 
         void ensure_open() const {
@@ -295,9 +293,6 @@ namespace sync {
         }
 
         bool open_watermark_if_exists(MDBX_txn* txn) const {
-            if (m_watermark_open) {
-                return true;
-            }
             const int rc = mdbx_dbi_open(
                 txn, m_watermark_dbi_name.c_str(),
                 static_cast<MDBX_db_flags_t>(0), &m_watermark_dbi);
@@ -305,16 +300,11 @@ namespace sync {
                 return false;
             }
             check_mdbx(rc, "Failed to open LogicalDeliveryStore watermark DBI");
-            m_watermark_open = true;
             return true;
         }
 
         void open_watermark_for_write(MDBX_txn* txn) const {
-            if (m_watermark_open) {
-                return;
-            }
             open_dbi_checked(txn, m_watermark_dbi_name, m_watermark_dbi);
-            m_watermark_open = true;
         }
 
         static void open_dbi_checked(MDBX_txn* txn,
@@ -669,7 +659,6 @@ namespace sync {
         mutable MDBX_dbi m_dbi;
         mutable MDBX_dbi m_watermark_dbi;
         mutable bool     m_marker_open;
-        mutable bool     m_watermark_open;
     };
 
 } // namespace sync

--- a/include/mdbx_containers/sync/stores/LogicalDeliveryStore.hpp
+++ b/include/mdbx_containers/sync/stores/LogicalDeliveryStore.hpp
@@ -50,7 +50,12 @@ namespace sync {
         explicit LogicalDeliveryStore(
                 MDBX_env* env,
                 const std::string& dbi_name = "_mdbxc_logical_delivery")
-            : m_env(env), m_dbi_name(dbi_name), m_dbi(0), m_open(false) {}
+            : m_env(env),
+              m_dbi_name(dbi_name),
+              m_watermark_dbi_name(dbi_name + "_watermarks"),
+              m_dbi(0),
+              m_watermark_dbi(0),
+              m_open(false) {}
 
         /// \brief Opens the store DBI inside the supplied transaction.
         void open(MDBX_txn* txn) {
@@ -135,12 +140,87 @@ namespace sync {
             return out;
         }
 
+        /// \brief Returns the persisted replay-pruning watermark for \p origin.
+        /// \return Zero when no markers for \p origin have been pruned.
+        std::uint64_t watermark(MDBX_txn* txn,
+                                const NodeId& origin) const {
+            txn = checked_txn(txn, "LogicalDeliveryStore::watermark");
+            open_const(txn);
+            return read_watermark(txn, origin);
+        }
+
+        /// \brief Prunes markers through \p safe_through_sequence for one origin.
+        /// \details This persists a monotonic replay watermark in the same
+        /// transaction as marker removal. Future envelopes from \p origin
+        /// whose sequence is at or below the watermark are treated as stale
+        /// successful no-ops. The caller must advance this boundary only after
+        /// its delivery protocol guarantees that no unseen envelope at or
+        /// below the boundary can arrive later.
+        /// \return Number of removed delivery markers.
+        std::size_t prune_up_to(MDBX_txn* txn,
+                                const NodeId& origin,
+                                std::uint64_t safe_through_sequence) {
+            txn = checked_txn(txn, "LogicalDeliveryStore::prune_up_to");
+            if (is_zero_sync_id(origin)) {
+                throw std::invalid_argument(
+                    "LogicalDeliveryStore prune origin is zero");
+            }
+            if (safe_through_sequence == 0u) {
+                throw std::invalid_argument(
+                    "LogicalDeliveryStore prune watermark is zero");
+            }
+            open(txn);
+            const std::uint64_t previous = read_watermark(txn, origin);
+            if (safe_through_sequence < previous) {
+                throw std::invalid_argument(
+                    "LogicalDeliveryStore prune watermark moved backwards");
+            }
+            if (safe_through_sequence == previous) {
+                return 0u;
+            }
+
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "LogicalDeliveryStore prune cursor open failed");
+            std::size_t removed = 0u;
+            try {
+                MDBX_val key;
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    const LogicalDeliveryMarkerInfo marker =
+                        decode_and_validate_marker(key, value);
+                    if (compare_node_id(marker.origin_node_id, origin) == 0 &&
+                        marker.origin_sequence <= safe_through_sequence) {
+                        check_mdbx(mdbx_cursor_del(cursor, MDBX_CURRENT),
+                                   "LogicalDeliveryStore prune cursor delete failed");
+                        ++removed;
+                    }
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc,
+                               "LogicalDeliveryStore prune cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            write_watermark(txn, origin, safe_through_sequence);
+            return removed;
+        }
+
         /// \brief Returns true when \p envelope already has an applied marker.
         bool contains(MDBX_txn* txn,
                       const LogicalDeliveryEnvelope& envelope,
                       const CodecBounds* bounds = nullptr) const {
             txn = checked_txn(txn, "LogicalDeliveryStore::contains");
             open_const(txn);
+            validate_logical_delivery_envelope(envelope, bounds);
+            if (is_at_or_below_watermark(txn, envelope)) {
+                return true;
+            }
             const std::vector<std::uint8_t> key =
                 make_key(envelope, bounds);
             MDBX_val k = {
@@ -162,6 +242,10 @@ namespace sync {
                               const CodecBounds* bounds = nullptr) {
             txn = checked_txn(txn, "LogicalDeliveryStore::try_mark_applied");
             open(txn);
+            validate_logical_delivery_envelope(envelope, bounds);
+            if (is_at_or_below_watermark(txn, envelope)) {
+                return false;
+            }
             const std::vector<std::uint8_t> key =
                 make_key(envelope, bounds);
             MDBX_val k = {
@@ -198,13 +282,61 @@ namespace sync {
         }
 
         void open_checked(MDBX_txn* txn) const {
-            int rc = mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE, &m_dbi);
+            open_dbi_checked(txn, m_dbi_name, m_dbi);
+            open_dbi_checked(txn, m_watermark_dbi_name, m_watermark_dbi);
+            m_open = true;
+        }
+
+        static void open_dbi_checked(MDBX_txn* txn,
+                                     const std::string& name,
+                                     MDBX_dbi& dbi) {
+            int rc = mdbx_dbi_open(txn, name.c_str(), MDBX_CREATE, &dbi);
             if (rc == MDBX_EACCESS) {
-                rc = mdbx_dbi_open(txn, m_dbi_name.c_str(),
-                                   static_cast<MDBX_db_flags_t>(0), &m_dbi);
+                rc = mdbx_dbi_open(txn, name.c_str(),
+                                   static_cast<MDBX_db_flags_t>(0), &dbi);
             }
             check_mdbx(rc, "Failed to open LogicalDeliveryStore DBI");
-            m_open = true;
+        }
+
+        std::uint64_t read_watermark(MDBX_txn* txn,
+                                     const NodeId& origin) const {
+            MDBX_val key = {
+                const_cast<std::uint8_t*>(&origin[0]),
+                origin.size()
+            };
+            MDBX_val value;
+            const int rc = mdbx_get(txn, m_watermark_dbi, &key, &value);
+            if (rc == MDBX_NOTFOUND) {
+                return 0u;
+            }
+            check_mdbx(rc, "LogicalDeliveryStore watermark read failed");
+            return decode_watermark(value);
+        }
+
+        void write_watermark(MDBX_txn* txn,
+                             const NodeId& origin,
+                             std::uint64_t sequence) const {
+            MDBX_val key = {
+                const_cast<std::uint8_t*>(&origin[0]),
+                origin.size()
+            };
+            const std::vector<std::uint8_t> bytes =
+                encode_watermark(sequence);
+            MDBX_val value = {
+                const_cast<std::uint8_t*>(
+                    bytes.empty() ? nullptr : &bytes[0]),
+                bytes.size()
+            };
+            check_mdbx(mdbx_put(txn, m_watermark_dbi, &key, &value,
+                                MDBX_UPSERT),
+                       "LogicalDeliveryStore watermark write failed");
+        }
+
+        bool is_at_or_below_watermark(
+                MDBX_txn* txn,
+                const LogicalDeliveryEnvelope& envelope) const {
+            return envelope.origin_sequence <=
+                read_watermark(txn, envelope.origin_node_id);
         }
 
         static std::vector<std::uint8_t> make_key(
@@ -319,6 +451,36 @@ namespace sync {
         static std::uint16_t marker_key_version() { return 1; }
 
         static std::uint16_t marker_value_version() { return 1; }
+
+        static std::uint16_t watermark_value_version() { return 1; }
+
+        static std::vector<std::uint8_t> encode_watermark(
+                std::uint64_t sequence) {
+            std::vector<std::uint8_t> out;
+            out.reserve(2u + 8u);
+            detail::append_u16_le(out, watermark_value_version());
+            detail::append_u64_le(out, sequence);
+            return out;
+        }
+
+        static std::uint64_t decode_watermark(const MDBX_val& value) {
+            if (value.iov_len != 2u + 8u || value.iov_base == nullptr) {
+                throw std::runtime_error(
+                    "LogicalDeliveryStore watermark has invalid size");
+            }
+            const std::uint8_t* bytes =
+                static_cast<const std::uint8_t*>(value.iov_base);
+            if (detail::read_u16_le(bytes) != watermark_value_version()) {
+                throw std::runtime_error(
+                    "Unsupported LogicalDeliveryStore watermark version");
+            }
+            const std::uint64_t sequence = detail::read_u64_le(bytes + 2u);
+            if (sequence == 0u) {
+                throw std::runtime_error(
+                    "LogicalDeliveryStore watermark is zero");
+            }
+            return sequence;
+        }
 
         struct ValueCursor {
             const std::uint8_t* data;
@@ -469,7 +631,9 @@ namespace sync {
 
         MDBX_env*   m_env;
         std::string m_dbi_name;
+        std::string m_watermark_dbi_name;
         mutable MDBX_dbi m_dbi;
+        mutable MDBX_dbi m_watermark_dbi;
         mutable bool     m_open;
     };
 

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -1980,7 +1980,19 @@ void test_key_value_logical_delivery_prunes_markers_behind_watermark() {
             MDBXC_TEST_ASSERT(
                 delivery.watermark(txn.handle(), origin_node) == 1u);
             MDBXC_TEST_ASSERT(delivery.count(txn.handle()) == 3u);
+            MDBXC_TEST_ASSERT(!delivery.contains(txn.handle(), first));
+            MDBXC_TEST_ASSERT(delivery.contains(txn.handle(), second));
         }
+
+        MDBXC_TEST_ASSERT(
+            engine.prune_logical_delivery_markers(origin_node, 3) == 2u);
+        bool decreasing_threw = false;
+        try {
+            (void)engine.prune_logical_delivery_markers(origin_node, 2);
+        } catch (const std::invalid_argument&) {
+            decreasing_threw = true;
+        }
+        MDBXC_TEST_ASSERT(decreasing_threw);
 
         conn->disconnect();
     }
@@ -2003,6 +2015,70 @@ void test_key_value_logical_delivery_prunes_markers_behind_watermark() {
         conn->disconnect();
     }
 
+    cleanup(path);
+}
+
+void test_logical_delivery_store_reads_legacy_layout_without_watermarks() {
+    const std::string path =
+        "test_logical_delivery_legacy_without_watermarks.mdbx";
+    const std::string dbi_name = "logical_delivery_legacy_table";
+    const std::string schema_id = "app.logical_delivery_legacy.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId local_node = make_node(0x50);
+    const mdbxc::sync::NodeId origin_node = make_node(0x51);
+    const mdbxc::sync::NodeId db_uuid = make_node(0xD6);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(local_node, db_uuid);
+    engine.register_logical_schema(schema_id, make_record(dbi_name));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    IntStringAdapter adapter(table, schema_id);
+    engine.register_logical_adapter(adapter);
+
+    mdbxc::sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = db_uuid;
+    envelope.origin_node_id = origin_node;
+    envelope.origin_sequence = 1;
+    envelope.frame_id = "legacy-layout-marker";
+    envelope.frame.changes.push_back(adapter.make_upsert(92, "legacy"));
+    MDBXC_TEST_ASSERT(engine.apply_logical_delivery_envelope(envelope).ok);
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        MDBX_dbi watermark_dbi = 0;
+        const int open_rc = mdbx_dbi_open(
+            txn.handle(), "_mdbxc_logical_delivery_watermarks",
+            static_cast<MDBX_db_flags_t>(0), &watermark_dbi);
+        if (open_rc == MDBX_SUCCESS) {
+            mdbxc::check_mdbx(mdbx_drop(txn.handle(), watermark_dbi, 1),
+                              "test legacy watermark DBI drop failed");
+        } else {
+            MDBXC_TEST_ASSERT(open_rc == MDBX_NOTFOUND);
+        }
+        txn.commit();
+    }
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        mdbxc::sync::LogicalDeliveryStore delivery(conn->env_handle());
+        MDBXC_TEST_ASSERT(delivery.count(txn.handle()) == 1u);
+        MDBXC_TEST_ASSERT(delivery.list_markers(txn.handle()).size() == 1u);
+        MDBXC_TEST_ASSERT(
+            delivery.watermark(txn.handle(), origin_node) == 0u);
+        MDBXC_TEST_ASSERT(delivery.contains(txn.handle(), envelope));
+    }
+
+    conn->disconnect();
     cleanup(path);
 }
 
@@ -2969,6 +3045,7 @@ int main() {
     test_key_value_logical_delivery_marker_rolls_back_after_apply_failure();
     test_key_value_logical_delivery_envelope_skips_self_origin();
     test_key_value_logical_delivery_prunes_markers_behind_watermark();
+    test_logical_delivery_store_reads_legacy_layout_without_watermarks();
     test_key_value_logical_delivery_envelope_accepts_long_frame_id();
     test_key_value_logical_delivery_envelope_keeps_custom_bounds();
     test_key_value_logical_delivery_object_api_rejects_frame_id_bound();

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -1893,6 +1893,119 @@ void test_key_value_logical_delivery_envelope_skips_self_origin() {
     cleanup(path);
 }
 
+void test_key_value_logical_delivery_prunes_markers_behind_watermark() {
+    const std::string path =
+        "test_key_value_logical_delivery_prune.mdbx";
+    const std::string dbi_name = "logical_key_value_delivery_prune";
+    const std::string schema_id = "app.logical_kv_delivery_prune.v1";
+    cleanup(path);
+
+    const mdbxc::sync::NodeId local_node = make_node(0x4D);
+    const mdbxc::sync::NodeId origin_node = make_node(0x4E);
+    const mdbxc::sync::NodeId other_origin_node = make_node(0x4F);
+    const mdbxc::sync::NodeId db_uuid = make_node(0xD5);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+
+    mdbxc::sync::LogicalDeliveryEnvelope first;
+    first.destination_db_uuid = db_uuid;
+    first.origin_node_id = origin_node;
+    first.origin_sequence = 1;
+    first.frame_id = "delivery-prune-1";
+
+    mdbxc::sync::LogicalDeliveryEnvelope second;
+    second.destination_db_uuid = db_uuid;
+    second.origin_node_id = origin_node;
+    second.origin_sequence = 2;
+    second.frame_id = "delivery-prune-2";
+
+    mdbxc::sync::LogicalDeliveryEnvelope third;
+    third.destination_db_uuid = db_uuid;
+    third.origin_node_id = origin_node;
+    third.origin_sequence = 3;
+    third.frame_id = "delivery-prune-3";
+
+    mdbxc::sync::LogicalDeliveryEnvelope other_origin;
+    other_origin.destination_db_uuid = db_uuid;
+    other_origin.origin_node_id = other_origin_node;
+    other_origin.origin_sequence = 1;
+    other_origin.frame_id = "delivery-prune-other-origin";
+
+    {
+        std::shared_ptr<mdbxc::Connection> conn =
+            mdbxc::Connection::create(cfg);
+        mdbxc::sync::SyncEngine engine(conn);
+        engine.initialize_local_identity(local_node, db_uuid);
+        engine.register_logical_schema(schema_id, make_record(dbi_name));
+
+        mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+        IntStringAdapter adapter(table, schema_id);
+        engine.register_logical_adapter(adapter);
+
+        first.frame.changes.push_back(adapter.make_upsert(90, "one"));
+        second.frame.changes.push_back(adapter.make_upsert(90, "two"));
+        third.frame.changes.push_back(adapter.make_upsert(90, "three"));
+        other_origin.frame.changes.push_back(
+            adapter.make_upsert(91, "other-origin"));
+
+        MDBXC_TEST_ASSERT(
+            engine.apply_logical_delivery_envelope(first).ok);
+        MDBXC_TEST_ASSERT(
+            engine.apply_logical_delivery_envelope(second).ok);
+        MDBXC_TEST_ASSERT(
+            engine.apply_logical_delivery_envelope(other_origin).ok);
+        MDBXC_TEST_ASSERT(table.find_compat(90).second == "two");
+
+        MDBXC_TEST_ASSERT(
+            engine.prune_logical_delivery_markers(origin_node, 1) == 1u);
+        MDBXC_TEST_ASSERT(
+            engine.prune_logical_delivery_markers(origin_node, 1) == 0u);
+
+        MDBXC_TEST_ASSERT(
+            engine.apply_logical_delivery_envelope(first).ok);
+        MDBXC_TEST_ASSERT(table.find_compat(90).second == "two");
+        MDBXC_TEST_ASSERT(
+            engine.apply_logical_delivery_envelope(third).ok);
+        MDBXC_TEST_ASSERT(table.find_compat(90).second == "three");
+        MDBXC_TEST_ASSERT(table.find_compat(91).second == "other-origin");
+
+        {
+            mdbxc::Transaction txn =
+                conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+            mdbxc::sync::LogicalDeliveryStore delivery(conn->env_handle());
+            delivery.open(txn.handle());
+            MDBXC_TEST_ASSERT(
+                delivery.watermark(txn.handle(), origin_node) == 1u);
+            MDBXC_TEST_ASSERT(delivery.count(txn.handle()) == 3u);
+        }
+
+        conn->disconnect();
+    }
+
+    {
+        std::shared_ptr<mdbxc::Connection> conn =
+            mdbxc::Connection::create(cfg);
+        mdbxc::sync::SyncEngine engine(conn);
+        engine.initialize_local_identity(local_node, db_uuid);
+        engine.register_logical_schema(schema_id, make_record(dbi_name));
+
+        mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+        IntStringAdapter adapter(table, schema_id);
+        engine.register_logical_adapter(adapter);
+
+        MDBXC_TEST_ASSERT(
+            engine.apply_logical_delivery_envelope(first).ok);
+        MDBXC_TEST_ASSERT(table.find_compat(90).second == "three");
+
+        conn->disconnect();
+    }
+
+    cleanup(path);
+}
+
 void test_key_value_logical_delivery_envelope_accepts_long_frame_id() {
     const std::string path =
         "test_key_value_logical_delivery_long_frame_id.mdbx";
@@ -2855,6 +2968,7 @@ int main() {
     test_key_value_logical_delivery_envelope_rejects_identity_collision();
     test_key_value_logical_delivery_marker_rolls_back_after_apply_failure();
     test_key_value_logical_delivery_envelope_skips_self_origin();
+    test_key_value_logical_delivery_prunes_markers_behind_watermark();
     test_key_value_logical_delivery_envelope_accepts_long_frame_id();
     test_key_value_logical_delivery_envelope_keeps_custom_bounds();
     test_key_value_logical_delivery_object_api_rejects_frame_id_bound();

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -2082,6 +2082,51 @@ void test_logical_delivery_store_reads_legacy_layout_without_watermarks() {
     cleanup(path);
 }
 
+void test_logical_delivery_store_reopens_watermark_after_aborted_create() {
+    const std::string path =
+        "test_logical_delivery_watermark_abort_reopen.mdbx";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn =
+        mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId origin = make_node(0x52);
+    mdbxc::sync::LogicalDeliveryStore store(conn->env_handle());
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        MDBXC_TEST_ASSERT(store.prune_up_to(txn.handle(), origin, 7u) == 0u);
+        txn.rollback();
+    }
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        MDBXC_TEST_ASSERT(store.watermark(txn.handle(), origin) == 0u);
+    }
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        MDBXC_TEST_ASSERT(store.prune_up_to(txn.handle(), origin, 7u) == 0u);
+        txn.commit();
+    }
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        MDBXC_TEST_ASSERT(store.watermark(txn.handle(), origin) == 7u);
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 void test_key_value_logical_delivery_envelope_accepts_long_frame_id() {
     const std::string path =
         "test_key_value_logical_delivery_long_frame_id.mdbx";
@@ -3046,6 +3091,7 @@ int main() {
     test_key_value_logical_delivery_envelope_skips_self_origin();
     test_key_value_logical_delivery_prunes_markers_behind_watermark();
     test_logical_delivery_store_reads_legacy_layout_without_watermarks();
+    test_logical_delivery_store_reopens_watermark_after_aborted_create();
     test_key_value_logical_delivery_envelope_accepts_long_frame_id();
     test_key_value_logical_delivery_envelope_keeps_custom_bounds();
     test_key_value_logical_delivery_object_api_rejects_frame_id_bound();


### PR DESCRIPTION
## What changed

Adds explicit logical-delivery replay-marker retention through a persisted per-origin watermark.

## Contract

`SyncEngine::prune_logical_delivery_markers(origin, safe_through_sequence)` atomically removes matching markers and persists the monotonic replay boundary. A later envelope at or below that boundary is a stale no-op and does not call adapters.

## Important limitation

The engine does not order, buffer, or acknowledge envelopes. The caller may advance a watermark only after its delivery protocol guarantees that no unseen envelope at or below that sequence can arrive later.

## Validation

- `test_key_value_logical_adapter` passed with MinGW C++11.
- `test_key_value_logical_adapter` passed with MinGW C++17.
- Standalone `KeyTableLogicalAdapter` and `LogicalDeliveryStore` header tests passed in both configurations.
