### PR TITLE
test(sync): reserve DBIs for randomized engine test

### DIFF
--- a/tests/test_sync_randomized.cpp
+++ b/tests/test_sync_randomized.cpp
@@ -35,7 +35,9 @@ std::shared_ptr<mdbxc::Connection> open_env(const std::string& path) {
     using namespace mdbxc;
     Config c;
     c.pathname = path;
-    c.max_dbs = 8;
+    // SyncEngine owns seven system DBIs; this test also opens an application
+    // table and the origin index while validating changelog pagination.
+    c.max_dbs = 16;
     c.no_subdir = true;
     return Connection::create(c);
 }


### PR DESCRIPTION
## Summary
- raise the randomized sync test DBI limit from 8 to 16
- leave capacity for SyncEngine system stores, the application table, and the origin index

## Validation
- static DBI accounting; full CI pending