### PR TITLE
feat(sync): negotiate cumulative delivery acknowledgements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -527,6 +527,8 @@ if(MDBXC_BUILD_TESTS)
               NOT CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")))
         target_compile_options(header_sync_umbrella_test PRIVATE
             -Woverloaded-virtual -Werror)
+        target_compile_options(test_logical_delivery_protocol PRIVATE
+            -Woverloaded-virtual -Werror)
     endif()
 
     set(_mdbxc_generated_test_dir "${CMAKE_CURRENT_BINARY_DIR}/generated_tests")

--- a/include/mdbx_containers/sync/DirectLogicalDeliveryPeer.hpp
+++ b/include/mdbx_containers/sync/DirectLogicalDeliveryPeer.hpp
@@ -27,6 +27,13 @@ namespace sync {
                 envelope, bounds);
         }
 
+        LogicalDeliveryAcknowledgement deliver_ordered_logical_delivery(
+                const LogicalDeliveryRequest& request,
+                const CodecBounds* bounds = nullptr) override {
+            return m_remote.apply_ordered_logical_delivery_envelope(
+                request.envelope, &request.sender_capabilities, bounds);
+        }
+
     private:
         SyncEngine& m_remote;
     };

--- a/include/mdbx_containers/sync/DirectLogicalDeliveryPeer.hpp
+++ b/include/mdbx_containers/sync/DirectLogicalDeliveryPeer.hpp
@@ -27,7 +27,7 @@ namespace sync {
                 envelope, bounds);
         }
 
-        LogicalDeliveryAcknowledgement deliver_ordered_logical_delivery(
+        LogicalDeliveryAcknowledgement deliver_ordered_logical_request(
                 const LogicalDeliveryRequest& request,
                 const CodecBounds* bounds = nullptr) override {
             return m_remote.apply_ordered_logical_delivery_envelope(

--- a/include/mdbx_containers/sync/ILogicalDeliveryPeer.hpp
+++ b/include/mdbx_containers/sync/ILogicalDeliveryPeer.hpp
@@ -28,7 +28,7 @@ namespace sync {
         /// \details The default preserves existing peers that implemented the
         /// earlier envelope-only virtual method. Such peers remain on the
         /// conservative acknowledgement path until they override this overload.
-        virtual LogicalDeliveryAcknowledgement deliver_ordered_logical_delivery(
+        virtual LogicalDeliveryAcknowledgement deliver_ordered_logical_request(
                 const LogicalDeliveryRequest& request,
                 const CodecBounds* bounds = nullptr) {
             return deliver_ordered_logical_delivery(request.envelope, bounds);

--- a/include/mdbx_containers/sync/ILogicalDeliveryPeer.hpp
+++ b/include/mdbx_containers/sync/ILogicalDeliveryPeer.hpp
@@ -23,6 +23,16 @@ namespace sync {
         virtual LogicalDeliveryAcknowledgement deliver_ordered_logical_delivery(
                 const LogicalDeliveryEnvelope& envelope,
                 const CodecBounds* bounds = nullptr) = 0;
+
+        /// \brief Delivers one request with sender feature context.
+        /// \details The default preserves existing peers that implemented the
+        /// earlier envelope-only virtual method. Such peers remain on the
+        /// conservative acknowledgement path until they override this overload.
+        virtual LogicalDeliveryAcknowledgement deliver_ordered_logical_delivery(
+                const LogicalDeliveryRequest& request,
+                const CodecBounds* bounds = nullptr) {
+            return deliver_ordered_logical_delivery(request.envelope, bounds);
+        }
     };
 
     /// \brief Outcome of sending pending deliveries to one peer.

--- a/include/mdbx_containers/sync/LogicalDeliveryProtocol.hpp
+++ b/include/mdbx_containers/sync/LogicalDeliveryProtocol.hpp
@@ -22,7 +22,8 @@ namespace sync {
     /// \brief Optional features understood by a logical-delivery peer.
     enum class LogicalDeliveryCapability : std::uint64_t {
         None = 0u,
-        OrderedDelivery = UINT64_C(1) << 0
+        OrderedDelivery = UINT64_C(1) << 0,
+        CumulativeAcknowledgement = UINT64_C(1) << 1
     };
 
     /// \brief Capability set exchanged before logical delivery.
@@ -43,11 +44,21 @@ namespace sync {
         LogicalDeliveryCapabilities capabilities;
     };
 
-    /// \brief Conservative cumulative response to one delivery attempt.
-    /// \details A successful response acknowledges exactly the delivery it
-    /// answers. A receiver that has already advanced farther caps a duplicate
-    /// response at that delivery's sequence, so sender cleanup remains local
-    /// to the attempted envelope.
+    /// \brief One ordered delivery attempt with sender feature context.
+    /// \details The envelope remains the stable persisted object. Capability
+    /// context describes only this peer exchange and lets a receiver retain
+    /// conservative acknowledgements for older senders.
+    struct LogicalDeliveryRequest {
+        LogicalDeliveryEnvelope envelope;
+        LogicalDeliveryCapabilities sender_capabilities;
+    };
+
+    /// \brief Cumulative response to one delivery attempt.
+    /// \details Without negotiated
+    /// \c CumulativeAcknowledgement a successful response acknowledges exactly
+    /// the delivery it answers. With that capability, a receiver can return a
+    /// higher persisted contiguous frontier, bounded by the sender's durable
+    /// known tail during validation.
     struct LogicalDeliveryAcknowledgement {
         DbId destination_db_uuid{};
         NodeId origin_node_id{};
@@ -112,6 +123,52 @@ namespace sync {
         }
     }
 
+    /// \brief Validates an acknowledgement against sender recovery state.
+    /// \details A negotiated cumulative success may acknowledge a known local
+    /// prefix beyond the delivery that triggered it. Failed acknowledgements
+    /// remain restricted to an earlier prefix, so they never report success for
+    /// the delivery that failed.
+    inline void validate_logical_delivery_acknowledgement_for_sender(
+            const LogicalDeliveryAcknowledgement& acknowledgement,
+            const LogicalDeliveryEnvelope& delivery,
+            std::uint64_t known_tail,
+            bool cumulative_acknowledgement_negotiated,
+            const CodecBounds* bounds = nullptr) {
+        validate_logical_delivery_acknowledgement(acknowledgement, bounds);
+        if (compare_node_id(acknowledgement.destination_db_uuid,
+                            delivery.destination_db_uuid) != 0 ||
+            compare_node_id(acknowledgement.origin_node_id,
+                            delivery.origin_node_id) != 0) {
+            throw std::runtime_error(
+                "Logical delivery acknowledgement identity does not match delivery");
+        }
+        if (known_tail < delivery.origin_sequence) {
+            throw std::invalid_argument(
+                "Logical delivery sender known tail precedes delivery");
+        }
+        if (acknowledgement.acknowledged_through > known_tail) {
+            throw std::runtime_error(
+                "Logical delivery acknowledgement exceeds sender known tail");
+        }
+        if (acknowledgement.ok) {
+            if (acknowledgement.acknowledged_through <
+                delivery.origin_sequence) {
+                throw std::runtime_error(
+                    "Successful logical delivery acknowledgement is incomplete");
+            }
+            if (!cumulative_acknowledgement_negotiated &&
+                acknowledgement.acknowledged_through !=
+                delivery.origin_sequence) {
+                throw std::runtime_error(
+                    "Logical delivery cumulative acknowledgement was not negotiated");
+            }
+        } else if (acknowledgement.acknowledged_through >=
+                   delivery.origin_sequence) {
+            throw std::runtime_error(
+                "Failed logical delivery acknowledgement includes delivery");
+        }
+    }
+
     /// \brief Truncates an acknowledgement diagnostic to its wire bound.
     inline std::string bounded_logical_delivery_acknowledgement_error(
             const std::string& error,
@@ -123,10 +180,12 @@ namespace sync {
             : error.substr(0u, effective.max_error_len);
     }
 
-    /// \brief Returns the only capabilities this protocol version understands.
+    /// \brief Returns the capabilities this protocol version understands.
     inline std::uint64_t logical_delivery_supported_capability_flags() {
         return static_cast<std::uint64_t>(
-            LogicalDeliveryCapability::OrderedDelivery);
+            LogicalDeliveryCapability::OrderedDelivery) |
+            static_cast<std::uint64_t>(
+                LogicalDeliveryCapability::CumulativeAcknowledgement);
     }
 
     /// \brief Returns true when both peers offer \p capability.

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -429,7 +429,9 @@ namespace sync {
         LogicalDeliveryCapabilities logical_delivery_capabilities() const {
             LogicalDeliveryCapabilities out;
             out.flags = static_cast<std::uint64_t>(
-                LogicalDeliveryCapability::OrderedDelivery);
+                LogicalDeliveryCapability::OrderedDelivery) |
+                static_cast<std::uint64_t>(
+                    LogicalDeliveryCapability::CumulativeAcknowledgement);
             return out;
         }
 
@@ -457,6 +459,19 @@ namespace sync {
         /// logical adapters.
         LogicalDeliveryAcknowledgement apply_ordered_logical_delivery_envelope(
                 const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds = nullptr) {
+            return apply_ordered_logical_delivery_envelope(
+                envelope,
+                static_cast<const LogicalDeliveryCapabilities*>(nullptr),
+                bounds);
+        }
+
+        /// \brief Applies one ordered delivery with sender feature context.
+        /// \details The envelope-only overload preserves the earlier public
+        /// contract and therefore uses conservative acknowledgements.
+        LogicalDeliveryAcknowledgement apply_ordered_logical_delivery_envelope(
+                const LogicalDeliveryEnvelope& envelope,
+                const LogicalDeliveryCapabilities* sender_capabilities,
                 const CodecBounds* bounds = nullptr) {
             LogicalDeliveryAcknowledgement acknowledgement;
             acknowledgement.destination_db_uuid = envelope.destination_db_uuid;
@@ -514,8 +529,14 @@ namespace sync {
                     txn.handle(), envelope.origin_node_id);
                 acknowledgement.acknowledged_through = last;
                 if (envelope.origin_sequence <= last) {
-                    acknowledgement.acknowledged_through =
-                        envelope.origin_sequence;
+                    if (sender_capabilities != nullptr &&
+                        sender_capabilities->supports(
+                            LogicalDeliveryCapability::CumulativeAcknowledgement)) {
+                        acknowledgement.acknowledged_through = last;
+                    } else {
+                        acknowledgement.acknowledged_through =
+                            envelope.origin_sequence;
+                    }
                     txn.rollback();
                     return acknowledgement;
                 }

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -3522,6 +3522,18 @@ void test_ordered_logical_delivery_enforces_receiver_frontier() {
         decoded_receiver_ahead_duplicate, first);
     MDBXC_TEST_ASSERT(apply_calls == 2);
 
+    mdbxc::sync::LogicalDeliveryCapabilities cumulative_sender;
+    cumulative_sender.flags = static_cast<std::uint64_t>(
+        mdbxc::sync::LogicalDeliveryCapability::CumulativeAcknowledgement);
+    const mdbxc::sync::LogicalDeliveryAcknowledgement cumulative_duplicate =
+        engine.apply_ordered_logical_delivery_envelope(
+            first, &cumulative_sender);
+    MDBXC_TEST_ASSERT(cumulative_duplicate.ok);
+    MDBXC_TEST_ASSERT(cumulative_duplicate.acknowledged_through == 2u);
+    mdbxc::sync::validate_logical_delivery_acknowledgement_for_sender(
+        cumulative_duplicate, first, 2u, true);
+    MDBXC_TEST_ASSERT(apply_calls == 2);
+
     mdbxc::sync::LogicalDeliveryEnvelope wrong_destination = second;
     wrong_destination.destination_db_uuid = make_node(0x01);
     wrong_destination.origin_sequence = 3u;

--- a/tests/test_logical_delivery_protocol.cpp
+++ b/tests/test_logical_delivery_protocol.cpp
@@ -45,6 +45,35 @@ bool throws_runtime_error(Fn fn) {
     return false;
 }
 
+class LegacyLogicalDeliveryPeer : public mdbxc::sync::ILogicalDeliveryPeer {
+public:
+    explicit LegacyLogicalDeliveryPeer(const mdbxc::sync::LogicalDeliveryHello& hello)
+        : m_hello(hello),
+          m_calls(0u) {}
+
+    mdbxc::sync::LogicalDeliveryHello logical_delivery_hello() override {
+        return m_hello;
+    }
+
+    mdbxc::sync::LogicalDeliveryAcknowledgement
+    deliver_ordered_logical_delivery(
+            const mdbxc::sync::LogicalDeliveryEnvelope& envelope,
+            const mdbxc::sync::CodecBounds* /* bounds */ = nullptr) override {
+        ++m_calls;
+        mdbxc::sync::LogicalDeliveryAcknowledgement out;
+        out.destination_db_uuid = envelope.destination_db_uuid;
+        out.origin_node_id = envelope.origin_node_id;
+        out.acknowledged_through = envelope.origin_sequence;
+        return out;
+    }
+
+    std::size_t calls() const { return m_calls; }
+
+private:
+    mdbxc::sync::LogicalDeliveryHello m_hello;
+    std::size_t m_calls;
+};
+
 void test_hello_round_trip_and_capability_negotiation() {
     mdbxc::sync::LogicalDeliveryHello hello;
     hello.node_id = make_node(0x30);
@@ -181,6 +210,28 @@ void test_cumulative_acknowledgement_respects_sender_tail() {
     }));
 }
 
+void test_legacy_peer_receives_request_through_default_forwarding() {
+    const mdbxc::sync::LogicalDeliveryEnvelope envelope = make_envelope();
+    mdbxc::sync::LogicalDeliveryHello hello;
+    hello.node_id = make_node(0x91);
+    hello.db_uuid = envelope.destination_db_uuid;
+    LegacyLogicalDeliveryPeer peer(hello);
+    mdbxc::sync::LogicalDeliveryRequest request;
+    request.envelope = envelope;
+    request.sender_capabilities.flags = static_cast<std::uint64_t>(
+        mdbxc::sync::LogicalDeliveryCapability::OrderedDelivery);
+
+    const mdbxc::sync::LogicalDeliveryAcknowledgement acknowledgement =
+        peer.deliver_ordered_logical_request(request);
+    MDBXC_TEST_ASSERT(peer.calls() == 1u);
+    MDBXC_TEST_ASSERT(acknowledgement.destination_db_uuid ==
+                      envelope.destination_db_uuid);
+    MDBXC_TEST_ASSERT(acknowledgement.origin_node_id ==
+                      envelope.origin_node_id);
+    MDBXC_TEST_ASSERT(acknowledgement.acknowledged_through ==
+                      envelope.origin_sequence);
+}
+
 } // namespace
 
 int main() {
@@ -189,5 +240,6 @@ int main() {
     test_protocol_rejects_invalid_header_and_acknowledgement();
     test_acknowledgement_matches_its_delivery();
     test_cumulative_acknowledgement_respects_sender_tail();
+    test_legacy_peer_receives_request_through_default_forwarding();
     return 0;
 }

--- a/tests/test_logical_delivery_protocol.cpp
+++ b/tests/test_logical_delivery_protocol.cpp
@@ -52,6 +52,8 @@ void test_hello_round_trip_and_capability_negotiation() {
     hello.capabilities.flags =
         static_cast<std::uint64_t>(
             mdbxc::sync::LogicalDeliveryCapability::OrderedDelivery) |
+        static_cast<std::uint64_t>(
+            mdbxc::sync::LogicalDeliveryCapability::CumulativeAcknowledgement) |
         (UINT64_C(1) << 48);
 
     const std::vector<std::uint8_t> encoded =
@@ -67,10 +69,15 @@ void test_hello_round_trip_and_capability_negotiation() {
 
     mdbxc::sync::LogicalDeliveryCapabilities local;
     local.flags = static_cast<std::uint64_t>(
-        mdbxc::sync::LogicalDeliveryCapability::OrderedDelivery);
+        mdbxc::sync::LogicalDeliveryCapability::OrderedDelivery) |
+        static_cast<std::uint64_t>(
+            mdbxc::sync::LogicalDeliveryCapability::CumulativeAcknowledgement);
     MDBXC_TEST_ASSERT(mdbxc::sync::logical_delivery_capability_negotiated(
         local, decoded.capabilities,
         mdbxc::sync::LogicalDeliveryCapability::OrderedDelivery));
+    MDBXC_TEST_ASSERT(mdbxc::sync::logical_delivery_capability_negotiated(
+        local, decoded.capabilities,
+        mdbxc::sync::LogicalDeliveryCapability::CumulativeAcknowledgement));
 }
 
 void test_delivery_and_acknowledgement_round_trip() {
@@ -155,6 +162,25 @@ void test_acknowledgement_matches_its_delivery() {
         acknowledgement, envelope);
 }
 
+void test_cumulative_acknowledgement_respects_sender_tail() {
+    const mdbxc::sync::LogicalDeliveryEnvelope envelope = make_envelope();
+    mdbxc::sync::LogicalDeliveryAcknowledgement acknowledgement;
+    acknowledgement.destination_db_uuid = envelope.destination_db_uuid;
+    acknowledgement.origin_node_id = envelope.origin_node_id;
+    acknowledgement.acknowledged_through = envelope.origin_sequence + 2u;
+
+    mdbxc::sync::validate_logical_delivery_acknowledgement_for_sender(
+        acknowledgement, envelope, envelope.origin_sequence + 2u, true);
+    MDBXC_TEST_ASSERT(throws_runtime_error([&acknowledgement, &envelope]() {
+        mdbxc::sync::validate_logical_delivery_acknowledgement_for_sender(
+            acknowledgement, envelope, envelope.origin_sequence + 1u, true);
+    }));
+    MDBXC_TEST_ASSERT(throws_runtime_error([&acknowledgement, &envelope]() {
+        mdbxc::sync::validate_logical_delivery_acknowledgement_for_sender(
+            acknowledgement, envelope, envelope.origin_sequence + 2u, false);
+    }));
+}
+
 } // namespace
 
 int main() {
@@ -162,5 +188,6 @@ int main() {
     test_delivery_and_acknowledgement_round_trip();
     test_protocol_rejects_invalid_header_and_acknowledgement();
     test_acknowledgement_matches_its_delivery();
+    test_cumulative_acknowledgement_respects_sender_tail();
     return 0;
 }


### PR DESCRIPTION
Adds the CumulativeAcknowledgement capability, a source-compatible request overload for delivery peers, receiver-side frontier responses only when requested, and sender-side known-tail acknowledgement validation.