### PR TITLE
feat(sync): persist logical delivery known tail

### DIFF
--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -703,6 +703,16 @@ namespace sync {
             return outbox.acknowledged_through(txn.handle(), destination);
         }
 
+        /// \brief Returns the highest locally persisted delivery sequence.
+        /// \details This durable value bounds any cumulative acknowledgement
+        /// accepted from a peer, including after a sender restart.
+        std::uint64_t logical_delivery_known_tail(
+                const DbId& destination) const {
+            auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
+            LogicalOutboxStore outbox(m_conn->env_handle());
+            return outbox.known_tail(txn.handle(), destination);
+        }
+
         /// \brief Delivers a pending ordered outbox prefix to one capable peer.
         /// \details A validated cumulative acknowledgement first advances the
         /// local outbox frontier. A failed acknowledgement can advance only an

--- a/include/mdbx_containers/sync/stores/LogicalOutboxStore.hpp
+++ b/include/mdbx_containers/sync/stores/LogicalOutboxStore.hpp
@@ -173,6 +173,22 @@ namespace sync {
             return read_metadata(txn, destination).acknowledged_through;
         }
 
+        /// \brief Returns the highest sequence durably allocated locally.
+        /// \details This is the sender's persisted known-tail bound. A peer
+        /// acknowledgement must never advance beyond it, including after the
+        /// sender restarts and redelivers an earlier pending entry.
+        std::uint64_t known_tail(MDBX_txn* txn,
+                                 const DbId& destination) const {
+            txn = checked_txn(txn, "LogicalOutboxStore::known_tail");
+            if (is_zero_sync_id(destination)) {
+                throw std::invalid_argument(
+                    "LogicalOutboxStore destination is zero");
+            }
+            open_existing(txn);
+            const Metadata metadata = read_metadata(txn, destination);
+            return metadata.next_sequence - 1u;
+        }
+
         /// \brief Advances one destination's cumulative acknowledgement.
         /// \return Number of deleted pending entries.
         std::size_t acknowledge_through(MDBX_txn* txn,
@@ -207,6 +223,7 @@ namespace sync {
             check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
                        "LogicalOutboxStore acknowledgement cursor open failed");
             std::size_t removed = 0u;
+            std::uint64_t expected = metadata.acknowledged_through + 1u;
             try {
                 MDBX_val key = make_val(first_key);
                 MDBX_val value;
@@ -216,14 +233,23 @@ namespace sync {
                     if (current > sequence) {
                         break;
                     }
+                    if (current != expected) {
+                        throw std::runtime_error(
+                            "LogicalOutboxStore acknowledgement prefix is not contiguous");
+                    }
                     check_mdbx(mdbx_cursor_del(cursor, MDBX_CURRENT),
                                "LogicalOutboxStore acknowledgement delete failed");
                     ++removed;
+                    ++expected;
                     rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
                 }
                 if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
                     check_mdbx(rc,
                                "LogicalOutboxStore acknowledgement cursor read failed");
+                }
+                if (expected != sequence + 1u) {
+                    throw std::runtime_error(
+                        "LogicalOutboxStore acknowledgement prefix is incomplete");
                 }
             } catch (...) {
                 mdbx_cursor_close(cursor);

--- a/include/mdbx_containers/sync/stores/LogicalOutboxStore.hpp
+++ b/include/mdbx_containers/sync/stores/LogicalOutboxStore.hpp
@@ -219,11 +219,14 @@ namespace sync {
             std::vector<std::uint8_t> first_key = prefix;
             detail::append_u64_be(first_key,
                                   metadata.acknowledged_through + 1u);
+            validate_acknowledgement_prefix(
+                txn, prefix, first_key, metadata.acknowledged_through + 1u,
+                sequence);
+
             MDBX_cursor* cursor = nullptr;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
                        "LogicalOutboxStore acknowledgement cursor open failed");
             std::size_t removed = 0u;
-            std::uint64_t expected = metadata.acknowledged_through + 1u;
             try {
                 MDBX_val key = make_val(first_key);
                 MDBX_val value;
@@ -233,23 +236,19 @@ namespace sync {
                     if (current > sequence) {
                         break;
                     }
-                    if (current != expected) {
-                        throw std::runtime_error(
-                            "LogicalOutboxStore acknowledgement prefix is not contiguous");
-                    }
                     check_mdbx(mdbx_cursor_del(cursor, MDBX_CURRENT),
                                "LogicalOutboxStore acknowledgement delete failed");
                     ++removed;
-                    ++expected;
                     rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
                 }
                 if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
                     check_mdbx(rc,
                                "LogicalOutboxStore acknowledgement cursor read failed");
                 }
-                if (expected != sequence + 1u) {
+                if (removed != static_cast<std::size_t>(
+                        sequence - metadata.acknowledged_through)) {
                     throw std::runtime_error(
-                        "LogicalOutboxStore acknowledgement prefix is incomplete");
+                        "LogicalOutboxStore acknowledgement delete count is invalid");
                 }
             } catch (...) {
                 mdbx_cursor_close(cursor);
@@ -366,6 +365,43 @@ namespace sync {
                     "LogicalOutboxStore entry key has invalid prefix");
             }
             return detail::read_u64_be(bytes + entry_prefix_size());
+        }
+
+        void validate_acknowledgement_prefix(
+                MDBX_txn* txn,
+                const std::vector<std::uint8_t>& prefix,
+                const std::vector<std::uint8_t>& first_key,
+                std::uint64_t first_sequence,
+                std::uint64_t last_sequence) const {
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "LogicalOutboxStore acknowledgement validation cursor open failed");
+            try {
+                std::uint64_t expected = first_sequence;
+                MDBX_val key = make_val(first_key);
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_SET_RANGE);
+                while (expected <= last_sequence) {
+                    if (rc != MDBX_SUCCESS || !has_entry_prefix(key, prefix) ||
+                        decode_entry_sequence(key) != expected) {
+                        throw std::runtime_error(
+                            "LogicalOutboxStore acknowledgement prefix is not contiguous");
+                    }
+                    if (expected == last_sequence) {
+                        break;
+                    }
+                    ++expected;
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc,
+                               "LogicalOutboxStore acknowledgement validation cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
         }
 
         Metadata read_metadata(MDBX_txn* txn,

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -3350,6 +3350,73 @@ void test_logical_outbox_persists_ordered_destination_streams() {
     cleanup(path);
 }
 
+void test_logical_outbox_acknowledgement_gap_preserves_caller_transaction() {
+    const std::string path = "test_logical_outbox_acknowledgement_gap.mdbx";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 20;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+    const mdbxc::sync::NodeId local_node = make_node(0xD1);
+    const mdbxc::sync::DbId local_db = make_node(0xE1);
+    const mdbxc::sync::DbId destination = make_node(0xF1);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(local_node, local_db);
+    engine.enqueue_logical_delivery(
+        destination, make_outbox_test_frame("app.outbox.gap", 1u));
+    engine.enqueue_logical_delivery(
+        destination, make_outbox_test_frame("app.outbox.gap", 2u));
+    engine.enqueue_logical_delivery(
+        destination, make_outbox_test_frame("app.outbox.gap", 3u));
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        mdbxc::sync::LogicalOutboxStore outbox(conn->env_handle());
+        const MDBX_dbi dbi = outbox.handle(txn.handle());
+        std::vector<std::uint8_t> key;
+        key.reserve(2u + destination.size() + 8u);
+        key.push_back(1u);
+        key.push_back(1u);
+        key.insert(key.end(), destination.begin(), destination.end());
+        mdbxc::sync::detail::append_u64_be(key, 2u);
+        MDBX_val raw_key = {
+            key.empty() ? nullptr : &key[0],
+            key.size()
+        };
+        MDBXC_TEST_ASSERT(mdbx_del(txn.handle(), dbi, &raw_key, nullptr) ==
+                          MDBX_SUCCESS);
+        txn.commit();
+    }
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        mdbxc::sync::LogicalOutboxStore outbox(conn->env_handle());
+        bool rejected = false;
+        try {
+            outbox.acknowledge_through(txn.handle(), destination, 3u);
+        } catch (const std::runtime_error&) {
+            rejected = true;
+        }
+        MDBXC_TEST_ASSERT(rejected);
+        txn.commit();
+    }
+
+    MDBXC_TEST_ASSERT(
+        engine.logical_delivery_acknowledged_through(destination) == 0u);
+    const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending =
+        engine.pending_logical_deliveries(destination);
+    MDBXC_TEST_ASSERT(pending.size() == 2u);
+    MDBXC_TEST_ASSERT(pending[0].origin_sequence == 1u);
+    MDBXC_TEST_ASSERT(pending[1].origin_sequence == 3u);
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 void test_ordered_logical_delivery_enforces_receiver_frontier() {
     const std::string path = "test_ordered_logical_delivery.mdbx";
     const std::string dbi_name = "ordered_logical_delivery";
@@ -3686,6 +3753,7 @@ int main() {
     test_key_value_logical_adapter_decodes_literal_little_endian_payload();
     test_key_value_logical_apply_does_not_recapture_incoming_change();
     test_logical_outbox_persists_ordered_destination_streams();
+    test_logical_outbox_acknowledgement_gap_preserves_caller_transaction();
     test_ordered_logical_delivery_enforces_receiver_frontier();
     test_ordered_logical_delivery_dispatch_cleans_outbox_and_markers();
     test_ordered_logical_delivery_loopback_cleans_outbox();

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -3281,6 +3281,8 @@ void test_logical_outbox_persists_ordered_destination_streams() {
         MDBXC_TEST_ASSERT(pending_a[1].origin_sequence == 2u);
         MDBXC_TEST_ASSERT(pending_b.size() == 1u);
         MDBXC_TEST_ASSERT(pending_b[0].origin_sequence == 1u);
+        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_a) == 2u);
+        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_b) == 1u);
 
         bool origin_mismatch_caught = false;
         {
@@ -3303,6 +3305,7 @@ void test_logical_outbox_persists_ordered_destination_streams() {
             engine.acknowledge_logical_deliveries(destination_a, 1u) == 1u);
         MDBXC_TEST_ASSERT(
             engine.logical_delivery_acknowledged_through(destination_a) == 1u);
+        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_a) == 2u);
         MDBXC_TEST_ASSERT(
             engine.acknowledge_logical_deliveries(destination_a, 1u) == 0u);
         const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> after_ack =
@@ -3328,10 +3331,12 @@ void test_logical_outbox_persists_ordered_destination_streams() {
         MDBXC_TEST_ASSERT(pending[0].origin_sequence == 2u);
         MDBXC_TEST_ASSERT(
             engine.logical_delivery_acknowledged_through(destination_a) == 1u);
+        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_a) == 2u);
         const mdbxc::sync::LogicalDeliveryEnvelope next =
             engine.enqueue_logical_delivery(
                 destination_a, make_outbox_test_frame("app.outbox.a", 5u));
         MDBXC_TEST_ASSERT(next.origin_sequence == 3u);
+        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_a) == 3u);
         MDBXC_TEST_ASSERT(
             engine.acknowledge_logical_deliveries(destination_a, 3u) == 2u);
         MDBXC_TEST_ASSERT(


### PR DESCRIPTION
Adds the durable sender known-tail bound and validates that outbox acknowledgement cleanup removes only a contiguous persisted prefix. This is the recovery-state foundation for negotiated cumulative ACKs.