### PR TITLE
feat(sync): capture ordered multivalue appends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 - Added `KeyOrderedMultiValueTableLogicalAdapter` for append-only logical
   apply through ordered delivery. It preserves repeated values and per-key
-  append order for the schema marker's authoritative origin; typed capture and
+  append order for the schema marker's authoritative origin. Its typed capture
+  session atomically commits local appends plus an ordered outbox envelope;
   destructive operations remain deferred.
 - Ordered logical schemas now persist an explicit authoritative origin in
   `_mdbxc_sync_schema`. Ordered delivery validates that binding before replay

--- a/README-RU.md
+++ b/README-RU.md
@@ -95,9 +95,10 @@
   adapter-а. См. `sync/DESIGN.md`.
   `KeyOrderedMultiValueTableLogicalAdapter` даёт opt-in append-only apply
   через ordered logical delivery для одного origin stream. Direct logical frame
-  и unordered delivery отклоняются; typed capture и destructive ordered
-  операции остаются deferred. Для `AnyValueTable` и `HashedKeyValueStore` ещё
-  нужны дизайны type tags и hash-index identity.
+  и unordered delivery отклоняются. Его typed capture session атомарно
+  коммитит локальные append вместе с ordered outbox envelope; destructive
+  ordered операции остаются deferred. Для `AnyValueTable` и
+  `HashedKeyValueStore` ещё нужны дизайны type tags и hash-index identity.
 - Для поддерживаемых таблиц прикладной CRUD-код не нужно оборачивать
   отдельными sync-вызовами на каждый метод. Прикрепите
   `ThreadLocalChangeAccumulator` к пишущему `Connection`; используйте

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@
   erase remain outside that adapter scope. See `sync/DESIGN.md`.
   `KeyOrderedMultiValueTableLogicalAdapter` provides opt-in append-only apply
   through ordered logical delivery for one origin stream. Direct logical frames
-  and unordered delivery are rejected; typed capture and destructive ordered
+  and unordered delivery are rejected. Its typed capture session atomically
+  commits local appends plus an ordered outbox envelope; destructive ordered
   operations remain deferred. `AnyValueTable` and `HashedKeyValueStore` still
   need type-tag and hash-index identity designs.
 - Application CRUD code does not need per-method sync wrappers for supported

--- a/guides/sync-table-coverage.md
+++ b/guides/sync-table-coverage.md
@@ -21,7 +21,7 @@ values during transport, and remote apply replays the captured physical
 | `VectorStore` | Indirectly supported | Captured through its internal `SequenceTable` and `KeyValueTable` members. | The internal table operations are replicated; `VectorStore` has no separate wire type. This raw path requires one authoritative or externally serialized writer per collection. Already-open instances compare `Connection::sync_apply_generation()` and lazily rebuild their RAM index before index-dependent operations after remote apply. A connection apply/read barrier serializes remote `handle_push()` apply commits with cache-backed `VectorStore` operations. Each `VectorStore` instance serializes its own methods; C++17 builds let different readers share the connection read side, while C++11 builds use an exclusive connection mutex fallback. | `test_sync_capture`, `test_sync_replication` |
 | `AnyValueTable<K>` | Deferred | No `ChangeOp` in v0.1. | Not applied by sync as a typed heterogeneous table. | `test_sync_capture` negative coverage |
 | `KeyMultiValueTable<K, V>` | Limited logical adapter | No raw `ChangeOp` in v0.1. | `KeyMultiValueTableLogicalAdapter` explicitly captures unordered insert, key erase, all-matching-value erase, and clear for one writer or causally serialized updates. Raw calls, append, reconcile, range erase, and general multi-writer destructive convergence remain deferred. | `test_key_value_logical_adapter`, `test_sync_capture` negative coverage |
-| `KeyOrderedMultiValueTable<K, V>` | Limited ordered logical adapter | No raw `ChangeOp` in v0.1. | Append-only logical changes require one ordered origin stream; direct logical frames and unordered delivery fail closed. Typed capture is pending; destructive operations remain deferred pending persistent element identity and tombstones. | `test_key_value_logical_adapter`; capture regressions pending |
+| `KeyOrderedMultiValueTable<K, V>` | Limited ordered logical adapter | No raw `ChangeOp` in v0.1. | Append-only logical changes require one ordered origin stream; direct logical frames and unordered delivery fail closed. Typed capture atomically commits local appends plus an ordered outbox envelope; destructive operations remain deferred pending persistent element identity and tombstones. | `test_key_value_logical_adapter` |
 | `HashedKeyValueStore<K, V, H, Layout>` | Deferred | No `ChangeOp` in v0.1. | Hash-index identity and logical-key mapping are deferred. | `test_sync_capture` negative coverage |
 
 ## Supported Capture Contract
@@ -112,9 +112,17 @@ logical-adapter extension, not a claim that those operations are supported.
 The detailed deferred contract lives in
 `include/mdbx_containers/sync/DESIGN.md`: it requires explicit multivalue wire
 sub-operations and receiver-side logical apply helpers before capture can be
-enabled. Order-sensitive histories belong to `KeyOrderedMultiValueTable<K, V>`;
-that table exists for local storage, but its sync capture/apply contract is
-still deferred.
+enabled.
+
+`KeyOrderedMultiValueTable<K, V>` has an append-only ordered logical adapter.
+The following coverage is intentionally deferred until the next ordered-adapter
+extension; it does not widen the current append-only contract:
+
+- malformed ordered pair payloads: truncated key or value, oversized declared
+  lengths, and trailing bytes;
+- destruction rollback of an active ordered capture session;
+- native transaction commit failure after ordered capture preparation;
+- missing, stale, or DBI-mismatched schema markers for ordered capture sessions.
 
 `AnyValueTable<K>` needs value type-tag propagation or another explicit
 compatibility policy. The current sync wire operation only carries raw value

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -107,7 +107,8 @@ The logical sync scaffolding is preparatory only:
   path for its limited unordered multiset operation set. It does not enable raw
   `ChangeOp` capture for the table wrapper.
 - `KeyOrderedMultiValueTableLogicalAdapter` applies append-only logical changes
-  only through ordered delivery for one origin stream. Typed capture and all
+  only through ordered delivery for one origin stream. Its typed capture
+  session can atomically commit local appends and an ordered outbox envelope;
   destructive ordered-table operations remain deferred.
 - Logical delivery replay markers can be pruned through a persisted per-origin
   watermark. The watermark DBI is created lazily on the first pruning call, so

--- a/include/mdbx_containers/KeyOrderedMultiValueTable.hpp
+++ b/include/mdbx_containers/KeyOrderedMultiValueTable.hpp
@@ -35,9 +35,10 @@ namespace mdbxc {
     /// significant. Use \ref KeyMultiValueTable when only pair multiplicity is
     /// significant and reconciliation by unordered multiset semantics is desired.
     ///
-    /// \note Sync v0.1 does not capture this wrapper yet. The physical format is
-    ///       intentionally explicit, but wire-level ordered multi-value
-    ///       replication needs separate capture/apply tests before being enabled.
+    /// \note Sync v0.1 emits no raw \c ChangeOp for this wrapper. The opt-in
+    ///       \c KeyOrderedMultiValueTableLogicalAdapter instead captures only
+    ///       append history through one ordered logical-delivery origin;
+    ///       destructive operations remain local-only.
     ///
     /// \note \c MDBX_DB_ACCEDE is accepted only for DBIs created with a
     ///       compatible \c KeyOrderedMultiValueTable storage contract: the same

--- a/include/mdbx_containers/detail/utils.hpp
+++ b/include/mdbx_containers/detail/utils.hpp
@@ -30,6 +30,8 @@
 #include <utility>
 #include <vector>
 
+#include "../common/MdbxException.hpp"
+
 #if __cplusplus >= 201703L
 #   define MDBXC_NODISCARD [[nodiscard]]
 #else

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -96,7 +96,7 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
 | `VectorStore` | Supported indirectly | Does not own a separate wire format. Its persistent writes go through `SequenceTable` and `KeyValueTable` member tables. Raw replication requires one authoritative or externally serialized writer per collection. Already-open instances refresh their RAM index lazily after completed remote apply when the connection sync-apply generation changes. |
 | `AnyValueTable` | Not supported in v0.1 | Deferred until heterogeneous value type tags are part of the sync wire format. |
 | `KeyMultiValueTable` | Limited logical adapter | Raw v0.1 capture remains unsupported. `KeyMultiValueTableLogicalAdapter` explicitly captures unordered insert, key erase, all-matching-value erase, and clear under one-writer or causally serialized updates. |
-| `KeyOrderedMultiValueTable` | Append-only logical adapter | `KeyOrderedMultiValueTableLogicalAdapter` applies append-only changes through ordered delivery for one origin stream. Typed capture and destructive operations remain deferred. |
+| `KeyOrderedMultiValueTable` | Append-only logical adapter | `KeyOrderedMultiValueTableLogicalAdapter` captures and applies append-only changes through ordered delivery for the schema marker's one authoritative origin. Destructive operations remain deferred. |
 | `HashedKeyValueStore` | Not supported in v0.1 | Deferred until hash-index and identity-key mapping semantics are specified. |
 
 Do not add `record_op()` paths for unsupported table types without first
@@ -305,12 +305,14 @@ between nodes. A causally meaningful distributed history would need an explicit
 Lamport/HLC-style component or another causal-ordering model.
 
 The initial adapter supports only `append(key, value)`. `insert` is an alias for
-that operation and may use the same capture method. `erase`, `erase_at`,
+that operation and uses the same typed capture method. Its capture session owns
+one writable transaction and can atomically commit local appends plus an ordered
+outbox envelope through `commit_to_outbox()`. `erase`, `erase_at`,
 `clear`, and `replace_with` remain local-only until a persistent element
 identity, delete/tombstone semantics, and a new round-trip contract are
 specified.
 
-Required tests before enabling capture:
+Further ordered-history extensions require:
 
 - codec tests proving unknown multivalue operation bits/subtypes are rejected by
   older or capability-limited decoders;
@@ -342,9 +344,8 @@ anchors, see the
   format; deferred until an explicit identity-mapping scheme lands.
 - `KeyMultiValueTable` — DUPSORT duplicate values need the unordered multiset
   model described above before capture can be enabled.
-- `KeyOrderedMultiValueTable` — local ordered storage exists, but ordered
-  distributed histories need the explicit sync wire identity described above
-  before capture can be enabled.
+- `KeyOrderedMultiValueTable` — destructive ordered-history operations remain
+  deferred until a persistent element identity and tombstone contract exists.
 - `AnyValueTable` — heterogeneous values need type-tag propagation on the wire.
 - `IdentityProvider` integration in `BaseTable` — declared in v0.1, no
   write path until HashedKeyValueStore.
@@ -710,6 +711,12 @@ transaction, before any local mutation can be performed. For `KeyTable`, only
 successful membership changes are captured: inserting an existing key or
 erasing an absent key leaves the pending logical frame unchanged; an explicit
 clear request is captured even when the table is already empty.
+
+`KeyOrderedMultiValueTableLogicalAdapter` additionally requires its persistent
+schema marker to name the local node as the authoritative ordered origin before
+it starts capture. This prevents a local append from being committed into an
+outbox stream that the ordered receiver must reject. Its capture factory is
+lvalue-qualified because a session holds a reference to its adapter.
 
 The adapter payload codec is not the table storage serializer. The initial
 codec surface is deliberately small and explicit: callers provide key/value

--- a/include/mdbx_containers/sync/LogicalSchemaValidation.hpp
+++ b/include/mdbx_containers/sync/LogicalSchemaValidation.hpp
@@ -12,6 +12,7 @@
 #include <mdbx.h>
 
 #include "LogicalTableAdapter.hpp"
+#include "stores/MetaStore.hpp"
 #include "stores/SchemaRegistryStore.hpp"
 
 namespace mdbxc {
@@ -76,6 +77,50 @@ namespace sync {
         if (record.dbi_name != primary_dbi) {
             return LogicalApplyResult::failure(
                 "Persistent logical schema marker primary DBI does not match adapter");
+        }
+
+        return LogicalApplyResult::success();
+    }
+
+    /// \brief Verifies that an ordered adapter is bound to this local origin.
+    /// \details Capture must not create an ordered outbox envelope that its
+    /// receiver will reject because the persistent schema marker names another
+    /// authoritative origin.
+    inline LogicalApplyResult validate_ordered_logical_adapter_origin(
+            MDBX_txn* txn,
+            MDBX_env* env,
+            const ILogicalTableAdapter& adapter) {
+        const LogicalApplyResult marker_result =
+            validate_logical_adapter_marker(txn, env, adapter);
+        if (!marker_result.ok) {
+            return marker_result;
+        }
+
+        if (!adapter.requires_ordered_delivery()) {
+            return LogicalApplyResult::failure(
+                "Logical adapter does not require ordered delivery");
+        }
+
+        const LogicalSchemaRef ref = adapter.schema_ref();
+        SchemaRegistryStore schemas(env);
+        LogicalSchemaRecord record;
+        if (!schemas.get(txn, ref.schema_id, record)) {
+            return LogicalApplyResult::failure(
+                "Persistent logical schema marker is missing");
+        }
+        if (is_zero_sync_id(record.ordered_delivery_origin_node_id)) {
+            return LogicalApplyResult::failure(
+                "Persistent logical schema marker has no ordered delivery origin");
+        }
+
+        MetaStore meta(env);
+        meta.open(txn);
+        const NodeId local_node_id = meta.get_node_id(txn);
+        if (is_zero_sync_id(local_node_id) ||
+            compare_node_id(record.ordered_delivery_origin_node_id,
+                            local_node_id) != 0) {
+            return LogicalApplyResult::failure(
+                "Local node does not match ordered logical schema origin");
         }
 
         return LogicalApplyResult::success();

--- a/include/mdbx_containers/sync/LogicalSchemaValidation.hpp
+++ b/include/mdbx_containers/sync/LogicalSchemaValidation.hpp
@@ -11,6 +11,7 @@
 
 #include <mdbx.h>
 
+#include "LogicalDeliveryEnvelope.hpp"
 #include "LogicalTableAdapter.hpp"
 #include "stores/MetaStore.hpp"
 #include "stores/SchemaRegistryStore.hpp"

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableLogicalAdapter.hpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -15,6 +16,7 @@
 #include <vector>
 
 #include "../../KeyOrderedMultiValueTable.hpp"
+#include "../ILogicalDeliveryOutbox.hpp"
 #include "KeyValueTableLogicalAdapter.hpp"
 
 namespace mdbxc {
@@ -100,6 +102,160 @@ namespace sync {
         LogicalChange make_insert(const KeyT& key, const ValueT& value) const {
             return make_append(key, value);
         }
+
+        /// \brief Transaction-bound typed capture session for append history.
+        /// \details The session owns one writable transaction, suppresses raw
+        /// capture, and records only \c append and its \c insert alias. A
+        /// failure after physical mutation, outbox enqueue, or native commit
+        /// processing begins rolls back and deactivates the session.
+        class LogicalCaptureSession {
+        public:
+            explicit LogicalCaptureSession(
+                    const KeyOrderedMultiValueTableLogicalAdapter& adapter)
+                : m_adapter(adapter),
+                  m_txn(adapter.m_table.connection()->transaction(
+                      TransactionMode::WRITABLE)),
+                  m_active(true) {
+                const LogicalApplyResult marker_result =
+                    validate_logical_adapter_marker(
+                        m_txn.handle(),
+                        adapter.m_table.connection()->env_handle(),
+                        adapter);
+                if (!marker_result.ok) {
+                    throw std::runtime_error(marker_result.error);
+                }
+                const LogicalApplyResult origin_result =
+                    validate_ordered_logical_adapter_origin(
+                        m_txn.handle(),
+                        adapter.m_table.connection()->env_handle(),
+                        adapter);
+                if (!origin_result.ok) {
+                    throw std::runtime_error(origin_result.error);
+                }
+            }
+
+            ~LogicalCaptureSession() noexcept {
+                rollback();
+            }
+
+            LogicalCaptureSession(const LogicalCaptureSession&) = delete;
+            LogicalCaptureSession& operator=(
+                    const LogicalCaptureSession&) = delete;
+
+            void append(const KeyT& key, const ValueT& value) {
+                ensure_active();
+                append_then_mutate(m_adapter.make_append(key, value),
+                    [this, &key, &value]() {
+                        m_adapter.m_table.append(key, value, m_txn.handle());
+                    });
+            }
+
+            void insert(const KeyT& key, const ValueT& value) {
+                append(key, value);
+            }
+
+            /// \brief Commits local appends and returns their logical changes.
+            /// \warning Returned changes are not atomically published. Use
+            /// \c commit_to_outbox() when durable delivery is required.
+            void commit(std::vector<LogicalChange>& out) {
+                ensure_active();
+                const std::size_t old_size = out.size();
+                out.insert(out.end(), m_pending.begin(), m_pending.end());
+                try {
+                    m_txn.commit();
+                } catch (...) {
+                    out.erase(out.begin() +
+                              static_cast<std::ptrdiff_t>(old_size),
+                              out.end());
+                    rollback_and_deactivate();
+                    throw;
+                }
+                m_pending.clear();
+                m_active = false;
+            }
+
+            /// \brief Commits appends and an ordered delivery atomically.
+            LogicalDeliveryEnvelope commit_to_outbox(
+                    ILogicalDeliveryOutbox& outbox,
+                    const DbId& destination,
+                    const CodecBounds* bounds = nullptr) {
+                ensure_active();
+                LogicalChangeFrame frame;
+                frame.changes = m_pending;
+                try {
+                    const LogicalDeliveryEnvelope envelope =
+                        outbox.enqueue_logical_delivery(
+                            m_txn.handle(), destination, frame, bounds);
+                    m_txn.commit();
+                    m_pending.clear();
+                    m_active = false;
+                    return envelope;
+                } catch (...) {
+                    rollback_and_deactivate();
+                    throw;
+                }
+            }
+
+            void rollback() noexcept {
+                if (!m_active) {
+                    return;
+                }
+                rollback_and_deactivate();
+            }
+
+            std::size_t pending_size() const {
+                return m_pending.size();
+            }
+
+        private:
+            template<class Mutation>
+            void append_then_mutate(const LogicalChange& change,
+                                    const Mutation& mutation) {
+                m_pending.push_back(change);
+                try {
+                    Connection::SyncCaptureSuppressionScope suppress_capture(
+                        *m_adapter.m_table.connection(), m_txn.handle());
+                    mutation();
+                } catch (...) {
+                    rollback_and_deactivate();
+                    throw;
+                }
+            }
+
+            void rollback_and_deactivate() noexcept {
+                try {
+                    m_pending.clear();
+                } catch (...) {
+                }
+                try {
+                    m_txn.rollback();
+                } catch (...) {
+                }
+                m_active = false;
+            }
+
+            void ensure_active() const {
+                if (!m_active) {
+                    throw std::logic_error(
+                        "KeyOrderedMultiValue logical capture session is not active");
+                }
+            }
+
+            const KeyOrderedMultiValueTableLogicalAdapter& m_adapter;
+            Transaction m_txn;
+            std::vector<LogicalChange> m_pending;
+            bool m_active;
+        };
+
+        /// \brief Starts a capture session bound to this adapter instance.
+        /// \details The session stores an adapter reference, so construction is
+        /// restricted to an lvalue adapter that outlives the session.
+        std::unique_ptr<LogicalCaptureSession> begin_capture_session() const & {
+            return std::unique_ptr<LogicalCaptureSession>(
+                new LogicalCaptureSession(*this));
+        }
+
+        std::unique_ptr<LogicalCaptureSession> begin_capture_session() const && = delete;
 
         LogicalApplyResult preflight(
                 MDBX_txn* txn,

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -1320,6 +1320,271 @@ void test_key_ordered_multi_value_logical_adapter_replays_append_history() {
     cleanup(replica_path);
 }
 
+void test_key_ordered_multi_value_logical_capture_commits_to_outbox() {
+    const std::string path =
+        "test_key_ordered_multi_value_logical_capture_outbox.mdbx";
+    const std::string dbi_name = "logical_key_ordered_multi_value_capture";
+    const std::string schema_id =
+        "app.logical_key_ordered_multi_value_capture.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId node = make_node(0x6Eu);
+    const mdbxc::sync::DbId local_db_uuid = make_node(0xDDu);
+    const mdbxc::sync::DbId destination = make_node(0xDEu);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(node, local_db_uuid);
+    mdbxc::sync::LogicalSchemaRecord record =
+        make_key_ordered_multi_value_record(dbi_name);
+    record.ordered_delivery_origin_node_id = node;
+    engine.register_logical_schema(schema_id, record);
+
+    mdbxc::KeyOrderedMultiValueTable<int, std::string> table(conn, dbi_name);
+    IntStringOrderedAdapter adapter(table, schema_id);
+    {
+        std::unique_ptr<IntStringOrderedAdapter::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->append(7, "created");
+        session->insert(7, "sent");
+        const mdbxc::sync::LogicalDeliveryEnvelope envelope =
+            session->commit_to_outbox(engine, destination);
+        MDBXC_TEST_ASSERT(envelope.destination_db_uuid == destination);
+        MDBXC_TEST_ASSERT(envelope.origin_node_id == node);
+        MDBXC_TEST_ASSERT(envelope.origin_sequence == 1u);
+        MDBXC_TEST_ASSERT(envelope.frame.changes.size() == 2u);
+        MDBXC_TEST_ASSERT(envelope.frame.changes[0].opcode ==
+            mdbxc::sync::KeyOrderedMultiValueLogicalAppendOne);
+        MDBXC_TEST_ASSERT(envelope.frame.changes[1].opcode ==
+            mdbxc::sync::KeyOrderedMultiValueLogicalAppendOne);
+    }
+
+    const std::vector<std::string> values = table.find(7);
+    MDBXC_TEST_ASSERT(values.size() == 2u);
+    MDBXC_TEST_ASSERT(values[0] == "created");
+    MDBXC_TEST_ASSERT(values[1] == "sent");
+    const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending =
+        engine.pending_logical_deliveries(destination);
+    MDBXC_TEST_ASSERT(pending.size() == 1u);
+    MDBXC_TEST_ASSERT(pending[0].frame.changes.size() == 2u);
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_ordered_multi_value_logical_capture_delivers_and_replays() {
+    const std::string source_path =
+        "test_key_ordered_multi_value_logical_capture_source.mdbx";
+    const std::string replica_path =
+        "test_key_ordered_multi_value_logical_capture_replica.mdbx";
+    const std::string dbi_name = "logical_key_ordered_multi_value_delivery";
+    const std::string schema_id =
+        "app.logical_key_ordered_multi_value_delivery.v1";
+    cleanup(source_path);
+    cleanup(replica_path);
+
+    mdbxc::Config source_cfg;
+    source_cfg.pathname = source_path;
+    source_cfg.max_dbs = 20;
+    source_cfg.no_subdir = true;
+    mdbxc::Config replica_cfg = source_cfg;
+    replica_cfg.pathname = replica_path;
+
+    const mdbxc::sync::NodeId source_node = make_node(0x70u);
+    const mdbxc::sync::NodeId replica_node = make_node(0x71u);
+    const mdbxc::sync::DbId source_db_uuid = make_node(0xE1u);
+    const mdbxc::sync::DbId replica_db_uuid = make_node(0xE2u);
+    mdbxc::sync::LogicalSchemaRecord record =
+        make_key_ordered_multi_value_record(dbi_name);
+    record.ordered_delivery_origin_node_id = source_node;
+    mdbxc::sync::LogicalDeliveryEnvelope envelope;
+
+    {
+        std::shared_ptr<mdbxc::Connection> source =
+            mdbxc::Connection::create(source_cfg);
+        std::shared_ptr<mdbxc::Connection> replica =
+            mdbxc::Connection::create(replica_cfg);
+        mdbxc::sync::SyncEngine source_engine(source);
+        mdbxc::sync::SyncEngine replica_engine(replica);
+        source_engine.initialize_local_identity(source_node, source_db_uuid);
+        replica_engine.initialize_local_identity(replica_node, replica_db_uuid);
+        source_engine.register_logical_schema(schema_id, record);
+        replica_engine.register_logical_schema(schema_id, record);
+
+        mdbxc::KeyOrderedMultiValueTable<int, std::string> source_table(
+            source, dbi_name);
+        mdbxc::KeyOrderedMultiValueTable<int, std::string> replica_table(
+            replica, dbi_name);
+        IntStringOrderedAdapter source_adapter(source_table, schema_id);
+        IntStringOrderedAdapter replica_adapter(replica_table, schema_id);
+        replica_engine.register_logical_adapter(replica_adapter);
+
+        std::unique_ptr<IntStringOrderedAdapter::LogicalCaptureSession> session =
+            source_adapter.begin_capture_session();
+        session->append(11, "first");
+        session->append(11, "first");
+        session->insert(11, "second");
+        envelope = session->commit_to_outbox(source_engine, replica_db_uuid);
+
+        MDBXC_TEST_ASSERT(
+            source_engine.pending_logical_deliveries(replica_db_uuid).size() ==
+            1u);
+        mdbxc::sync::DirectLogicalDeliveryPeer peer(replica_engine);
+        const mdbxc::sync::LogicalDeliveryDispatchResult dispatched =
+            source_engine.deliver_pending_logical_deliveries(
+                peer, replica_db_uuid);
+        MDBXC_TEST_ASSERT(dispatched.ok);
+        MDBXC_TEST_ASSERT(dispatched.delivered == 1u);
+        MDBXC_TEST_ASSERT(
+            source_engine.pending_logical_deliveries(replica_db_uuid).empty());
+        const std::vector<std::string> values = replica_table.find(11);
+        MDBXC_TEST_ASSERT(values.size() == 3u);
+        MDBXC_TEST_ASSERT(values[0] == "first");
+        MDBXC_TEST_ASSERT(values[1] == "first");
+        MDBXC_TEST_ASSERT(values[2] == "second");
+
+        source->disconnect();
+        replica->disconnect();
+    }
+
+    {
+        std::shared_ptr<mdbxc::Connection> replica =
+            mdbxc::Connection::create(replica_cfg);
+        mdbxc::sync::SyncEngine replica_engine(replica);
+        replica_engine.initialize_local_identity(replica_node, replica_db_uuid);
+        replica_engine.register_logical_schema(schema_id, record);
+        mdbxc::KeyOrderedMultiValueTable<int, std::string> replica_table(
+            replica, dbi_name);
+        IntStringOrderedAdapter replica_adapter(replica_table, schema_id);
+        replica_engine.register_logical_adapter(replica_adapter);
+
+        const mdbxc::sync::LogicalDeliveryAcknowledgement duplicate =
+            replica_engine.apply_ordered_logical_delivery_envelope(envelope);
+        MDBXC_TEST_ASSERT(duplicate.ok);
+        MDBXC_TEST_ASSERT(duplicate.acknowledged_through ==
+                          envelope.origin_sequence);
+        const std::vector<std::string> values = replica_table.find(11);
+        MDBXC_TEST_ASSERT(values.size() == 3u);
+        MDBXC_TEST_ASSERT(values[0] == "first");
+        MDBXC_TEST_ASSERT(values[1] == "first");
+        MDBXC_TEST_ASSERT(values[2] == "second");
+        replica->disconnect();
+    }
+
+    cleanup(source_path);
+    cleanup(replica_path);
+}
+
+void test_key_ordered_multi_value_logical_capture_rejects_wrong_origin() {
+    const std::string path =
+        "test_key_ordered_multi_value_logical_capture_wrong_origin.mdbx";
+    const std::string dbi_name =
+        "logical_key_ordered_multi_value_capture_wrong_origin";
+    const std::string schema_id =
+        "app.logical_key_ordered_multi_value_capture_wrong_origin.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId local_node = make_node(0x72u);
+    const mdbxc::sync::NodeId other_node = make_node(0x73u);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(local_node, make_node(0xE3u));
+    mdbxc::sync::LogicalSchemaRecord record =
+        make_key_ordered_multi_value_record(dbi_name);
+    record.ordered_delivery_origin_node_id = other_node;
+    engine.register_logical_schema(schema_id, record);
+
+    mdbxc::KeyOrderedMultiValueTable<int, std::string> table(conn, dbi_name);
+    IntStringOrderedAdapter adapter(table, schema_id);
+    bool rejected = false;
+    try {
+        std::unique_ptr<IntStringOrderedAdapter::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        (void)session;
+    } catch (const std::runtime_error&) {
+        rejected = true;
+    }
+    MDBXC_TEST_ASSERT(rejected);
+    MDBXC_TEST_ASSERT(table.empty());
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_ordered_multi_value_logical_capture_rolls_back_outbox_failure() {
+    const std::string path =
+        "test_key_ordered_multi_value_logical_capture_outbox_failure.mdbx";
+    const std::string dbi_name =
+        "logical_key_ordered_multi_value_capture_failure";
+    const std::string schema_id =
+        "app.logical_key_ordered_multi_value_capture_failure.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId node = make_node(0x6Fu);
+    const mdbxc::sync::DbId destination = make_node(0xDFu);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(node, make_node(0xE0u));
+    mdbxc::sync::LogicalSchemaRecord record =
+        make_key_ordered_multi_value_record(dbi_name);
+    record.ordered_delivery_origin_node_id = node;
+    engine.register_logical_schema(schema_id, record);
+
+    mdbxc::KeyOrderedMultiValueTable<int, std::string> table(conn, dbi_name);
+    IntStringOrderedAdapter adapter(table, schema_id);
+    ThrowingLogicalDeliveryOutbox outbox;
+    bool outbox_failure = false;
+    bool commit_rejected = false;
+    bool retry_rejected = false;
+    {
+        std::unique_ptr<IntStringOrderedAdapter::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->append(8, "eight");
+        try {
+            session->commit_to_outbox(outbox, destination);
+        } catch (const std::runtime_error&) {
+            outbox_failure = true;
+        }
+        MDBXC_TEST_ASSERT(session->pending_size() == 0u);
+
+        std::vector<mdbxc::sync::LogicalChange> changes;
+        try {
+            session->commit(changes);
+        } catch (const std::logic_error&) {
+            commit_rejected = true;
+        }
+        try {
+            session->commit_to_outbox(outbox, destination);
+        } catch (const std::logic_error&) {
+            retry_rejected = true;
+        }
+        MDBXC_TEST_ASSERT(changes.empty());
+    }
+
+    MDBXC_TEST_ASSERT(outbox_failure);
+    MDBXC_TEST_ASSERT(commit_rejected);
+    MDBXC_TEST_ASSERT(retry_rejected);
+    MDBXC_TEST_ASSERT(table.empty());
+    MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(destination).empty());
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 void test_key_multi_value_logical_adapter_applies_multiset_operations() {
     const std::string path =
         "test_key_multi_value_logical_adapter_engine.mdbx";
@@ -4851,6 +5116,10 @@ int main() {
     test_ordered_logical_delivery_exact_retry_survives_reopen_without_adapter();
     test_ordered_logical_delivery_exact_retry_survives_origin_migration();
     test_key_ordered_multi_value_logical_adapter_replays_append_history();
+    test_key_ordered_multi_value_logical_capture_commits_to_outbox();
+    test_key_ordered_multi_value_logical_capture_delivers_and_replays();
+    test_key_ordered_multi_value_logical_capture_rejects_wrong_origin();
+    test_key_ordered_multi_value_logical_capture_rolls_back_outbox_failure();
     test_key_multi_value_logical_adapter_applies_multiset_operations();
     test_key_multi_value_logical_adapter_rejects_invalid_payload();
     test_key_multi_value_logical_capture_session_commits_typed_writes();


### PR DESCRIPTION
## Summary
- adds typed append/insert capture for `KeyOrderedMultiValueTableLogicalAdapter`
- atomically commits local ordered-table appends and an ordered logical outbox envelope
- rolls back and deactivates the session after publisher failure

## Scope
- append-only, one origin stream
- no raw ChangeOp capture and no destructive ordered-table operations

## Validation
- `test_key_value_logical_adapter` and `header_sync_umbrella_test` passed in Debug MinGW C++11 and C++17