### PR TITLE
feat(sync): recover cumulative delivery acknowledgements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Added negotiated `CumulativeAcknowledgement` for ordered logical delivery.
+  Sender outbox metadata now exposes a durable known-tail bound, allowing a
+  receiver-ahead duplicate acknowledgement to clean a verified contiguous
+  prefix after sender restart. Legacy envelope-only delivery peers remain on
+  the conservative exact-sequence acknowledgement contract.
 - Added capability-gated ordered logical delivery dispatch through
   `ILogicalDeliveryPeer`, including the in-process `DirectLogicalDeliveryPeer`.
   Valid cumulative acknowledgements clean the matching sender outbox prefix;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -527,6 +527,8 @@ if(MDBXC_BUILD_TESTS)
               NOT CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")))
         target_compile_options(header_sync_umbrella_test PRIVATE
             -Woverloaded-virtual -Werror)
+        target_compile_options(test_logical_delivery_protocol PRIVATE
+            -Woverloaded-virtual -Werror)
     endif()
 
     set(_mdbxc_generated_test_dir "${CMAKE_CURRENT_BINARY_DIR}/generated_tests")

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -566,39 +566,42 @@ unordered and is not implicitly redirected through this outbox.
 that future exchange. Its `Hello` message carries optional capability bits; an
 unknown bit is preserved but does not become negotiated unless both peers expose
 a known capability. `Delivery` wraps a strict `LogicalDeliveryEnvelope`, and
-`Acknowledgement` carries a destination-scoped, conservative cumulative lower
-bound with explicit success/retryability. A successful response is capped at
-the sequence of the delivery it answers, even if the receiver has already
-persisted a higher frontier. This lets the sender validate and clean up only
-the attempted envelope. The first defined capability is `OrderedDelivery`. No
-existing HTTP, WebSocket, or raw pull/push endpoint advertises or accepts this
-protocol yet, so current transports remain backward-compatible raw-sync-only.
-
-Allowing a receiver to acknowledge a frontier ahead of the attempted delivery
-is deferred. That optimization requires a separate recovery contract for
-sender-state rollback, a local known-tail bound, and safe removal of multiple
-pending entries from one acknowledgement.
+`Acknowledgement` carries a destination-scoped cumulative lower bound with
+explicit success/retryability. `OrderedDelivery` alone keeps the conservative
+contract: a success acknowledges exactly the delivery it answers. When both
+peers negotiate `CumulativeAcknowledgement`, the receiver may return its higher
+persisted contiguous frontier for a duplicate. The sender validates that value
+against its own durable outbox known tail, then atomically removes the verified
+contiguous local prefix. This supports a sender restart after the receiver
+committed an earlier delivery but before the sender persisted cleanup. Existing
+peers that implement only the envelope-only delivery virtual method remain on
+the conservative contract. No existing HTTP, WebSocket, or raw pull/push
+endpoint advertises or accepts this protocol yet, so current transports remain
+backward-compatible raw-sync-only.
 
 `SyncEngine::apply_ordered_logical_delivery_envelope()` is the receiver-side
 implementation of `OrderedDelivery`. `_mdbxc_logical_delivery_order` stores the
 highest committed contiguous sequence for each remote origin. A sequence at or
-below that frontier is a successful no-op acknowledged through the attempted
-sequence; this intentionally caps the receiver's higher frontier. Only the
-exact next sequence reaches schema validation and adapters; a gap is a
-retryable acknowledgement and leaves both user data and markers untouched. The
-generic unordered delivery API remains separate, so applications do not acquire
-ordering merely by changing a call site. Order-state advance, replay marker, and
-adapter mutations commit in one transaction.
+below that frontier is a successful no-op. It acknowledges through the attempted
+sequence by default, or through the persisted frontier when the sender advertises
+`CumulativeAcknowledgement`. Only the exact next sequence reaches schema
+validation and adapters; a gap is a retryable acknowledgement and leaves both
+user data and markers untouched. The generic unordered delivery API remains
+separate, so applications do not acquire ordering merely by changing a call site.
+Order-state advance, replay marker, and adapter mutations commit in one
+transaction.
 
 `ILogicalDeliveryPeer` and `DirectLogicalDeliveryPeer` provide the capability-
 gated dispatch boundary. `SyncEngine::deliver_pending_logical_deliveries()`
 checks destination identity and negotiated `OrderedDelivery` before sending its
-outbox prefix. Each valid cumulative acknowledgement advances only that
-destination's local outbox frontier; a retryable negative acknowledgement can
-still acknowledge an earlier prefix. Receiver marker retention remains an
-explicit lifecycle choice: `prune_ordered_logical_delivery_markers(origin)`
-prunes only through the persisted contiguous frontier. It must be used only for
-origins that do not mix legacy unordered delivery with the ordered protocol.
+outbox prefix. A negotiated cumulative success is bounded by the sender's
+durable known tail, so it can safely clean a prefix that was delivered before a
+sender restart; entries already removed by that acknowledgement are skipped from
+the in-memory pending snapshot. A retryable negative acknowledgement can still
+acknowledge only an earlier prefix. Receiver marker retention remains an explicit
+lifecycle choice: `prune_ordered_logical_delivery_markers(origin)` prunes only
+through the persisted contiguous frontier. It must be used only for origins that
+do not mix legacy unordered delivery with the ordered protocol.
 
 `LogicalDeliveryStore` persists one monotonic per-origin watermark in the
 optional `_mdbxc_logical_delivery_watermarks` DBI. The DBI is created lazily by

--- a/include/mdbx_containers/sync/DirectLogicalDeliveryPeer.hpp
+++ b/include/mdbx_containers/sync/DirectLogicalDeliveryPeer.hpp
@@ -27,6 +27,13 @@ namespace sync {
                 envelope, bounds);
         }
 
+        LogicalDeliveryAcknowledgement deliver_ordered_logical_delivery(
+                const LogicalDeliveryRequest& request,
+                const CodecBounds* bounds = nullptr) override {
+            return m_remote.apply_ordered_logical_delivery_envelope(
+                request.envelope, &request.sender_capabilities, bounds);
+        }
+
     private:
         SyncEngine& m_remote;
     };

--- a/include/mdbx_containers/sync/DirectLogicalDeliveryPeer.hpp
+++ b/include/mdbx_containers/sync/DirectLogicalDeliveryPeer.hpp
@@ -27,7 +27,7 @@ namespace sync {
                 envelope, bounds);
         }
 
-        LogicalDeliveryAcknowledgement deliver_ordered_logical_delivery(
+        LogicalDeliveryAcknowledgement deliver_ordered_logical_request(
                 const LogicalDeliveryRequest& request,
                 const CodecBounds* bounds = nullptr) override {
             return m_remote.apply_ordered_logical_delivery_envelope(

--- a/include/mdbx_containers/sync/ILogicalDeliveryPeer.hpp
+++ b/include/mdbx_containers/sync/ILogicalDeliveryPeer.hpp
@@ -28,7 +28,7 @@ namespace sync {
         /// \details The default preserves existing peers that implemented the
         /// earlier envelope-only virtual method. Such peers remain on the
         /// conservative acknowledgement path until they override this overload.
-        virtual LogicalDeliveryAcknowledgement deliver_ordered_logical_delivery(
+        virtual LogicalDeliveryAcknowledgement deliver_ordered_logical_request(
                 const LogicalDeliveryRequest& request,
                 const CodecBounds* bounds = nullptr) {
             return deliver_ordered_logical_delivery(request.envelope, bounds);

--- a/include/mdbx_containers/sync/ILogicalDeliveryPeer.hpp
+++ b/include/mdbx_containers/sync/ILogicalDeliveryPeer.hpp
@@ -27,7 +27,7 @@ namespace sync {
         /// \brief Delivers one request with sender feature context.
         /// \details The default preserves existing peers that implemented the
         /// earlier envelope-only virtual method. Such peers remain on the
-        /// conservative acknowledgement path until they override this overload.
+        /// conservative acknowledgement path until they override this method.
         virtual LogicalDeliveryAcknowledgement deliver_ordered_logical_request(
                 const LogicalDeliveryRequest& request,
                 const CodecBounds* bounds = nullptr) {

--- a/include/mdbx_containers/sync/ILogicalDeliveryPeer.hpp
+++ b/include/mdbx_containers/sync/ILogicalDeliveryPeer.hpp
@@ -23,6 +23,16 @@ namespace sync {
         virtual LogicalDeliveryAcknowledgement deliver_ordered_logical_delivery(
                 const LogicalDeliveryEnvelope& envelope,
                 const CodecBounds* bounds = nullptr) = 0;
+
+        /// \brief Delivers one request with sender feature context.
+        /// \details The default preserves existing peers that implemented the
+        /// earlier envelope-only virtual method. Such peers remain on the
+        /// conservative acknowledgement path until they override this overload.
+        virtual LogicalDeliveryAcknowledgement deliver_ordered_logical_delivery(
+                const LogicalDeliveryRequest& request,
+                const CodecBounds* bounds = nullptr) {
+            return deliver_ordered_logical_delivery(request.envelope, bounds);
+        }
     };
 
     /// \brief Outcome of sending pending deliveries to one peer.

--- a/include/mdbx_containers/sync/LogicalDeliveryProtocol.hpp
+++ b/include/mdbx_containers/sync/LogicalDeliveryProtocol.hpp
@@ -22,7 +22,8 @@ namespace sync {
     /// \brief Optional features understood by a logical-delivery peer.
     enum class LogicalDeliveryCapability : std::uint64_t {
         None = 0u,
-        OrderedDelivery = UINT64_C(1) << 0
+        OrderedDelivery = UINT64_C(1) << 0,
+        CumulativeAcknowledgement = UINT64_C(1) << 1
     };
 
     /// \brief Capability set exchanged before logical delivery.
@@ -43,11 +44,21 @@ namespace sync {
         LogicalDeliveryCapabilities capabilities;
     };
 
-    /// \brief Conservative cumulative response to one delivery attempt.
-    /// \details A successful response acknowledges exactly the delivery it
-    /// answers. A receiver that has already advanced farther caps a duplicate
-    /// response at that delivery's sequence, so sender cleanup remains local
-    /// to the attempted envelope.
+    /// \brief One ordered delivery attempt with sender feature context.
+    /// \details The envelope remains the stable persisted object. Capability
+    /// context describes only this peer exchange and lets a receiver retain
+    /// conservative acknowledgements for older senders.
+    struct LogicalDeliveryRequest {
+        LogicalDeliveryEnvelope envelope;
+        LogicalDeliveryCapabilities sender_capabilities;
+    };
+
+    /// \brief Cumulative response to one delivery attempt.
+    /// \details Without negotiated
+    /// \c CumulativeAcknowledgement a successful response acknowledges exactly
+    /// the delivery it answers. With that capability, a receiver can return a
+    /// higher persisted contiguous frontier, bounded by the sender's durable
+    /// known tail during validation.
     struct LogicalDeliveryAcknowledgement {
         DbId destination_db_uuid{};
         NodeId origin_node_id{};
@@ -112,6 +123,52 @@ namespace sync {
         }
     }
 
+    /// \brief Validates an acknowledgement against sender recovery state.
+    /// \details A negotiated cumulative success may acknowledge a known local
+    /// prefix beyond the delivery that triggered it. Failed acknowledgements
+    /// remain restricted to an earlier prefix, so they never report success for
+    /// the delivery that failed.
+    inline void validate_logical_delivery_acknowledgement_for_sender(
+            const LogicalDeliveryAcknowledgement& acknowledgement,
+            const LogicalDeliveryEnvelope& delivery,
+            std::uint64_t known_tail,
+            bool cumulative_acknowledgement_negotiated,
+            const CodecBounds* bounds = nullptr) {
+        validate_logical_delivery_acknowledgement(acknowledgement, bounds);
+        if (compare_node_id(acknowledgement.destination_db_uuid,
+                            delivery.destination_db_uuid) != 0 ||
+            compare_node_id(acknowledgement.origin_node_id,
+                            delivery.origin_node_id) != 0) {
+            throw std::runtime_error(
+                "Logical delivery acknowledgement identity does not match delivery");
+        }
+        if (known_tail < delivery.origin_sequence) {
+            throw std::invalid_argument(
+                "Logical delivery sender known tail precedes delivery");
+        }
+        if (acknowledgement.acknowledged_through > known_tail) {
+            throw std::runtime_error(
+                "Logical delivery acknowledgement exceeds sender known tail");
+        }
+        if (acknowledgement.ok) {
+            if (acknowledgement.acknowledged_through <
+                delivery.origin_sequence) {
+                throw std::runtime_error(
+                    "Successful logical delivery acknowledgement is incomplete");
+            }
+            if (!cumulative_acknowledgement_negotiated &&
+                acknowledgement.acknowledged_through !=
+                delivery.origin_sequence) {
+                throw std::runtime_error(
+                    "Logical delivery cumulative acknowledgement was not negotiated");
+            }
+        } else if (acknowledgement.acknowledged_through >=
+                   delivery.origin_sequence) {
+            throw std::runtime_error(
+                "Failed logical delivery acknowledgement includes delivery");
+        }
+    }
+
     /// \brief Truncates an acknowledgement diagnostic to its wire bound.
     inline std::string bounded_logical_delivery_acknowledgement_error(
             const std::string& error,
@@ -123,10 +180,12 @@ namespace sync {
             : error.substr(0u, effective.max_error_len);
     }
 
-    /// \brief Returns the only capabilities this protocol version understands.
+    /// \brief Returns the capabilities this protocol version understands.
     inline std::uint64_t logical_delivery_supported_capability_flags() {
         return static_cast<std::uint64_t>(
-            LogicalDeliveryCapability::OrderedDelivery);
+            LogicalDeliveryCapability::OrderedDelivery) |
+            static_cast<std::uint64_t>(
+                LogicalDeliveryCapability::CumulativeAcknowledgement);
     }
 
     /// \brief Returns true when both peers offer \p capability.

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -429,7 +429,9 @@ namespace sync {
         LogicalDeliveryCapabilities logical_delivery_capabilities() const {
             LogicalDeliveryCapabilities out;
             out.flags = static_cast<std::uint64_t>(
-                LogicalDeliveryCapability::OrderedDelivery);
+                LogicalDeliveryCapability::OrderedDelivery) |
+                static_cast<std::uint64_t>(
+                    LogicalDeliveryCapability::CumulativeAcknowledgement);
             return out;
         }
 
@@ -457,6 +459,19 @@ namespace sync {
         /// logical adapters.
         LogicalDeliveryAcknowledgement apply_ordered_logical_delivery_envelope(
                 const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds = nullptr) {
+            return apply_ordered_logical_delivery_envelope(
+                envelope,
+                static_cast<const LogicalDeliveryCapabilities*>(nullptr),
+                bounds);
+        }
+
+        /// \brief Applies one ordered delivery with sender feature context.
+        /// \details The envelope-only overload preserves the earlier public
+        /// contract and therefore uses conservative acknowledgements.
+        LogicalDeliveryAcknowledgement apply_ordered_logical_delivery_envelope(
+                const LogicalDeliveryEnvelope& envelope,
+                const LogicalDeliveryCapabilities* sender_capabilities,
                 const CodecBounds* bounds = nullptr) {
             LogicalDeliveryAcknowledgement acknowledgement;
             acknowledgement.destination_db_uuid = envelope.destination_db_uuid;
@@ -514,8 +529,14 @@ namespace sync {
                     txn.handle(), envelope.origin_node_id);
                 acknowledgement.acknowledged_through = last;
                 if (envelope.origin_sequence <= last) {
-                    acknowledgement.acknowledged_through =
-                        envelope.origin_sequence;
+                    if (sender_capabilities != nullptr &&
+                        sender_capabilities->supports(
+                            LogicalDeliveryCapability::CumulativeAcknowledgement)) {
+                        acknowledgement.acknowledged_through = last;
+                    } else {
+                        acknowledgement.acknowledged_through =
+                            envelope.origin_sequence;
+                    }
                     txn.rollback();
                     return acknowledgement;
                 }

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -703,6 +703,16 @@ namespace sync {
             return outbox.acknowledged_through(txn.handle(), destination);
         }
 
+        /// \brief Returns the highest locally persisted delivery sequence.
+        /// \details This durable value bounds any cumulative acknowledgement
+        /// accepted from a peer, including after a sender restart.
+        std::uint64_t logical_delivery_known_tail(
+                const DbId& destination) const {
+            auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
+            LogicalOutboxStore outbox(m_conn->env_handle());
+            return outbox.known_tail(txn.handle(), destination);
+        }
+
         /// \brief Delivers a pending ordered outbox prefix to one capable peer.
         /// \details A validated cumulative acknowledgement first advances the
         /// local outbox frontier. A failed acknowledgement can advance only an

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -735,9 +735,10 @@ namespace sync {
         }
 
         /// \brief Delivers a pending ordered outbox prefix to one capable peer.
-        /// \details A validated cumulative acknowledgement first advances the
-        /// local outbox frontier. A failed acknowledgement can advance only an
-        /// earlier prefix; it can never acknowledge the delivery that failed.
+        /// \details A negotiated cumulative acknowledgement can advance through
+        /// the sender's persisted known tail, including after restart. A failed
+        /// acknowledgement can advance only an earlier prefix; it can never
+        /// acknowledge the delivery that failed.
         /// Existing raw sync peers do not implement \c ILogicalDeliveryPeer and
         /// therefore cannot be passed to this opt-in API.
         LogicalDeliveryDispatchResult deliver_pending_logical_deliveries(
@@ -758,18 +759,32 @@ namespace sync {
                     return LogicalDeliveryDispatchResult::failure(
                         "Logical delivery peer does not support OrderedDelivery");
                 }
+                const bool cumulative_acknowledgement_negotiated =
+                    logical_delivery_capability_negotiated(
+                        local.capabilities, remote.capabilities,
+                        LogicalDeliveryCapability::CumulativeAcknowledgement);
 
                 LogicalDeliveryDispatchResult out;
                 const std::vector<LogicalDeliveryEnvelope> pending =
                     pending_logical_deliveries(destination, limit, bounds);
                 out.acknowledged_through =
                     logical_delivery_acknowledged_through(destination);
+                const std::uint64_t known_tail =
+                    logical_delivery_known_tail(destination);
                 for (std::size_t i = 0; i < pending.size(); ++i) {
+                    if (pending[i].origin_sequence <=
+                        out.acknowledged_through) {
+                        continue;
+                    }
+                    LogicalDeliveryRequest request;
+                    request.envelope = pending[i];
+                    request.sender_capabilities = local.capabilities;
                     const LogicalDeliveryAcknowledgement acknowledgement =
-                        peer.deliver_ordered_logical_delivery(pending[i], bounds);
+                        peer.deliver_ordered_logical_delivery(request, bounds);
                     try {
-                        validate_logical_delivery_acknowledgement_for_delivery(
-                            acknowledgement, pending[i], bounds);
+                        validate_logical_delivery_acknowledgement_for_sender(
+                            acknowledgement, pending[i], known_tail,
+                            cumulative_acknowledgement_negotiated, bounds);
                     } catch (const std::exception& e) {
                         return LogicalDeliveryDispatchResult::failure(
                             e.what());

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -780,7 +780,7 @@ namespace sync {
                     request.envelope = pending[i];
                     request.sender_capabilities = local.capabilities;
                     const LogicalDeliveryAcknowledgement acknowledgement =
-                        peer.deliver_ordered_logical_delivery(request, bounds);
+                        peer.deliver_ordered_logical_request(request, bounds);
                     try {
                         validate_logical_delivery_acknowledgement_for_sender(
                             acknowledgement, pending[i], known_tail,

--- a/include/mdbx_containers/sync/stores/LogicalOutboxStore.hpp
+++ b/include/mdbx_containers/sync/stores/LogicalOutboxStore.hpp
@@ -173,6 +173,22 @@ namespace sync {
             return read_metadata(txn, destination).acknowledged_through;
         }
 
+        /// \brief Returns the highest sequence durably allocated locally.
+        /// \details This is the sender's persisted known-tail bound. A peer
+        /// acknowledgement must never advance beyond it, including after the
+        /// sender restarts and redelivers an earlier pending entry.
+        std::uint64_t known_tail(MDBX_txn* txn,
+                                 const DbId& destination) const {
+            txn = checked_txn(txn, "LogicalOutboxStore::known_tail");
+            if (is_zero_sync_id(destination)) {
+                throw std::invalid_argument(
+                    "LogicalOutboxStore destination is zero");
+            }
+            open_existing(txn);
+            const Metadata metadata = read_metadata(txn, destination);
+            return metadata.next_sequence - 1u;
+        }
+
         /// \brief Advances one destination's cumulative acknowledgement.
         /// \return Number of deleted pending entries.
         std::size_t acknowledge_through(MDBX_txn* txn,
@@ -207,6 +223,7 @@ namespace sync {
             check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
                        "LogicalOutboxStore acknowledgement cursor open failed");
             std::size_t removed = 0u;
+            std::uint64_t expected = metadata.acknowledged_through + 1u;
             try {
                 MDBX_val key = make_val(first_key);
                 MDBX_val value;
@@ -216,14 +233,23 @@ namespace sync {
                     if (current > sequence) {
                         break;
                     }
+                    if (current != expected) {
+                        throw std::runtime_error(
+                            "LogicalOutboxStore acknowledgement prefix is not contiguous");
+                    }
                     check_mdbx(mdbx_cursor_del(cursor, MDBX_CURRENT),
                                "LogicalOutboxStore acknowledgement delete failed");
                     ++removed;
+                    ++expected;
                     rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
                 }
                 if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
                     check_mdbx(rc,
                                "LogicalOutboxStore acknowledgement cursor read failed");
+                }
+                if (expected != sequence + 1u) {
+                    throw std::runtime_error(
+                        "LogicalOutboxStore acknowledgement prefix is incomplete");
                 }
             } catch (...) {
                 mdbx_cursor_close(cursor);

--- a/include/mdbx_containers/sync/stores/LogicalOutboxStore.hpp
+++ b/include/mdbx_containers/sync/stores/LogicalOutboxStore.hpp
@@ -219,11 +219,14 @@ namespace sync {
             std::vector<std::uint8_t> first_key = prefix;
             detail::append_u64_be(first_key,
                                   metadata.acknowledged_through + 1u);
+            validate_acknowledgement_prefix(
+                txn, prefix, first_key, metadata.acknowledged_through + 1u,
+                sequence);
+
             MDBX_cursor* cursor = nullptr;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
                        "LogicalOutboxStore acknowledgement cursor open failed");
             std::size_t removed = 0u;
-            std::uint64_t expected = metadata.acknowledged_through + 1u;
             try {
                 MDBX_val key = make_val(first_key);
                 MDBX_val value;
@@ -233,23 +236,19 @@ namespace sync {
                     if (current > sequence) {
                         break;
                     }
-                    if (current != expected) {
-                        throw std::runtime_error(
-                            "LogicalOutboxStore acknowledgement prefix is not contiguous");
-                    }
                     check_mdbx(mdbx_cursor_del(cursor, MDBX_CURRENT),
                                "LogicalOutboxStore acknowledgement delete failed");
                     ++removed;
-                    ++expected;
                     rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
                 }
                 if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
                     check_mdbx(rc,
                                "LogicalOutboxStore acknowledgement cursor read failed");
                 }
-                if (expected != sequence + 1u) {
+                if (removed != static_cast<std::size_t>(
+                        sequence - metadata.acknowledged_through)) {
                     throw std::runtime_error(
-                        "LogicalOutboxStore acknowledgement prefix is incomplete");
+                        "LogicalOutboxStore acknowledgement delete count is invalid");
                 }
             } catch (...) {
                 mdbx_cursor_close(cursor);
@@ -366,6 +365,43 @@ namespace sync {
                     "LogicalOutboxStore entry key has invalid prefix");
             }
             return detail::read_u64_be(bytes + entry_prefix_size());
+        }
+
+        void validate_acknowledgement_prefix(
+                MDBX_txn* txn,
+                const std::vector<std::uint8_t>& prefix,
+                const std::vector<std::uint8_t>& first_key,
+                std::uint64_t first_sequence,
+                std::uint64_t last_sequence) const {
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "LogicalOutboxStore acknowledgement validation cursor open failed");
+            try {
+                std::uint64_t expected = first_sequence;
+                MDBX_val key = make_val(first_key);
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_SET_RANGE);
+                while (expected <= last_sequence) {
+                    if (rc != MDBX_SUCCESS || !has_entry_prefix(key, prefix) ||
+                        decode_entry_sequence(key) != expected) {
+                        throw std::runtime_error(
+                            "LogicalOutboxStore acknowledgement prefix is not contiguous");
+                    }
+                    if (expected == last_sequence) {
+                        break;
+                    }
+                    ++expected;
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc,
+                               "LogicalOutboxStore acknowledgement validation cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
         }
 
         Metadata read_metadata(MDBX_txn* txn,

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -3522,6 +3522,18 @@ void test_ordered_logical_delivery_enforces_receiver_frontier() {
         decoded_receiver_ahead_duplicate, first);
     MDBXC_TEST_ASSERT(apply_calls == 2);
 
+    mdbxc::sync::LogicalDeliveryCapabilities cumulative_sender;
+    cumulative_sender.flags = static_cast<std::uint64_t>(
+        mdbxc::sync::LogicalDeliveryCapability::CumulativeAcknowledgement);
+    const mdbxc::sync::LogicalDeliveryAcknowledgement cumulative_duplicate =
+        engine.apply_ordered_logical_delivery_envelope(
+            first, &cumulative_sender);
+    MDBXC_TEST_ASSERT(cumulative_duplicate.ok);
+    MDBXC_TEST_ASSERT(cumulative_duplicate.acknowledged_through == 2u);
+    mdbxc::sync::validate_logical_delivery_acknowledgement_for_sender(
+        cumulative_duplicate, first, 2u, true);
+    MDBXC_TEST_ASSERT(apply_calls == 2);
+
     mdbxc::sync::LogicalDeliveryEnvelope wrong_destination = second;
     wrong_destination.destination_db_uuid = make_node(0x01);
     wrong_destination.origin_sequence = 3u;

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -3350,6 +3350,73 @@ void test_logical_outbox_persists_ordered_destination_streams() {
     cleanup(path);
 }
 
+void test_logical_outbox_acknowledgement_gap_preserves_caller_transaction() {
+    const std::string path = "test_logical_outbox_acknowledgement_gap.mdbx";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 20;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+    const mdbxc::sync::NodeId local_node = make_node(0xD1);
+    const mdbxc::sync::DbId local_db = make_node(0xE1);
+    const mdbxc::sync::DbId destination = make_node(0xF1);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(local_node, local_db);
+    engine.enqueue_logical_delivery(
+        destination, make_outbox_test_frame("app.outbox.gap", 1u));
+    engine.enqueue_logical_delivery(
+        destination, make_outbox_test_frame("app.outbox.gap", 2u));
+    engine.enqueue_logical_delivery(
+        destination, make_outbox_test_frame("app.outbox.gap", 3u));
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        mdbxc::sync::LogicalOutboxStore outbox(conn->env_handle());
+        const MDBX_dbi dbi = outbox.handle(txn.handle());
+        std::vector<std::uint8_t> key;
+        key.reserve(2u + destination.size() + 8u);
+        key.push_back(1u);
+        key.push_back(1u);
+        key.insert(key.end(), destination.begin(), destination.end());
+        mdbxc::sync::detail::append_u64_be(key, 2u);
+        MDBX_val raw_key = {
+            key.empty() ? nullptr : &key[0],
+            key.size()
+        };
+        MDBXC_TEST_ASSERT(mdbx_del(txn.handle(), dbi, &raw_key, nullptr) ==
+                          MDBX_SUCCESS);
+        txn.commit();
+    }
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        mdbxc::sync::LogicalOutboxStore outbox(conn->env_handle());
+        bool rejected = false;
+        try {
+            outbox.acknowledge_through(txn.handle(), destination, 3u);
+        } catch (const std::runtime_error&) {
+            rejected = true;
+        }
+        MDBXC_TEST_ASSERT(rejected);
+        txn.commit();
+    }
+
+    MDBXC_TEST_ASSERT(
+        engine.logical_delivery_acknowledged_through(destination) == 0u);
+    const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending =
+        engine.pending_logical_deliveries(destination);
+    MDBXC_TEST_ASSERT(pending.size() == 2u);
+    MDBXC_TEST_ASSERT(pending[0].origin_sequence == 1u);
+    MDBXC_TEST_ASSERT(pending[1].origin_sequence == 3u);
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 void test_ordered_logical_delivery_enforces_receiver_frontier() {
     const std::string path = "test_ordered_logical_delivery.mdbx";
     const std::string dbi_name = "ordered_logical_delivery";
@@ -3686,6 +3753,7 @@ int main() {
     test_key_value_logical_adapter_decodes_literal_little_endian_payload();
     test_key_value_logical_apply_does_not_recapture_incoming_change();
     test_logical_outbox_persists_ordered_destination_streams();
+    test_logical_outbox_acknowledgement_gap_preserves_caller_transaction();
     test_ordered_logical_delivery_enforces_receiver_frontier();
     test_ordered_logical_delivery_dispatch_cleans_outbox_and_markers();
     test_ordered_logical_delivery_loopback_cleans_outbox();

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -3281,6 +3281,8 @@ void test_logical_outbox_persists_ordered_destination_streams() {
         MDBXC_TEST_ASSERT(pending_a[1].origin_sequence == 2u);
         MDBXC_TEST_ASSERT(pending_b.size() == 1u);
         MDBXC_TEST_ASSERT(pending_b[0].origin_sequence == 1u);
+        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_a) == 2u);
+        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_b) == 1u);
 
         bool origin_mismatch_caught = false;
         {
@@ -3303,6 +3305,7 @@ void test_logical_outbox_persists_ordered_destination_streams() {
             engine.acknowledge_logical_deliveries(destination_a, 1u) == 1u);
         MDBXC_TEST_ASSERT(
             engine.logical_delivery_acknowledged_through(destination_a) == 1u);
+        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_a) == 2u);
         MDBXC_TEST_ASSERT(
             engine.acknowledge_logical_deliveries(destination_a, 1u) == 0u);
         const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> after_ack =
@@ -3328,10 +3331,12 @@ void test_logical_outbox_persists_ordered_destination_streams() {
         MDBXC_TEST_ASSERT(pending[0].origin_sequence == 2u);
         MDBXC_TEST_ASSERT(
             engine.logical_delivery_acknowledged_through(destination_a) == 1u);
+        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_a) == 2u);
         const mdbxc::sync::LogicalDeliveryEnvelope next =
             engine.enqueue_logical_delivery(
                 destination_a, make_outbox_test_frame("app.outbox.a", 5u));
         MDBXC_TEST_ASSERT(next.origin_sequence == 3u);
+        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_a) == 3u);
         MDBXC_TEST_ASSERT(
             engine.acknowledge_logical_deliveries(destination_a, 3u) == 2u);
         MDBXC_TEST_ASSERT(

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -3624,6 +3624,88 @@ void test_ordered_logical_delivery_dispatch_cleans_outbox_and_markers() {
     cleanup(receiver_path);
 }
 
+void test_cumulative_logical_delivery_acknowledgement_recovers_after_restart() {
+    const std::string sender_path = "test_cumulative_logical_sender.mdbx";
+    const std::string receiver_path = "test_cumulative_logical_receiver.mdbx";
+    const std::string dbi_name = "cumulative_logical_dispatch";
+    const std::string schema_id = "app.cumulative_logical_dispatch.v1";
+    cleanup(sender_path);
+    cleanup(receiver_path);
+
+    mdbxc::Config sender_cfg;
+    sender_cfg.pathname = sender_path;
+    sender_cfg.max_dbs = 20;
+    sender_cfg.no_subdir = true;
+    mdbxc::Config receiver_cfg = sender_cfg;
+    receiver_cfg.pathname = receiver_path;
+    std::shared_ptr<mdbxc::Connection> sender_conn =
+        mdbxc::Connection::create(sender_cfg);
+    std::shared_ptr<mdbxc::Connection> receiver_conn =
+        mdbxc::Connection::create(receiver_cfg);
+
+    const mdbxc::sync::NodeId sender_node = make_node(0x51);
+    const mdbxc::sync::NodeId receiver_node = make_node(0x61);
+    const mdbxc::sync::DbId sender_db = make_node(0x71);
+    const mdbxc::sync::DbId receiver_db = make_node(0x81);
+    mdbxc::sync::SyncEngine receiver(receiver_conn);
+    receiver.initialize_local_identity(receiver_node, receiver_db);
+    receiver.register_logical_schema(schema_id, make_record(dbi_name));
+
+    mdbxc::KeyValueTable<int, std::string> table(receiver_conn, dbi_name);
+    int apply_calls = 0;
+    CountingDeliveryLogicalAdapter adapter(table, schema_id, apply_calls);
+    receiver.register_logical_adapter(adapter);
+
+    mdbxc::sync::LogicalSchemaRef ref;
+    ref.schema_id = schema_id;
+    ref.kind = mdbxc::sync::LogicalTableKind::KeyValue;
+    ref.schema_version = 1u;
+    mdbxc::sync::LogicalChangeFrame frame;
+    frame.changes.push_back(mdbxc::sync::LogicalChange(
+        ref, 1u, 0u, std::vector<std::uint8_t>()));
+    std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending;
+    {
+        mdbxc::sync::SyncEngine sender(sender_conn);
+        sender.initialize_local_identity(sender_node, sender_db);
+        sender.enqueue_logical_delivery(receiver_db, frame);
+        sender.enqueue_logical_delivery(receiver_db, frame);
+        pending = sender.pending_logical_deliveries(receiver_db);
+        MDBXC_TEST_ASSERT(pending.size() == 2u);
+        MDBXC_TEST_ASSERT(receiver.apply_ordered_logical_delivery_envelope(
+            pending[0]).ok);
+        MDBXC_TEST_ASSERT(receiver.apply_ordered_logical_delivery_envelope(
+            pending[1]).ok);
+        MDBXC_TEST_ASSERT(apply_calls == 2);
+        MDBXC_TEST_ASSERT(sender.logical_delivery_known_tail(receiver_db) == 2u);
+    }
+    sender_conn->disconnect();
+    sender_conn.reset();
+    sender_conn = mdbxc::Connection::create(sender_cfg);
+
+    {
+        mdbxc::sync::SyncEngine restarted_sender(sender_conn);
+        restarted_sender.initialize_local_identity(sender_node, sender_db);
+        mdbxc::sync::DirectLogicalDeliveryPeer peer(receiver);
+        const mdbxc::sync::LogicalDeliveryDispatchResult dispatched =
+            restarted_sender.deliver_pending_logical_deliveries(
+                peer, receiver_db, 1u);
+        MDBXC_TEST_ASSERT(dispatched.ok);
+        MDBXC_TEST_ASSERT(dispatched.delivered == 1u);
+        MDBXC_TEST_ASSERT(dispatched.acknowledged_through == 2u);
+        MDBXC_TEST_ASSERT(
+            restarted_sender.logical_delivery_acknowledged_through(receiver_db) ==
+            2u);
+        MDBXC_TEST_ASSERT(
+            restarted_sender.pending_logical_deliveries(receiver_db).empty());
+        MDBXC_TEST_ASSERT(apply_calls == 2);
+    }
+
+    sender_conn->disconnect();
+    receiver_conn->disconnect();
+    cleanup(sender_path);
+    cleanup(receiver_path);
+}
+
 void test_ordered_logical_delivery_loopback_cleans_outbox() {
     const std::string path = "test_ordered_logical_loopback.mdbx";
     const std::string dbi_name = "ordered_logical_loopback";
@@ -3768,6 +3850,7 @@ int main() {
     test_logical_outbox_acknowledgement_gap_preserves_caller_transaction();
     test_ordered_logical_delivery_enforces_receiver_frontier();
     test_ordered_logical_delivery_dispatch_cleans_outbox_and_markers();
+    test_cumulative_logical_delivery_acknowledgement_recovers_after_restart();
     test_ordered_logical_delivery_loopback_cleans_outbox();
     test_ordered_logical_delivery_dispatch_rejects_invalid_acknowledgements();
     return 0;

--- a/tests/test_logical_delivery_protocol.cpp
+++ b/tests/test_logical_delivery_protocol.cpp
@@ -45,6 +45,35 @@ bool throws_runtime_error(Fn fn) {
     return false;
 }
 
+class LegacyLogicalDeliveryPeer : public mdbxc::sync::ILogicalDeliveryPeer {
+public:
+    explicit LegacyLogicalDeliveryPeer(const mdbxc::sync::LogicalDeliveryHello& hello)
+        : m_hello(hello),
+          m_calls(0u) {}
+
+    mdbxc::sync::LogicalDeliveryHello logical_delivery_hello() override {
+        return m_hello;
+    }
+
+    mdbxc::sync::LogicalDeliveryAcknowledgement
+    deliver_ordered_logical_delivery(
+            const mdbxc::sync::LogicalDeliveryEnvelope& envelope,
+            const mdbxc::sync::CodecBounds* /* bounds */ = nullptr) override {
+        ++m_calls;
+        mdbxc::sync::LogicalDeliveryAcknowledgement out;
+        out.destination_db_uuid = envelope.destination_db_uuid;
+        out.origin_node_id = envelope.origin_node_id;
+        out.acknowledged_through = envelope.origin_sequence;
+        return out;
+    }
+
+    std::size_t calls() const { return m_calls; }
+
+private:
+    mdbxc::sync::LogicalDeliveryHello m_hello;
+    std::size_t m_calls;
+};
+
 void test_hello_round_trip_and_capability_negotiation() {
     mdbxc::sync::LogicalDeliveryHello hello;
     hello.node_id = make_node(0x30);
@@ -181,6 +210,28 @@ void test_cumulative_acknowledgement_respects_sender_tail() {
     }));
 }
 
+void test_legacy_peer_receives_request_through_default_forwarding() {
+    const mdbxc::sync::LogicalDeliveryEnvelope envelope = make_envelope();
+    mdbxc::sync::LogicalDeliveryHello hello;
+    hello.node_id = make_node(0x91);
+    hello.db_uuid = envelope.destination_db_uuid;
+    LegacyLogicalDeliveryPeer peer(hello);
+    mdbxc::sync::LogicalDeliveryRequest request;
+    request.envelope = envelope;
+    request.sender_capabilities.flags = static_cast<std::uint64_t>(
+        mdbxc::sync::LogicalDeliveryCapability::OrderedDelivery);
+
+    const mdbxc::sync::LogicalDeliveryAcknowledgement acknowledgement =
+        peer.deliver_ordered_logical_request(request);
+    MDBXC_TEST_ASSERT(peer.calls() == 1u);
+    MDBXC_TEST_ASSERT(acknowledgement.destination_db_uuid ==
+                      envelope.destination_db_uuid);
+    MDBXC_TEST_ASSERT(acknowledgement.origin_node_id ==
+                      envelope.origin_node_id);
+    MDBXC_TEST_ASSERT(acknowledgement.acknowledged_through ==
+                      envelope.origin_sequence);
+}
+
 } // namespace
 
 int main() {
@@ -189,5 +240,6 @@ int main() {
     test_protocol_rejects_invalid_header_and_acknowledgement();
     test_acknowledgement_matches_its_delivery();
     test_cumulative_acknowledgement_respects_sender_tail();
+    test_legacy_peer_receives_request_through_default_forwarding();
     return 0;
 }

--- a/tests/test_logical_delivery_protocol.cpp
+++ b/tests/test_logical_delivery_protocol.cpp
@@ -52,6 +52,8 @@ void test_hello_round_trip_and_capability_negotiation() {
     hello.capabilities.flags =
         static_cast<std::uint64_t>(
             mdbxc::sync::LogicalDeliveryCapability::OrderedDelivery) |
+        static_cast<std::uint64_t>(
+            mdbxc::sync::LogicalDeliveryCapability::CumulativeAcknowledgement) |
         (UINT64_C(1) << 48);
 
     const std::vector<std::uint8_t> encoded =
@@ -67,10 +69,15 @@ void test_hello_round_trip_and_capability_negotiation() {
 
     mdbxc::sync::LogicalDeliveryCapabilities local;
     local.flags = static_cast<std::uint64_t>(
-        mdbxc::sync::LogicalDeliveryCapability::OrderedDelivery);
+        mdbxc::sync::LogicalDeliveryCapability::OrderedDelivery) |
+        static_cast<std::uint64_t>(
+            mdbxc::sync::LogicalDeliveryCapability::CumulativeAcknowledgement);
     MDBXC_TEST_ASSERT(mdbxc::sync::logical_delivery_capability_negotiated(
         local, decoded.capabilities,
         mdbxc::sync::LogicalDeliveryCapability::OrderedDelivery));
+    MDBXC_TEST_ASSERT(mdbxc::sync::logical_delivery_capability_negotiated(
+        local, decoded.capabilities,
+        mdbxc::sync::LogicalDeliveryCapability::CumulativeAcknowledgement));
 }
 
 void test_delivery_and_acknowledgement_round_trip() {
@@ -155,6 +162,25 @@ void test_acknowledgement_matches_its_delivery() {
         acknowledgement, envelope);
 }
 
+void test_cumulative_acknowledgement_respects_sender_tail() {
+    const mdbxc::sync::LogicalDeliveryEnvelope envelope = make_envelope();
+    mdbxc::sync::LogicalDeliveryAcknowledgement acknowledgement;
+    acknowledgement.destination_db_uuid = envelope.destination_db_uuid;
+    acknowledgement.origin_node_id = envelope.origin_node_id;
+    acknowledgement.acknowledged_through = envelope.origin_sequence + 2u;
+
+    mdbxc::sync::validate_logical_delivery_acknowledgement_for_sender(
+        acknowledgement, envelope, envelope.origin_sequence + 2u, true);
+    MDBXC_TEST_ASSERT(throws_runtime_error([&acknowledgement, &envelope]() {
+        mdbxc::sync::validate_logical_delivery_acknowledgement_for_sender(
+            acknowledgement, envelope, envelope.origin_sequence + 1u, true);
+    }));
+    MDBXC_TEST_ASSERT(throws_runtime_error([&acknowledgement, &envelope]() {
+        mdbxc::sync::validate_logical_delivery_acknowledgement_for_sender(
+            acknowledgement, envelope, envelope.origin_sequence + 2u, false);
+    }));
+}
+
 } // namespace
 
 int main() {
@@ -162,5 +188,6 @@ int main() {
     test_delivery_and_acknowledgement_round_trip();
     test_protocol_rejects_invalid_header_and_acknowledgement();
     test_acknowledgement_matches_its_delivery();
+    test_cumulative_acknowledgement_respects_sender_tail();
     return 0;
 }


### PR DESCRIPTION
Uses negotiated CumulativeAcknowledgement during dispatch, validates a peer frontier against the sender's durable known tail, skips entries cleaned from the pending snapshot, and covers receiver-ahead recovery after sender restart.