### PR TITLE
feat(sync): add KeyMultiValue logical capture

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -87,8 +87,12 @@
   для leader/follower либо для одного внешне сериализованного writer'а на
   коллекцию, а не multi-writer logical репликация.
 - `AnyValueTable`, `KeyMultiValueTable`, `KeyOrderedMultiValueTable` и
-  `HashedKeyValueStore` не реплицируются в v0.1. Для `KeyMultiValueTable` в
-  `sync/DESIGN.md` описан отложенный unordered multiset sync design.
+  `HashedKeyValueStore` не имеют raw-репликации в v0.1.
+  `KeyMultiValueTableLogicalAdapter` даёт opt-in logical capture для
+  неупорядоченных `insert`, удаления ключа, удаления всех совпадающих значений и очистки при
+  одном writer'е либо причинно сериализованных обновлениях. Raw-вызовы,
+  `append`, `reconcile` и удаление диапазона остаются за пределами scope этого
+  adapter-а. См. `sync/DESIGN.md`.
   `KeyOrderedMultiValueTable` является order-sensitive table API, но её
   sync capture/apply контракт остаётся выключенным, пока не появятся capture и
   round-trip tests. Для `AnyValueTable` и `HashedKeyValueStore` ещё нужны

--- a/README.md
+++ b/README.md
@@ -61,8 +61,11 @@
   raw physical replication for a leader/follower or otherwise externally
   serialized writer per collection, not multi-writer logical replication.
 - `AnyValueTable`, `KeyMultiValueTable`, `KeyOrderedMultiValueTable`, and
-  `HashedKeyValueStore` are not replicated in v0.1. `KeyMultiValueTable` has a
-  deferred unordered multiset sync design in `sync/DESIGN.md`.
+  `HashedKeyValueStore` are not raw-replicated in v0.1.
+  `KeyMultiValueTableLogicalAdapter` provides opt-in logical capture for
+  unordered `insert`, key erase, all-matching-value erase, and clear under a single writer
+  or causally serialized updates. Raw calls, `append`, `reconcile`, and range
+  erase remain outside that adapter scope. See `sync/DESIGN.md`.
   `KeyOrderedMultiValueTable` is the order-sensitive table API, but its sync
   capture/apply contract remains disabled until capture and round-trip tests
   exist. `AnyValueTable` and `HashedKeyValueStore` still need type-tag and

--- a/guides/sync-table-coverage.md
+++ b/guides/sync-table-coverage.md
@@ -104,6 +104,11 @@ unordered multiset model. Repeated identical `(key, value)` pairs preserve
 multiplicity under single-writer or causally serialized updates. Raw v0.1
 capture, bulk/reconcile/range capture, and general concurrent destructive
 updates remain deferred.
+Before adding another `KeyMultiValueTableLogicalAdapter` opcode or capture
+method, expand its malformed-payload regression matrix to cover truncated
+pair payloads, oversized declared lengths, trailing bytes, payload-bearing
+clear, and unknown opcodes. This is deferred coverage work for the next
+logical-adapter extension, not a claim that those operations are supported.
 The detailed deferred contract lives in
 `include/mdbx_containers/sync/DESIGN.md`: it requires explicit multivalue wire
 sub-operations and receiver-side logical apply helpers before capture can be

--- a/guides/sync-table-coverage.md
+++ b/guides/sync-table-coverage.md
@@ -20,7 +20,7 @@ values during transport, and remote apply replays the captured physical
 | `SequenceTable<V>` | Supported | `Put`, `Delete`, `ClearTable`; append, `insert_or_assign`, erase, and clear paths are implemented. | Stable `uint64_t` sequence keys and value bytes are replayed. | `test_sync_capture`, `test_sync_replication` |
 | `VectorStore` | Indirectly supported | Captured through its internal `SequenceTable` and `KeyValueTable` members. | The internal table operations are replicated; `VectorStore` has no separate wire type. This raw path requires one authoritative or externally serialized writer per collection. Already-open instances compare `Connection::sync_apply_generation()` and lazily rebuild their RAM index before index-dependent operations after remote apply. A connection apply/read barrier serializes remote `handle_push()` apply commits with cache-backed `VectorStore` operations. Each `VectorStore` instance serializes its own methods; C++17 builds let different readers share the connection read side, while C++11 builds use an exclusive connection mutex fallback. | `test_sync_capture`, `test_sync_replication` |
 | `AnyValueTable<K>` | Deferred | No `ChangeOp` in v0.1. | Not applied by sync as a typed heterogeneous table. | `test_sync_capture` negative coverage |
-| `KeyMultiValueTable<K, V>` | Deferred | No `ChangeOp` in v0.1. | DUPSORT duplicate multiplicity and unordered multiset semantics are deferred. | `test_sync_capture` negative coverage |
+| `KeyMultiValueTable<K, V>` | Limited logical adapter | No raw `ChangeOp` in v0.1. | `KeyMultiValueTableLogicalAdapter` explicitly captures unordered insert, key erase, all-matching-value erase, and clear for one writer or causally serialized updates. Raw calls, append, reconcile, range erase, and general multi-writer destructive convergence remain deferred. | `test_key_value_logical_adapter`, `test_sync_capture` negative coverage |
 | `KeyOrderedMultiValueTable<K, V>` | Deferred | No `ChangeOp` in v0.1. | Per-key append order is explicit in local storage, but sync capture/apply is deferred until ordered multi-value wire semantics are tested. | `test_sync_capture` negative coverage |
 | `HashedKeyValueStore<K, V, H, Layout>` | Deferred | No `ChangeOp` in v0.1. | Hash-index identity and logical-key mapping are deferred. | `test_sync_capture` negative coverage |
 
@@ -99,9 +99,11 @@ successful while source and destination table semantics diverge.
 
 ## Deferred Designs
 
-`KeyMultiValueTable<K, V>` needs an unordered multiset model before v0.1 can
-claim support for duplicate values. Repeated identical `(key, value)` pairs
-must preserve multiplicity under single-writer or causally serialized updates.
+`KeyMultiValueTable<K, V>` has a limited explicit logical adapter for the
+unordered multiset model. Repeated identical `(key, value)` pairs preserve
+multiplicity under single-writer or causally serialized updates. Raw v0.1
+capture, bulk/reconcile/range capture, and general concurrent destructive
+updates remain deferred.
 The detailed deferred contract lives in
 `include/mdbx_containers/sync/DESIGN.md`: it requires explicit multivalue wire
 sub-operations and receiver-side logical apply helpers before capture can be

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -75,9 +75,10 @@ These table families intentionally emit no `ChangeOp` in v0.1:
 
 - `AnyValueTable`, until a wire-level type tag and compatibility policy is
   specified.
-- `KeyMultiValueTable`, until the deferred unordered multiset design for
-  single-writer or causally serialized updates in `sync/DESIGN.md` is
-  implemented and covered by capture and round-trip tests.
+- raw `KeyMultiValueTable` capture, bulk/reconcile/range operations, and
+  general multi-writer destructive convergence. The explicit unordered logical
+  adapter covers only insert, key erase, all-matching-value erase, and clear for one writer
+  or causally serialized updates.
 - `KeyOrderedMultiValueTable`, until its ordered multi-value sync wire contract
   and round-trip tests are implemented.
 - `HashedKeyValueStore`, until the relationship between logical key bytes,
@@ -101,6 +102,9 @@ The logical sync scaffolding is preparatory only:
 - `KeyValueTableLogicalAdapter` and `KeyTableLogicalAdapter` are explicit
   apply helpers with opt-in typed capture sessions. Neither is connected to
   the transport pull/push path yet; callers own logical frame delivery.
+- `KeyMultiValueTableLogicalAdapter` follows the same explicit logical-frame
+  path for its limited unordered multiset operation set. It does not enable raw
+  `ChangeOp` capture for the table wrapper.
 - Logical delivery replay markers can be pruned through a persisted per-origin
   watermark. The watermark DBI is created lazily on the first pruning call, so
   deployments that use pruning must reserve one additional named-DBI slot in
@@ -120,14 +124,14 @@ tables.
 - Add optional table identity filters on top of the affected DBI names already
   reported by `ISyncApplyObserver`, if more cached wrappers need narrower
   subscriptions.
-- Add codec framing for logical table changes, including capability bits and
-  fail-closed tests for old or capability-limited decoders.
+- Extend logical-frame capability negotiation only when a new adapter requires
+  a compatibility distinction beyond the existing schema marker and adapter
+  registry fail-closed checks.
 - Integrate `LogicalTableRegistry` with `SyncEngine::handle_push()` only after
   logical changes can be parsed separately from raw DBI operations.
-- Prototype `KeyMultiValueTable` capture/apply using the deferred
-  single-writer/serialized unordered multiset design. Add explicit wire
-  sub-operation framing, registry integration, and repeated-pair round-trip
-  tests before enabling capture.
+- Extend `KeyMultiValueTable` logical capture only after every added bulk or
+  reconcile operation has explicit multiset replay semantics and round-trip
+  coverage. Raw capture remains disabled.
 - Implement the deferred full snapshot protocol before treating
   `SnapshotRequired` as automatically recoverable by sync itself.
 - Define explicit conflict/CRDT semantics before claiming general concurrent

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -95,7 +95,7 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
 | `SequenceTable` | Supported | Captures set/append/delete/clear against stable `uint64_t` record ids. `append()` remains a local single-writer helper; external synchronization is still required for concurrent appenders. |
 | `VectorStore` | Supported indirectly | Does not own a separate wire format. Its persistent writes go through `SequenceTable` and `KeyValueTable` member tables. Raw replication requires one authoritative or externally serialized writer per collection. Already-open instances refresh their RAM index lazily after completed remote apply when the connection sync-apply generation changes. |
 | `AnyValueTable` | Not supported in v0.1 | Deferred until heterogeneous value type tags are part of the sync wire format. |
-| `KeyMultiValueTable` | Not supported in v0.1 | Deferred until unordered multiset replication and DUPSORT duplicate-value payload framing are implemented and tested. |
+| `KeyMultiValueTable` | Limited logical adapter | Raw v0.1 capture remains unsupported. `KeyMultiValueTableLogicalAdapter` explicitly captures unordered insert, key erase, all-matching-value erase, and clear under one-writer or causally serialized updates. |
 | `KeyOrderedMultiValueTable` | Not supported in v0.1 | Local ordered multi-value table exists, but sync capture/apply is deferred until ordered-history wire identity and conflict semantics are specified and tested. |
 | `HashedKeyValueStore` | Not supported in v0.1 | Deferred until hash-index and identity-key mapping semantics are specified. |
 
@@ -148,8 +148,8 @@ C++11 builds fall back to an exclusive connection mutex model.
 
 This section documents the logical replication contract for
 `KeyMultiValueTable`. Raw v0.1 capture remains unsupported:
-`KeyMultiValueTable` emits no raw `ChangeOp` records. A future explicit typed
-capture session may emit only the operations defined by this contract.
+`KeyMultiValueTable` emits no raw `ChangeOp` records. Its explicit typed
+capture session emits only the operations defined by this contract.
 
 `KeyMultiValueTable` cannot safely reuse the v0.1 raw DBI put/delete model as
 an undocumented implementation detail. The table stores one MDBX DUPSORT record

--- a/include/mdbx_containers/sync/adapters/KeyMultiValueTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyMultiValueTableLogicalAdapter.hpp
@@ -116,6 +116,9 @@ namespace sync {
         /// capture for its mutations. It captures only unordered multiset
         /// operations exposed by this class; direct table calls, bulk
         /// reconciliation, and range erasure remain local-only operations.
+        /// The adapter, table, and connection referenced by the adapter must
+        /// outlive the session. If a mutation throws after it begins, the
+        /// session rolls back its transaction and becomes inactive.
         class LogicalCaptureSession {
         public:
             explicit LogicalCaptureSession(
@@ -166,7 +169,7 @@ namespace sync {
                     }
                     return removed;
                 } catch (...) {
-                    m_pending.resize(previous_size);
+                    abort_after_mutation_failure(previous_size);
                     throw;
                 }
             }
@@ -187,7 +190,7 @@ namespace sync {
                     }
                     return removed;
                 } catch (...) {
-                    m_pending.resize(previous_size);
+                    abort_after_mutation_failure(previous_size);
                     throw;
                 }
             }
@@ -263,9 +266,23 @@ namespace sync {
                         *m_adapter.m_table.connection(), m_txn.handle());
                     mutation();
                 } catch (...) {
-                    m_pending.resize(previous_size);
+                    abort_after_mutation_failure(previous_size);
                     throw;
                 }
+            }
+
+            void abort_after_mutation_failure(
+                    std::size_t previous_size) noexcept {
+                try {
+                    m_pending.resize(previous_size);
+                } catch (...) {
+                    m_pending.clear();
+                }
+                try {
+                    m_txn.rollback();
+                } catch (...) {
+                }
+                m_active = false;
             }
 
             void ensure_active() const {

--- a/include/mdbx_containers/sync/adapters/KeyMultiValueTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyMultiValueTableLogicalAdapter.hpp
@@ -5,8 +5,10 @@
 /// \file KeyMultiValueTableLogicalAdapter.hpp
 /// \brief Logical adapter for unordered \c KeyMultiValueTable operations.
 
+#include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -14,6 +16,7 @@
 #include <vector>
 
 #include "../../KeyMultiValueTable.hpp"
+#include "../ILogicalDeliveryOutbox.hpp"
 #include "KeyValueTableLogicalAdapter.hpp"
 
 namespace mdbxc {
@@ -106,6 +109,181 @@ namespace sync {
             change.schema = schema_ref();
             change.opcode = KeyMultiValueLogicalClear;
             return change;
+        }
+
+        /// \brief Transaction-bound typed logical capture session.
+        /// \details The session owns a writable transaction and suppresses raw
+        /// capture for its mutations. It captures only unordered multiset
+        /// operations exposed by this class; direct table calls, bulk
+        /// reconciliation, and range erasure remain local-only operations.
+        class LogicalCaptureSession {
+        public:
+            explicit LogicalCaptureSession(
+                    const KeyMultiValueTableLogicalAdapter& adapter)
+                : m_adapter(adapter),
+                  m_txn(adapter.m_table.connection()->transaction(
+                      TransactionMode::WRITABLE)),
+                  m_active(true) {
+                const LogicalApplyResult marker_result =
+                    validate_logical_adapter_marker(
+                        m_txn.handle(),
+                        adapter.m_table.connection()->env_handle(),
+                        adapter);
+                if (!marker_result.ok) {
+                    throw std::runtime_error(marker_result.error);
+                }
+            }
+
+            ~LogicalCaptureSession() noexcept {
+                rollback();
+            }
+
+            LogicalCaptureSession(const LogicalCaptureSession&) = delete;
+            LogicalCaptureSession& operator=(
+                    const LogicalCaptureSession&) = delete;
+
+            void insert(const KeyT& key, const ValueT& value) {
+                ensure_active();
+                append_then_mutate(m_adapter.make_insert_one(key, value),
+                    [this, &key, &value]() {
+                        m_adapter.m_table.insert(
+                            key, value, m_txn.handle());
+                    });
+            }
+
+            bool erase(const KeyT& key) {
+                ensure_active();
+                const LogicalChange change = m_adapter.make_erase_key(key);
+                const std::size_t previous_size = m_pending.size();
+                m_pending.push_back(change);
+                try {
+                    Connection::SyncCaptureSuppressionScope suppress_capture(
+                        *m_adapter.m_table.connection(), m_txn.handle());
+                    const bool removed = m_adapter.m_table.erase(
+                        key, m_txn.handle());
+                    if (!removed) {
+                        m_pending.resize(previous_size);
+                    }
+                    return removed;
+                } catch (...) {
+                    m_pending.resize(previous_size);
+                    throw;
+                }
+            }
+
+            std::size_t erase(const KeyT& key, const ValueT& value) {
+                ensure_active();
+                const LogicalChange change =
+                    m_adapter.make_erase_all_values(key, value);
+                const std::size_t previous_size = m_pending.size();
+                m_pending.push_back(change);
+                try {
+                    Connection::SyncCaptureSuppressionScope suppress_capture(
+                        *m_adapter.m_table.connection(), m_txn.handle());
+                    const std::size_t removed = m_adapter.m_table.erase(
+                        key, value, m_txn.handle());
+                    if (removed == 0u) {
+                        m_pending.resize(previous_size);
+                    }
+                    return removed;
+                } catch (...) {
+                    m_pending.resize(previous_size);
+                    throw;
+                }
+            }
+
+            void clear() {
+                ensure_active();
+                append_then_mutate(m_adapter.make_clear(), [this]() {
+                    m_adapter.m_table.clear(m_txn.handle());
+                });
+            }
+
+            /// \brief Commits local mutations and returns their logical changes.
+            /// \warning The returned changes are not published atomically with
+            /// the table transaction. Use \c commit_to_outbox() when local
+            /// durability and delivery enqueueing must share one transaction.
+            void commit(std::vector<LogicalChange>& out) {
+                ensure_active();
+                const std::size_t old_size = out.size();
+                out.insert(out.end(), m_pending.begin(), m_pending.end());
+                try {
+                    m_txn.commit();
+                } catch (...) {
+                    out.erase(out.begin() +
+                              static_cast<std::ptrdiff_t>(old_size),
+                              out.end());
+                    throw;
+                }
+                m_pending.clear();
+                m_active = false;
+            }
+
+            /// \brief Commits captured mutations and their delivery atomically.
+            LogicalDeliveryEnvelope commit_to_outbox(
+                    ILogicalDeliveryOutbox& outbox,
+                    const DbId& destination,
+                    const CodecBounds* bounds = nullptr) {
+                ensure_active();
+                LogicalChangeFrame frame;
+                frame.changes = m_pending;
+                const LogicalDeliveryEnvelope envelope =
+                    outbox.enqueue_logical_delivery(
+                        m_txn.handle(), destination, frame, bounds);
+                m_txn.commit();
+                m_pending.clear();
+                m_active = false;
+                return envelope;
+            }
+
+            void rollback() noexcept {
+                if (!m_active) {
+                    return;
+                }
+                try {
+                    m_pending.clear();
+                    m_txn.rollback();
+                } catch (...) {
+                }
+                m_active = false;
+            }
+
+            std::size_t pending_size() const {
+                return m_pending.size();
+            }
+
+        private:
+            template<class Mutation>
+            void append_then_mutate(const LogicalChange& change,
+                                    const Mutation& mutation) {
+                const std::size_t previous_size = m_pending.size();
+                m_pending.push_back(change);
+                try {
+                    Connection::SyncCaptureSuppressionScope suppress_capture(
+                        *m_adapter.m_table.connection(), m_txn.handle());
+                    mutation();
+                } catch (...) {
+                    m_pending.resize(previous_size);
+                    throw;
+                }
+            }
+
+            void ensure_active() const {
+                if (!m_active) {
+                    throw std::logic_error(
+                        "KeyMultiValue logical capture session is not active");
+                }
+            }
+
+            const KeyMultiValueTableLogicalAdapter& m_adapter;
+            Transaction m_txn;
+            std::vector<LogicalChange> m_pending;
+            bool m_active;
+        };
+
+        std::unique_ptr<LogicalCaptureSession> begin_capture_session() const {
+            return std::unique_ptr<LogicalCaptureSession>(
+                new LogicalCaptureSession(*this));
         }
 
         LogicalApplyResult preflight(

--- a/include/mdbx_containers/sync/adapters/KeyMultiValueTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyMultiValueTableLogicalAdapter.hpp
@@ -117,8 +117,9 @@ namespace sync {
         /// operations exposed by this class; direct table calls, bulk
         /// reconciliation, and range erasure remain local-only operations.
         /// The adapter, table, and connection referenced by the adapter must
-        /// outlive the session. If a mutation throws after it begins, the
-        /// session rolls back its transaction and becomes inactive.
+        /// outlive the session. If a session operation throws after it begins,
+        /// the session requests rollback of its transaction and becomes
+        /// inactive.
         class LogicalCaptureSession {
         public:
             explicit LogicalCaptureSession(
@@ -169,7 +170,7 @@ namespace sync {
                     }
                     return removed;
                 } catch (...) {
-                    abort_after_mutation_failure(previous_size);
+                    rollback_and_deactivate();
                     throw;
                 }
             }
@@ -190,7 +191,7 @@ namespace sync {
                     }
                     return removed;
                 } catch (...) {
-                    abort_after_mutation_failure(previous_size);
+                    rollback_and_deactivate();
                     throw;
                 }
             }
@@ -216,6 +217,7 @@ namespace sync {
                     out.erase(out.begin() +
                               static_cast<std::ptrdiff_t>(old_size),
                               out.end());
+                    rollback_and_deactivate();
                     throw;
                 }
                 m_pending.clear();
@@ -230,25 +232,25 @@ namespace sync {
                 ensure_active();
                 LogicalChangeFrame frame;
                 frame.changes = m_pending;
-                const LogicalDeliveryEnvelope envelope =
-                    outbox.enqueue_logical_delivery(
-                        m_txn.handle(), destination, frame, bounds);
-                m_txn.commit();
-                m_pending.clear();
-                m_active = false;
-                return envelope;
+                try {
+                    const LogicalDeliveryEnvelope envelope =
+                        outbox.enqueue_logical_delivery(
+                            m_txn.handle(), destination, frame, bounds);
+                    m_txn.commit();
+                    m_pending.clear();
+                    m_active = false;
+                    return envelope;
+                } catch (...) {
+                    rollback_and_deactivate();
+                    throw;
+                }
             }
 
             void rollback() noexcept {
                 if (!m_active) {
                     return;
                 }
-                try {
-                    m_pending.clear();
-                    m_txn.rollback();
-                } catch (...) {
-                }
-                m_active = false;
+                rollback_and_deactivate();
             }
 
             std::size_t pending_size() const {
@@ -259,24 +261,21 @@ namespace sync {
             template<class Mutation>
             void append_then_mutate(const LogicalChange& change,
                                     const Mutation& mutation) {
-                const std::size_t previous_size = m_pending.size();
                 m_pending.push_back(change);
                 try {
                     Connection::SyncCaptureSuppressionScope suppress_capture(
                         *m_adapter.m_table.connection(), m_txn.handle());
                     mutation();
                 } catch (...) {
-                    abort_after_mutation_failure(previous_size);
+                    rollback_and_deactivate();
                     throw;
                 }
             }
 
-            void abort_after_mutation_failure(
-                    std::size_t previous_size) noexcept {
+            void rollback_and_deactivate() noexcept {
                 try {
-                    m_pending.resize(previous_size);
-                } catch (...) {
                     m_pending.clear();
+                } catch (...) {
                 }
                 try {
                     m_txn.rollback();

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -1081,6 +1081,8 @@ void test_key_multi_value_logical_capture_session_rolls_back_on_outbox_failure()
     IntStringMultiAdapter adapter(table, schema_id);
     ThrowingLogicalDeliveryOutbox outbox;
     bool caught = false;
+    bool commit_rejected = false;
+    bool retry_rejected = false;
     {
         std::unique_ptr<IntStringMultiAdapter::LogicalCaptureSession> session =
             adapter.begin_capture_session();
@@ -1090,9 +1092,28 @@ void test_key_multi_value_logical_capture_session_rolls_back_on_outbox_failure()
         } catch (const std::runtime_error&) {
             caught = true;
         }
+        MDBXC_TEST_ASSERT(session->pending_size() == 0u);
+
+        std::vector<mdbxc::sync::LogicalChange> changes;
+        try {
+            session->commit(changes);
+        } catch (const std::logic_error&) {
+            commit_rejected = true;
+        }
+        MDBXC_TEST_ASSERT(changes.empty());
+
+        try {
+            session->commit_to_outbox(outbox, make_node(0xDB));
+        } catch (const std::logic_error&) {
+            retry_rejected = true;
+        }
     }
     MDBXC_TEST_ASSERT(caught);
+    MDBXC_TEST_ASSERT(commit_rejected);
+    MDBXC_TEST_ASSERT(retry_rejected);
     MDBXC_TEST_ASSERT(table.count() == 0u);
+    MDBXC_TEST_ASSERT(
+        engine.pending_logical_deliveries(make_node(0xDB)).empty());
 
     conn->disconnect();
     cleanup(path);

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -949,6 +949,225 @@ void test_key_multi_value_logical_adapter_rejects_invalid_payload() {
     cleanup(path);
 }
 
+void test_key_multi_value_logical_capture_session_commits_typed_writes() {
+    const std::string path =
+        "test_key_multi_value_logical_adapter_session.mdbx";
+    const std::string dbi_name = "logical_key_multi_value_session";
+    const std::string schema_id = "app.logical_key_multi_value_session.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId node = make_node(0x4F);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(node, make_node(0xD7));
+    engine.register_logical_schema(
+        schema_id, make_key_multi_value_record(dbi_name));
+
+    mdbxc::KeyMultiValueTable<int, std::string> table(conn, dbi_name);
+    IntStringMultiAdapter adapter(table, schema_id);
+    mdbxc::sync::ThreadLocalChangeAccumulator raw_capture(conn);
+    conn->attach_sync_capture(&raw_capture);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    {
+        std::unique_ptr<IntStringMultiAdapter::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->insert(1, "one");
+        session->insert(1, "one");
+        session->insert(2, "two");
+        MDBXC_TEST_ASSERT(session->erase(1, "one") == 2u);
+        MDBXC_TEST_ASSERT(session->erase(2));
+        session->clear();
+        MDBXC_TEST_ASSERT(session->pending_size() == 6u);
+        session->commit(changes);
+    }
+    conn->detach_sync_capture();
+
+    MDBXC_TEST_ASSERT(changes.size() == 6u);
+    MDBXC_TEST_ASSERT(changes[0].opcode ==
+                      mdbxc::sync::KeyMultiValueLogicalInsertOne);
+    MDBXC_TEST_ASSERT(changes[3].opcode ==
+                      mdbxc::sync::KeyMultiValueLogicalEraseAllValues);
+    MDBXC_TEST_ASSERT(changes[4].opcode ==
+                      mdbxc::sync::KeyMultiValueLogicalEraseKey);
+    MDBXC_TEST_ASSERT(changes[5].opcode ==
+                      mdbxc::sync::KeyMultiValueLogicalClear);
+    MDBXC_TEST_ASSERT(table.count() == 0u);
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        mdbxc::sync::ChangeLogStore changelog(conn->env_handle());
+        changelog.open(txn.handle());
+        MDBXC_TEST_ASSERT(!changelog.contains(txn.handle(), node, 1));
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_multi_value_logical_capture_session_commits_to_outbox() {
+    const std::string path =
+        "test_key_multi_value_logical_adapter_session_outbox.mdbx";
+    const std::string dbi_name = "logical_key_multi_value_session_outbox";
+    const std::string schema_id =
+        "app.logical_key_multi_value_session_outbox.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId node = make_node(0x50);
+    const mdbxc::sync::DbId destination = make_node(0xD8);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(node, make_node(0xD8));
+    engine.register_logical_schema(
+        schema_id, make_key_multi_value_record(dbi_name));
+
+    mdbxc::KeyMultiValueTable<int, std::string> table(conn, dbi_name);
+    IntStringMultiAdapter adapter(table, schema_id);
+    {
+        std::unique_ptr<IntStringMultiAdapter::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->insert(7, "seven");
+        const mdbxc::sync::LogicalDeliveryEnvelope envelope =
+            session->commit_to_outbox(engine, destination);
+        MDBXC_TEST_ASSERT(envelope.destination_db_uuid == destination);
+        MDBXC_TEST_ASSERT(envelope.origin_node_id == node);
+        MDBXC_TEST_ASSERT(envelope.origin_sequence == 1u);
+    }
+
+    MDBXC_TEST_ASSERT(table.count(7, "seven") == 1u);
+    const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending =
+        engine.pending_logical_deliveries(destination);
+    MDBXC_TEST_ASSERT(pending.size() == 1u);
+    MDBXC_TEST_ASSERT(pending[0].frame.changes.size() == 1u);
+    MDBXC_TEST_ASSERT(pending[0].frame.changes[0].opcode ==
+                      mdbxc::sync::KeyMultiValueLogicalInsertOne);
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_multi_value_logical_capture_session_rolls_back_on_outbox_failure() {
+    const std::string path =
+        "test_key_multi_value_logical_adapter_session_outbox_failure.mdbx";
+    const std::string dbi_name =
+        "logical_key_multi_value_session_outbox_failure";
+    const std::string schema_id =
+        "app.logical_key_multi_value_session_outbox_failure.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x53), make_node(0xDA));
+    engine.register_logical_schema(
+        schema_id, make_key_multi_value_record(dbi_name));
+
+    mdbxc::KeyMultiValueTable<int, std::string> table(conn, dbi_name);
+    IntStringMultiAdapter adapter(table, schema_id);
+    ThrowingLogicalDeliveryOutbox outbox;
+    bool caught = false;
+    {
+        std::unique_ptr<IntStringMultiAdapter::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->insert(8, "eight");
+        try {
+            session->commit_to_outbox(outbox, make_node(0xDB));
+        } catch (const std::runtime_error&) {
+            caught = true;
+        }
+    }
+    MDBXC_TEST_ASSERT(caught);
+    MDBXC_TEST_ASSERT(table.count() == 0u);
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_multi_value_logical_frame_replicates_capture_session() {
+    const std::string source_path =
+        "test_key_multi_value_logical_frame_source.mdbx";
+    const std::string replica_path =
+        "test_key_multi_value_logical_frame_replica.mdbx";
+    const std::string dbi_name = "logical_key_multi_value_frame";
+    const std::string schema_id = "app.logical_key_multi_value_frame.v1";
+    cleanup(source_path);
+    cleanup(replica_path);
+
+    mdbxc::Config source_cfg;
+    source_cfg.pathname = source_path;
+    source_cfg.max_dbs = 16;
+    source_cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> source =
+        mdbxc::Connection::create(source_cfg);
+
+    mdbxc::Config replica_cfg;
+    replica_cfg.pathname = replica_path;
+    replica_cfg.max_dbs = 16;
+    replica_cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> replica =
+        mdbxc::Connection::create(replica_cfg);
+
+    mdbxc::sync::SyncEngine source_engine(source);
+    source_engine.initialize_local_identity(make_node(0x51), make_node(0xD9));
+    source_engine.register_logical_schema(
+        schema_id, make_key_multi_value_record(dbi_name));
+
+    mdbxc::sync::SyncEngine replica_engine(replica);
+    replica_engine.initialize_local_identity(make_node(0x52), make_node(0xD9));
+    replica_engine.register_logical_schema(
+        schema_id, make_key_multi_value_record(dbi_name));
+
+    mdbxc::KeyMultiValueTable<int, std::string> source_table(source, dbi_name);
+    mdbxc::KeyMultiValueTable<int, std::string> replica_table(replica, dbi_name);
+    IntStringMultiAdapter source_adapter(source_table, schema_id);
+    IntStringMultiAdapter replica_adapter(replica_table, schema_id);
+    replica_engine.register_logical_adapter(replica_adapter);
+
+    std::vector<mdbxc::sync::LogicalChange> captured;
+    {
+        std::unique_ptr<IntStringMultiAdapter::LogicalCaptureSession> session =
+            source_adapter.begin_capture_session();
+        session->insert(41, "forty-one");
+        session->insert(41, "forty-one");
+        session->insert(41, "other");
+        MDBXC_TEST_ASSERT(session->erase(41, "forty-one") == 2u);
+        session->commit(captured);
+    }
+
+    MDBXC_TEST_ASSERT(source_table.count(41, "forty-one") == 0u);
+    MDBXC_TEST_ASSERT(source_table.count(41, "other") == 1u);
+
+    mdbxc::sync::LogicalChangeFrame frame;
+    frame.changes = captured;
+    const std::vector<std::uint8_t> wire =
+        mdbxc::sync::LogicalChangeFrameCodec::encode(frame);
+    const mdbxc::sync::LogicalApplyResult result =
+        replica_engine.apply_logical_frame_bytes(wire);
+    MDBXC_TEST_ASSERT(result.ok);
+    MDBXC_TEST_ASSERT(replica_table.count(41, "forty-one") == 0u);
+    MDBXC_TEST_ASSERT(replica_table.count(41, "other") == 1u);
+
+    source->disconnect();
+    replica->disconnect();
+    cleanup(source_path);
+    cleanup(replica_path);
+}
+
 void test_key_table_logical_capture_session_commits_typed_local_writes() {
     const std::string path =
         "test_key_table_logical_adapter_session.mdbx";
@@ -3976,6 +4195,10 @@ int main() {
     test_key_table_logical_adapter_rejects_malformed_payload();
     test_key_multi_value_logical_adapter_applies_multiset_operations();
     test_key_multi_value_logical_adapter_rejects_invalid_payload();
+    test_key_multi_value_logical_capture_session_commits_typed_writes();
+    test_key_multi_value_logical_capture_session_commits_to_outbox();
+    test_key_multi_value_logical_capture_session_rolls_back_on_outbox_failure();
+    test_key_multi_value_logical_frame_replicates_capture_session();
     test_key_table_logical_capture_session_commits_typed_local_writes();
     test_key_table_logical_frame_replicates_capture_session();
     test_key_value_logical_adapter_engine_rejects_unknown_schema();

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -1098,6 +1098,82 @@ void test_key_multi_value_logical_capture_session_rolls_back_on_outbox_failure()
     cleanup(path);
 }
 
+void test_key_multi_value_logical_capture_session_rolls_back_partial_erase() {
+    const std::string path =
+        "test_key_multi_value_logical_adapter_partial_erase.mdbx";
+    const std::string dbi_name = "logical_key_multi_value_partial_erase";
+    const std::string schema_id =
+        "app.logical_key_multi_value_partial_erase.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+
+    {
+        mdbxc::sync::SyncEngine engine(conn);
+        engine.initialize_local_identity(make_node(0x54), make_node(0xDB));
+        engine.register_logical_schema(
+            schema_id, make_key_multi_value_record(dbi_name));
+
+        mdbxc::KeyMultiValueTable<int, std::string> table(conn, dbi_name);
+        IntStringMultiAdapter adapter(table, schema_id);
+        table.insert(9, "nine");
+
+        {
+            mdbxc::Transaction txn =
+                conn->transaction(mdbxc::TransactionMode::WRITABLE);
+            MDBX_dbi dbi = 0;
+            MDBXC_TEST_ASSERT(
+                mdbx_dbi_open(txn.handle(), dbi_name.c_str(),
+                              MDBX_DUPSORT | mdbxc::get_mdbx_flags<int>(),
+                              &dbi) == MDBX_SUCCESS);
+
+            mdbxc::SerializeScratch key_scratch;
+            MDBX_val key = mdbxc::serialize_key<
+                mdbxc::DefaultTableOptions::safe_integer_key>(
+                    9, key_scratch);
+            std::uint8_t corrupt_value_byte = 0xFFu;
+            MDBX_val corrupt_value = {&corrupt_value_byte, 1u};
+            MDBXC_TEST_ASSERT(
+                mdbx_put(txn.handle(), dbi, &key, &corrupt_value,
+                         MDBX_UPSERT) == MDBX_SUCCESS);
+            txn.commit();
+        }
+
+        std::unique_ptr<IntStringMultiAdapter::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        bool caught = false;
+        try {
+            session->erase(9, "nine");
+        } catch (const std::runtime_error&) {
+            caught = true;
+        }
+        MDBXC_TEST_ASSERT(caught);
+        MDBXC_TEST_ASSERT(session->pending_size() == 0u);
+
+        std::vector<mdbxc::sync::LogicalChange> changes;
+        bool commit_rejected = false;
+        try {
+            session->commit(changes);
+        } catch (const std::logic_error&) {
+            commit_rejected = true;
+        }
+        MDBXC_TEST_ASSERT(commit_rejected);
+        MDBXC_TEST_ASSERT(changes.empty());
+    }
+
+    conn->disconnect();
+    conn = mdbxc::Connection::create(cfg);
+    mdbxc::KeyMultiValueTable<int, std::string> reopened_table(conn, dbi_name);
+    MDBXC_TEST_ASSERT(reopened_table.count(9) == 2u);
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 void test_key_multi_value_logical_frame_replicates_capture_session() {
     const std::string source_path =
         "test_key_multi_value_logical_frame_source.mdbx";
@@ -4198,6 +4274,7 @@ int main() {
     test_key_multi_value_logical_capture_session_commits_typed_writes();
     test_key_multi_value_logical_capture_session_commits_to_outbox();
     test_key_multi_value_logical_capture_session_rolls_back_on_outbox_failure();
+    test_key_multi_value_logical_capture_session_rolls_back_partial_erase();
     test_key_multi_value_logical_frame_replicates_capture_session();
     test_key_table_logical_capture_session_commits_typed_local_writes();
     test_key_table_logical_frame_replicates_capture_session();


### PR DESCRIPTION
## Summary
- add a transaction-bound typed capture session for the scoped KeyMultiValue logical operations
- atomically enqueue captured delivery with the local table transaction
- document the limited logical-adapter scope without claiming raw v0.1 or ordered-table support

## Validation
- MinGW C++11: `test_key_value_logical_adapter`, sync umbrella, and standalone adapter header
- MinGW C++17: same targets and tests