### PR TITLE
feat(sync): add durable logical delivery outbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Added `_mdbxc_logical_outbox` and the sender-side
+  `SyncEngine::enqueue_logical_delivery()` lifecycle for future ordered logical
+  delivery. The outbox persists independent monotonic streams per destination,
+  lists pending envelopes in numeric order, and atomically removes an
+  acknowledged prefix through `acknowledge_logical_deliveries()`. It is a local
+  durable queue only: transport capability negotiation, receiver ordering, and
+  wire acknowledgements remain subsequent protocol work. Sync environments now
+  reserve one additional named-DBI slot in `Config::max_dbs` for the committed
+  `_mdbxc_logical_outbox` system store.
 - Added explicit logical-delivery replay-marker pruning with persistent
   per-origin watermarks. `SyncEngine::prune_logical_delivery_markers()` lazily
   creates its watermark DBI, removes acknowledged markers atomically, and turns

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,6 +443,7 @@ if(MDBXC_BUILD_TESTS)
         mdbx_containers/sync/LogicalChangeFrameCodec.hpp
         mdbx_containers/sync/LogicalDeliveryEnvelope.hpp
         mdbx_containers/sync/LogicalDeliveryEnvelopeCodec.hpp
+        mdbx_containers/sync/ILogicalDeliveryOutbox.hpp
         mdbx_containers/sync/LogicalTableAdapter.hpp
         mdbx_containers/sync/LogicalSchemaValidation.hpp
         mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,6 +453,7 @@ if(MDBXC_BUILD_TESTS)
         mdbx_containers/sync/SyncNodeSession.hpp
         mdbx_containers/sync/SyncWorkerGuard.hpp
         mdbx_containers/sync/stores/LogicalDeliveryStore.hpp
+        mdbx_containers/sync/stores/LogicalOutboxStore.hpp
         mdbx_containers/sync/stores/SchemaRegistryStore.hpp
         mdbx_containers/sync/TransportMessageCodec.hpp
     )

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -20,6 +20,7 @@
 #include "sync/LogicalChange.hpp"
 #include "sync/LogicalChangeFrameCodec.hpp"
 #include "sync/LogicalDeliveryEnvelopeCodec.hpp"
+#include "sync/ILogicalDeliveryOutbox.hpp"
 #include "sync/LogicalTableAdapter.hpp"
 #include "sync/LogicalSchemaValidation.hpp"
 #include "sync/adapters/KeyValueTableLogicalAdapter.hpp"

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -52,6 +52,7 @@
 #include "sync/stores/AppliedStore.hpp"
 #include "sync/stores/IdentityIndexStore.hpp"
 #include "sync/stores/LogicalDeliveryStore.hpp"
+#include "sync/stores/LogicalOutboxStore.hpp"
 #include "sync/stores/SchemaRegistryStore.hpp"
 #endif
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -542,6 +542,26 @@ the numeric `origin_sequence`: it does not decide whether an envelope is an
 exact duplicate delivery identity, persist a watermark, buffer missing frames,
 or decide whether it is safe to advance one.
 
+`LogicalOutboxStore` is the sender-side durable foundation for a future ordered
+delivery protocol. `SyncEngine::enqueue_logical_delivery()` persists an envelope
+in `_mdbxc_logical_outbox` and allocates a monotonic `origin_sequence` per
+destination database, not globally across unrelated destinations. Its MDBX entry
+keys contain the destination and a big-endian sequence suffix, so
+`pending_logical_deliveries()` reads the stream in numeric order. The generated
+frame id is stable for that stored sequence, and allocating a frame, updating the
+next sequence, acknowledging a prefix, and deleting acknowledged entries are all
+transactional. A rollback therefore neither consumes a sequence nor leaves a
+queue entry behind. `_mdbxc_logical_outbox` is created during the normal
+committed sync-system initialization lifecycle, so deployments need one
+additional named-DBI slot in `Config::max_dbs` compared with a layout that did
+not use the outbox.
+
+`acknowledge_logical_deliveries()` currently exposes only a local cumulative
+frontier and deletes its acknowledged outbox prefix. It does not establish a
+wire acknowledgement, receiver-side ordering, capability negotiation, or retry
+scheduling. The older `apply_logical_delivery_envelope()` API remains intentionally
+unordered and is not implicitly redirected through this outbox.
+
 `LogicalDeliveryStore` persists one monotonic per-origin watermark in the
 optional `_mdbxc_logical_delivery_watermarks` DBI. The DBI is created lazily by
 the first `SyncEngine::prune_logical_delivery_markers()` call; normal logical

--- a/include/mdbx_containers/sync/ILogicalDeliveryOutbox.hpp
+++ b/include/mdbx_containers/sync/ILogicalDeliveryOutbox.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_ILOGICAL_DELIVERY_OUTBOX_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_ILOGICAL_DELIVERY_OUTBOX_HPP_INCLUDED
+
+/// \file ILogicalDeliveryOutbox.hpp
+/// \brief Transaction-bound publisher for ordered logical delivery frames.
+
+#include <mdbx.h>
+
+#include "LogicalDeliveryEnvelope.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Persists logical deliveries in a caller-owned write transaction.
+    /// \details Implementations must not commit or roll back \p txn. This lets
+    /// a logical capture session commit table mutations and its delivery
+    /// envelope atomically.
+    class ILogicalDeliveryOutbox {
+    public:
+        virtual ~ILogicalDeliveryOutbox() {}
+
+        virtual LogicalDeliveryEnvelope enqueue_logical_delivery(
+                MDBX_txn* txn,
+                const DbId& destination,
+                const LogicalChangeFrame& frame,
+                const CodecBounds* bounds = nullptr) = 0;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_ILOGICAL_DELIVERY_OUTBOX_HPP_INCLUDED

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -42,6 +42,7 @@
 #include "ChangeBatchCodec.hpp"
 #include "ChangeOp.hpp"
 #include "LogicalDeliveryEnvelopeCodec.hpp"
+#include "ILogicalDeliveryOutbox.hpp"
 #include "LogicalChangeFrameCodec.hpp"
 #include "LogicalTableAdapter.hpp"
 #include "LogicalSchemaValidation.hpp"
@@ -127,7 +128,7 @@ namespace sync {
     };
 
     /// \brief Pull/push/apply coordinator bound to a single \c Connection.
-    class SyncEngine {
+    class SyncEngine : public ILogicalDeliveryOutbox {
         struct PullOrigin {
             NodeId origin;
             std::uint64_t last_seq;
@@ -483,19 +484,33 @@ namespace sync {
                 const LogicalChangeFrame& frame,
                 const CodecBounds* bounds = nullptr) {
             auto txn = m_conn->transaction(TransactionMode::WRITABLE);
-            initialize_system_stores(txn.handle());
+            const LogicalDeliveryEnvelope envelope = enqueue_logical_delivery(
+                txn.handle(), destination, frame, bounds);
+            txn.commit();
+            return envelope;
+        }
+
+        /// \brief Persists one delivery in a caller-owned write transaction.
+        /// \details This does not commit or roll back \p txn. It is the
+        /// transaction-bound outbox API used by logical capture sessions to
+        /// atomically commit their table mutations and queued delivery.
+        LogicalDeliveryEnvelope enqueue_logical_delivery(
+                MDBX_txn* txn,
+                const DbId& destination,
+                const LogicalChangeFrame& frame,
+                const CodecBounds* bounds = nullptr) override {
+            txn = checked_external_txn(
+                txn, "SyncEngine::enqueue_logical_delivery");
+            initialize_system_stores(txn);
             MetaStore meta(m_conn->env_handle());
             LogicalOutboxStore outbox(m_conn->env_handle());
-            meta.open(txn.handle());
-            const NodeId origin = meta.get_node_id(txn.handle());
+            meta.open(txn);
+            const NodeId origin = meta.get_node_id(txn);
             if (is_zero_sync_id(origin)) {
                 throw std::logic_error(
                     "SyncEngine local node identity is not initialised");
             }
-            const LogicalDeliveryEnvelope envelope = outbox.enqueue(
-                txn.handle(), destination, origin, frame, bounds);
-            txn.commit();
-            return envelope;
+            return outbox.enqueue(txn, destination, origin, frame, bounds);
         }
 
         /// \brief Lists locally queued ordered deliveries for one destination.

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -50,6 +50,7 @@
 #include "stores/AppliedStore.hpp"
 #include "stores/ChangeLogStore.hpp"
 #include "stores/LogicalDeliveryStore.hpp"
+#include "stores/LogicalOutboxStore.hpp"
 #include "stores/MetaStore.hpp"
 #include "stores/OriginIndexStore.hpp"
 #include "stores/SchemaRegistryStore.hpp"
@@ -473,6 +474,61 @@ namespace sync {
             return removed;
         }
 
+        /// \brief Persists a locally-originated ordered logical delivery.
+        /// \details Sequences are allocated independently for each destination.
+        /// This only enqueues the envelope; transport dispatch and receiver
+        /// acknowledgements are separate protocol layers.
+        LogicalDeliveryEnvelope enqueue_logical_delivery(
+                const DbId& destination,
+                const LogicalChangeFrame& frame,
+                const CodecBounds* bounds = nullptr) {
+            auto txn = m_conn->transaction(TransactionMode::WRITABLE);
+            initialize_system_stores(txn.handle());
+            MetaStore meta(m_conn->env_handle());
+            LogicalOutboxStore outbox(m_conn->env_handle());
+            meta.open(txn.handle());
+            const NodeId origin = meta.get_node_id(txn.handle());
+            if (is_zero_sync_id(origin)) {
+                throw std::logic_error(
+                    "SyncEngine local node identity is not initialised");
+            }
+            const LogicalDeliveryEnvelope envelope = outbox.enqueue(
+                txn.handle(), destination, origin, frame, bounds);
+            txn.commit();
+            return envelope;
+        }
+
+        /// \brief Lists locally queued ordered deliveries for one destination.
+        std::vector<LogicalDeliveryEnvelope> pending_logical_deliveries(
+                const DbId& destination,
+                std::size_t limit = 0u,
+                const CodecBounds* bounds = nullptr) const {
+            auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
+            LogicalOutboxStore outbox(m_conn->env_handle());
+            return outbox.list_pending(txn.handle(), destination, limit, bounds);
+        }
+
+        /// \brief Persists a cumulative acknowledgement and removes its prefix.
+        std::size_t acknowledge_logical_deliveries(
+                const DbId& destination,
+                std::uint64_t acknowledged_through) {
+            auto txn = m_conn->transaction(TransactionMode::WRITABLE);
+            initialize_system_stores(txn.handle());
+            LogicalOutboxStore outbox(m_conn->env_handle());
+            const std::size_t removed = outbox.acknowledge_through(
+                txn.handle(), destination, acknowledged_through);
+            txn.commit();
+            return removed;
+        }
+
+        /// \brief Returns the persisted cumulative acknowledgement frontier.
+        std::uint64_t logical_delivery_acknowledged_through(
+                const DbId& destination) const {
+            auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
+            LogicalOutboxStore outbox(m_conn->env_handle());
+            return outbox.acknowledged_through(txn.handle(), destination);
+        }
+
         /// \brief Applies a single \c ChangeBatch to local DBIs inside \p txn.
         /// \details See class-level docs for the seq / apply rules. The
         /// caller commits the transaction. User DBIs are opened lazily by
@@ -807,11 +863,13 @@ namespace sync {
             AppliedStore applied(m_conn->env_handle());
             SchemaRegistryStore schemas(m_conn->env_handle());
             LogicalDeliveryStore logical_delivery(m_conn->env_handle());
+            LogicalOutboxStore logical_outbox(m_conn->env_handle());
             meta.open(txn);
             change_log.open(txn);
             applied.open(txn);
             schemas.open(txn);
             logical_delivery.open(txn);
+            logical_outbox.open(txn);
         }
 
         static ApplyOutcome make_apply_outcome(ApplyResult result,

--- a/include/mdbx_containers/sync/adapters/KeyTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyTableLogicalAdapter.hpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "../../KeyTable.hpp"
+#include "../ILogicalDeliveryOutbox.hpp"
 #include "KeyValueTableLogicalAdapter.hpp"
 
 namespace mdbxc {
@@ -192,6 +193,10 @@ namespace sync {
                 }
             }
 
+            /// \brief Commits local mutations and returns their logical changes.
+            /// \warning The returned changes are not published atomically with
+            /// the table transaction. Use \c commit_to_outbox() when local
+            /// durability and delivery enqueueing must share one transaction.
             void commit(std::vector<LogicalChange>& out) {
                 ensure_active();
                 const std::size_t old_size = out.size();
@@ -206,6 +211,23 @@ namespace sync {
                 }
                 m_pending.clear();
                 m_active = false;
+            }
+
+            /// \brief Commits captured table mutations and their delivery atomically.
+            LogicalDeliveryEnvelope commit_to_outbox(
+                    ILogicalDeliveryOutbox& outbox,
+                    const DbId& destination,
+                    const CodecBounds* bounds = nullptr) {
+                ensure_active();
+                LogicalChangeFrame frame;
+                frame.changes = m_pending;
+                const LogicalDeliveryEnvelope envelope =
+                    outbox.enqueue_logical_delivery(
+                        m_txn.handle(), destination, frame, bounds);
+                m_txn.commit();
+                m_pending.clear();
+                m_active = false;
+                return envelope;
             }
 
             void rollback() noexcept {

--- a/include/mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "../../KeyValueTable.hpp"
+#include "../ILogicalDeliveryOutbox.hpp"
 #include "../LogicalTableAdapter.hpp"
 #include "../LogicalSchemaValidation.hpp"
 #include "../common.hpp"
@@ -478,6 +479,10 @@ namespace detail {
                 }
             }
 
+            /// \brief Commits local mutations and returns their logical changes.
+            /// \warning The returned changes are not published atomically with
+            /// the table transaction. Use \c commit_to_outbox() when local
+            /// durability and delivery enqueueing must share one transaction.
             void commit(std::vector<LogicalChange>& out) {
                 ensure_active();
                 const std::size_t old_size = out.size();
@@ -492,6 +497,23 @@ namespace detail {
                 }
                 m_pending.clear();
                 m_active = false;
+            }
+
+            /// \brief Commits captured table mutations and their delivery atomically.
+            LogicalDeliveryEnvelope commit_to_outbox(
+                    ILogicalDeliveryOutbox& outbox,
+                    const DbId& destination,
+                    const CodecBounds* bounds = nullptr) {
+                ensure_active();
+                LogicalChangeFrame frame;
+                frame.changes = m_pending;
+                const LogicalDeliveryEnvelope envelope =
+                    outbox.enqueue_logical_delivery(
+                        m_txn.handle(), destination, frame, bounds);
+                m_txn.commit();
+                m_pending.clear();
+                m_active = false;
+                return envelope;
             }
 
             void rollback() noexcept {

--- a/include/mdbx_containers/sync/common.hpp
+++ b/include/mdbx_containers/sync/common.hpp
@@ -141,6 +141,16 @@ namespace sync {
             out.insert(out.end(), bytes, bytes + sizeof(bytes));
         }
 
+        /// \brief Appends an unsigned integer in big-endian byte order.
+        /// \details This is for bytewise MDBX keys whose lexical order must
+        /// match their numeric order. Protocol payloads remain little-endian.
+        inline void append_u64_be(std::vector<std::uint8_t>& out,
+                                  std::uint64_t value) {
+            std::uint8_t bytes[8];
+            write_u64_be(value, bytes);
+            out.insert(out.end(), bytes, bytes + sizeof(bytes));
+        }
+
     } // namespace detail
 
 } // namespace sync

--- a/include/mdbx_containers/sync/stores/LogicalOutboxStore.hpp
+++ b/include/mdbx_containers/sync/stores/LogicalOutboxStore.hpp
@@ -62,6 +62,12 @@ namespace sync {
             open_for_write(txn);
 
             Metadata metadata = read_metadata(txn, destination);
+            if (is_zero_sync_id(metadata.origin_node_id)) {
+                metadata.origin_node_id = origin;
+            } else if (compare_node_id(metadata.origin_node_id, origin) != 0) {
+                throw std::invalid_argument(
+                    "LogicalOutboxStore destination already belongs to a different origin");
+            }
             if (metadata.next_sequence ==
                 (std::numeric_limits<std::uint64_t>::max)()) {
                 throw std::overflow_error(
@@ -129,6 +135,8 @@ namespace sync {
                     LogicalDeliveryEnvelope envelope = decode_value(value, bounds);
                     if (compare_node_id(envelope.destination_db_uuid,
                                         destination) != 0 ||
+                        compare_node_id(envelope.origin_node_id,
+                                        metadata.origin_node_id) != 0 ||
                         envelope.origin_sequence != sequence) {
                         throw std::runtime_error(
                             "LogicalOutboxStore entry key/value mismatch");
@@ -231,10 +239,12 @@ namespace sync {
         struct Metadata {
             Metadata()
                 : next_sequence(1u),
-                  acknowledged_through(0u) {}
+                  acknowledged_through(0u),
+                  origin_node_id() {}
 
             std::uint64_t next_sequence;
             std::uint64_t acknowledged_through;
+            NodeId origin_node_id;
         };
 
         MDBX_txn* checked_txn(MDBX_txn* txn, const char* context) const {
@@ -360,15 +370,18 @@ namespace sync {
         static std::vector<std::uint8_t> encode_metadata(
                 const Metadata& metadata) {
             if (metadata.next_sequence == 0u ||
-                metadata.acknowledged_through >= metadata.next_sequence) {
+                metadata.acknowledged_through >= metadata.next_sequence ||
+                is_zero_sync_id(metadata.origin_node_id)) {
                 throw std::logic_error(
                     "LogicalOutboxStore metadata is invalid");
             }
             std::vector<std::uint8_t> out;
-            out.reserve(2u + 8u + 8u);
+            out.reserve(2u + 8u + 8u + metadata.origin_node_id.size());
             detail::append_u16_le(out, metadata_value_version());
             detail::append_u64_le(out, metadata.next_sequence);
             detail::append_u64_le(out, metadata.acknowledged_through);
+            out.insert(out.end(), metadata.origin_node_id.begin(),
+                       metadata.origin_node_id.end());
             return out;
         }
 
@@ -387,8 +400,11 @@ namespace sync {
             Metadata out;
             out.next_sequence = detail::read_u64_le(bytes + 2u);
             out.acknowledged_through = detail::read_u64_le(bytes + 10u);
+            std::memcpy(out.origin_node_id.data(), bytes + 18u,
+                        out.origin_node_id.size());
             if (out.next_sequence == 0u ||
-                out.acknowledged_through >= out.next_sequence) {
+                out.acknowledged_through >= out.next_sequence ||
+                is_zero_sync_id(out.origin_node_id)) {
                 throw std::runtime_error(
                     "LogicalOutboxStore metadata is invalid");
             }
@@ -412,10 +428,12 @@ namespace sync {
         static std::uint8_t key_version() { return 1u; }
         static std::uint8_t metadata_key_kind() { return 0u; }
         static std::uint8_t entry_key_kind() { return 1u; }
-        static std::uint16_t metadata_value_version() { return 1u; }
+        static std::uint16_t metadata_value_version() { return 2u; }
         static std::size_t entry_prefix_size() { return 2u + DbId().size(); }
         static std::size_t entry_key_size() { return entry_prefix_size() + 8u; }
-        static std::size_t metadata_value_size() { return 2u + 8u + 8u; }
+        static std::size_t metadata_value_size() {
+            return 2u + 8u + 8u + NodeId().size();
+        }
 
         MDBX_env* m_env;
         std::string m_dbi_name;

--- a/include/mdbx_containers/sync/stores/LogicalOutboxStore.hpp
+++ b/include/mdbx_containers/sync/stores/LogicalOutboxStore.hpp
@@ -1,0 +1,428 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_STORES_LOGICAL_OUTBOX_STORE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_STORES_LOGICAL_OUTBOX_STORE_HPP_INCLUDED
+
+/// \file LogicalOutboxStore.hpp
+/// \brief Persistent sender-side queue for ordered logical delivery.
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mdbx.h>
+
+#include "../../common.hpp"
+#include "../LogicalDeliveryEnvelopeCodec.hpp"
+#include "../common.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Persists ordered logical delivery envelopes per destination.
+    /// \details Each destination has an independent monotonic sequence. Entry
+    /// keys use a big-endian sequence suffix so MDBX cursor scans return the
+    /// pending stream in delivery order. This store owns sender-side queueing;
+    /// it does not send frames or interpret receiver acknowledgements.
+    class LogicalOutboxStore {
+    public:
+        explicit LogicalOutboxStore(
+                MDBX_env* env,
+                const std::string& dbi_name = "_mdbxc_logical_outbox")
+            : m_env(env),
+              m_dbi_name(dbi_name),
+              m_dbi(0) {}
+
+        /// \brief Creates or opens the outbox DBI in \p txn.
+        void open(MDBX_txn* txn) {
+            txn = checked_txn(txn, "LogicalOutboxStore::open");
+            open_for_write(txn);
+        }
+
+        /// \brief Returns the DBI handle valid for \p txn.
+        MDBX_dbi handle(MDBX_txn* txn) const {
+            txn = checked_txn(txn, "LogicalOutboxStore::handle");
+            open_existing(txn);
+            return m_dbi;
+        }
+
+        /// \brief Appends one envelope to \p destination's ordered stream.
+        /// \details The generated frame id is stable for the persisted
+        /// sequence. A rollback also rolls back the sequence allocation.
+        LogicalDeliveryEnvelope enqueue(
+                MDBX_txn* txn,
+                const DbId& destination,
+                const NodeId& origin,
+                const LogicalChangeFrame& frame,
+                const CodecBounds* bounds = nullptr) {
+            txn = checked_txn(txn, "LogicalOutboxStore::enqueue");
+            validate_identity(destination, origin);
+            open_for_write(txn);
+
+            Metadata metadata = read_metadata(txn, destination);
+            if (metadata.next_sequence ==
+                (std::numeric_limits<std::uint64_t>::max)()) {
+                throw std::overflow_error(
+                    "LogicalOutboxStore sequence exhausted");
+            }
+
+            LogicalDeliveryEnvelope envelope;
+            envelope.destination_db_uuid = destination;
+            envelope.origin_node_id = origin;
+            envelope.origin_sequence = metadata.next_sequence;
+            envelope.frame_id = make_frame_id(metadata.next_sequence);
+            envelope.frame = frame;
+            const std::vector<std::uint8_t> encoded =
+                LogicalDeliveryEnvelopeCodec::encode(envelope, bounds);
+            const std::vector<std::uint8_t> key =
+                make_entry_key(destination, metadata.next_sequence);
+            MDBX_val raw_key = make_val(key);
+            MDBX_val raw_value = make_val(encoded);
+            check_mdbx(mdbx_put(txn, m_dbi, &raw_key, &raw_value,
+                                MDBX_NOOVERWRITE),
+                       "LogicalOutboxStore enqueue failed");
+
+            ++metadata.next_sequence;
+            write_metadata(txn, destination, metadata);
+            return envelope;
+        }
+
+        /// \brief Returns envelopes still pending for \p destination.
+        /// \param limit Maximum number of envelopes, or zero for all pending.
+        std::vector<LogicalDeliveryEnvelope> list_pending(
+                MDBX_txn* txn,
+                const DbId& destination,
+                std::size_t limit = 0,
+                const CodecBounds* bounds = nullptr) const {
+            txn = checked_txn(txn, "LogicalOutboxStore::list_pending");
+            if (is_zero_sync_id(destination)) {
+                throw std::invalid_argument(
+                    "LogicalOutboxStore destination is zero");
+            }
+            open_existing(txn);
+            const Metadata metadata = read_metadata(txn, destination);
+            std::vector<LogicalDeliveryEnvelope> out;
+            if (metadata.acknowledged_through + 1u >=
+                metadata.next_sequence) {
+                return out;
+            }
+
+            const std::vector<std::uint8_t> prefix =
+                make_entry_prefix(destination);
+            std::vector<std::uint8_t> first_key = prefix;
+            detail::append_u64_be(first_key,
+                                  metadata.acknowledged_through + 1u);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "LogicalOutboxStore pending cursor open failed");
+            try {
+                MDBX_val key = make_val(first_key);
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_SET_RANGE);
+                while (rc == MDBX_SUCCESS && has_entry_prefix(key, prefix)) {
+                    const std::uint64_t sequence = decode_entry_sequence(key);
+                    if (sequence >= metadata.next_sequence) {
+                        break;
+                    }
+                    LogicalDeliveryEnvelope envelope = decode_value(value, bounds);
+                    if (compare_node_id(envelope.destination_db_uuid,
+                                        destination) != 0 ||
+                        envelope.origin_sequence != sequence) {
+                        throw std::runtime_error(
+                            "LogicalOutboxStore entry key/value mismatch");
+                    }
+                    out.push_back(envelope);
+                    if (limit != 0u && out.size() >= limit) {
+                        break;
+                    }
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc,
+                               "LogicalOutboxStore pending cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return out;
+        }
+
+        /// \brief Returns the persisted cumulative acknowledgement frontier.
+        std::uint64_t acknowledged_through(
+                MDBX_txn* txn,
+                const DbId& destination) const {
+            txn = checked_txn(txn,
+                              "LogicalOutboxStore::acknowledged_through");
+            if (is_zero_sync_id(destination)) {
+                throw std::invalid_argument(
+                    "LogicalOutboxStore destination is zero");
+            }
+            open_existing(txn);
+            return read_metadata(txn, destination).acknowledged_through;
+        }
+
+        /// \brief Advances one destination's cumulative acknowledgement.
+        /// \return Number of deleted pending entries.
+        std::size_t acknowledge_through(MDBX_txn* txn,
+                                        const DbId& destination,
+                                        std::uint64_t sequence) {
+            txn = checked_txn(txn,
+                              "LogicalOutboxStore::acknowledge_through");
+            if (is_zero_sync_id(destination)) {
+                throw std::invalid_argument(
+                    "LogicalOutboxStore destination is zero");
+            }
+            open_for_write(txn);
+            Metadata metadata = read_metadata(txn, destination);
+            if (sequence < metadata.acknowledged_through) {
+                throw std::invalid_argument(
+                    "LogicalOutboxStore acknowledgement moved backwards");
+            }
+            if (sequence == metadata.acknowledged_through) {
+                return 0u;
+            }
+            if (sequence >= metadata.next_sequence) {
+                throw std::invalid_argument(
+                    "LogicalOutboxStore acknowledgement exceeds enqueued sequence");
+            }
+
+            const std::vector<std::uint8_t> prefix =
+                make_entry_prefix(destination);
+            std::vector<std::uint8_t> first_key = prefix;
+            detail::append_u64_be(first_key,
+                                  metadata.acknowledged_through + 1u);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "LogicalOutboxStore acknowledgement cursor open failed");
+            std::size_t removed = 0u;
+            try {
+                MDBX_val key = make_val(first_key);
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_SET_RANGE);
+                while (rc == MDBX_SUCCESS && has_entry_prefix(key, prefix)) {
+                    const std::uint64_t current = decode_entry_sequence(key);
+                    if (current > sequence) {
+                        break;
+                    }
+                    check_mdbx(mdbx_cursor_del(cursor, MDBX_CURRENT),
+                               "LogicalOutboxStore acknowledgement delete failed");
+                    ++removed;
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc,
+                               "LogicalOutboxStore acknowledgement cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            metadata.acknowledged_through = sequence;
+            write_metadata(txn, destination, metadata);
+            return removed;
+        }
+
+    private:
+        struct Metadata {
+            Metadata()
+                : next_sequence(1u),
+                  acknowledged_through(0u) {}
+
+            std::uint64_t next_sequence;
+            std::uint64_t acknowledged_through;
+        };
+
+        MDBX_txn* checked_txn(MDBX_txn* txn, const char* context) const {
+            return checked_txn_env(txn, m_env, context);
+        }
+
+        void open_existing(MDBX_txn* txn) const {
+            check_mdbx(mdbx_dbi_open(txn, m_dbi_name.c_str(),
+                                     static_cast<MDBX_db_flags_t>(0), &m_dbi),
+                       "Failed to open LogicalOutboxStore DBI");
+        }
+
+        void open_for_write(MDBX_txn* txn) const {
+            int rc = mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE,
+                                   &m_dbi);
+            if (rc == MDBX_EACCESS) {
+                rc = mdbx_dbi_open(txn, m_dbi_name.c_str(),
+                                   static_cast<MDBX_db_flags_t>(0), &m_dbi);
+            }
+            check_mdbx(rc, "Failed to open LogicalOutboxStore DBI");
+        }
+
+        static void validate_identity(const DbId& destination,
+                                      const NodeId& origin) {
+            if (is_zero_sync_id(destination)) {
+                throw std::invalid_argument(
+                    "LogicalOutboxStore destination is zero");
+            }
+            if (is_zero_sync_id(origin)) {
+                throw std::invalid_argument(
+                    "LogicalOutboxStore origin is zero");
+            }
+        }
+
+        static std::string make_frame_id(std::uint64_t sequence) {
+            return std::string("mdbxc-ordered-") + std::to_string(sequence);
+        }
+
+        static std::vector<std::uint8_t> make_metadata_key(
+                const DbId& destination) {
+            std::vector<std::uint8_t> out;
+            out.reserve(2u + destination.size());
+            out.push_back(key_version());
+            out.push_back(metadata_key_kind());
+            out.insert(out.end(), destination.begin(), destination.end());
+            return out;
+        }
+
+        static std::vector<std::uint8_t> make_entry_prefix(
+                const DbId& destination) {
+            std::vector<std::uint8_t> out;
+            out.reserve(2u + destination.size());
+            out.push_back(key_version());
+            out.push_back(entry_key_kind());
+            out.insert(out.end(), destination.begin(), destination.end());
+            return out;
+        }
+
+        static std::vector<std::uint8_t> make_entry_key(
+                const DbId& destination,
+                std::uint64_t sequence) {
+            std::vector<std::uint8_t> out = make_entry_prefix(destination);
+            detail::append_u64_be(out, sequence);
+            return out;
+        }
+
+        static MDBX_val make_val(const std::vector<std::uint8_t>& bytes) {
+            MDBX_val out = {
+                const_cast<std::uint8_t*>(
+                    bytes.empty() ? nullptr : &bytes[0]),
+                bytes.size()
+            };
+            return out;
+        }
+
+        static bool has_entry_prefix(const MDBX_val& key,
+                                     const std::vector<std::uint8_t>& prefix) {
+            return key.iov_len == prefix.size() + 8u &&
+                   key.iov_base != nullptr &&
+                   std::memcmp(key.iov_base, &prefix[0], prefix.size()) == 0;
+        }
+
+        static std::uint64_t decode_entry_sequence(const MDBX_val& key) {
+            if (key.iov_len != entry_key_size() || key.iov_base == nullptr) {
+                throw std::runtime_error(
+                    "LogicalOutboxStore entry key has invalid size");
+            }
+            const std::uint8_t* bytes =
+                static_cast<const std::uint8_t*>(key.iov_base);
+            if (bytes[0] != key_version() ||
+                bytes[1] != entry_key_kind()) {
+                throw std::runtime_error(
+                    "LogicalOutboxStore entry key has invalid prefix");
+            }
+            return detail::read_u64_be(bytes + entry_prefix_size());
+        }
+
+        Metadata read_metadata(MDBX_txn* txn,
+                               const DbId& destination) const {
+            const std::vector<std::uint8_t> key = make_metadata_key(destination);
+            MDBX_val raw_key = make_val(key);
+            MDBX_val raw_value;
+            const int rc = mdbx_get(txn, m_dbi, &raw_key, &raw_value);
+            if (rc == MDBX_NOTFOUND) {
+                return Metadata();
+            }
+            check_mdbx(rc, "LogicalOutboxStore metadata read failed");
+            return decode_metadata(raw_value);
+        }
+
+        void write_metadata(MDBX_txn* txn,
+                            const DbId& destination,
+                            const Metadata& metadata) const {
+            const std::vector<std::uint8_t> key = make_metadata_key(destination);
+            const std::vector<std::uint8_t> value = encode_metadata(metadata);
+            MDBX_val raw_key = make_val(key);
+            MDBX_val raw_value = make_val(value);
+            check_mdbx(mdbx_put(txn, m_dbi, &raw_key, &raw_value,
+                                MDBX_UPSERT),
+                       "LogicalOutboxStore metadata write failed");
+        }
+
+        static std::vector<std::uint8_t> encode_metadata(
+                const Metadata& metadata) {
+            if (metadata.next_sequence == 0u ||
+                metadata.acknowledged_through >= metadata.next_sequence) {
+                throw std::logic_error(
+                    "LogicalOutboxStore metadata is invalid");
+            }
+            std::vector<std::uint8_t> out;
+            out.reserve(2u + 8u + 8u);
+            detail::append_u16_le(out, metadata_value_version());
+            detail::append_u64_le(out, metadata.next_sequence);
+            detail::append_u64_le(out, metadata.acknowledged_through);
+            return out;
+        }
+
+        static Metadata decode_metadata(const MDBX_val& value) {
+            if (value.iov_len != metadata_value_size() ||
+                value.iov_base == nullptr) {
+                throw std::runtime_error(
+                    "LogicalOutboxStore metadata has invalid size");
+            }
+            const std::uint8_t* bytes =
+                static_cast<const std::uint8_t*>(value.iov_base);
+            if (detail::read_u16_le(bytes) != metadata_value_version()) {
+                throw std::runtime_error(
+                    "Unsupported LogicalOutboxStore metadata version");
+            }
+            Metadata out;
+            out.next_sequence = detail::read_u64_le(bytes + 2u);
+            out.acknowledged_through = detail::read_u64_le(bytes + 10u);
+            if (out.next_sequence == 0u ||
+                out.acknowledged_through >= out.next_sequence) {
+                throw std::runtime_error(
+                    "LogicalOutboxStore metadata is invalid");
+            }
+            return out;
+        }
+
+        static LogicalDeliveryEnvelope decode_value(
+                const MDBX_val& value,
+                const CodecBounds* bounds) {
+            if (value.iov_len == 0u || value.iov_base == nullptr) {
+                throw std::runtime_error(
+                    "LogicalOutboxStore entry value is empty");
+            }
+            const std::uint8_t* begin =
+                static_cast<const std::uint8_t*>(value.iov_base);
+            const std::vector<std::uint8_t> encoded(
+                begin, begin + value.iov_len);
+            return LogicalDeliveryEnvelopeCodec::decode(encoded, bounds);
+        }
+
+        static std::uint8_t key_version() { return 1u; }
+        static std::uint8_t metadata_key_kind() { return 0u; }
+        static std::uint8_t entry_key_kind() { return 1u; }
+        static std::uint16_t metadata_value_version() { return 1u; }
+        static std::size_t entry_prefix_size() { return 2u + DbId().size(); }
+        static std::size_t entry_key_size() { return entry_prefix_size() + 8u; }
+        static std::size_t metadata_value_size() { return 2u + 8u + 8u; }
+
+        MDBX_env* m_env;
+        std::string m_dbi_name;
+        mutable MDBX_dbi m_dbi;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_STORES_LOGICAL_OUTBOX_STORE_HPP_INCLUDED

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -158,6 +158,18 @@ public:
     std::vector<std::string> affected_dbi_names;
 };
 
+class ThrowingLogicalDeliveryOutbox
+        : public mdbxc::sync::ILogicalDeliveryOutbox {
+public:
+    mdbxc::sync::LogicalDeliveryEnvelope enqueue_logical_delivery(
+            MDBX_txn*,
+            const mdbxc::sync::DbId&,
+            const mdbxc::sync::LogicalChangeFrame&,
+            const mdbxc::sync::CodecBounds*) override {
+        throw std::runtime_error("logical delivery outbox failure");
+    }
+};
+
 class RawWritingLogicalAdapter : public mdbxc::sync::ILogicalTableAdapter {
 public:
     RawWritingLogicalAdapter(
@@ -1435,6 +1447,90 @@ void test_key_value_logical_capture_session_commits_typed_local_writes() {
     replica->disconnect();
     cleanup(source_path);
     cleanup(replica_path);
+}
+
+void test_key_value_logical_capture_session_commits_to_outbox_atomically() {
+    const std::string path =
+        "test_key_value_logical_adapter_session_outbox.mdbx";
+    const std::string dbi_name = "logical_key_value_session_outbox";
+    const std::string schema_id = "app.logical_kv_session_outbox.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId node = make_node(0x69);
+    const mdbxc::sync::DbId destination = make_node(0xD9);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(node, make_node(0xC9));
+    engine.register_logical_schema(schema_id, make_record(dbi_name));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    IntStringAdapter adapter(table, schema_id);
+    {
+        std::unique_ptr<IntStringAdapter::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->insert_or_assign(7, "seven");
+        const mdbxc::sync::LogicalDeliveryEnvelope envelope =
+            session->commit_to_outbox(engine, destination);
+        MDBXC_TEST_ASSERT(envelope.destination_db_uuid == destination);
+        MDBXC_TEST_ASSERT(envelope.origin_node_id == node);
+        MDBXC_TEST_ASSERT(envelope.origin_sequence == 1u);
+    }
+
+    const std::pair<bool, std::string> found = table.find_compat(7);
+    MDBXC_TEST_ASSERT(found.first);
+    MDBXC_TEST_ASSERT(found.second == "seven");
+    const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending =
+        engine.pending_logical_deliveries(destination);
+    MDBXC_TEST_ASSERT(pending.size() == 1u);
+    MDBXC_TEST_ASSERT(pending[0].frame.changes.size() == 1u);
+    MDBXC_TEST_ASSERT(pending[0].frame.changes[0].opcode ==
+                      mdbxc::sync::KeyValueLogicalUpsert);
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_value_logical_capture_session_rolls_back_when_outbox_fails() {
+    const std::string path =
+        "test_key_value_logical_adapter_session_outbox_failure.mdbx";
+    const std::string dbi_name = "logical_key_value_session_outbox_failure";
+    const std::string schema_id = "app.logical_kv_session_outbox_failure.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x6A), make_node(0xCA));
+    engine.register_logical_schema(schema_id, make_record(dbi_name));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    IntStringAdapter adapter(table, schema_id);
+    ThrowingLogicalDeliveryOutbox outbox;
+    bool caught = false;
+    {
+        std::unique_ptr<IntStringAdapter::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->insert_or_assign(8, "eight");
+        try {
+            session->commit_to_outbox(outbox, make_node(0xDA));
+        } catch (const std::runtime_error&) {
+            caught = true;
+        }
+    }
+    MDBXC_TEST_ASSERT(caught);
+    MDBXC_TEST_ASSERT(!table.contains(8));
+
+    conn->disconnect();
+    cleanup(path);
 }
 
 void test_key_value_logical_frame_replicates_capture_session() {
@@ -3127,6 +3223,23 @@ void test_logical_outbox_persists_ordered_destination_streams() {
         MDBXC_TEST_ASSERT(pending_b.size() == 1u);
         MDBXC_TEST_ASSERT(pending_b[0].origin_sequence == 1u);
 
+        bool origin_mismatch_caught = false;
+        {
+            mdbxc::Transaction txn =
+                conn->transaction(mdbxc::TransactionMode::WRITABLE);
+            mdbxc::sync::LogicalOutboxStore outbox(conn->env_handle());
+            try {
+                outbox.enqueue(txn.handle(), destination_a, make_node(0x92),
+                               make_outbox_test_frame("app.outbox.bad", 5u));
+            } catch (const std::invalid_argument&) {
+                origin_mismatch_caught = true;
+            }
+            txn.rollback();
+        }
+        MDBXC_TEST_ASSERT(origin_mismatch_caught);
+        MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(destination_a).size() ==
+                          2u);
+
         MDBXC_TEST_ASSERT(
             engine.acknowledge_logical_deliveries(destination_a, 1u) == 1u);
         MDBXC_TEST_ASSERT(
@@ -3195,6 +3308,8 @@ int main() {
     test_key_value_logical_engine_rejects_duplicate_affected_dbis();
     test_key_value_logical_engine_suppresses_generic_raw_capture();
     test_key_value_logical_capture_session_commits_typed_local_writes();
+    test_key_value_logical_capture_session_commits_to_outbox_atomically();
+    test_key_value_logical_capture_session_rolls_back_when_outbox_fails();
     test_key_value_logical_frame_replicates_capture_session();
     test_key_value_logical_frame_rejects_malformed_bytes_before_apply();
     test_key_value_logical_frame_reports_apply_stage_exception();

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -123,6 +123,20 @@ mdbxc::sync::LogicalSchemaRecord make_key_table_record(
     return record;
 }
 
+mdbxc::sync::LogicalChangeFrame make_outbox_test_frame(
+        const std::string& schema_id,
+        std::uint8_t payload_byte) {
+    mdbxc::sync::LogicalSchemaRef ref;
+    ref.schema_id = schema_id;
+    ref.kind = mdbxc::sync::LogicalTableKind::KeyValue;
+    ref.schema_version = 1u;
+    std::vector<std::uint8_t> payload(1u, payload_byte);
+    mdbxc::sync::LogicalChangeFrame frame;
+    frame.changes.push_back(mdbxc::sync::LogicalChange(
+        ref, 1u, 0u, payload));
+    return frame;
+}
+
 class CountingApplyObserver : public mdbxc::sync::ISyncApplyObserver {
 public:
     CountingApplyObserver()
@@ -3059,6 +3073,106 @@ void test_key_value_logical_apply_does_not_recapture_incoming_change() {
     cleanup(path);
 }
 
+void test_logical_outbox_persists_ordered_destination_streams() {
+    const std::string path = "test_logical_outbox_ordered.mdbx";
+    cleanup(path);
+
+    const mdbxc::sync::NodeId local_node = make_node(0x91);
+    const mdbxc::sync::DbId local_db = make_node(0xA1);
+    const mdbxc::sync::DbId destination_a = make_node(0xB1);
+    const mdbxc::sync::DbId destination_b = make_node(0xC1);
+
+    {
+        mdbxc::Config cfg;
+        cfg.pathname = path;
+        cfg.max_dbs = 16;
+        cfg.no_subdir = true;
+        std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+        mdbxc::sync::SyncEngine engine(conn);
+        engine.initialize_local_identity(local_node, local_db);
+
+        {
+            mdbxc::Transaction txn =
+                conn->transaction(mdbxc::TransactionMode::WRITABLE);
+            mdbxc::sync::LogicalOutboxStore outbox(conn->env_handle());
+            const mdbxc::sync::LogicalDeliveryEnvelope rolled_back =
+                outbox.enqueue(txn.handle(), destination_a, local_node,
+                               make_outbox_test_frame("app.outbox.rollback", 1u));
+            MDBXC_TEST_ASSERT(rolled_back.origin_sequence == 1u);
+            txn.rollback();
+        }
+
+        const mdbxc::sync::LogicalDeliveryEnvelope first =
+            engine.enqueue_logical_delivery(
+                destination_a, make_outbox_test_frame("app.outbox.a", 2u));
+        const mdbxc::sync::LogicalDeliveryEnvelope second =
+            engine.enqueue_logical_delivery(
+                destination_a, make_outbox_test_frame("app.outbox.a", 3u));
+        const mdbxc::sync::LogicalDeliveryEnvelope other_destination =
+            engine.enqueue_logical_delivery(
+                destination_b, make_outbox_test_frame("app.outbox.b", 4u));
+        MDBXC_TEST_ASSERT(first.origin_sequence == 1u);
+        MDBXC_TEST_ASSERT(second.origin_sequence == 2u);
+        MDBXC_TEST_ASSERT(other_destination.origin_sequence == 1u);
+        MDBXC_TEST_ASSERT(first.origin_node_id == local_node);
+        MDBXC_TEST_ASSERT(first.frame_id == "mdbxc-ordered-1");
+
+        const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending_a =
+            engine.pending_logical_deliveries(destination_a);
+        const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending_b =
+            engine.pending_logical_deliveries(destination_b);
+        MDBXC_TEST_ASSERT(pending_a.size() == 2u);
+        MDBXC_TEST_ASSERT(pending_a[0].origin_sequence == 1u);
+        MDBXC_TEST_ASSERT(pending_a[1].origin_sequence == 2u);
+        MDBXC_TEST_ASSERT(pending_b.size() == 1u);
+        MDBXC_TEST_ASSERT(pending_b[0].origin_sequence == 1u);
+
+        MDBXC_TEST_ASSERT(
+            engine.acknowledge_logical_deliveries(destination_a, 1u) == 1u);
+        MDBXC_TEST_ASSERT(
+            engine.logical_delivery_acknowledged_through(destination_a) == 1u);
+        MDBXC_TEST_ASSERT(
+            engine.acknowledge_logical_deliveries(destination_a, 1u) == 0u);
+        const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> after_ack =
+            engine.pending_logical_deliveries(destination_a);
+        MDBXC_TEST_ASSERT(after_ack.size() == 1u);
+        MDBXC_TEST_ASSERT(after_ack[0].origin_sequence == 2u);
+
+        conn->disconnect();
+    }
+
+    {
+        mdbxc::Config cfg;
+        cfg.pathname = path;
+        cfg.max_dbs = 16;
+        cfg.no_subdir = true;
+        std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+        mdbxc::sync::SyncEngine engine(conn);
+        engine.initialize_local_identity(local_node, local_db);
+
+        const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending =
+            engine.pending_logical_deliveries(destination_a);
+        MDBXC_TEST_ASSERT(pending.size() == 1u);
+        MDBXC_TEST_ASSERT(pending[0].origin_sequence == 2u);
+        MDBXC_TEST_ASSERT(
+            engine.logical_delivery_acknowledged_through(destination_a) == 1u);
+        const mdbxc::sync::LogicalDeliveryEnvelope next =
+            engine.enqueue_logical_delivery(
+                destination_a, make_outbox_test_frame("app.outbox.a", 5u));
+        MDBXC_TEST_ASSERT(next.origin_sequence == 3u);
+        MDBXC_TEST_ASSERT(
+            engine.acknowledge_logical_deliveries(destination_a, 3u) == 2u);
+        MDBXC_TEST_ASSERT(
+            engine.pending_logical_deliveries(destination_a).empty());
+        MDBXC_TEST_ASSERT(
+            engine.logical_delivery_acknowledged_through(destination_a) == 3u);
+
+        conn->disconnect();
+    }
+
+    cleanup(path);
+}
+
 } // namespace
 
 int main() {
@@ -3110,5 +3224,6 @@ int main() {
     test_key_value_logical_adapter_uses_stable_payload();
     test_key_value_logical_adapter_decodes_literal_little_endian_payload();
     test_key_value_logical_apply_does_not_recapture_incoming_change();
+    test_logical_outbox_persists_ordered_destination_streams();
     return 0;
 }


### PR DESCRIPTION
## Summary
- add a persistent per-destination logical delivery outbox
- expose local enqueue, pending, and cumulative acknowledgement APIs
- initialise the outbox as a committed sync system store

## Validation
- MinGW C++11: test_key_value_logical_adapter and LogicalOutboxStore standalone header smoke
- MinGW C++17: same targets