### PR TITLE
feat(sync): add logical adapter batch preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 - Restricted `KeyOrderedMultiValueTableLogicalAdapter` to its fixed
   schema-version-1 append payload contract. Future destructive ordered
   semantics require a separate versioned adapter.
+- Added batch preflight to `ILogicalTableAdapter`. Existing adapters retain
+  per-change preflight behavior by default; adapters with frame-local
+  invariants can validate their complete schema-local batch before apply.
 - Ordered logical schemas now persist an explicit authoritative origin in
   `_mdbxc_sync_schema`. Ordered delivery validates that binding before replay
   marker insertion or adapter callbacks, so independent origins cannot append

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ All notable changes to this project will be documented in this file.
   semantics require a separate versioned adapter.
 - Added batch preflight to `ILogicalTableAdapter`. Existing adapters retain
   per-change preflight behavior by default; adapters with frame-local
-  invariants can validate their complete schema-local batch before apply.
+  invariants can validate a non-owning schema-local batch view before apply
+  without copying logical payload bytes.
 - Ordered logical schemas now persist an explicit authoritative origin in
   `_mdbxc_sync_schema`. Ordered delivery validates that binding before replay
   marker insertion or adapter callbacks, so independent origins cannot append

--- a/include/mdbx_containers/sync/LogicalTableAdapter.hpp
+++ b/include/mdbx_containers/sync/LogicalTableAdapter.hpp
@@ -8,6 +8,7 @@
 #include <map>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <mdbx.h>
@@ -39,8 +40,8 @@ namespace sync {
 
     /// \brief Type-erased adapter for one logical table schema.
     /// \details Implementations own table-specific decoding and apply logic.
-    /// The sync core must call \c preflight() for all logical changes in a
-    /// transaction before calling \c apply() for any of them.
+    /// The sync core must validate every schema-local batch in a transaction
+    /// before calling \c apply() for any logical change.
     class ILogicalTableAdapter {
     public:
         virtual ~ILogicalTableAdapter() {}
@@ -74,6 +75,22 @@ namespace sync {
         virtual LogicalApplyResult preflight(
                 MDBX_txn* txn,
                 const LogicalChange& change) const = 0;
+
+        /// \brief Validates all changes for this registered schema at once.
+        /// \details The default preserves existing adapters by calling
+        /// \c preflight() for every change in relative frame order. Adapters
+        /// with frame-local invariants may override this method. The registry
+        /// calls it only after all changes have passed schema validation and
+        /// before any adapter \c apply() call.
+        virtual LogicalApplyResult preflight_batch(
+                MDBX_txn* txn,
+                const std::vector<LogicalChange>& changes) const {
+            for (std::size_t i = 0u; i < changes.size(); ++i) {
+                const LogicalApplyResult result = preflight(txn, changes[i]);
+                if (!result.ok) return result;
+            }
+            return LogicalApplyResult::success();
+        }
 
         /// \brief Applies a logical change after all preflights succeeded.
         virtual LogicalApplyResult apply(
@@ -133,6 +150,9 @@ namespace sync {
                 bool has_ordered_delivery = false) const {
             std::vector<AdapterRegistration> registrations;
             registrations.reserve(changes.size());
+            std::vector<AdapterRegistration> batch_registrations;
+            std::vector<std::vector<LogicalChange> > batches;
+            std::map<std::string, std::size_t> batch_indices;
 
             for (std::size_t i = 0; i < changes.size(); ++i) {
                 AdapterMap::const_iterator it =
@@ -150,11 +170,21 @@ namespace sync {
                         "Logical adapter requires ordered delivery");
                 }
                 registrations.push_back(it->second);
+
+                const std::pair<std::map<std::string, std::size_t>::iterator,
+                                bool> inserted = batch_indices.insert(
+                    std::make_pair(changes[i].schema.schema_id, batches.size()));
+                if (inserted.second) {
+                    batch_registrations.push_back(it->second);
+                    batches.push_back(std::vector<LogicalChange>());
+                }
+                batches[inserted.first->second].push_back(changes[i]);
             }
 
-            for (std::size_t i = 0; i < changes.size(); ++i) {
+            for (std::size_t i = 0u; i < batches.size(); ++i) {
                 const LogicalApplyResult result =
-                    registrations[i].adapter->preflight(txn, changes[i]);
+                    batch_registrations[i].adapter->preflight_batch(
+                        txn, batches[i]);
                 if (!result.ok) return result;
             }
 

--- a/include/mdbx_containers/sync/LogicalTableAdapter.hpp
+++ b/include/mdbx_containers/sync/LogicalTableAdapter.hpp
@@ -38,6 +38,35 @@ namespace sync {
         }
     };
 
+    class LogicalTableRegistry;
+
+    /// \brief Transient, non-owning view of one schema-local logical batch.
+    /// \details The view is valid only for the duration of the synchronous
+    /// \c preflight_batch() callback. It references changes owned by the
+    /// caller-provided change vector and never copies their payload bytes.
+    class LogicalChangeBatchView {
+    public:
+        /// \brief Returns the number of changes in this schema-local batch.
+        std::size_t size() const { return m_changes.size(); }
+
+        /// \brief Returns whether this schema-local batch has no changes.
+        bool empty() const { return m_changes.empty(); }
+
+        /// \brief Returns one change in its relative frame order.
+        const LogicalChange& operator[](std::size_t index) const {
+            return *m_changes[index];
+        }
+
+    private:
+        explicit LogicalChangeBatchView(
+                const std::vector<const LogicalChange*>& changes)
+            : m_changes(changes) {}
+
+        const std::vector<const LogicalChange*>& m_changes;
+
+        friend class LogicalTableRegistry;
+    };
+
     /// \brief Type-erased adapter for one logical table schema.
     /// \details Implementations own table-specific decoding and apply logic.
     /// The sync core must validate every schema-local batch in a transaction
@@ -84,7 +113,7 @@ namespace sync {
         /// before any adapter \c apply() call.
         virtual LogicalApplyResult preflight_batch(
                 MDBX_txn* txn,
-                const std::vector<LogicalChange>& changes) const {
+                const LogicalChangeBatchView& changes) const {
             for (std::size_t i = 0u; i < changes.size(); ++i) {
                 const LogicalApplyResult result = preflight(txn, changes[i]);
                 if (!result.ok) return result;
@@ -151,7 +180,7 @@ namespace sync {
             std::vector<AdapterRegistration> registrations;
             registrations.reserve(changes.size());
             std::vector<AdapterRegistration> batch_registrations;
-            std::vector<std::vector<LogicalChange> > batches;
+            std::vector<std::vector<const LogicalChange*> > batches;
             std::map<std::string, std::size_t> batch_indices;
 
             for (std::size_t i = 0; i < changes.size(); ++i) {
@@ -176,15 +205,15 @@ namespace sync {
                     std::make_pair(changes[i].schema.schema_id, batches.size()));
                 if (inserted.second) {
                     batch_registrations.push_back(it->second);
-                    batches.push_back(std::vector<LogicalChange>());
+                    batches.push_back(std::vector<const LogicalChange*>());
                 }
-                batches[inserted.first->second].push_back(changes[i]);
+                batches[inserted.first->second].push_back(&changes[i]);
             }
 
             for (std::size_t i = 0u; i < batches.size(); ++i) {
                 const LogicalApplyResult result =
                     batch_registrations[i].adapter->preflight_batch(
-                        txn, batches[i]);
+                        txn, LogicalChangeBatchView(batches[i]));
                 if (!result.ok) return result;
             }
 

--- a/tests/test_logical_table_adapter.cpp
+++ b/tests/test_logical_table_adapter.cpp
@@ -95,10 +95,11 @@ public:
 
     mdbxc::sync::LogicalApplyResult preflight_batch(
             MDBX_txn* txn,
-            const std::vector<mdbxc::sync::LogicalChange>& changes) const override {
+            const mdbxc::sync::LogicalChangeBatchView& changes) const override {
         (void)txn;
         ++m_preflight_batch_calls;
         for (std::size_t i = 0u; i < changes.size(); ++i) {
+            m_batch_changes.push_back(&changes[i]);
             m_batch_opcodes.push_back(changes[i].opcode);
             for (std::size_t previous = 0u; previous < i; ++previous) {
                 if (changes[previous].opcode == changes[i].opcode) {
@@ -123,6 +124,7 @@ public:
     }
 
     mutable std::size_t m_preflight_batch_calls = 0;
+    mutable std::vector<const mdbxc::sync::LogicalChange*> m_batch_changes;
     mutable std::vector<std::uint32_t> m_batch_opcodes;
 
 private:
@@ -288,8 +290,11 @@ void test_batch_preflight_receives_schema_local_changes() {
         first.m_batch_opcodes.size() != 2u ||
         first.m_batch_opcodes[0] != 1u ||
         first.m_batch_opcodes[1] != 3u ||
+        first.m_batch_changes[0] != &changes[0] ||
+        first.m_batch_changes[1] != &changes[2] ||
         second.m_batch_opcodes.size() != 1u ||
         second.m_batch_opcodes[0] != 2u ||
+        second.m_batch_changes[0] != &changes[1] ||
         first.m_events.size() != 2u ||
         second.m_events.size() != 1u ||
         first.m_events[0] != "A1" ||

--- a/tests/test_logical_table_adapter.cpp
+++ b/tests/test_logical_table_adapter.cpp
@@ -85,6 +85,50 @@ private:
     std::uint32_t m_schema_version;
 };
 
+class BatchRecordingAdapter : public RecordingAdapter {
+public:
+    explicit BatchRecordingAdapter(
+            const std::string& schema_id,
+            std::vector<std::string>* apply_order = nullptr)
+        : RecordingAdapter(schema_id),
+          m_apply_order(apply_order) {}
+
+    mdbxc::sync::LogicalApplyResult preflight_batch(
+            MDBX_txn* txn,
+            const std::vector<mdbxc::sync::LogicalChange>& changes) const override {
+        (void)txn;
+        ++m_preflight_batch_calls;
+        for (std::size_t i = 0u; i < changes.size(); ++i) {
+            m_batch_opcodes.push_back(changes[i].opcode);
+            for (std::size_t previous = 0u; previous < i; ++previous) {
+                if (changes[previous].opcode == changes[i].opcode) {
+                    return mdbxc::sync::LogicalApplyResult::failure(
+                        "duplicate logical operation in schema batch");
+                }
+            }
+        }
+        return mdbxc::sync::LogicalApplyResult::success();
+    }
+
+    mdbxc::sync::LogicalApplyResult apply(
+            MDBX_txn* txn,
+            const mdbxc::sync::LogicalChange& change) override {
+        const mdbxc::sync::LogicalApplyResult result =
+            RecordingAdapter::apply(txn, change);
+        if (result.ok && m_apply_order != nullptr) {
+            m_apply_order->push_back(
+                std::string("A") + std::to_string(change.opcode));
+        }
+        return result;
+    }
+
+    mutable std::size_t m_preflight_batch_calls = 0;
+    mutable std::vector<std::uint32_t> m_batch_opcodes;
+
+private:
+    std::vector<std::string>* m_apply_order;
+};
+
 class MdbxMutatingAdapter : public RecordingAdapter {
 public:
     MdbxMutatingAdapter(const std::string& schema_id,
@@ -218,6 +262,72 @@ void test_preflight_then_apply_order() {
         adapter.m_applied_opcodes[0] != 1u ||
         adapter.m_applied_opcodes[1] != 2u) {
         throw std::runtime_error("logical preflight/apply order mismatch");
+    }
+}
+
+void test_batch_preflight_receives_schema_local_changes() {
+    mdbxc::sync::LogicalTableRegistry registry;
+    std::vector<std::string> apply_order;
+    BatchRecordingAdapter first("schema.first.v1", &apply_order);
+    BatchRecordingAdapter second("schema.second.v1", &apply_order);
+    registry.register_adapter(&first);
+    registry.register_adapter(&second);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(make_change("schema.first.v1", 1u));
+    changes.push_back(make_change("schema.second.v1", 2u));
+    changes.push_back(make_change("schema.first.v1", 3u));
+
+    const mdbxc::sync::LogicalApplyResult result =
+        registry.preflight_then_apply(nullptr, changes);
+    if (!result.ok ||
+        first.m_preflight_calls != 0u ||
+        second.m_preflight_calls != 0u ||
+        first.m_preflight_batch_calls != 1u ||
+        second.m_preflight_batch_calls != 1u ||
+        first.m_batch_opcodes.size() != 2u ||
+        first.m_batch_opcodes[0] != 1u ||
+        first.m_batch_opcodes[1] != 3u ||
+        second.m_batch_opcodes.size() != 1u ||
+        second.m_batch_opcodes[0] != 2u ||
+        first.m_events.size() != 2u ||
+        second.m_events.size() != 1u ||
+        first.m_events[0] != "A1" ||
+        second.m_events[0] != "A2" ||
+        first.m_events[1] != "A3" ||
+        apply_order.size() != 3u ||
+        apply_order[0] != "A1" ||
+        apply_order[1] != "A2" ||
+        apply_order[2] != "A3") {
+        throw std::runtime_error(
+            "logical batch preflight did not preserve schema and apply order");
+    }
+}
+
+void test_batch_preflight_blocks_all_apply() {
+    mdbxc::sync::LogicalTableRegistry registry;
+    BatchRecordingAdapter accepted("schema.accepted.v1");
+    BatchRecordingAdapter rejected("schema.duplicates.v1");
+    registry.register_adapter(&accepted);
+    registry.register_adapter(&rejected);
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(make_change("schema.accepted.v1", 1u));
+    changes.push_back(make_change("schema.duplicates.v1", 7u));
+    changes.push_back(make_change("schema.duplicates.v1", 7u));
+
+    const mdbxc::sync::LogicalApplyResult result =
+        registry.preflight_then_apply(nullptr, changes);
+    if (result.ok ||
+        accepted.m_preflight_batch_calls != 1u ||
+        rejected.m_preflight_batch_calls != 1u ||
+        accepted.m_preflight_calls != 0u ||
+        rejected.m_preflight_calls != 0u ||
+        accepted.m_apply_calls != 0u ||
+        rejected.m_apply_calls != 0u ||
+        rejected.m_batch_opcodes.size() != 2u) {
+        throw std::runtime_error(
+            "logical batch preflight failure reached apply phase");
     }
 }
 
@@ -539,6 +649,8 @@ int main() {
     test_registry_rejects_invalid_adapters();
     test_registry_rejects_duplicate_schema_id();
     test_preflight_then_apply_order();
+    test_batch_preflight_receives_schema_local_changes();
+    test_batch_preflight_blocks_all_apply();
     test_preflight_failure_blocks_apply();
     test_schema_mismatch_blocks_adapter_calls();
     test_schema_version_mismatch_blocks_adapter_calls();

--- a/tests/test_logical_table_adapter.cpp
+++ b/tests/test_logical_table_adapter.cpp
@@ -91,15 +91,25 @@ public:
             const std::string& schema_id,
             std::vector<std::string>* apply_order = nullptr)
         : RecordingAdapter(schema_id),
-          m_apply_order(apply_order) {}
+          m_apply_order(apply_order),
+          m_received_original_changes(true) {}
 
     mdbxc::sync::LogicalApplyResult preflight_batch(
             MDBX_txn* txn,
             const mdbxc::sync::LogicalChangeBatchView& changes) const override {
         (void)txn;
         ++m_preflight_batch_calls;
+        if (!m_expected_changes.empty() &&
+            changes.size() != m_expected_changes.size()) {
+            m_received_original_changes = false;
+            return mdbxc::sync::LogicalApplyResult::failure(
+                "unexpected logical batch size");
+        }
         for (std::size_t i = 0u; i < changes.size(); ++i) {
-            m_batch_changes.push_back(&changes[i]);
+            if (!m_expected_changes.empty() &&
+                &changes[i] != m_expected_changes[i]) {
+                m_received_original_changes = false;
+            }
             m_batch_opcodes.push_back(changes[i].opcode);
             for (std::size_t previous = 0u; previous < i; ++previous) {
                 if (changes[previous].opcode == changes[i].opcode) {
@@ -124,7 +134,8 @@ public:
     }
 
     mutable std::size_t m_preflight_batch_calls = 0;
-    mutable std::vector<const mdbxc::sync::LogicalChange*> m_batch_changes;
+    std::vector<const mdbxc::sync::LogicalChange*> m_expected_changes;
+    mutable bool m_received_original_changes;
     mutable std::vector<std::uint32_t> m_batch_opcodes;
 
 private:
@@ -279,6 +290,9 @@ void test_batch_preflight_receives_schema_local_changes() {
     changes.push_back(make_change("schema.first.v1", 1u));
     changes.push_back(make_change("schema.second.v1", 2u));
     changes.push_back(make_change("schema.first.v1", 3u));
+    first.m_expected_changes.push_back(&changes[0]);
+    first.m_expected_changes.push_back(&changes[2]);
+    second.m_expected_changes.push_back(&changes[1]);
 
     const mdbxc::sync::LogicalApplyResult result =
         registry.preflight_then_apply(nullptr, changes);
@@ -290,11 +304,10 @@ void test_batch_preflight_receives_schema_local_changes() {
         first.m_batch_opcodes.size() != 2u ||
         first.m_batch_opcodes[0] != 1u ||
         first.m_batch_opcodes[1] != 3u ||
-        first.m_batch_changes[0] != &changes[0] ||
-        first.m_batch_changes[1] != &changes[2] ||
+        !first.m_received_original_changes ||
         second.m_batch_opcodes.size() != 1u ||
         second.m_batch_opcodes[0] != 2u ||
-        second.m_batch_changes[0] != &changes[1] ||
+        !second.m_received_original_changes ||
         first.m_events.size() != 2u ||
         second.m_events.size() != 1u ||
         first.m_events[0] != "A1" ||


### PR DESCRIPTION
## Summary
- add a source-compatible preflight_batch() hook to logical adapters
- group validated changes by registered schema before any apply callback
- preserve the original frame order for apply callbacks
- cover legacy and batch-aware adapters in C++11/C++17 tests

## Validation
- test_logical_table_adapter (MinGW C++11)
- test_key_value_logical_adapter (MinGW C++11)
- standalone LogicalTableAdapter header (MinGW C++11)
- corresponding C++17 targets