### PR TITLE
feat(sync): recover cumulative delivery acknowledgements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Added negotiated `CumulativeAcknowledgement` for ordered logical delivery.
+  Sender outbox metadata now exposes a durable known-tail bound, allowing a
+  receiver-ahead duplicate acknowledgement to clean a verified contiguous
+  prefix after sender restart. Legacy envelope-only delivery peers remain on
+  the conservative exact-sequence acknowledgement contract.
 - Added capability-gated ordered logical delivery dispatch through
   `ILogicalDeliveryPeer`, including the in-process `DirectLogicalDeliveryPeer`.
   Valid cumulative acknowledgements clean the matching sender outbox prefix;

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -566,39 +566,42 @@ unordered and is not implicitly redirected through this outbox.
 that future exchange. Its `Hello` message carries optional capability bits; an
 unknown bit is preserved but does not become negotiated unless both peers expose
 a known capability. `Delivery` wraps a strict `LogicalDeliveryEnvelope`, and
-`Acknowledgement` carries a destination-scoped, conservative cumulative lower
-bound with explicit success/retryability. A successful response is capped at
-the sequence of the delivery it answers, even if the receiver has already
-persisted a higher frontier. This lets the sender validate and clean up only
-the attempted envelope. The first defined capability is `OrderedDelivery`. No
-existing HTTP, WebSocket, or raw pull/push endpoint advertises or accepts this
-protocol yet, so current transports remain backward-compatible raw-sync-only.
-
-Allowing a receiver to acknowledge a frontier ahead of the attempted delivery
-is deferred. That optimization requires a separate recovery contract for
-sender-state rollback, a local known-tail bound, and safe removal of multiple
-pending entries from one acknowledgement.
+`Acknowledgement` carries a destination-scoped cumulative lower bound with
+explicit success/retryability. `OrderedDelivery` alone keeps the conservative
+contract: a success acknowledges exactly the delivery it answers. When both
+peers negotiate `CumulativeAcknowledgement`, the receiver may return its higher
+persisted contiguous frontier for a duplicate. The sender validates that value
+against its own durable outbox known tail, then atomically removes the verified
+contiguous local prefix. This supports a sender restart after the receiver
+committed an earlier delivery but before the sender persisted cleanup. Existing
+peers that implement only the envelope-only delivery virtual method remain on
+the conservative contract. No existing HTTP, WebSocket, or raw pull/push
+endpoint advertises or accepts this protocol yet, so current transports remain
+backward-compatible raw-sync-only.
 
 `SyncEngine::apply_ordered_logical_delivery_envelope()` is the receiver-side
 implementation of `OrderedDelivery`. `_mdbxc_logical_delivery_order` stores the
 highest committed contiguous sequence for each remote origin. A sequence at or
-below that frontier is a successful no-op acknowledged through the attempted
-sequence; this intentionally caps the receiver's higher frontier. Only the
-exact next sequence reaches schema validation and adapters; a gap is a
-retryable acknowledgement and leaves both user data and markers untouched. The
-generic unordered delivery API remains separate, so applications do not acquire
-ordering merely by changing a call site. Order-state advance, replay marker, and
-adapter mutations commit in one transaction.
+below that frontier is a successful no-op. It acknowledges through the attempted
+sequence by default, or through the persisted frontier when the sender advertises
+`CumulativeAcknowledgement`. Only the exact next sequence reaches schema
+validation and adapters; a gap is a retryable acknowledgement and leaves both
+user data and markers untouched. The generic unordered delivery API remains
+separate, so applications do not acquire ordering merely by changing a call site.
+Order-state advance, replay marker, and adapter mutations commit in one
+transaction.
 
 `ILogicalDeliveryPeer` and `DirectLogicalDeliveryPeer` provide the capability-
 gated dispatch boundary. `SyncEngine::deliver_pending_logical_deliveries()`
 checks destination identity and negotiated `OrderedDelivery` before sending its
-outbox prefix. Each valid cumulative acknowledgement advances only that
-destination's local outbox frontier; a retryable negative acknowledgement can
-still acknowledge an earlier prefix. Receiver marker retention remains an
-explicit lifecycle choice: `prune_ordered_logical_delivery_markers(origin)`
-prunes only through the persisted contiguous frontier. It must be used only for
-origins that do not mix legacy unordered delivery with the ordered protocol.
+outbox prefix. A negotiated cumulative success is bounded by the sender's
+durable known tail, so it can safely clean a prefix that was delivered before a
+sender restart; entries already removed by that acknowledgement are skipped from
+the in-memory pending snapshot. A retryable negative acknowledgement can still
+acknowledge only an earlier prefix. Receiver marker retention remains an explicit
+lifecycle choice: `prune_ordered_logical_delivery_markers(origin)` prunes only
+through the persisted contiguous frontier. It must be used only for origins that
+do not mix legacy unordered delivery with the ordered protocol.
 
 `LogicalDeliveryStore` persists one monotonic per-origin watermark in the
 optional `_mdbxc_logical_delivery_watermarks` DBI. The DBI is created lazily by

--- a/include/mdbx_containers/sync/ILogicalDeliveryPeer.hpp
+++ b/include/mdbx_containers/sync/ILogicalDeliveryPeer.hpp
@@ -27,7 +27,7 @@ namespace sync {
         /// \brief Delivers one request with sender feature context.
         /// \details The default preserves existing peers that implemented the
         /// earlier envelope-only virtual method. Such peers remain on the
-        /// conservative acknowledgement path until they override this overload.
+        /// conservative acknowledgement path until they override this method.
         virtual LogicalDeliveryAcknowledgement deliver_ordered_logical_request(
                 const LogicalDeliveryRequest& request,
                 const CodecBounds* bounds = nullptr) {

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -735,9 +735,10 @@ namespace sync {
         }
 
         /// \brief Delivers a pending ordered outbox prefix to one capable peer.
-        /// \details A validated cumulative acknowledgement first advances the
-        /// local outbox frontier. A failed acknowledgement can advance only an
-        /// earlier prefix; it can never acknowledge the delivery that failed.
+        /// \details A negotiated cumulative acknowledgement can advance through
+        /// the sender's persisted known tail, including after restart. A failed
+        /// acknowledgement can advance only an earlier prefix; it can never
+        /// acknowledge the delivery that failed.
         /// Existing raw sync peers do not implement \c ILogicalDeliveryPeer and
         /// therefore cannot be passed to this opt-in API.
         LogicalDeliveryDispatchResult deliver_pending_logical_deliveries(
@@ -758,18 +759,32 @@ namespace sync {
                     return LogicalDeliveryDispatchResult::failure(
                         "Logical delivery peer does not support OrderedDelivery");
                 }
+                const bool cumulative_acknowledgement_negotiated =
+                    logical_delivery_capability_negotiated(
+                        local.capabilities, remote.capabilities,
+                        LogicalDeliveryCapability::CumulativeAcknowledgement);
 
                 LogicalDeliveryDispatchResult out;
                 const std::vector<LogicalDeliveryEnvelope> pending =
                     pending_logical_deliveries(destination, limit, bounds);
                 out.acknowledged_through =
                     logical_delivery_acknowledged_through(destination);
+                const std::uint64_t known_tail =
+                    logical_delivery_known_tail(destination);
                 for (std::size_t i = 0; i < pending.size(); ++i) {
+                    if (pending[i].origin_sequence <=
+                        out.acknowledged_through) {
+                        continue;
+                    }
+                    LogicalDeliveryRequest request;
+                    request.envelope = pending[i];
+                    request.sender_capabilities = local.capabilities;
                     const LogicalDeliveryAcknowledgement acknowledgement =
-                        peer.deliver_ordered_logical_delivery(pending[i], bounds);
+                        peer.deliver_ordered_logical_delivery(request, bounds);
                     try {
-                        validate_logical_delivery_acknowledgement_for_delivery(
-                            acknowledgement, pending[i], bounds);
+                        validate_logical_delivery_acknowledgement_for_sender(
+                            acknowledgement, pending[i], known_tail,
+                            cumulative_acknowledgement_negotiated, bounds);
                     } catch (const std::exception& e) {
                         return LogicalDeliveryDispatchResult::failure(
                             e.what());

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -780,7 +780,7 @@ namespace sync {
                     request.envelope = pending[i];
                     request.sender_capabilities = local.capabilities;
                     const LogicalDeliveryAcknowledgement acknowledgement =
-                        peer.deliver_ordered_logical_delivery(request, bounds);
+                        peer.deliver_ordered_logical_request(request, bounds);
                     try {
                         validate_logical_delivery_acknowledgement_for_sender(
                             acknowledgement, pending[i], known_tail,

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -3624,6 +3624,88 @@ void test_ordered_logical_delivery_dispatch_cleans_outbox_and_markers() {
     cleanup(receiver_path);
 }
 
+void test_cumulative_logical_delivery_acknowledgement_recovers_after_restart() {
+    const std::string sender_path = "test_cumulative_logical_sender.mdbx";
+    const std::string receiver_path = "test_cumulative_logical_receiver.mdbx";
+    const std::string dbi_name = "cumulative_logical_dispatch";
+    const std::string schema_id = "app.cumulative_logical_dispatch.v1";
+    cleanup(sender_path);
+    cleanup(receiver_path);
+
+    mdbxc::Config sender_cfg;
+    sender_cfg.pathname = sender_path;
+    sender_cfg.max_dbs = 20;
+    sender_cfg.no_subdir = true;
+    mdbxc::Config receiver_cfg = sender_cfg;
+    receiver_cfg.pathname = receiver_path;
+    std::shared_ptr<mdbxc::Connection> sender_conn =
+        mdbxc::Connection::create(sender_cfg);
+    std::shared_ptr<mdbxc::Connection> receiver_conn =
+        mdbxc::Connection::create(receiver_cfg);
+
+    const mdbxc::sync::NodeId sender_node = make_node(0x51);
+    const mdbxc::sync::NodeId receiver_node = make_node(0x61);
+    const mdbxc::sync::DbId sender_db = make_node(0x71);
+    const mdbxc::sync::DbId receiver_db = make_node(0x81);
+    mdbxc::sync::SyncEngine receiver(receiver_conn);
+    receiver.initialize_local_identity(receiver_node, receiver_db);
+    receiver.register_logical_schema(schema_id, make_record(dbi_name));
+
+    mdbxc::KeyValueTable<int, std::string> table(receiver_conn, dbi_name);
+    int apply_calls = 0;
+    CountingDeliveryLogicalAdapter adapter(table, schema_id, apply_calls);
+    receiver.register_logical_adapter(adapter);
+
+    mdbxc::sync::LogicalSchemaRef ref;
+    ref.schema_id = schema_id;
+    ref.kind = mdbxc::sync::LogicalTableKind::KeyValue;
+    ref.schema_version = 1u;
+    mdbxc::sync::LogicalChangeFrame frame;
+    frame.changes.push_back(mdbxc::sync::LogicalChange(
+        ref, 1u, 0u, std::vector<std::uint8_t>()));
+    std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending;
+    {
+        mdbxc::sync::SyncEngine sender(sender_conn);
+        sender.initialize_local_identity(sender_node, sender_db);
+        sender.enqueue_logical_delivery(receiver_db, frame);
+        sender.enqueue_logical_delivery(receiver_db, frame);
+        pending = sender.pending_logical_deliveries(receiver_db);
+        MDBXC_TEST_ASSERT(pending.size() == 2u);
+        MDBXC_TEST_ASSERT(receiver.apply_ordered_logical_delivery_envelope(
+            pending[0]).ok);
+        MDBXC_TEST_ASSERT(receiver.apply_ordered_logical_delivery_envelope(
+            pending[1]).ok);
+        MDBXC_TEST_ASSERT(apply_calls == 2);
+        MDBXC_TEST_ASSERT(sender.logical_delivery_known_tail(receiver_db) == 2u);
+    }
+    sender_conn->disconnect();
+    sender_conn.reset();
+    sender_conn = mdbxc::Connection::create(sender_cfg);
+
+    {
+        mdbxc::sync::SyncEngine restarted_sender(sender_conn);
+        restarted_sender.initialize_local_identity(sender_node, sender_db);
+        mdbxc::sync::DirectLogicalDeliveryPeer peer(receiver);
+        const mdbxc::sync::LogicalDeliveryDispatchResult dispatched =
+            restarted_sender.deliver_pending_logical_deliveries(
+                peer, receiver_db, 1u);
+        MDBXC_TEST_ASSERT(dispatched.ok);
+        MDBXC_TEST_ASSERT(dispatched.delivered == 1u);
+        MDBXC_TEST_ASSERT(dispatched.acknowledged_through == 2u);
+        MDBXC_TEST_ASSERT(
+            restarted_sender.logical_delivery_acknowledged_through(receiver_db) ==
+            2u);
+        MDBXC_TEST_ASSERT(
+            restarted_sender.pending_logical_deliveries(receiver_db).empty());
+        MDBXC_TEST_ASSERT(apply_calls == 2);
+    }
+
+    sender_conn->disconnect();
+    receiver_conn->disconnect();
+    cleanup(sender_path);
+    cleanup(receiver_path);
+}
+
 void test_ordered_logical_delivery_loopback_cleans_outbox() {
     const std::string path = "test_ordered_logical_loopback.mdbx";
     const std::string dbi_name = "ordered_logical_loopback";
@@ -3768,6 +3850,7 @@ int main() {
     test_logical_outbox_acknowledgement_gap_preserves_caller_transaction();
     test_ordered_logical_delivery_enforces_receiver_frontier();
     test_ordered_logical_delivery_dispatch_cleans_outbox_and_markers();
+    test_cumulative_logical_delivery_acknowledgement_recovers_after_restart();
     test_ordered_logical_delivery_loopback_cleans_outbox();
     test_ordered_logical_delivery_dispatch_rejects_invalid_acknowledgements();
     return 0;


### PR DESCRIPTION
Uses negotiated CumulativeAcknowledgement during dispatch, validates a peer frontier against the sender's durable known tail, skips entries cleaned from the pending snapshot, and covers receiver-ahead recovery after sender restart.

Restacked from closed PR #222 after its former stacked base was merged and deleted.