### PR TITLE
docs(sync): clarify VectorStore raw replication boundary

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -83,7 +83,9 @@
   перед подключением `mdbx_containers/sync.hpp`.
 - v0.1 захватывает обычные write-path'ы `KeyValueTable`, `KeyTable`,
   `ValueTable` и `SequenceTable`; `VectorStore` реплицируется косвенно через
-  внутренние `SequenceTable` и `KeyValueTable`.
+  внутренние `SequenceTable` и `KeyValueTable`. Это raw physical репликация
+  для leader/follower либо для одного внешне сериализованного writer'а на
+  коллекцию, а не multi-writer logical репликация.
 - `AnyValueTable`, `KeyMultiValueTable`, `KeyOrderedMultiValueTable` и
   `HashedKeyValueStore` не реплицируются в v0.1. Для `KeyMultiValueTable` в
   `sync/DESIGN.md` описан отложенный unordered multiset sync design.
@@ -271,6 +273,14 @@ metadata filtering и генерация embeddings не входят в обл�
 
 Имена коллекций валидируются, а не переписываются: используйте непустые имена
 только из ASCII-букв, цифр, `_` и `-`.
+
+Сейчас sync воспроизводит четыре внутренних DBI этого store как raw physical
+изменения. На всех replica используйте одно имя коллекции, одну vector metric
+и совместимый embedding codec. У коллекции должен быть один authoritative
+writer либо приложение должно внешне сериализовать всех writer'ов: локальный
+`add()` выделяет id из локального состояния и не даёт cross-node identity
+allocation или conflict resolution. Logical sync adapter для `VectorStore`
+пока отсутствует.
 
 ```cpp
 #include <mdbx_containers/vector.hpp>

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@
   `mdbx_containers/sync.hpp`.
 - v0.1 captures normal write paths for `KeyValueTable`, `KeyTable`,
   `ValueTable`, and `SequenceTable`; `VectorStore` is replicated indirectly
-  through its internal `SequenceTable` and `KeyValueTable` members.
+  through its internal `SequenceTable` and `KeyValueTable` members. This is
+  raw physical replication for a leader/follower or otherwise externally
+  serialized writer per collection, not multi-writer logical replication.
 - `AnyValueTable`, `KeyMultiValueTable`, `KeyOrderedMultiValueTable`, and
   `HashedKeyValueStore` are not replicated in v0.1. `KeyMultiValueTable` has a
   deferred unordered multiset sync design in `sync/DESIGN.md`.
@@ -240,6 +242,13 @@ an exact RAM index on open. It is intended as a local RAG MVP: search is exact
 filtering, and generated embeddings are out of scope.
 Collection names are validated, not rewritten: use non-empty names containing
 only ASCII letters, digits, `_`, and `-`.
+
+Sync currently replays this store's four internal DBIs as raw physical changes.
+Use the same collection name, vector metric, and compatible embedding codec on
+every replica. A collection has one authoritative writer, or the application
+must serialize all writers externally: local `add()` allocates ids from local
+state and does not provide cross-node identity allocation or conflict
+resolution. There is no logical `VectorStore` sync adapter yet.
 
 ```cpp
 #include <mdbx_containers/vector.hpp>

--- a/guides/sync-table-coverage.md
+++ b/guides/sync-table-coverage.md
@@ -18,7 +18,7 @@ values during transport, and remote apply replays the captured physical
 | `KeyTable<K>` | Supported | `Put`, `Delete`, `ClearTable`; insert, erase, range erase, and clear paths are implemented. | Raw key bytes are replayed with empty values. | `test_sync_capture`, `test_sync_engine`, `test_sync_replication` |
 | `ValueTable<V>` | Supported | `Put`, `Delete`, `ClearTable`; set, insert, update, erase, and clear paths are implemented. | The singleton physical key and serialized value bytes are replayed. | `test_sync_capture`, `test_sync_replication` |
 | `SequenceTable<V>` | Supported | `Put`, `Delete`, `ClearTable`; append, `insert_or_assign`, erase, and clear paths are implemented. | Stable `uint64_t` sequence keys and value bytes are replayed. | `test_sync_capture`, `test_sync_replication` |
-| `VectorStore` | Indirectly supported | Captured through its internal `SequenceTable` and `KeyValueTable` members. | The internal table operations are replicated; `VectorStore` has no separate wire type. Already-open instances compare `Connection::sync_apply_generation()` and lazily rebuild their RAM index before index-dependent operations after remote apply. A connection apply/read barrier serializes remote `handle_push()` apply commits with cache-backed `VectorStore` operations. Each `VectorStore` instance serializes its own methods; C++17 builds let different readers share the connection read side, while C++11 builds use an exclusive connection mutex fallback. | `test_sync_capture`, `test_sync_replication` |
+| `VectorStore` | Indirectly supported | Captured through its internal `SequenceTable` and `KeyValueTable` members. | The internal table operations are replicated; `VectorStore` has no separate wire type. This raw path requires one authoritative or externally serialized writer per collection. Already-open instances compare `Connection::sync_apply_generation()` and lazily rebuild their RAM index before index-dependent operations after remote apply. A connection apply/read barrier serializes remote `handle_push()` apply commits with cache-backed `VectorStore` operations. Each `VectorStore` instance serializes its own methods; C++17 builds let different readers share the connection read side, while C++11 builds use an exclusive connection mutex fallback. | `test_sync_capture`, `test_sync_replication` |
 | `AnyValueTable<K>` | Deferred | No `ChangeOp` in v0.1. | Not applied by sync as a typed heterogeneous table. | `test_sync_capture` negative coverage |
 | `KeyMultiValueTable<K, V>` | Deferred | No `ChangeOp` in v0.1. | DUPSORT duplicate multiplicity and unordered multiset semantics are deferred. | `test_sync_capture` negative coverage |
 | `KeyOrderedMultiValueTable<K, V>` | Deferred | No `ChangeOp` in v0.1. | Per-key append order is explicit in local storage, but sync capture/apply is deferred until ordered multi-value wire semantics are tested. | `test_sync_capture` negative coverage |
@@ -61,6 +61,21 @@ logical or raw `ChangeOp` records.
 Focused capture and round-trip tests currently cover representative write,
 delete, bulk, range-erase, wrapper-specific `ClearTable`, indirect
 `VectorStore`, and deferred-table negative paths.
+
+## VectorStore Raw Replication Boundary
+
+`VectorStore` currently participates only through raw replication of its four
+internal DBIs: ids, embeddings, text, and metadata. This supports a
+leader/follower topology or an application that serializes writers externally.
+It does not provide a distributed id allocator, cross-node conflict resolution,
+or a logical `VectorStore` wire type.
+
+Replicas must use the same collection name, vector metric, and compatible
+embedding serialization. A remote apply invalidates an already-open store's
+RAM index through the connection generation and it rebuilds lazily before the
+next index-dependent operation. A future multi-DBI logical adapter needs a
+global record identity scheme and explicit ordering/conflict policy before this
+restriction can be relaxed.
 
 ## Deferred Table Rules
 

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -13,7 +13,9 @@ rules, see [Sync table coverage matrix](sync-table-coverage.md).
   `ThreadLocalChangeAccumulator` is attached to the writing `Connection`;
   `SyncCaptureScope` provides RAII attach/restore for write phases.
 - `VectorStore` is covered indirectly through its internal `SequenceTable` and
-  `KeyValueTable` members.
+  `KeyValueTable` members. This is raw physical replication only: use one
+  authoritative or externally serialized writer per collection. It is not a
+  multi-writer logical `VectorStore` contract.
 - Standalone writes become standalone sync batches; an explicit transaction
   spanning multiple supported tables becomes one local atomic batch.
 - Reads, scans, vector search, and other non-mutating APIs are not captured.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -93,7 +93,7 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
 | `KeyTable` | Supported | Captures insert/delete, range erase, reconcile/clear paths that operate on physical keys. |
 | `ValueTable` | Supported | Captures singleton put/delete/clear using its fixed physical key. |
 | `SequenceTable` | Supported | Captures set/append/delete/clear against stable `uint64_t` record ids. `append()` remains a local single-writer helper; external synchronization is still required for concurrent appenders. |
-| `VectorStore` | Supported indirectly | Does not own a separate wire format. Its persistent writes go through `SequenceTable` and `KeyValueTable` member tables. Already-open instances refresh their RAM index lazily after completed remote apply when the connection sync-apply generation changes. |
+| `VectorStore` | Supported indirectly | Does not own a separate wire format. Its persistent writes go through `SequenceTable` and `KeyValueTable` member tables. Raw replication requires one authoritative or externally serialized writer per collection. Already-open instances refresh their RAM index lazily after completed remote apply when the connection sync-apply generation changes. |
 | `AnyValueTable` | Not supported in v0.1 | Deferred until heterogeneous value type tags are part of the sync wire format. |
 | `KeyMultiValueTable` | Not supported in v0.1 | Deferred until unordered multiset replication and DUPSORT duplicate-value payload framing are implemented and tested. |
 | `KeyOrderedMultiValueTable` | Not supported in v0.1 | Local ordered multi-value table exists, but sync capture/apply is deferred until ordered-history wire identity and conflict semantics are specified and tested. |
@@ -107,6 +107,16 @@ new wire-format semantics.
 be non-empty and contain only ASCII letters, digits, `_`, and `-`; unsupported
 characters are rejected before internal DBI names are built. This prevents
 different logical collections from collapsing to the same physical DBI names.
+
+`VectorStore` sync is currently a raw physical replication path over its ids,
+embeddings, text, and metadata DBIs. Replicas must agree on collection name,
+vector metric, and embedding serialization. `VectorStore::add()` assigns ids
+from local table state, so concurrent independent writers can collide and have
+no conflict-resolution rule. The supported topology is therefore
+leader/follower or application-serialized writers per collection. A future
+multi-DBI logical adapter must introduce a global record identity scheme and
+explicit ordering/conflict semantics; raw capture must not be presented as that
+adapter.
 
 `Connection::sync_apply_generation()` is a coarse invalidation marker for sync
 apply commits. `SyncEngine::handle_push()` increments it after a successful


### PR DESCRIPTION
## Summary
- document the current leader/follower or externally serialized-writer requirement for each VectorStore collection
- state replica compatibility requirements for collection, metric, and embedding serialization
- distinguish raw physical replication from the future multi-DBI logical adapter

## Validation
- documentation-only diff
- parent PR #229: MinGW C++11/C++17 `table_sequence_test` and standalone-header smoke