### PR TITLE
fix(sync): restrict ordered adapter to schema v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
   append order for the schema marker's authoritative origin. Its typed capture
   session atomically commits local appends plus an ordered outbox envelope;
   destructive operations remain deferred.
+- Restricted `KeyOrderedMultiValueTableLogicalAdapter` to its fixed
+  schema-version-1 append payload contract. Future destructive ordered
+  semantics require a separate versioned adapter.
 - Ordered logical schemas now persist an explicit authoritative origin in
   `_mdbxc_sync_schema`. Ordered delivery validates that binding before replay
   marker insertion or adapter callbacks, so independent origins cannot append

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableLogicalAdapter.hpp
@@ -48,6 +48,9 @@ namespace sync {
                                    ValueT>::value,
                       "KeyOrderedMultiValueTableLogicalAdapter value codec local type must match ValueT");
 
+        /// \brief Creates the append-only schema-version-1 adapter.
+        /// \details The optional argument is retained for source compatibility,
+        /// but this adapter owns only the version-1 append payload contract.
         KeyOrderedMultiValueTableLogicalAdapter(
                 table_type& table,
                 const std::string& schema_id,
@@ -63,9 +66,9 @@ namespace sync {
                 throw std::invalid_argument(
                     "KeyOrderedMultiValueTableLogicalAdapter DBI name is empty");
             }
-            if (m_schema_version == 0u) {
+            if (m_schema_version != 1u) {
                 throw std::invalid_argument(
-                    "KeyOrderedMultiValueTableLogicalAdapter schema version is zero");
+                    "KeyOrderedMultiValueTableLogicalAdapter supports only schema version 1");
             }
         }
 

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -1208,6 +1208,41 @@ void test_ordered_logical_delivery_exact_retry_survives_origin_migration() {
     cleanup(path);
 }
 
+void test_key_ordered_multi_value_logical_adapter_requires_schema_v1() {
+    const std::string path =
+        "test_key_ordered_multi_value_logical_adapter_schema_version.mdbx";
+    const std::string dbi_name = "logical_key_ordered_multi_value";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+    mdbxc::KeyOrderedMultiValueTable<int, std::string> table(conn, dbi_name);
+
+    const IntStringOrderedAdapter current(table,
+                                          "app.ordered_schema_version.v1");
+    MDBXC_TEST_ASSERT(current.schema_ref().schema_version == 1u);
+
+    const std::uint32_t invalid_versions[] = {0u, 2u};
+    for (std::size_t i = 0u;
+         i < sizeof(invalid_versions) / sizeof(invalid_versions[0]); ++i) {
+        bool rejected = false;
+        try {
+            IntStringOrderedAdapter invalid(
+                table, "app.ordered_schema_version.invalid", invalid_versions[i]);
+            (void)invalid;
+        } catch (const std::invalid_argument&) {
+            rejected = true;
+        }
+        MDBXC_TEST_ASSERT(rejected);
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 void test_key_ordered_multi_value_logical_adapter_replays_append_history() {
     const std::string source_path =
         "test_key_ordered_multi_value_logical_source.mdbx";
@@ -5383,6 +5418,7 @@ int main() {
     test_ordered_logical_delivery_origin_binding_survives_reopen();
     test_ordered_logical_delivery_exact_retry_survives_reopen_without_adapter();
     test_ordered_logical_delivery_exact_retry_survives_origin_migration();
+    test_key_ordered_multi_value_logical_adapter_requires_schema_v1();
     test_key_ordered_multi_value_logical_adapter_replays_append_history();
     test_key_ordered_multi_value_logical_capture_commits_to_outbox();
     test_key_ordered_multi_value_logical_capture_delivers_and_replays();


### PR DESCRIPTION
## Summary
- restrict the append-only ordered adapter to schema version 1
- retain the constructor argument for source compatibility while rejecting incompatible payload versions
- add C++11/C++17 regression coverage

## Validation
- test_key_value_logical_adapter (MinGW C++11)
- test_key_value_logical_adapter (MinGW C++17)