### PR TITLE
fix(sync): unify logical capture failure lifecycle

### DIFF
--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -674,9 +674,11 @@ pipeline.
 `LogicalCaptureSession`. The session owns a writable transaction, suppresses
 raw capture for its typed writes, buffers logical changes privately, and copies
 them to the caller only from `commit(out)`. Rollback, destruction, or commit
-failure discards the pending logical changes. A failure after a session
-operation begins also requests transaction rollback and deactivates the
-session, so later `commit()` or `commit_to_outbox()` calls are rejected.
+failure discards the pending logical changes. An exception after physical
+mutation, outbox enqueue, or native commit processing begins requests
+transaction rollback and deactivates the session, so later `commit()` or
+`commit_to_outbox()` calls are rejected. Preparation or encoding failures
+before transaction mutation leave the session active.
 Session construction validates
 the adapter against the persistent schema marker in the same writable
 transaction, before any local mutation can be performed. For `KeyTable`, only

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -674,7 +674,10 @@ pipeline.
 `LogicalCaptureSession`. The session owns a writable transaction, suppresses
 raw capture for its typed writes, buffers logical changes privately, and copies
 them to the caller only from `commit(out)`. Rollback, destruction, or commit
-failure discards the pending logical changes. Session construction validates
+failure discards the pending logical changes. A failure after a session
+operation begins also requests transaction rollback and deactivates the
+session, so later `commit()` or `commit_to_outbox()` calls are rejected.
+Session construction validates
 the adapter against the persistent schema marker in the same writable
 transaction, before any local mutation can be performed. For `KeyTable`, only
 successful membership changes are captured: inserting an existing key or

--- a/include/mdbx_containers/sync/adapters/KeyMultiValueTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyMultiValueTableLogicalAdapter.hpp
@@ -117,9 +117,10 @@ namespace sync {
         /// operations exposed by this class; direct table calls, bulk
         /// reconciliation, and range erasure remain local-only operations.
         /// The adapter, table, and connection referenced by the adapter must
-        /// outlive the session. If a session operation throws after it begins,
-        /// the session requests rollback of its transaction and becomes
-        /// inactive.
+        /// outlive the session. An exception after physical mutation, outbox
+        /// enqueue, or native commit processing begins requests rollback of
+        /// the transaction and deactivates the session. Preparation or
+        /// encoding failures before transaction mutation leave it active.
         class LogicalCaptureSession {
         public:
             explicit LogicalCaptureSession(

--- a/include/mdbx_containers/sync/adapters/KeyTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyTableLogicalAdapter.hpp
@@ -109,8 +109,10 @@ namespace sync {
         /// suppressed for the transaction. Pending changes are copied to the
         /// caller only by \c commit(out), after the session has prepared the
         /// destination vector and before the native commit. If a session
-        /// operation throws after it begins, the session requests rollback of
-        /// its transaction and becomes inactive. The adapter, table, and
+        /// operation throws after physical mutation, outbox enqueue, or native
+        /// commit processing begins, the session requests transaction rollback
+        /// and becomes inactive. Preparation or encoding failures before
+        /// transaction mutation leave it active. The adapter, table, and
         /// connection referenced by the adapter must outlive the session.
         class LogicalCaptureSession {
         public:

--- a/include/mdbx_containers/sync/adapters/KeyTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyTableLogicalAdapter.hpp
@@ -108,10 +108,10 @@ namespace sync {
         /// writes are buffered as logical changes and raw capture is
         /// suppressed for the transaction. Pending changes are copied to the
         /// caller only by \c commit(out), after the session has prepared the
-        /// destination vector and before the native commit. If commit fails,
-        /// the appended tail is erased and the destructor rolls back the
-        /// transaction. The adapter, table, and connection referenced by the
-        /// adapter must outlive the session.
+        /// destination vector and before the native commit. If a session
+        /// operation throws after it begins, the session requests rollback of
+        /// its transaction and becomes inactive. The adapter, table, and
+        /// connection referenced by the adapter must outlive the session.
         class LogicalCaptureSession {
         public:
             explicit LogicalCaptureSession(
@@ -153,7 +153,7 @@ namespace sync {
                     }
                     return inserted;
                 } catch (...) {
-                    m_pending.resize(previous_size);
+                    rollback_and_deactivate();
                     throw;
                 }
             }
@@ -173,7 +173,7 @@ namespace sync {
                     }
                     return removed;
                 } catch (...) {
-                    m_pending.resize(previous_size);
+                    rollback_and_deactivate();
                     throw;
                 }
             }
@@ -181,14 +181,13 @@ namespace sync {
             void clear() {
                 ensure_active();
                 const LogicalChange change = m_adapter.make_clear();
-                const std::size_t previous_size = m_pending.size();
                 m_pending.push_back(change);
                 try {
                     Connection::SyncCaptureSuppressionScope suppress_capture(
                         *m_adapter.m_table.connection(), m_txn.handle());
                     m_adapter.m_table.clear(m_txn.handle());
                 } catch (...) {
-                    m_pending.resize(previous_size);
+                    rollback_and_deactivate();
                     throw;
                 }
             }
@@ -207,6 +206,7 @@ namespace sync {
                     out.erase(out.begin() +
                               static_cast<std::ptrdiff_t>(old_size),
                               out.end());
+                    rollback_and_deactivate();
                     throw;
                 }
                 m_pending.clear();
@@ -221,19 +221,33 @@ namespace sync {
                 ensure_active();
                 LogicalChangeFrame frame;
                 frame.changes = m_pending;
-                const LogicalDeliveryEnvelope envelope =
-                    outbox.enqueue_logical_delivery(
-                        m_txn.handle(), destination, frame, bounds);
-                m_txn.commit();
-                m_pending.clear();
-                m_active = false;
-                return envelope;
+                try {
+                    const LogicalDeliveryEnvelope envelope =
+                        outbox.enqueue_logical_delivery(
+                            m_txn.handle(), destination, frame, bounds);
+                    m_txn.commit();
+                    m_pending.clear();
+                    m_active = false;
+                    return envelope;
+                } catch (...) {
+                    rollback_and_deactivate();
+                    throw;
+                }
             }
 
             void rollback() noexcept {
                 if (!m_active) {
                     return;
                 }
+                rollback_and_deactivate();
+            }
+
+            std::size_t pending_size() const {
+                return m_pending.size();
+            }
+
+        private:
+            void rollback_and_deactivate() noexcept {
                 try {
                     m_pending.clear();
                     m_txn.rollback();
@@ -242,11 +256,6 @@ namespace sync {
                 m_active = false;
             }
 
-            std::size_t pending_size() const {
-                return m_pending.size();
-            }
-
-        private:
             void ensure_active() const {
                 if (!m_active) {
                     throw std::logic_error(

--- a/include/mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp
@@ -398,10 +398,10 @@ namespace detail {
         /// buffered as logical changes and raw capture is suppressed for the
         /// transaction. Pending changes are copied to the caller only by
         /// \c commit(out), after the session has prepared the destination
-        /// vector and before the native commit. If commit fails, the appended
-        /// tail is erased and the destructor rolls back the transaction.
-        /// The adapter, table, and connection referenced by the adapter must
-        /// outlive the session.
+        /// vector and before the native commit. If a session operation throws
+        /// after it begins, the session requests rollback of its transaction
+        /// and becomes inactive. The adapter, table, and connection referenced
+        /// by the adapter must outlive the session.
         class LogicalCaptureSession {
         public:
             explicit LogicalCaptureSession(
@@ -431,7 +431,6 @@ namespace detail {
             void insert_or_assign(const KeyT& key, const ValueT& value) {
                 ensure_active();
                 LogicalChange change = m_adapter.make_upsert(key, value);
-                const std::size_t previous_size = m_pending.size();
                 m_pending.push_back(change);
                 try {
                     Connection::SyncCaptureSuppressionScope suppress_capture(
@@ -439,7 +438,7 @@ namespace detail {
                     m_adapter.m_table.insert_or_assign(
                         key, value, m_txn.handle());
                 } catch (...) {
-                    m_pending.resize(previous_size);
+                    rollback_and_deactivate();
                     throw;
                 }
             }
@@ -459,7 +458,7 @@ namespace detail {
                     }
                     return removed;
                 } catch (...) {
-                    m_pending.resize(previous_size);
+                    rollback_and_deactivate();
                     throw;
                 }
             }
@@ -467,14 +466,13 @@ namespace detail {
             void clear() {
                 ensure_active();
                 LogicalChange change = m_adapter.make_clear();
-                const std::size_t previous_size = m_pending.size();
                 m_pending.push_back(change);
                 try {
                     Connection::SyncCaptureSuppressionScope suppress_capture(
                         *m_adapter.m_table.connection(), m_txn.handle());
                     m_adapter.m_table.clear(m_txn.handle());
                 } catch (...) {
-                    m_pending.resize(previous_size);
+                    rollback_and_deactivate();
                     throw;
                 }
             }
@@ -493,6 +491,7 @@ namespace detail {
                     out.erase(out.begin() +
                               static_cast<std::ptrdiff_t>(old_size),
                               out.end());
+                    rollback_and_deactivate();
                     throw;
                 }
                 m_pending.clear();
@@ -507,19 +506,33 @@ namespace detail {
                 ensure_active();
                 LogicalChangeFrame frame;
                 frame.changes = m_pending;
-                const LogicalDeliveryEnvelope envelope =
-                    outbox.enqueue_logical_delivery(
-                        m_txn.handle(), destination, frame, bounds);
-                m_txn.commit();
-                m_pending.clear();
-                m_active = false;
-                return envelope;
+                try {
+                    const LogicalDeliveryEnvelope envelope =
+                        outbox.enqueue_logical_delivery(
+                            m_txn.handle(), destination, frame, bounds);
+                    m_txn.commit();
+                    m_pending.clear();
+                    m_active = false;
+                    return envelope;
+                } catch (...) {
+                    rollback_and_deactivate();
+                    throw;
+                }
             }
 
             void rollback() noexcept {
                 if (!m_active) {
                     return;
                 }
+                rollback_and_deactivate();
+            }
+
+            std::size_t pending_size() const {
+                return m_pending.size();
+            }
+
+        private:
+            void rollback_and_deactivate() noexcept {
                 try {
                     m_pending.clear();
                     m_txn.rollback();
@@ -528,11 +541,6 @@ namespace detail {
                 m_active = false;
             }
 
-            std::size_t pending_size() const {
-                return m_pending.size();
-            }
-
-        private:
             void ensure_active() const {
                 if (!m_active) {
                     throw std::logic_error(

--- a/include/mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyValueTableLogicalAdapter.hpp
@@ -399,9 +399,11 @@ namespace detail {
         /// transaction. Pending changes are copied to the caller only by
         /// \c commit(out), after the session has prepared the destination
         /// vector and before the native commit. If a session operation throws
-        /// after it begins, the session requests rollback of its transaction
-        /// and becomes inactive. The adapter, table, and connection referenced
-        /// by the adapter must outlive the session.
+        /// after physical mutation, outbox enqueue, or native commit
+        /// processing begins, the session requests transaction rollback and
+        /// becomes inactive. Preparation or encoding failures before
+        /// transaction mutation leave it active. The adapter, table, and
+        /// connection referenced by the adapter must outlive the session.
         class LogicalCaptureSession {
         public:
             explicit LogicalCaptureSession(

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -1326,6 +1326,67 @@ void test_key_table_logical_capture_session_commits_typed_local_writes() {
     cleanup(path);
 }
 
+void test_key_table_logical_capture_session_rolls_back_when_outbox_fails() {
+    const std::string path =
+        "test_key_table_logical_adapter_session_outbox_failure.mdbx";
+    const std::string dbi_name = "logical_key_table_session_outbox_failure";
+    const std::string schema_id =
+        "app.logical_key_table_session_outbox_failure.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0x4D), make_node(0xD5));
+    engine.register_logical_schema(
+        schema_id, make_key_table_record(dbi_name));
+
+    mdbxc::KeyTable<int> table(conn, dbi_name);
+    IntKeyTableAdapter adapter(table, schema_id);
+    ThrowingLogicalDeliveryOutbox outbox;
+    bool caught = false;
+    bool commit_rejected = false;
+    bool retry_rejected = false;
+    {
+        std::unique_ptr<IntKeyTableAdapter::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        MDBXC_TEST_ASSERT(session->insert(8));
+        try {
+            session->commit_to_outbox(outbox, make_node(0xD6));
+        } catch (const std::runtime_error&) {
+            caught = true;
+        }
+        MDBXC_TEST_ASSERT(session->pending_size() == 0u);
+
+        std::vector<mdbxc::sync::LogicalChange> changes;
+        try {
+            session->commit(changes);
+        } catch (const std::logic_error&) {
+            commit_rejected = true;
+        }
+        MDBXC_TEST_ASSERT(changes.empty());
+
+        try {
+            session->commit_to_outbox(outbox, make_node(0xD6));
+        } catch (const std::logic_error&) {
+            retry_rejected = true;
+        }
+    }
+    MDBXC_TEST_ASSERT(caught);
+    MDBXC_TEST_ASSERT(commit_rejected);
+    MDBXC_TEST_ASSERT(retry_rejected);
+    MDBXC_TEST_ASSERT(!table.contains(8));
+    MDBXC_TEST_ASSERT(
+        engine.pending_logical_deliveries(make_node(0xD6)).empty());
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 void test_key_table_logical_frame_replicates_capture_session() {
     const std::string source_path =
         "test_key_table_logical_frame_source.mdbx";
@@ -1998,6 +2059,8 @@ void test_key_value_logical_capture_session_rolls_back_when_outbox_fails() {
     IntStringAdapter adapter(table, schema_id);
     ThrowingLogicalDeliveryOutbox outbox;
     bool caught = false;
+    bool commit_rejected = false;
+    bool retry_rejected = false;
     {
         std::unique_ptr<IntStringAdapter::LogicalCaptureSession> session =
             adapter.begin_capture_session();
@@ -2007,9 +2070,28 @@ void test_key_value_logical_capture_session_rolls_back_when_outbox_fails() {
         } catch (const std::runtime_error&) {
             caught = true;
         }
+        MDBXC_TEST_ASSERT(session->pending_size() == 0u);
+
+        std::vector<mdbxc::sync::LogicalChange> changes;
+        try {
+            session->commit(changes);
+        } catch (const std::logic_error&) {
+            commit_rejected = true;
+        }
+        MDBXC_TEST_ASSERT(changes.empty());
+
+        try {
+            session->commit_to_outbox(outbox, make_node(0xDA));
+        } catch (const std::logic_error&) {
+            retry_rejected = true;
+        }
     }
     MDBXC_TEST_ASSERT(caught);
+    MDBXC_TEST_ASSERT(commit_rejected);
+    MDBXC_TEST_ASSERT(retry_rejected);
     MDBXC_TEST_ASSERT(!table.contains(8));
+    MDBXC_TEST_ASSERT(
+        engine.pending_logical_deliveries(make_node(0xDA)).empty());
 
     conn->disconnect();
     cleanup(path);
@@ -4298,6 +4380,7 @@ int main() {
     test_key_multi_value_logical_capture_session_rolls_back_partial_erase();
     test_key_multi_value_logical_frame_replicates_capture_session();
     test_key_table_logical_capture_session_commits_typed_local_writes();
+    test_key_table_logical_capture_session_rolls_back_when_outbox_fails();
     test_key_table_logical_frame_replicates_capture_session();
     test_key_value_logical_adapter_engine_rejects_unknown_schema();
     test_key_value_logical_engine_rejects_missing_schema_marker();


### PR DESCRIPTION
## Summary
- Roll back and deactivate KeyValue and KeyTable logical capture sessions after mutation, direct commit, or outbox enqueue failures.
- Add outbox-failure regressions that verify later commit attempts are rejected.
- Document the one-shot capture-session lifecycle.

## Validation
- MinGW C++11 and C++17: logical-adapter target and standalone adapter headers.
- Clean Release MinGW C++11: full test_key_value_logical_adapter.