### PR TITLE
feat(sync): persist ordered logical delivery state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Added persisted receiver-side ordering for the `OrderedDelivery` capability.
+  `SyncEngine::apply_ordered_logical_delivery_envelope()` accepts only the next
+  contiguous sequence per remote origin, returns a cumulative acknowledgement,
+  treats duplicates as no-ops, and reports gaps as retryable without adapter
+  mutation. `_mdbxc_logical_delivery_order` is created as a committed sync
+  system store; it requires one additional `Config::max_dbs` slot.
 - Added the versioned `LogicalDeliveryProtocol` wire contract with capability
   hello, nested delivery, and cumulative acknowledgement messages. The first
   optional capability is `OrderedDelivery`; unknown capability bits are not

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,6 +455,7 @@ if(MDBXC_BUILD_TESTS)
         mdbx_containers/sync/SyncNodeSession.hpp
         mdbx_containers/sync/SyncWorkerGuard.hpp
         mdbx_containers/sync/stores/LogicalDeliveryStore.hpp
+        mdbx_containers/sync/stores/LogicalDeliveryOrderStore.hpp
         mdbx_containers/sync/stores/LogicalOutboxStore.hpp
         mdbx_containers/sync/stores/SchemaRegistryStore.hpp
         mdbx_containers/sync/TransportMessageCodec.hpp

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -54,6 +54,7 @@
 #include "sync/stores/AppliedStore.hpp"
 #include "sync/stores/IdentityIndexStore.hpp"
 #include "sync/stores/LogicalDeliveryStore.hpp"
+#include "sync/stores/LogicalDeliveryOrderStore.hpp"
 #include "sync/stores/LogicalOutboxStore.hpp"
 #include "sync/stores/SchemaRegistryStore.hpp"
 #endif

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -579,6 +579,17 @@ is deferred. That optimization requires a separate recovery contract for
 sender-state rollback, a local known-tail bound, and safe removal of multiple
 pending entries from one acknowledgement.
 
+`SyncEngine::apply_ordered_logical_delivery_envelope()` is the receiver-side
+implementation of `OrderedDelivery`. `_mdbxc_logical_delivery_order` stores the
+highest committed contiguous sequence for each remote origin. A sequence at or
+below that frontier is a successful no-op acknowledged through the attempted
+sequence; this intentionally caps the receiver's higher frontier. Only the
+exact next sequence reaches schema validation and adapters; a gap is a
+retryable acknowledgement and leaves both user data and markers untouched. The
+generic unordered delivery API remains separate, so applications do not acquire
+ordering merely by changing a call site. Order-state advance, replay marker, and
+adapter mutations commit in one transaction.
+
 `LogicalDeliveryStore` persists one monotonic per-origin watermark in the
 optional `_mdbxc_logical_delivery_watermarks` DBI. The DBI is created lazily by
 the first `SyncEngine::prune_logical_delivery_markers()` call; normal logical

--- a/include/mdbx_containers/sync/LogicalDeliveryProtocol.hpp
+++ b/include/mdbx_containers/sync/LogicalDeliveryProtocol.hpp
@@ -112,6 +112,17 @@ namespace sync {
         }
     }
 
+    /// \brief Truncates an acknowledgement diagnostic to its wire bound.
+    inline std::string bounded_logical_delivery_acknowledgement_error(
+            const std::string& error,
+            const CodecBounds* bounds = nullptr) {
+        const CodecBounds& effective =
+            logical_delivery_effective_bounds(bounds);
+        return error.size() <= effective.max_error_len
+            ? error
+            : error.substr(0u, effective.max_error_len);
+    }
+
     /// \brief Returns the only capabilities this protocol version understands.
     inline std::uint64_t logical_delivery_supported_capability_flags() {
         return static_cast<std::uint64_t>(

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -450,9 +450,10 @@ namespace sync {
 
         /// \brief Applies one strictly ordered logical delivery envelope.
         /// \details This is distinct from the legacy unordered delivery API.
-        /// It accepts only the next contiguous origin sequence, returns the
-        /// persisted cumulative receiver frontier, and reports a gap as a
-        /// retryable acknowledgement without invoking logical adapters.
+        /// It accepts only the next contiguous origin sequence, acknowledges
+        /// duplicate and self-origin no-ops through their own sequence, and
+        /// reports a gap as a retryable acknowledgement without invoking
+        /// logical adapters.
         LogicalDeliveryAcknowledgement apply_ordered_logical_delivery_envelope(
                 const LogicalDeliveryEnvelope& envelope,
                 const CodecBounds* bounds = nullptr) {
@@ -502,7 +503,8 @@ namespace sync {
                 }
                 if (compare_node_id(local_node_id,
                                     envelope.origin_node_id) == 0) {
-                    acknowledgement.acknowledged_through = 0u;
+                    acknowledgement.acknowledged_through =
+                        envelope.origin_sequence;
                     txn.rollback();
                     return acknowledgement;
                 }
@@ -511,6 +513,8 @@ namespace sync {
                     txn.handle(), envelope.origin_node_id);
                 acknowledgement.acknowledged_through = last;
                 if (envelope.origin_sequence <= last) {
+                    acknowledgement.acknowledged_through =
+                        envelope.origin_sequence;
                     txn.rollback();
                     return acknowledgement;
                 }

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -462,13 +462,14 @@ namespace sync {
             try {
                 validate_logical_delivery_envelope(envelope, bounds);
             } catch (const std::exception& e) {
-                acknowledgement.ok = false;
-                acknowledgement.error = e.what();
+                set_logical_delivery_acknowledgement_failure(
+                    acknowledgement, e.what(), false, bounds);
                 return acknowledgement;
             } catch (...) {
-                acknowledgement.ok = false;
-                acknowledgement.error =
-                    "Logical ordered delivery envelope validation failed";
+                set_logical_delivery_acknowledgement_failure(
+                    acknowledgement,
+                    "Logical ordered delivery envelope validation failed",
+                    false, bounds);
                 return acknowledgement;
             }
 
@@ -492,9 +493,10 @@ namespace sync {
                 acknowledgement.destination_db_uuid = local_db_uuid;
                 if (compare_node_id(local_db_uuid,
                                     envelope.destination_db_uuid) != 0) {
-                    acknowledgement.ok = false;
-                    acknowledgement.error =
-                        "Logical ordered delivery destination db_uuid mismatch";
+                    set_logical_delivery_acknowledgement_failure(
+                        acknowledgement,
+                        "Logical ordered delivery destination db_uuid mismatch",
+                        false, bounds);
                     txn.rollback();
                     return acknowledgement;
                 }
@@ -514,16 +516,17 @@ namespace sync {
                 }
                 if (last == (std::numeric_limits<std::uint64_t>::max)() ||
                     envelope.origin_sequence != last + 1u) {
-                    acknowledgement.ok = false;
-                    acknowledgement.retryable = true;
-                    acknowledgement.error = "Logical ordered delivery sequence gap";
+                    set_logical_delivery_acknowledgement_failure(
+                        acknowledgement,
+                        "Logical ordered delivery sequence gap", true, bounds);
                     txn.rollback();
                     return acknowledgement;
                 }
                 if (!delivery.try_mark_applied(txn.handle(), envelope, bounds)) {
-                    acknowledgement.ok = false;
-                    acknowledgement.error =
-                        "Logical ordered delivery marker conflicts with order state";
+                    set_logical_delivery_acknowledgement_failure(
+                        acknowledgement,
+                        "Logical ordered delivery marker conflicts with order state",
+                        false, bounds);
                     txn.rollback();
                     return acknowledgement;
                 }
@@ -532,9 +535,9 @@ namespace sync {
                 const LogicalApplyResult validation =
                     validate_logical_schema_markers(txn.handle(), changes);
                 if (!validation.ok) {
-                    acknowledgement.ok = false;
-                    acknowledgement.retryable = validation.retryable;
-                    acknowledgement.error = validation.error;
+                    set_logical_delivery_acknowledgement_failure(
+                        acknowledgement, validation.error,
+                        validation.retryable, bounds);
                     txn.rollback();
                     return acknowledgement;
                 }
@@ -546,9 +549,9 @@ namespace sync {
                         txn.handle(), changes);
                 }
                 if (!apply_result.ok) {
-                    acknowledgement.ok = false;
-                    acknowledgement.retryable = apply_result.retryable;
-                    acknowledgement.error = apply_result.error;
+                    set_logical_delivery_acknowledgement_failure(
+                        acknowledgement, apply_result.error,
+                        apply_result.retryable, bounds);
                     txn.rollback();
                     return acknowledgement;
                 }
@@ -1004,6 +1007,17 @@ namespace sync {
         }
 
     private:
+        static void set_logical_delivery_acknowledgement_failure(
+                LogicalDeliveryAcknowledgement& acknowledgement,
+                const std::string& error,
+                bool retryable,
+                const CodecBounds* bounds) {
+            acknowledgement.ok = false;
+            acknowledgement.retryable = retryable;
+            acknowledgement.error =
+                bounded_logical_delivery_acknowledgement_error(error, bounds);
+        }
+
         struct CursorGuard {
             explicit CursorGuard(MDBX_cursor* cursor) : raw(cursor) {}
             ~CursorGuard() { if (raw) mdbx_cursor_close(raw); }

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -43,6 +43,7 @@
 #include "ChangeOp.hpp"
 #include "LogicalDeliveryEnvelopeCodec.hpp"
 #include "ILogicalDeliveryOutbox.hpp"
+#include "LogicalDeliveryProtocol.hpp"
 #include "LogicalChangeFrameCodec.hpp"
 #include "LogicalTableAdapter.hpp"
 #include "LogicalSchemaValidation.hpp"
@@ -51,6 +52,7 @@
 #include "stores/AppliedStore.hpp"
 #include "stores/ChangeLogStore.hpp"
 #include "stores/LogicalDeliveryStore.hpp"
+#include "stores/LogicalDeliveryOrderStore.hpp"
 #include "stores/LogicalOutboxStore.hpp"
 #include "stores/MetaStore.hpp"
 #include "stores/OriginIndexStore.hpp"
@@ -420,6 +422,155 @@ namespace sync {
                 m_conn->notify_sync_apply_observers(notification);
             }
             return result;
+        }
+
+        /// \brief Returns logical delivery features implemented by this engine.
+        LogicalDeliveryCapabilities logical_delivery_capabilities() const {
+            LogicalDeliveryCapabilities out;
+            out.flags = static_cast<std::uint64_t>(
+                LogicalDeliveryCapability::OrderedDelivery);
+            return out;
+        }
+
+        /// \brief Builds this engine's capability hello after local init.
+        LogicalDeliveryHello logical_delivery_hello() const {
+            auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
+            MetaStore meta(m_conn->env_handle());
+            meta.open(txn.handle());
+            LogicalDeliveryHello out;
+            out.node_id = meta.get_node_id(txn.handle());
+            out.db_uuid = meta.get_db_uuid(txn.handle());
+            if (is_zero_sync_id(out.node_id) || is_zero_sync_id(out.db_uuid)) {
+                throw std::logic_error(
+                    "SyncEngine local identity is not initialised");
+            }
+            out.capabilities = logical_delivery_capabilities();
+            return out;
+        }
+
+        /// \brief Applies one strictly ordered logical delivery envelope.
+        /// \details This is distinct from the legacy unordered delivery API.
+        /// It accepts only the next contiguous origin sequence, returns the
+        /// persisted cumulative receiver frontier, and reports a gap as a
+        /// retryable acknowledgement without invoking logical adapters.
+        LogicalDeliveryAcknowledgement apply_ordered_logical_delivery_envelope(
+                const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds = nullptr) {
+            LogicalDeliveryAcknowledgement acknowledgement;
+            acknowledgement.destination_db_uuid = envelope.destination_db_uuid;
+            acknowledgement.origin_node_id = envelope.origin_node_id;
+            try {
+                validate_logical_delivery_envelope(envelope, bounds);
+            } catch (const std::exception& e) {
+                acknowledgement.ok = false;
+                acknowledgement.error = e.what();
+                return acknowledgement;
+            } catch (...) {
+                acknowledgement.ok = false;
+                acknowledgement.error =
+                    "Logical ordered delivery envelope validation failed";
+                return acknowledgement;
+            }
+
+            const std::vector<LogicalChange>& changes = envelope.frame.changes;
+            std::vector<std::string> affected_dbi_names;
+            Connection::SyncApplyNotification notification;
+            bool notify = false;
+            {
+                const Connection::SyncApplyWriteGuard sync_apply_guard =
+                    m_conn->sync_apply_write_guard();
+                auto txn = m_conn->transaction(TransactionMode::WRITABLE);
+                MetaStore meta(m_conn->env_handle());
+                LogicalDeliveryStore delivery(m_conn->env_handle());
+                LogicalDeliveryOrderStore order(m_conn->env_handle());
+                meta.open(txn.handle());
+                delivery.open(txn.handle());
+                order.open(txn.handle());
+
+                const DbId local_db_uuid = meta.get_db_uuid(txn.handle());
+                const NodeId local_node_id = meta.get_node_id(txn.handle());
+                acknowledgement.destination_db_uuid = local_db_uuid;
+                if (compare_node_id(local_db_uuid,
+                                    envelope.destination_db_uuid) != 0) {
+                    acknowledgement.ok = false;
+                    acknowledgement.error =
+                        "Logical ordered delivery destination db_uuid mismatch";
+                    txn.rollback();
+                    return acknowledgement;
+                }
+                if (compare_node_id(local_node_id,
+                                    envelope.origin_node_id) == 0) {
+                    acknowledgement.acknowledged_through = 0u;
+                    txn.rollback();
+                    return acknowledgement;
+                }
+
+                const std::uint64_t last = order.last_applied(
+                    txn.handle(), envelope.origin_node_id);
+                acknowledgement.acknowledged_through = last;
+                if (envelope.origin_sequence <= last) {
+                    txn.rollback();
+                    return acknowledgement;
+                }
+                if (last == (std::numeric_limits<std::uint64_t>::max)() ||
+                    envelope.origin_sequence != last + 1u) {
+                    acknowledgement.ok = false;
+                    acknowledgement.retryable = true;
+                    acknowledgement.error = "Logical ordered delivery sequence gap";
+                    txn.rollback();
+                    return acknowledgement;
+                }
+                if (!delivery.try_mark_applied(txn.handle(), envelope, bounds)) {
+                    acknowledgement.ok = false;
+                    acknowledgement.error =
+                        "Logical ordered delivery marker conflicts with order state";
+                    txn.rollback();
+                    return acknowledgement;
+                }
+
+                collect_logical_affected_dbis(changes, affected_dbi_names);
+                const LogicalApplyResult validation =
+                    validate_logical_schema_markers(txn.handle(), changes);
+                if (!validation.ok) {
+                    acknowledgement.ok = false;
+                    acknowledgement.retryable = validation.retryable;
+                    acknowledgement.error = validation.error;
+                    txn.rollback();
+                    return acknowledgement;
+                }
+                LogicalApplyResult apply_result;
+                {
+                    Connection::SyncCaptureSuppressionScope suppress_capture(
+                        *m_conn, txn.handle());
+                    apply_result = m_logical_registry.preflight_then_apply(
+                        txn.handle(), changes);
+                }
+                if (!apply_result.ok) {
+                    acknowledgement.ok = false;
+                    acknowledgement.retryable = apply_result.retryable;
+                    acknowledgement.error = apply_result.error;
+                    txn.rollback();
+                    return acknowledgement;
+                }
+                order.advance(txn.handle(), envelope.origin_node_id,
+                              envelope.origin_sequence);
+                txn.commit();
+                acknowledgement.acknowledged_through =
+                    envelope.origin_sequence;
+                if (!changes.empty()) {
+                    try {
+                        notification = m_conn->mark_sync_apply_committed(
+                            1u, changes.size(), affected_dbi_names);
+                        notify = true;
+                    } catch (...) {
+                        return acknowledgement;
+                    }
+                }
+            }
+            if (notify) {
+                m_conn->notify_sync_apply_observers(notification);
+            }
+            return acknowledgement;
         }
 
         /// \brief Decodes and applies a logical delivery envelope.
@@ -878,12 +1029,14 @@ namespace sync {
             AppliedStore applied(m_conn->env_handle());
             SchemaRegistryStore schemas(m_conn->env_handle());
             LogicalDeliveryStore logical_delivery(m_conn->env_handle());
+            LogicalDeliveryOrderStore logical_delivery_order(m_conn->env_handle());
             LogicalOutboxStore logical_outbox(m_conn->env_handle());
             meta.open(txn);
             change_log.open(txn);
             applied.open(txn);
             schemas.open(txn);
             logical_delivery.open(txn);
+            logical_delivery_order.open(txn);
             logical_outbox.open(txn);
         }
 

--- a/include/mdbx_containers/sync/stores/LogicalDeliveryOrderStore.hpp
+++ b/include/mdbx_containers/sync/stores/LogicalDeliveryOrderStore.hpp
@@ -1,0 +1,164 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_STORES_LOGICAL_DELIVERY_ORDER_STORE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_STORES_LOGICAL_DELIVERY_ORDER_STORE_HPP_INCLUDED
+
+/// \file LogicalDeliveryOrderStore.hpp
+/// \brief Persistent contiguous receiver frontier for ordered delivery.
+
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mdbx.h>
+
+#include "../../common.hpp"
+#include "../LogicalDeliveryEnvelope.hpp"
+#include "../common.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Persists the highest contiguous ordered delivery per origin.
+    class LogicalDeliveryOrderStore {
+    public:
+        explicit LogicalDeliveryOrderStore(
+                MDBX_env* env,
+                const std::string& dbi_name = "_mdbxc_logical_delivery_order")
+            : m_env(env),
+              m_dbi_name(dbi_name),
+              m_dbi(0) {}
+
+        /// \brief Creates or opens the order-state DBI in \p txn.
+        void open(MDBX_txn* txn) {
+            txn = checked_txn(txn, "LogicalDeliveryOrderStore::open");
+            open_for_write(txn);
+        }
+
+        /// \brief Returns the highest contiguous delivered sequence for origin.
+        /// \return Zero when no ordered delivery from \p origin was committed.
+        std::uint64_t last_applied(MDBX_txn* txn,
+                                   const NodeId& origin) const {
+            txn = checked_txn(txn, "LogicalDeliveryOrderStore::last_applied");
+            validate_origin(origin);
+            open_existing(txn);
+            MDBX_val key = make_key(origin);
+            MDBX_val value;
+            const int rc = mdbx_get(txn, m_dbi, &key, &value);
+            if (rc == MDBX_NOTFOUND) {
+                return 0u;
+            }
+            check_mdbx(rc, "LogicalDeliveryOrderStore read failed");
+            return decode_value(value);
+        }
+
+        /// \brief Advances one origin by exactly one contiguous sequence.
+        /// \throws std::invalid_argument unless \p sequence is last + 1.
+        void advance(MDBX_txn* txn,
+                     const NodeId& origin,
+                     std::uint64_t sequence) {
+            txn = checked_txn(txn, "LogicalDeliveryOrderStore::advance");
+            validate_origin(origin);
+            if (sequence == 0u) {
+                throw std::invalid_argument(
+                    "LogicalDeliveryOrderStore sequence is zero");
+            }
+            open_for_write(txn);
+            const std::uint64_t previous = last_applied(txn, origin);
+            if (previous == (std::numeric_limits<std::uint64_t>::max)() ||
+                sequence != previous + 1u) {
+                throw std::invalid_argument(
+                    "LogicalDeliveryOrderStore sequence is not contiguous");
+            }
+            MDBX_val key = make_key(origin);
+            const std::vector<std::uint8_t> encoded = encode_value(sequence);
+            MDBX_val value = make_val(encoded);
+            check_mdbx(mdbx_put(txn, m_dbi, &key, &value, MDBX_UPSERT),
+                       "LogicalDeliveryOrderStore write failed");
+        }
+
+    private:
+        MDBX_txn* checked_txn(MDBX_txn* txn, const char* context) const {
+            return checked_txn_env(txn, m_env, context);
+        }
+
+        void open_existing(MDBX_txn* txn) const {
+            check_mdbx(mdbx_dbi_open(txn, m_dbi_name.c_str(),
+                                     static_cast<MDBX_db_flags_t>(0), &m_dbi),
+                       "Failed to open LogicalDeliveryOrderStore DBI");
+        }
+
+        void open_for_write(MDBX_txn* txn) const {
+            int rc = mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE,
+                                   &m_dbi);
+            if (rc == MDBX_EACCESS) {
+                rc = mdbx_dbi_open(txn, m_dbi_name.c_str(),
+                                   static_cast<MDBX_db_flags_t>(0), &m_dbi);
+            }
+            check_mdbx(rc, "Failed to open LogicalDeliveryOrderStore DBI");
+        }
+
+        static void validate_origin(const NodeId& origin) {
+            if (is_zero_sync_id(origin)) {
+                throw std::invalid_argument(
+                    "LogicalDeliveryOrderStore origin is zero");
+            }
+        }
+
+        static MDBX_val make_key(const NodeId& origin) {
+            MDBX_val out = {
+                const_cast<std::uint8_t*>(origin.data()),
+                origin.size()
+            };
+            return out;
+        }
+
+        static MDBX_val make_val(const std::vector<std::uint8_t>& bytes) {
+            MDBX_val out = {
+                const_cast<std::uint8_t*>(
+                    bytes.empty() ? nullptr : &bytes[0]),
+                bytes.size()
+            };
+            return out;
+        }
+
+        static std::vector<std::uint8_t> encode_value(
+                std::uint64_t sequence) {
+            std::vector<std::uint8_t> out;
+            out.reserve(2u + 8u);
+            detail::append_u16_le(out, value_version());
+            detail::append_u64_le(out, sequence);
+            return out;
+        }
+
+        static std::uint64_t decode_value(const MDBX_val& value) {
+            if (value.iov_len != 2u + 8u || value.iov_base == nullptr) {
+                throw std::runtime_error(
+                    "LogicalDeliveryOrderStore value has invalid size");
+            }
+            const std::uint8_t* bytes =
+                static_cast<const std::uint8_t*>(value.iov_base);
+            if (detail::read_u16_le(bytes) != value_version()) {
+                throw std::runtime_error(
+                    "Unsupported LogicalDeliveryOrderStore value version");
+            }
+            const std::uint64_t sequence = detail::read_u64_le(bytes + 2u);
+            if (sequence == 0u) {
+                throw std::runtime_error(
+                    "LogicalDeliveryOrderStore value is zero");
+            }
+            return sequence;
+        }
+
+        static std::uint16_t value_version() { return 1u; }
+
+        MDBX_env* m_env;
+        std::string m_dbi_name;
+        mutable MDBX_dbi m_dbi;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_STORES_LOGICAL_DELIVERY_ORDER_STORE_HPP_INCLUDED

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -3374,6 +3374,23 @@ void test_ordered_logical_delivery_enforces_receiver_frontier() {
     MDBXC_TEST_ASSERT(second_ack.acknowledged_through == 2u);
     MDBXC_TEST_ASSERT(apply_calls == 2);
 
+    const mdbxc::sync::LogicalDeliveryAcknowledgement receiver_ahead_duplicate =
+        engine.apply_ordered_logical_delivery_envelope(first);
+    MDBXC_TEST_ASSERT(receiver_ahead_duplicate.ok);
+    MDBXC_TEST_ASSERT(receiver_ahead_duplicate.acknowledged_through == 1u);
+    mdbxc::sync::validate_logical_delivery_acknowledgement_for_delivery(
+        receiver_ahead_duplicate, first);
+    const std::vector<std::uint8_t> encoded_receiver_ahead_duplicate =
+        mdbxc::sync::LogicalDeliveryProtocolCodec::encode_acknowledgement(
+            receiver_ahead_duplicate);
+    const mdbxc::sync::LogicalDeliveryAcknowledgement
+        decoded_receiver_ahead_duplicate =
+            mdbxc::sync::LogicalDeliveryProtocolCodec::decode_acknowledgement(
+                encoded_receiver_ahead_duplicate);
+    mdbxc::sync::validate_logical_delivery_acknowledgement_for_delivery(
+        decoded_receiver_ahead_duplicate, first);
+    MDBXC_TEST_ASSERT(apply_calls == 2);
+
     mdbxc::sync::LogicalDeliveryEnvelope wrong_destination = second;
     wrong_destination.destination_db_uuid = make_node(0x01);
     wrong_destination.origin_sequence = 3u;

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -3341,6 +3341,21 @@ void test_ordered_logical_delivery_enforces_receiver_frontier() {
     MDBXC_TEST_ASSERT(gap.acknowledged_through == 0u);
     MDBXC_TEST_ASSERT(apply_calls == 0);
 
+    mdbxc::sync::CodecBounds small_error_bounds;
+    small_error_bounds.max_error_len = 8u;
+    const mdbxc::sync::LogicalDeliveryAcknowledgement bounded_gap =
+        engine.apply_ordered_logical_delivery_envelope(
+            second, &small_error_bounds);
+    MDBXC_TEST_ASSERT(!bounded_gap.ok);
+    MDBXC_TEST_ASSERT(bounded_gap.error.size() == 8u);
+    const std::vector<std::uint8_t> encoded_bounded_gap =
+        mdbxc::sync::LogicalDeliveryProtocolCodec::encode_acknowledgement(
+            bounded_gap, &small_error_bounds);
+    const mdbxc::sync::LogicalDeliveryAcknowledgement decoded_bounded_gap =
+        mdbxc::sync::LogicalDeliveryProtocolCodec::decode_acknowledgement(
+            encoded_bounded_gap, &small_error_bounds);
+    MDBXC_TEST_ASSERT(decoded_bounded_gap.error == bounded_gap.error);
+
     const mdbxc::sync::LogicalDeliveryAcknowledgement first_ack =
         engine.apply_ordered_logical_delivery_envelope(first);
     MDBXC_TEST_ASSERT(first_ack.ok);

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -3286,6 +3286,100 @@ void test_logical_outbox_persists_ordered_destination_streams() {
     cleanup(path);
 }
 
+void test_ordered_logical_delivery_enforces_receiver_frontier() {
+    const std::string path = "test_ordered_logical_delivery.mdbx";
+    const std::string dbi_name = "ordered_logical_delivery";
+    const std::string schema_id = "app.ordered_logical_delivery.v1";
+    cleanup(path);
+
+    const mdbxc::sync::NodeId local_node = make_node(0xD1);
+    const mdbxc::sync::DbId local_db = make_node(0xE1);
+    const mdbxc::sync::NodeId remote_node = make_node(0xF1);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(local_node, local_db);
+    engine.register_logical_schema(schema_id, make_record(dbi_name));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    int apply_calls = 0;
+    CountingDeliveryLogicalAdapter adapter(table, schema_id, apply_calls);
+    engine.register_logical_adapter(adapter);
+
+    const mdbxc::sync::LogicalDeliveryHello hello =
+        engine.logical_delivery_hello();
+    MDBXC_TEST_ASSERT(hello.node_id == local_node);
+    MDBXC_TEST_ASSERT(hello.db_uuid == local_db);
+    MDBXC_TEST_ASSERT(hello.capabilities.supports(
+        mdbxc::sync::LogicalDeliveryCapability::OrderedDelivery));
+
+    mdbxc::sync::LogicalSchemaRef ref;
+    ref.schema_id = schema_id;
+    ref.kind = mdbxc::sync::LogicalTableKind::KeyValue;
+    ref.schema_version = 1u;
+    const std::vector<std::uint8_t> payload;
+
+    mdbxc::sync::LogicalDeliveryEnvelope first;
+    first.destination_db_uuid = local_db;
+    first.origin_node_id = remote_node;
+    first.origin_sequence = 1u;
+    first.frame_id = "ordered-1";
+    first.frame.changes.push_back(
+        mdbxc::sync::LogicalChange(ref, 1u, 0u, payload));
+    mdbxc::sync::LogicalDeliveryEnvelope second = first;
+    second.origin_sequence = 2u;
+    second.frame_id = "ordered-2";
+
+    const mdbxc::sync::LogicalDeliveryAcknowledgement gap =
+        engine.apply_ordered_logical_delivery_envelope(second);
+    MDBXC_TEST_ASSERT(!gap.ok);
+    MDBXC_TEST_ASSERT(gap.retryable);
+    MDBXC_TEST_ASSERT(gap.acknowledged_through == 0u);
+    MDBXC_TEST_ASSERT(apply_calls == 0);
+
+    const mdbxc::sync::LogicalDeliveryAcknowledgement first_ack =
+        engine.apply_ordered_logical_delivery_envelope(first);
+    MDBXC_TEST_ASSERT(first_ack.ok);
+    MDBXC_TEST_ASSERT(first_ack.acknowledged_through == 1u);
+    MDBXC_TEST_ASSERT(apply_calls == 1);
+
+    const mdbxc::sync::LogicalDeliveryAcknowledgement duplicate =
+        engine.apply_ordered_logical_delivery_envelope(first);
+    MDBXC_TEST_ASSERT(duplicate.ok);
+    MDBXC_TEST_ASSERT(duplicate.acknowledged_through == 1u);
+    MDBXC_TEST_ASSERT(apply_calls == 1);
+
+    const mdbxc::sync::LogicalDeliveryAcknowledgement second_ack =
+        engine.apply_ordered_logical_delivery_envelope(second);
+    MDBXC_TEST_ASSERT(second_ack.ok);
+    MDBXC_TEST_ASSERT(second_ack.acknowledged_through == 2u);
+    MDBXC_TEST_ASSERT(apply_calls == 2);
+
+    mdbxc::sync::LogicalDeliveryEnvelope wrong_destination = second;
+    wrong_destination.destination_db_uuid = make_node(0x01);
+    wrong_destination.origin_sequence = 3u;
+    wrong_destination.frame_id = "ordered-wrong-destination";
+    const mdbxc::sync::LogicalDeliveryAcknowledgement rejected =
+        engine.apply_ordered_logical_delivery_envelope(wrong_destination);
+    MDBXC_TEST_ASSERT(!rejected.ok);
+    MDBXC_TEST_ASSERT(!rejected.retryable);
+    MDBXC_TEST_ASSERT(apply_calls == 2);
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        mdbxc::sync::LogicalDeliveryOrderStore order(conn->env_handle());
+        MDBXC_TEST_ASSERT(order.last_applied(txn.handle(), remote_node) == 2u);
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 } // namespace
 
 int main() {
@@ -3340,5 +3434,6 @@ int main() {
     test_key_value_logical_adapter_decodes_literal_little_endian_payload();
     test_key_value_logical_apply_does_not_recapture_incoming_change();
     test_logical_outbox_persists_ordered_destination_streams();
+    test_ordered_logical_delivery_enforces_receiver_frontier();
     return 0;
 }


### PR DESCRIPTION
## Summary
- add a persistent per-origin contiguous receiver frontier
- add an ordered engine apply path that returns cumulative acknowledgements
- retain the existing unordered delivery API unchanged

## Validation
- MinGW C++11: logical adapter ordering regression and order-store standalone header smoke