### PR TITLE
fix(sync): probe optional delivery DBIs safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Fixed `LogicalDeliveryStore` probing of absent optional DBIs. It now checks
+  the main DB before attempting a read-only named-DBI open, so a missing
+  logical-delivery watermark remains a normal legacy-layout condition in both
+  Debug and Release builds.
 - Added negotiated `CumulativeAcknowledgement` for ordered logical delivery.
   Sender outbox metadata now exposes a durable known-tail bound, allowing a
   receiver-ahead duplicate acknowledgement to clean a verified contiguous

--- a/include/mdbx_containers/sync/stores/LogicalDeliveryStore.hpp
+++ b/include/mdbx_containers/sync/stores/LogicalDeliveryStore.hpp
@@ -293,12 +293,12 @@ namespace sync {
         }
 
         bool open_watermark_if_exists(MDBX_txn* txn) const {
+            if (!named_dbi_exists(txn, m_watermark_dbi_name)) {
+                return false;
+            }
             const int rc = mdbx_dbi_open(
                 txn, m_watermark_dbi_name.c_str(),
                 static_cast<MDBX_db_flags_t>(0), &m_watermark_dbi);
-            if (rc == MDBX_NOTFOUND) {
-                return false;
-            }
             check_mdbx(rc, "Failed to open LogicalDeliveryStore watermark DBI");
             return true;
         }
@@ -312,10 +312,39 @@ namespace sync {
                                      MDBX_dbi& dbi) {
             int rc = mdbx_dbi_open(txn, name.c_str(), MDBX_CREATE, &dbi);
             if (rc == MDBX_EACCESS) {
+                if (!named_dbi_exists(txn, name)) {
+                    check_mdbx(MDBX_NOTFOUND,
+                               "Failed to open LogicalDeliveryStore DBI");
+                }
                 rc = mdbx_dbi_open(txn, name.c_str(),
                                    static_cast<MDBX_db_flags_t>(0), &dbi);
             }
             check_mdbx(rc, "Failed to open LogicalDeliveryStore DBI");
+        }
+
+        static bool named_dbi_exists(MDBX_txn* txn,
+                                     const std::string& name) {
+            // Check the main DB first so a missing named DBI is not opened.
+            MDBX_dbi main_dbi = 0;
+            check_mdbx(
+                mdbx_dbi_open(
+                    txn,
+                    static_cast<const char*>(MDBX_CHK_MAIN),
+                    static_cast<MDBX_db_flags_t>(0),
+                    &main_dbi),
+                "Failed to open main DBI while checking LogicalDeliveryStore DBI");
+            MDBX_val key = {
+                const_cast<char*>(name.data()),
+                name.size()
+            };
+            MDBX_val value;
+            const int rc = mdbx_get(txn, main_dbi, &key, &value);
+            if (rc == MDBX_NOTFOUND) {
+                return false;
+            }
+            check_mdbx(rc,
+                       "Failed to inspect LogicalDeliveryStore DBI");
+            return true;
         }
 
         std::uint64_t read_watermark(MDBX_txn* txn,


### PR DESCRIPTION
## Summary
- probe the main DB before opening an optional named logical-delivery DBI without MDBX_CREATE`n- preserve the legacy layout where the watermark DBI is absent
- prevent the Debug MDBX DBI-lifecycle assertion triggered by a failed absent-DBI probe

## Validation
- 	est_key_value_logical_adapter (Debug MinGW C++11)
- 	est_key_value_logical_adapter (Debug MinGW C++17)