### PR TITLE
feat(sync): add ordered destructive state store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Added persistent `OrderedElementId` and state-store primitives for the
+  planned destructive `KeyOrderedMultiValueTable` logical schema v2.
 - Added `KeyOrderedMultiValueTableLogicalAdapter` for append-only logical
   apply through ordered delivery. It preserves repeated values and per-key
   append order for the schema marker's authoritative origin. Its typed capture

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,6 +453,7 @@ if(MDBXC_BUILD_TESTS)
           mdbx_containers/sync/adapters/KeyTableLogicalAdapter.hpp
           mdbx_containers/sync/adapters/KeyMultiValueTableLogicalAdapter.hpp
           mdbx_containers/sync/adapters/KeyOrderedMultiValueTableLogicalAdapter.hpp
+          mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
         mdbx_containers/sync/ChangeBatch.hpp
         mdbx_containers/sync/ChangeBatchCodec.hpp
         mdbx_containers/sync/SyncApplyObserver.hpp

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -28,6 +28,7 @@
 #include "sync/adapters/KeyTableLogicalAdapter.hpp"
 #include "sync/adapters/KeyMultiValueTableLogicalAdapter.hpp"
 #include "sync/adapters/KeyOrderedMultiValueTableLogicalAdapter.hpp"
+#include "sync/adapters/KeyOrderedMultiValueDestructiveState.hpp"
 #include "sync/CodecBounds.hpp"
 #include "sync/ChangeBatch.hpp"
 #include "sync/ChangeBatchCodec.hpp"

--- a/include/mdbx_containers/sync/LogicalTableAdapter.hpp
+++ b/include/mdbx_containers/sync/LogicalTableAdapter.hpp
@@ -109,6 +109,16 @@ namespace sync {
             (void)txn;
         }
 
+        /// \brief Verifies adapter-owned persistent storage without creating it.
+        /// \details Setup calls this only after it has found an existing,
+        /// matching schema marker. The default keeps existing single-DBI
+        /// adapters source-compatible. Adapters with auxiliary DBIs override
+        /// this method to fail closed when already-marked storage is missing
+        /// or incompatible.
+        virtual void verify_storage(MDBX_txn* txn) const {
+            (void)txn;
+        }
+
         /// \brief Validates a logical change without mutating user tables.
         virtual LogicalApplyResult preflight(
                 MDBX_txn* txn,

--- a/include/mdbx_containers/sync/LogicalTableAdapter.hpp
+++ b/include/mdbx_containers/sync/LogicalTableAdapter.hpp
@@ -100,6 +100,15 @@ namespace sync {
             return false;
         }
 
+        /// \brief Initializes adapter-owned persistent storage in setup.
+        /// \details The default keeps existing adapters source-compatible.
+        /// Implementations that own auxiliary DBIs create and validate them in
+        /// this caller-owned transaction before their schema marker is
+        /// committed.
+        virtual void initialize_storage(MDBX_txn* txn) const {
+            (void)txn;
+        }
+
         /// \brief Validates a logical change without mutating user tables.
         virtual LogicalApplyResult preflight(
                 MDBX_txn* txn,

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -214,6 +214,35 @@ namespace sync {
             txn.commit();
         }
 
+        /// \brief Initializes adapter storage and commits its schema marker.
+        /// \details Adapters with auxiliary DBIs override
+        /// \c ILogicalTableAdapter::initialize_storage(). Both their storage
+        /// setup and the persistent marker belong to this one transaction, so
+        /// an apply path never treats missing auxiliary state as empty.
+        void initialize_logical_adapter_schema(
+                const ILogicalTableAdapter& adapter,
+                const LogicalSchemaRecord& record) {
+            const LogicalSchemaRef ref = adapter.schema_ref();
+            if (!is_logical_schema_ref_complete(ref) ||
+                record.kind != ref.kind ||
+                record.schema_version != ref.schema_version) {
+                throw std::invalid_argument(
+                    "Logical adapter schema marker does not match adapter");
+            }
+            auto txn = m_conn->transaction(TransactionMode::WRITABLE);
+            initialize_system_stores(txn.handle());
+            adapter.initialize_storage(txn.handle());
+            SchemaRegistryStore schemas(m_conn->env_handle());
+            schemas.register_or_verify(txn.handle(), ref.schema_id, record);
+            const LogicalApplyResult marker_result =
+                validate_logical_adapter_marker(
+                    txn.handle(), m_conn->env_handle(), adapter);
+            if (!marker_result.ok) {
+                throw std::runtime_error(marker_result.error);
+            }
+            txn.commit();
+        }
+
         /// \brief Migrates an existing persistent logical table schema marker.
         /// \details This is an explicit marker lifecycle operation. It does
         /// not migrate user table contents or changelog data. The current

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -214,11 +214,13 @@ namespace sync {
             txn.commit();
         }
 
-        /// \brief Initializes adapter storage and commits its schema marker.
+        /// \brief Initializes fresh adapter storage or verifies marked storage.
         /// \details Adapters with auxiliary DBIs override
-        /// \c ILogicalTableAdapter::initialize_storage(). Both their storage
-        /// setup and the persistent marker belong to this one transaction, so
-        /// an apply path never treats missing auxiliary state as empty.
+        /// \c ILogicalTableAdapter::initialize_storage() and
+        /// \c ILogicalTableAdapter::verify_storage(). Fresh setup and the
+        /// persistent marker belong to one transaction. Existing markers only
+        /// verify their storage, so an apply path never treats missing
+        /// auxiliary state as empty.
         void initialize_logical_adapter_schema(
                 const ILogicalTableAdapter& adapter,
                 const LogicalSchemaRecord& record) {
@@ -231,9 +233,17 @@ namespace sync {
             }
             auto txn = m_conn->transaction(TransactionMode::WRITABLE);
             initialize_system_stores(txn.handle());
-            adapter.initialize_storage(txn.handle());
             SchemaRegistryStore schemas(m_conn->env_handle());
-            schemas.register_or_verify(txn.handle(), ref.schema_id, record);
+            LogicalSchemaRecord existing;
+            if (schemas.get(txn.handle(), ref.schema_id, existing)) {
+                // An existing marker describes durable layout. Verify it first
+                // and never recreate an auxiliary DBI as implicit recovery.
+                schemas.register_or_verify(txn.handle(), ref.schema_id, record);
+                adapter.verify_storage(txn.handle());
+            } else {
+                adapter.initialize_storage(txn.handle());
+                schemas.register_or_verify(txn.handle(), ref.schema_id, record);
+            }
             const LogicalApplyResult marker_result =
                 validate_logical_adapter_marker(
                     txn.handle(), m_conn->env_handle(), adapter);

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
@@ -112,7 +112,8 @@ namespace sync {
     };
 
     /// \brief Transactional store for destructive ordered element state.
-    /// \details The state DBI stores origin counters and Live/Tombstone records.
+    /// \details The state DBI stores origin allocation counters, introduced
+    /// sequence high-water marks, and Live/Tombstone records.
     /// The DUPSORT index maps canonical logical key bytes to immutable ids.
     /// Every public operation participates in the caller-owned transaction.
     class OrderedElementStateStore {
@@ -138,28 +139,17 @@ namespace sync {
             }
             const MDBX_dbi state = open_state(txn);
             const std::vector<std::uint8_t> key = make_counter_key(origin);
-            MDBX_val raw_key = make_val(key);
-            MDBX_val raw_value;
-            std::uint64_t previous = 0u;
-            const int rc = mdbx_get(txn, state, &raw_key, &raw_value);
-            if (rc == MDBX_SUCCESS) {
-                if (raw_value.iov_len != 8u) {
-                    throw std::runtime_error("Ordered element counter is corrupt");
-                }
-                previous = detail::read_u64_le(
-                    static_cast<const std::uint8_t*>(raw_value.iov_base));
-            } else if (rc != MDBX_NOTFOUND) {
-                check_mdbx(rc, "Ordered element counter read failed");
-            }
+            const std::uint64_t allocated = read_sequence(
+                txn, state, key, "Ordered element counter");
+            const std::uint64_t introduced = highest_introduced(txn, origin);
+            const std::uint64_t previous = allocated > introduced ?
+                allocated : introduced;
             if (previous == (std::numeric_limits<std::uint64_t>::max)()) {
                 throw std::overflow_error("Ordered element counter overflow");
             }
             const std::uint64_t next = previous + 1u;
-            std::vector<std::uint8_t> encoded;
-            detail::append_u64_le(encoded, next);
-            MDBX_val raw_next = make_val(encoded);
-            check_mdbx(mdbx_put(txn, state, &raw_key, &raw_next, MDBX_UPSERT),
-                       "Ordered element counter write failed");
+            write_sequence(txn, state, key, next,
+                           "Ordered element counter write failed");
             OrderedElementId out;
             out.origin = origin;
             out.sequence = next;
@@ -182,6 +172,38 @@ namespace sync {
             open_by_key_create(txn);
         }
 
+        /// \brief Creates auxiliary DBIs only for a fresh, empty schema.
+        void initialize_empty(MDBX_txn* txn) const {
+            txn = checked_txn(
+                txn, "OrderedElementStateStore::initialize_empty");
+            const MDBX_dbi state = open_state_create(txn);
+            const MDBX_dbi by_key = open_by_key_create(txn);
+            require_empty(txn, state, "Ordered element state DBI is not empty");
+            require_empty(txn, by_key, "Ordered element key index DBI is not empty");
+        }
+
+        /// \brief Verifies already-marked auxiliary DBIs without creating them.
+        void verify_existing(MDBX_txn* txn) const {
+            txn = checked_txn(
+                txn, "OrderedElementStateStore::verify_existing");
+            open_state(txn);
+            open_by_key(txn);
+        }
+
+        /// \brief Returns the largest sequence ever introduced for one origin.
+        std::uint64_t highest_introduced(
+                MDBX_txn* txn,
+                const NodeId& origin) const {
+            txn = checked_txn(
+                txn, "OrderedElementStateStore::highest_introduced");
+            if (compare_node_id(origin, make_zero_node()) == 0) {
+                throw std::invalid_argument("Ordered element origin is zero");
+            }
+            const MDBX_dbi state = open_state(txn);
+            return read_sequence(txn, state, make_introduced_key(origin),
+                                 "Ordered element introduced high-water mark");
+        }
+
         void put_live(MDBX_txn* txn,
                       const OrderedElementId& id,
                       const std::vector<std::uint8_t>& key,
@@ -195,6 +217,11 @@ namespace sync {
 
             const MDBX_dbi state = open_state(txn);
             const MDBX_dbi by_key = open_by_key(txn);
+            const std::uint64_t introduced = highest_introduced(txn, id.origin);
+            if (id.sequence <= introduced) {
+                throw std::runtime_error(
+                    "Ordered element id is not above the introduced high-water mark");
+            }
             const std::vector<std::uint8_t> state_key = make_element_key(id);
             const std::vector<std::uint8_t> state_value = make_live_value(key, value);
             MDBX_val raw_state_key = make_val(state_key);
@@ -210,6 +237,9 @@ namespace sync {
             check_mdbx(mdbx_put(txn, by_key, &raw_key, &raw_index_value,
                                 MDBX_NODUPDATA),
                        "Ordered element key index write failed");
+            write_sequence(txn, state, make_introduced_key(id.origin),
+                           id.sequence,
+                           "Ordered element introduced high-water write failed");
         }
 
         void tombstone(MDBX_txn* txn, const OrderedElementId& id) const {
@@ -342,7 +372,8 @@ namespace sync {
                         throw std::runtime_error(
                             "Ordered element state key is invalid");
                     }
-                    if (bytes[0] == counter_tag()) {
+                    if (bytes[0] == counter_tag() ||
+                        bytes[0] == introduced_tag()) {
                         if (raw_key.iov_len != 1u + NodeId().size() ||
                             raw_value.iov_len != 8u) {
                             throw std::runtime_error(
@@ -376,6 +407,7 @@ namespace sync {
     private:
         static std::uint8_t counter_tag() { return 0x00u; }
         static std::uint8_t element_tag() { return 0x01u; }
+        static std::uint8_t introduced_tag() { return 0x02u; }
         static std::uint8_t live_tag() { return 0x01u; }
         static std::uint8_t tombstone_tag() { return 0x02u; }
 
@@ -407,6 +439,55 @@ namespace sync {
                 bytes.size()
             };
             return out;
+        }
+
+        static void require_empty(MDBX_txn* txn,
+                                  MDBX_dbi dbi,
+                                  const char* message) {
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, dbi, &cursor),
+                       "Ordered element state empty check cursor open failed");
+            MDBX_val key;
+            MDBX_val value;
+            const int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+            mdbx_cursor_close(cursor);
+            if (rc == MDBX_SUCCESS) {
+                throw std::runtime_error(message);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Ordered element state empty check failed");
+            }
+        }
+
+        static std::uint64_t read_sequence(
+                MDBX_txn* txn,
+                MDBX_dbi dbi,
+                const std::vector<std::uint8_t>& key,
+                const char* context) {
+            MDBX_val raw_key = make_val(key);
+            MDBX_val raw_value;
+            const int rc = mdbx_get(txn, dbi, &raw_key, &raw_value);
+            if (rc == MDBX_NOTFOUND) return 0u;
+            check_mdbx(rc, context);
+            if (raw_value.iov_len != 8u || raw_value.iov_base == nullptr) {
+                throw std::runtime_error(std::string(context) + " is corrupt");
+            }
+            return detail::read_u64_le(
+                static_cast<const std::uint8_t*>(raw_value.iov_base));
+        }
+
+        static void write_sequence(
+                MDBX_txn* txn,
+                MDBX_dbi dbi,
+                const std::vector<std::uint8_t>& key,
+                std::uint64_t value,
+                const char* context) {
+            std::vector<std::uint8_t> encoded;
+            detail::append_u64_le(encoded, value);
+            MDBX_val raw_key = make_val(key);
+            MDBX_val raw_value = make_val(encoded);
+            check_mdbx(mdbx_put(txn, dbi, &raw_key, &raw_value, MDBX_UPSERT),
+                       context);
         }
 
         MDBX_dbi open_named_existing(MDBX_txn* txn,
@@ -456,6 +537,14 @@ namespace sync {
         static std::vector<std::uint8_t> make_counter_key(const NodeId& origin) {
             std::vector<std::uint8_t> out;
             out.push_back(counter_tag());
+            out.insert(out.end(), origin.begin(), origin.end());
+            return out;
+        }
+
+        static std::vector<std::uint8_t> make_introduced_key(
+                const NodeId& origin) {
+            std::vector<std::uint8_t> out;
+            out.push_back(introduced_tag());
             out.insert(out.end(), origin.begin(), origin.end());
             return out;
         }

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
@@ -6,6 +6,7 @@
 /// \brief Persistent state primitives for destructive ordered logical schemas.
 
 #include <cstddef>
+#include <cstring>
 #include <cstdint>
 #include <limits>
 #include <stdexcept>
@@ -138,6 +139,7 @@ namespace sync {
                 throw std::invalid_argument("Ordered element origin is zero");
             }
             const MDBX_dbi state = open_state(txn);
+            verify_introduced_high_water(txn, origin);
             const std::vector<std::uint8_t> key = make_counter_key(origin);
             const std::uint64_t allocated = read_sequence(
                 txn, state, key, "Ordered element counter");
@@ -188,6 +190,60 @@ namespace sync {
                 txn, "OrderedElementStateStore::verify_existing");
             open_state(txn);
             open_by_key(txn);
+            verify_all_introduced_high_water(txn);
+        }
+
+        /// \brief Verifies the introduced high-water mark for one origin.
+        /// \details Every persisted Live or Tombstone id must be at or below
+        /// the durable high-water mark. This prevents a damaged marker from
+        /// admitting a lower id that would disagree with DUPSORT id order.
+        void verify_introduced_high_water(
+                MDBX_txn* txn,
+                const NodeId& origin) const {
+            txn = checked_txn(
+                txn, "OrderedElementStateStore::verify_introduced_high_water");
+            if (compare_node_id(origin, make_zero_node()) == 0) {
+                throw std::invalid_argument("Ordered element origin is zero");
+            }
+            const MDBX_dbi state = open_state(txn);
+            const std::vector<std::uint8_t> prefix = make_element_prefix(origin);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, state, &cursor),
+                       "Ordered element state high-water cursor open failed");
+            std::uint64_t highest_persisted = 0u;
+            try {
+                MDBX_val raw_key = make_val(prefix);
+                MDBX_val raw_value;
+                int rc = mdbx_cursor_get(cursor, &raw_key, &raw_value,
+                                         MDBX_SET_RANGE);
+                while (rc == MDBX_SUCCESS && has_prefix(raw_key, prefix)) {
+                    const OrderedElementId id = decode_element_key(raw_key);
+                    decode_state_value(raw_value);
+                    if (id.sequence > highest_persisted) {
+                        highest_persisted = id.sequence;
+                    }
+                    rc = mdbx_cursor_get(cursor, &raw_key, &raw_value,
+                                         MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND && rc != MDBX_SUCCESS) {
+                    check_mdbx(rc,
+                               "Ordered element state high-water cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+
+            if (highest_persisted == 0u) return;
+            std::uint64_t introduced = 0u;
+            if (!read_sequence_if_present(
+                    txn, state, make_introduced_key(origin), introduced,
+                    "Ordered element introduced high-water mark") ||
+                introduced < highest_persisted) {
+                throw std::runtime_error(
+                    "Ordered element introduced high-water mark is corrupt");
+            }
         }
 
         /// \brief Returns the largest sequence ever introduced for one origin.
@@ -203,13 +259,13 @@ namespace sync {
             return read_sequence(txn, state, make_introduced_key(origin),
                                  "Ordered element introduced high-water mark");
         }
-
         void put_live(MDBX_txn* txn,
                       const OrderedElementId& id,
                       const std::vector<std::uint8_t>& key,
                       const std::vector<std::uint8_t>& value) const {
             txn = checked_txn(txn, "OrderedElementStateStore::put_live");
             require_id(id);
+            verify_introduced_high_water(txn, id.origin);
             OrderedElementStateRecord existing;
             if (get(txn, id, existing)) {
                 throw std::runtime_error("Ordered element id already exists");
@@ -433,6 +489,75 @@ namespace sync {
             return open_named_create(txn, m_by_key_dbi_name, MDBX_DUPSORT);
         }
 
+        static bool has_prefix(const MDBX_val& value,
+                               const std::vector<std::uint8_t>& prefix) {
+            const std::uint8_t* data =
+                static_cast<const std::uint8_t*>(value.iov_base);
+            return data != nullptr && value.iov_len >= prefix.size() &&
+                   std::memcmp(data, &prefix[0], prefix.size()) == 0;
+        }
+
+        static bool contains_origin(const std::vector<NodeId>& origins,
+                                    const NodeId& origin) {
+            for (std::size_t i = 0u; i < origins.size(); ++i) {
+                if (compare_node_id(origins[i], origin) == 0) return true;
+            }
+            return false;
+        }
+
+        void verify_all_introduced_high_water(MDBX_txn* txn) const {
+            const MDBX_dbi state = open_state(txn);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, state, &cursor),
+                       "Ordered element state verification cursor open failed");
+            std::vector<NodeId> origins;
+            try {
+                MDBX_val raw_key;
+                MDBX_val raw_value;
+                int rc = mdbx_cursor_get(cursor, &raw_key, &raw_value,
+                                         MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    const std::uint8_t* bytes =
+                        static_cast<const std::uint8_t*>(raw_key.iov_base);
+                    if (bytes == nullptr || raw_key.iov_len == 0u) {
+                        throw std::runtime_error(
+                            "Ordered element state key is invalid");
+                    }
+                    if (bytes[0] == counter_tag() ||
+                        bytes[0] == introduced_tag()) {
+                        if (raw_key.iov_len != 1u + NodeId().size() ||
+                            raw_value.iov_len != 8u ||
+                            compare_node_id(make_node_id(bytes + 1u),
+                                            make_zero_node()) == 0) {
+                            throw std::runtime_error(
+                                "Ordered element counter record is corrupt");
+                        }
+                    } else if (bytes[0] == element_tag()) {
+                        const OrderedElementId id = decode_element_key(raw_key);
+                        decode_state_value(raw_value);
+                        if (!contains_origin(origins, id.origin)) {
+                            origins.push_back(id.origin);
+                        }
+                    } else {
+                        throw std::runtime_error(
+                            "Ordered element state key tag is invalid");
+                    }
+                    rc = mdbx_cursor_get(cursor, &raw_key, &raw_value,
+                                         MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "Ordered element state verification cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            for (std::size_t i = 0u; i < origins.size(); ++i) {
+                verify_introduced_high_water(txn, origins[i]);
+            }
+        }
+
         static MDBX_val make_val(const std::vector<std::uint8_t>& bytes) {
             MDBX_val out = {
                 const_cast<std::uint8_t*>(bytes.empty() ? nullptr : &bytes[0]),
@@ -464,16 +589,28 @@ namespace sync {
                 MDBX_dbi dbi,
                 const std::vector<std::uint8_t>& key,
                 const char* context) {
+            std::uint64_t out = 0u;
+            read_sequence_if_present(txn, dbi, key, out, context);
+            return out;
+        }
+
+        static bool read_sequence_if_present(
+                MDBX_txn* txn,
+                MDBX_dbi dbi,
+                const std::vector<std::uint8_t>& key,
+                std::uint64_t& out,
+                const char* context) {
             MDBX_val raw_key = make_val(key);
             MDBX_val raw_value;
             const int rc = mdbx_get(txn, dbi, &raw_key, &raw_value);
-            if (rc == MDBX_NOTFOUND) return 0u;
+            if (rc == MDBX_NOTFOUND) return false;
             check_mdbx(rc, context);
             if (raw_value.iov_len != 8u || raw_value.iov_base == nullptr) {
                 throw std::runtime_error(std::string(context) + " is corrupt");
             }
-            return detail::read_u64_le(
+            out = detail::read_u64_le(
                 static_cast<const std::uint8_t*>(raw_value.iov_base));
+            return true;
         }
 
         static void write_sequence(
@@ -551,11 +688,18 @@ namespace sync {
 
         static std::vector<std::uint8_t> make_element_key(
                 const OrderedElementId& id) {
-            std::vector<std::uint8_t> out;
-            out.push_back(element_tag());
+            std::vector<std::uint8_t> out = make_element_prefix(id.origin);
             const std::vector<std::uint8_t> encoded =
                 encode_ordered_element_id_index(id);
-            out.insert(out.end(), encoded.begin(), encoded.end());
+            out.insert(out.end(), encoded.begin() + id.origin.size(), encoded.end());
+            return out;
+        }
+
+        static std::vector<std::uint8_t> make_element_prefix(
+                const NodeId& origin) {
+            std::vector<std::uint8_t> out;
+            out.push_back(element_tag());
+            out.insert(out.end(), origin.begin(), origin.end());
             return out;
         }
 

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
@@ -41,6 +41,15 @@ namespace sync {
                id.sequence != 0u;
     }
 
+    struct OrderedElementIdLess {
+        bool operator()(const OrderedElementId& lhs,
+                        const OrderedElementId& rhs) const {
+            const int compared = compare_node_id(lhs.origin, rhs.origin);
+            return compared < 0 ||
+                   (compared == 0 && lhs.sequence < rhs.sequence);
+        }
+    };
+
     /// \brief Encodes an id for logical payloads: node bytes plus LE sequence.
     inline std::vector<std::uint8_t> encode_ordered_element_id_logical(
             const OrderedElementId& id) {
@@ -155,6 +164,22 @@ namespace sync {
             out.origin = origin;
             out.sequence = next;
             return out;
+        }
+
+        const std::string& state_dbi_name() const {
+            return m_state_dbi_name;
+        }
+
+        const std::string& by_key_dbi_name() const {
+            return m_by_key_dbi_name;
+        }
+
+        /// \brief Creates or verifies v2 state DBIs during schema setup.
+        /// \details Capture and apply open only existing DBIs afterwards.
+        void initialize(MDBX_txn* txn) const {
+            txn = checked_txn(txn, "OrderedElementStateStore::initialize");
+            open_state_create(txn);
+            open_by_key_create(txn);
         }
 
         void put_live(MDBX_txn* txn,
@@ -293,6 +318,61 @@ namespace sync {
             return out;
         }
 
+        /// \brief Reverse-scans Live records for \p key.
+        /// \details Used to detect state entries missing from the DUPSORT index.
+        std::vector<OrderedElementId> live_state_ids_for_key(
+                MDBX_txn* txn,
+                const std::vector<std::uint8_t>& key) const {
+            txn = checked_txn(
+                txn, "OrderedElementStateStore::live_state_ids_for_key");
+            const MDBX_dbi state = open_state(txn);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, state, &cursor),
+                       "Ordered element state cursor open failed");
+            std::vector<OrderedElementId> out;
+            try {
+                MDBX_val raw_key;
+                MDBX_val raw_value;
+                int rc = mdbx_cursor_get(cursor, &raw_key, &raw_value,
+                                         MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    const std::uint8_t* bytes =
+                        static_cast<const std::uint8_t*>(raw_key.iov_base);
+                    if (bytes == nullptr || raw_key.iov_len == 0u) {
+                        throw std::runtime_error(
+                            "Ordered element state key is invalid");
+                    }
+                    if (bytes[0] == counter_tag()) {
+                        if (raw_key.iov_len != 1u + NodeId().size() ||
+                            raw_value.iov_len != 8u) {
+                            throw std::runtime_error(
+                                "Ordered element counter record is corrupt");
+                        }
+                    } else if (bytes[0] == element_tag()) {
+                        const OrderedElementId id = decode_element_key(raw_key);
+                        const OrderedElementStateRecord record =
+                            decode_state_value(raw_value);
+                        if (record.live && record.key == key) {
+                            out.push_back(id);
+                        }
+                    } else {
+                        throw std::runtime_error(
+                            "Ordered element state key tag is invalid");
+                    }
+                    rc = mdbx_cursor_get(cursor, &raw_key, &raw_value,
+                                         MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "Ordered element state cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return out;
+        }
+
     private:
         static std::uint8_t counter_tag() { return 0x00u; }
         static std::uint8_t element_tag() { return 0x01u; }
@@ -304,12 +384,21 @@ namespace sync {
         }
 
         MDBX_dbi open_state(MDBX_txn* txn) const {
-            return open_named(txn, m_state_dbi_name,
-                              static_cast<MDBX_db_flags_t>(0));
+            return open_named_existing(txn, m_state_dbi_name,
+                                       static_cast<MDBX_db_flags_t>(0));
         }
 
         MDBX_dbi open_by_key(MDBX_txn* txn) const {
-            return open_named(txn, m_by_key_dbi_name, MDBX_DUPSORT);
+            return open_named_existing(txn, m_by_key_dbi_name, MDBX_DUPSORT);
+        }
+
+        MDBX_dbi open_state_create(MDBX_txn* txn) const {
+            return open_named_create(txn, m_state_dbi_name,
+                                     static_cast<MDBX_db_flags_t>(0));
+        }
+
+        MDBX_dbi open_by_key_create(MDBX_txn* txn) const {
+            return open_named_create(txn, m_by_key_dbi_name, MDBX_DUPSORT);
         }
 
         static MDBX_val make_val(const std::vector<std::uint8_t>& bytes) {
@@ -320,16 +409,42 @@ namespace sync {
             return out;
         }
 
-        MDBX_dbi open_named(MDBX_txn* txn,
-                            const std::string& name,
-                            MDBX_db_flags_t flags) const {
+        MDBX_dbi open_named_existing(MDBX_txn* txn,
+                                      const std::string& name,
+                                      MDBX_db_flags_t expected_flags) const {
             MDBX_dbi dbi = 0;
-            int rc = mdbx_dbi_open(txn, name.c_str(), flags | MDBX_CREATE, &dbi);
-            if (rc == MDBX_EACCESS) {
-                rc = mdbx_dbi_open(txn, name.c_str(), flags, &dbi);
-            }
+            const int rc = mdbx_dbi_open(txn, name.c_str(),
+                                         expected_flags, &dbi);
             check_mdbx(rc, "Ordered element state DBI open failed");
+            validate_dbi_flags(txn, dbi, expected_flags);
             return dbi;
+        }
+
+        MDBX_dbi open_named_create(MDBX_txn* txn,
+                                   const std::string& name,
+                                   MDBX_db_flags_t expected_flags) const {
+            MDBX_dbi dbi = 0;
+            const int rc = mdbx_dbi_open(
+                txn, name.c_str(), expected_flags | MDBX_CREATE, &dbi);
+            check_mdbx(rc, "Ordered element state DBI setup failed");
+            validate_dbi_flags(txn, dbi, expected_flags);
+            return dbi;
+        }
+
+        static void validate_dbi_flags(MDBX_txn* txn,
+                                       MDBX_dbi dbi,
+                                       MDBX_db_flags_t expected_flags) {
+            unsigned raw_flags = 0u;
+            check_mdbx(mdbx_dbi_flags(txn, dbi, &raw_flags),
+                       "Ordered element state DBI flags read failed");
+            const unsigned persistent_mask =
+                MDBX_REVERSEKEY | MDBX_DUPSORT | MDBX_INTEGERKEY |
+                MDBX_INTEGERDUP | MDBX_REVERSEDUP | MDBX_DUPFIXED;
+            if ((raw_flags & persistent_mask) !=
+                (static_cast<unsigned>(expected_flags) & persistent_mask)) {
+                throw std::runtime_error(
+                    "Ordered element state DBI flags are incompatible");
+            }
         }
 
         static void require_id(const OrderedElementId& id) {
@@ -433,6 +548,18 @@ namespace sync {
                 throw std::runtime_error("Ordered element key index value is invalid");
             }
             bytes.assign(data, data + value.iov_len);
+            return decode_ordered_element_id_index(bytes);
+        }
+
+        static OrderedElementId decode_element_key(const MDBX_val& key) {
+            const std::uint8_t* data =
+                static_cast<const std::uint8_t*>(key.iov_base);
+            const std::size_t id_size = NodeId().size() + 8u;
+            if (data == nullptr || key.iov_len != 1u + id_size ||
+                data[0] != element_tag()) {
+                throw std::runtime_error("Ordered element state key is invalid");
+            }
+            std::vector<std::uint8_t> bytes(data + 1u, data + key.iov_len);
             return decode_ordered_element_id_index(bytes);
         }
 

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
@@ -1,0 +1,447 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_ADAPTERS_KEY_ORDERED_MULTI_VALUE_DESTRUCTIVE_STATE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_ADAPTERS_KEY_ORDERED_MULTI_VALUE_DESTRUCTIVE_STATE_HPP_INCLUDED
+
+/// \file KeyOrderedMultiValueDestructiveState.hpp
+/// \brief Persistent state primitives for destructive ordered logical schemas.
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mdbx.h>
+
+#include "../../common/MdbxException.hpp"
+#include "../../detail/utils.hpp"
+#include "../common.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Immutable identity of one destructive ordered-table element.
+    struct OrderedElementId {
+        NodeId origin = make_zero_node();
+        std::uint64_t sequence = 0u;
+
+        bool operator==(const OrderedElementId& other) const {
+            return compare_node_id(origin, other.origin) == 0 &&
+                   sequence == other.sequence;
+        }
+
+        bool operator!=(const OrderedElementId& other) const {
+            return !(*this == other);
+        }
+    };
+
+    inline bool is_valid_ordered_element_id(const OrderedElementId& id) {
+        return compare_node_id(id.origin, make_zero_node()) != 0 &&
+               id.sequence != 0u;
+    }
+
+    /// \brief Encodes an id for logical payloads: node bytes plus LE sequence.
+    inline std::vector<std::uint8_t> encode_ordered_element_id_logical(
+            const OrderedElementId& id) {
+        if (!is_valid_ordered_element_id(id)) {
+            throw std::invalid_argument("Ordered element id is invalid");
+        }
+        std::vector<std::uint8_t> out;
+        out.insert(out.end(), id.origin.begin(), id.origin.end());
+        detail::append_u64_le(out, id.sequence);
+        return out;
+    }
+
+    /// \brief Encodes an id for bytewise ordered DBI values: node plus BE seq.
+    inline std::vector<std::uint8_t> encode_ordered_element_id_index(
+            const OrderedElementId& id) {
+        if (!is_valid_ordered_element_id(id)) {
+            throw std::invalid_argument("Ordered element id is invalid");
+        }
+        std::vector<std::uint8_t> out;
+        out.insert(out.end(), id.origin.begin(), id.origin.end());
+        detail::append_u64_be(out, id.sequence);
+        return out;
+    }
+
+    inline OrderedElementId decode_ordered_element_id_logical(
+            const std::vector<std::uint8_t>& bytes) {
+        const std::size_t expected = NodeId().size() + 8u;
+        if (bytes.size() != expected) {
+            throw std::runtime_error("Ordered logical element id has invalid size");
+        }
+        OrderedElementId out;
+        out.origin = make_node_id(&bytes[0]);
+        out.sequence = detail::read_u64_le(&bytes[0] + out.origin.size());
+        if (!is_valid_ordered_element_id(out)) {
+            throw std::runtime_error("Ordered logical element id is invalid");
+        }
+        return out;
+    }
+
+    inline OrderedElementId decode_ordered_element_id_index(
+            const std::vector<std::uint8_t>& bytes) {
+        const std::size_t expected = NodeId().size() + 8u;
+        if (bytes.size() != expected) {
+            throw std::runtime_error("Ordered element index id has invalid size");
+        }
+        OrderedElementId out;
+        out.origin = make_node_id(&bytes[0]);
+        out.sequence = detail::read_u64_be(&bytes[0] + out.origin.size());
+        if (!is_valid_ordered_element_id(out)) {
+            throw std::runtime_error("Ordered element index id is invalid");
+        }
+        return out;
+    }
+
+    /// \brief Persisted state for one destructive ordered-table element.
+    struct OrderedElementStateRecord {
+        bool live = false;
+        std::vector<std::uint8_t> key;
+        std::vector<std::uint8_t> value;
+    };
+
+    /// \brief Transactional store for destructive ordered element state.
+    /// \details The state DBI stores origin counters and Live/Tombstone records.
+    /// The DUPSORT index maps canonical logical key bytes to immutable ids.
+    /// Every public operation participates in the caller-owned transaction.
+    class OrderedElementStateStore {
+    public:
+        OrderedElementStateStore(MDBX_env* env,
+                                 const std::string& state_dbi_name,
+                                 const std::string& by_key_dbi_name)
+            : m_env(env),
+              m_state_dbi_name(state_dbi_name),
+              m_by_key_dbi_name(by_key_dbi_name) {
+            if (m_env == nullptr || m_state_dbi_name.empty() ||
+                m_by_key_dbi_name.empty() ||
+                m_state_dbi_name == m_by_key_dbi_name) {
+                throw std::invalid_argument(
+                    "Ordered element state DBI configuration is invalid");
+            }
+        }
+
+        OrderedElementId allocate_id(MDBX_txn* txn, const NodeId& origin) const {
+            txn = checked_txn(txn, "OrderedElementStateStore::allocate_id");
+            if (compare_node_id(origin, make_zero_node()) == 0) {
+                throw std::invalid_argument("Ordered element origin is zero");
+            }
+            const MDBX_dbi state = open_state(txn);
+            const std::vector<std::uint8_t> key = make_counter_key(origin);
+            MDBX_val raw_key = make_val(key);
+            MDBX_val raw_value;
+            std::uint64_t previous = 0u;
+            const int rc = mdbx_get(txn, state, &raw_key, &raw_value);
+            if (rc == MDBX_SUCCESS) {
+                if (raw_value.iov_len != 8u) {
+                    throw std::runtime_error("Ordered element counter is corrupt");
+                }
+                previous = detail::read_u64_le(
+                    static_cast<const std::uint8_t*>(raw_value.iov_base));
+            } else if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Ordered element counter read failed");
+            }
+            if (previous == (std::numeric_limits<std::uint64_t>::max)()) {
+                throw std::overflow_error("Ordered element counter overflow");
+            }
+            const std::uint64_t next = previous + 1u;
+            std::vector<std::uint8_t> encoded;
+            detail::append_u64_le(encoded, next);
+            MDBX_val raw_next = make_val(encoded);
+            check_mdbx(mdbx_put(txn, state, &raw_key, &raw_next, MDBX_UPSERT),
+                       "Ordered element counter write failed");
+            OrderedElementId out;
+            out.origin = origin;
+            out.sequence = next;
+            return out;
+        }
+
+        void put_live(MDBX_txn* txn,
+                      const OrderedElementId& id,
+                      const std::vector<std::uint8_t>& key,
+                      const std::vector<std::uint8_t>& value) const {
+            txn = checked_txn(txn, "OrderedElementStateStore::put_live");
+            require_id(id);
+            OrderedElementStateRecord existing;
+            if (get(txn, id, existing)) {
+                throw std::runtime_error("Ordered element id already exists");
+            }
+
+            const MDBX_dbi state = open_state(txn);
+            const MDBX_dbi by_key = open_by_key(txn);
+            const std::vector<std::uint8_t> state_key = make_element_key(id);
+            const std::vector<std::uint8_t> state_value = make_live_value(key, value);
+            MDBX_val raw_state_key = make_val(state_key);
+            MDBX_val raw_state_value = make_val(state_value);
+            check_mdbx(mdbx_put(txn, state, &raw_state_key, &raw_state_value,
+                                MDBX_NOOVERWRITE),
+                       "Ordered element state write failed");
+
+            const std::vector<std::uint8_t> index_value =
+                encode_ordered_element_id_index(id);
+            MDBX_val raw_key = make_val(key);
+            MDBX_val raw_index_value = make_val(index_value);
+            check_mdbx(mdbx_put(txn, by_key, &raw_key, &raw_index_value,
+                                MDBX_NODUPDATA),
+                       "Ordered element key index write failed");
+        }
+
+        void tombstone(MDBX_txn* txn, const OrderedElementId& id) const {
+            txn = checked_txn(txn, "OrderedElementStateStore::tombstone");
+            require_id(id);
+            OrderedElementStateRecord record;
+            if (!get(txn, id, record)) {
+                throw std::runtime_error("Ordered element id is missing");
+            }
+            if (!record.live) {
+                throw std::runtime_error("Ordered element id is already tombstoned");
+            }
+            const MDBX_dbi state = open_state(txn);
+            const std::vector<std::uint8_t> state_key = make_element_key(id);
+            const std::vector<std::uint8_t> tombstone_value(1u, tombstone_tag());
+            MDBX_val raw_key = make_val(state_key);
+            MDBX_val raw_value = make_val(tombstone_value);
+            check_mdbx(mdbx_put(txn, state, &raw_key, &raw_value, MDBX_UPSERT),
+                       "Ordered element tombstone write failed");
+
+            const MDBX_dbi by_key = open_by_key(txn);
+            const std::vector<std::uint8_t> index_value =
+                encode_ordered_element_id_index(id);
+            MDBX_val raw_index_key = make_val(record.key);
+            MDBX_val raw_index_value = make_val(index_value);
+            check_mdbx(mdbx_del(txn, by_key, &raw_index_key, &raw_index_value),
+                       "Ordered element key index tombstone delete failed");
+        }
+
+        /// \brief Removes a newly allocated live element without a tombstone.
+        /// \details Used when one local typed capture session coalesces its own
+        /// append and erase. The origin counter remains advanced.
+        void erase_live(MDBX_txn* txn, const OrderedElementId& id) const {
+            txn = checked_txn(txn, "OrderedElementStateStore::erase_live");
+            require_id(id);
+            OrderedElementStateRecord record;
+            if (!get(txn, id, record) || !record.live) {
+                throw std::runtime_error("Ordered live element is missing");
+            }
+            const MDBX_dbi state = open_state(txn);
+            const MDBX_dbi by_key = open_by_key(txn);
+            const std::vector<std::uint8_t> state_key = make_element_key(id);
+            const std::vector<std::uint8_t> index_value =
+                encode_ordered_element_id_index(id);
+            MDBX_val raw_state_key = make_val(state_key);
+            MDBX_val raw_index_key = make_val(record.key);
+            MDBX_val raw_index_value = make_val(index_value);
+            check_mdbx(mdbx_del(txn, by_key, &raw_index_key, &raw_index_value),
+                       "Ordered element key index erase failed");
+            check_mdbx(mdbx_del(txn, state, &raw_state_key, nullptr),
+                       "Ordered element state erase failed");
+        }
+
+        bool get(MDBX_txn* txn,
+                 const OrderedElementId& id,
+                 OrderedElementStateRecord& out) const {
+            txn = checked_txn(txn, "OrderedElementStateStore::get");
+            require_id(id);
+            const MDBX_dbi state = open_state(txn);
+            const std::vector<std::uint8_t> key = make_element_key(id);
+            MDBX_val raw_key = make_val(key);
+            MDBX_val raw_value;
+            const int rc = mdbx_get(txn, state, &raw_key, &raw_value);
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "Ordered element state read failed");
+            out = decode_state_value(raw_value);
+            return true;
+        }
+
+        std::vector<OrderedElementId> live_ids_for_key(
+                MDBX_txn* txn,
+                const std::vector<std::uint8_t>& key) const {
+            txn = checked_txn(txn, "OrderedElementStateStore::live_ids_for_key");
+            const MDBX_dbi by_key = open_by_key(txn);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, by_key, &cursor),
+                       "Ordered element key index cursor open failed");
+            std::vector<OrderedElementId> out;
+            try {
+                MDBX_val raw_key = make_val(key);
+                MDBX_val raw_value;
+                int rc = mdbx_cursor_get(cursor, &raw_key, &raw_value, MDBX_SET_KEY);
+                while (rc == MDBX_SUCCESS) {
+                    const OrderedElementId id = decode_index_value(raw_value);
+                    OrderedElementStateRecord record;
+                    if (!get(txn, id, record)) {
+                        throw std::runtime_error(
+                            "Ordered element key index references missing state");
+                    }
+                    if (!record.live || record.key != key) {
+                        throw std::runtime_error(
+                            "Ordered element key index state mismatch");
+                    }
+                    out.push_back(id);
+                    rc = mdbx_cursor_get(cursor, &raw_key, &raw_value,
+                                         MDBX_NEXT_DUP);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "Ordered element key index cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return out;
+        }
+
+    private:
+        static std::uint8_t counter_tag() { return 0x00u; }
+        static std::uint8_t element_tag() { return 0x01u; }
+        static std::uint8_t live_tag() { return 0x01u; }
+        static std::uint8_t tombstone_tag() { return 0x02u; }
+
+        MDBX_txn* checked_txn(MDBX_txn* txn, const char* context) const {
+            return checked_txn_env(txn, m_env, context);
+        }
+
+        MDBX_dbi open_state(MDBX_txn* txn) const {
+            return open_named(txn, m_state_dbi_name,
+                              static_cast<MDBX_db_flags_t>(0));
+        }
+
+        MDBX_dbi open_by_key(MDBX_txn* txn) const {
+            return open_named(txn, m_by_key_dbi_name, MDBX_DUPSORT);
+        }
+
+        static MDBX_val make_val(const std::vector<std::uint8_t>& bytes) {
+            MDBX_val out = {
+                const_cast<std::uint8_t*>(bytes.empty() ? nullptr : &bytes[0]),
+                bytes.size()
+            };
+            return out;
+        }
+
+        MDBX_dbi open_named(MDBX_txn* txn,
+                            const std::string& name,
+                            MDBX_db_flags_t flags) const {
+            MDBX_dbi dbi = 0;
+            int rc = mdbx_dbi_open(txn, name.c_str(), flags | MDBX_CREATE, &dbi);
+            if (rc == MDBX_EACCESS) {
+                rc = mdbx_dbi_open(txn, name.c_str(), flags, &dbi);
+            }
+            check_mdbx(rc, "Ordered element state DBI open failed");
+            return dbi;
+        }
+
+        static void require_id(const OrderedElementId& id) {
+            if (!is_valid_ordered_element_id(id)) {
+                throw std::invalid_argument("Ordered element id is invalid");
+            }
+        }
+
+        static std::vector<std::uint8_t> make_counter_key(const NodeId& origin) {
+            std::vector<std::uint8_t> out;
+            out.push_back(counter_tag());
+            out.insert(out.end(), origin.begin(), origin.end());
+            return out;
+        }
+
+        static std::vector<std::uint8_t> make_element_key(
+                const OrderedElementId& id) {
+            std::vector<std::uint8_t> out;
+            out.push_back(element_tag());
+            const std::vector<std::uint8_t> encoded =
+                encode_ordered_element_id_index(id);
+            out.insert(out.end(), encoded.begin(), encoded.end());
+            return out;
+        }
+
+        static void append_blob(std::vector<std::uint8_t>& out,
+                                const std::vector<std::uint8_t>& bytes) {
+            if (bytes.size() > static_cast<std::size_t>(
+                    (std::numeric_limits<std::uint32_t>::max)())) {
+                throw std::length_error("Ordered element state blob is too large");
+            }
+            detail::append_u32_le(out, static_cast<std::uint32_t>(bytes.size()));
+            out.insert(out.end(), bytes.begin(), bytes.end());
+        }
+
+        static std::vector<std::uint8_t> make_live_value(
+                const std::vector<std::uint8_t>& key,
+                const std::vector<std::uint8_t>& value) {
+            std::vector<std::uint8_t> out;
+            out.push_back(live_tag());
+            append_blob(out, key);
+            append_blob(out, value);
+            return out;
+        }
+
+        static void require(const std::uint8_t* data,
+                            std::size_t size,
+                            std::size_t pos,
+                            std::size_t need) {
+            if (data == nullptr || pos > size || need > size - pos) {
+                throw std::runtime_error("Ordered element state decode underrun");
+            }
+        }
+
+        static std::vector<std::uint8_t> read_blob(const std::uint8_t* data,
+                                                   std::size_t size,
+                                                   std::size_t& pos) {
+            require(data, size, pos, 4u);
+            const std::uint32_t length = detail::read_u32_le(data + pos);
+            pos += 4u;
+            require(data, size, pos, length);
+            std::vector<std::uint8_t> out;
+            if (length != 0u) {
+                out.assign(data + pos, data + pos + length);
+            }
+            pos += length;
+            return out;
+        }
+
+        static OrderedElementStateRecord decode_state_value(const MDBX_val& value) {
+            const std::uint8_t* data =
+                static_cast<const std::uint8_t*>(value.iov_base);
+            const std::size_t size = value.iov_len;
+            require(data, size, 0u, 1u);
+            if (data[0] == tombstone_tag()) {
+                if (size != 1u) {
+                    throw std::runtime_error(
+                        "Ordered element tombstone has trailing bytes");
+                }
+                return OrderedElementStateRecord();
+            }
+            if (data[0] != live_tag()) {
+                throw std::runtime_error("Ordered element state tag is invalid");
+            }
+            std::size_t pos = 1u;
+            OrderedElementStateRecord out;
+            out.live = true;
+            out.key = read_blob(data, size, pos);
+            out.value = read_blob(data, size, pos);
+            if (pos != size) {
+                throw std::runtime_error("Ordered element state has trailing bytes");
+            }
+            return out;
+        }
+
+        static OrderedElementId decode_index_value(const MDBX_val& value) {
+            const std::uint8_t* data =
+                static_cast<const std::uint8_t*>(value.iov_base);
+            std::vector<std::uint8_t> bytes;
+            if (value.iov_len != NodeId().size() + 8u || data == nullptr) {
+                throw std::runtime_error("Ordered element key index value is invalid");
+            }
+            bytes.assign(data, data + value.iov_len);
+            return decode_ordered_element_id_index(bytes);
+        }
+
+        MDBX_env* m_env;
+        std::string m_state_dbi_name;
+        std::string m_by_key_dbi_name;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_ADAPTERS_KEY_ORDERED_MULTI_VALUE_DESTRUCTIVE_STATE_HPP_INCLUDED

--- a/tests/test_key_ordered_multi_value_destructive_state.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_state.cpp
@@ -1,0 +1,90 @@
+#include <mdbx_containers/sync.hpp>
+
+#include <cstdio>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+void cleanup(const std::string& path) {
+    std::remove(path.c_str());
+}
+
+mdbxc::sync::NodeId make_node(std::uint8_t seed) {
+    mdbxc::sync::NodeId out{};
+    for (std::size_t i = 0u; i < out.size(); ++i) {
+        out[i] = static_cast<std::uint8_t>(seed + i);
+    }
+    return out;
+}
+
+void test_ordered_element_state_persists_live_and_tombstone_records() {
+    const std::string path = "test_ordered_element_state.mdbx";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId origin = make_node(0x41u);
+    const std::vector<std::uint8_t> key(1u, 0xABu);
+    const std::vector<std::uint8_t> value(2u, 0xCDu);
+
+    mdbxc::sync::OrderedElementStateStore store(
+        connection->env_handle(), "ordered_state", "ordered_by_key");
+    mdbxc::sync::OrderedElementId first;
+    mdbxc::sync::OrderedElementId second;
+    {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        first = store.allocate_id(transaction.handle(), origin);
+        second = store.allocate_id(transaction.handle(), origin);
+        if (first.sequence != 1u || second.sequence != 2u ||
+            first.origin != origin || second.origin != origin) {
+            throw std::runtime_error("ordered element counter allocation mismatch");
+        }
+        store.put_live(transaction.handle(), first, key, value);
+        store.put_live(transaction.handle(), second, key, value);
+        store.tombstone(transaction.handle(), first);
+        transaction.commit();
+    }
+
+    {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::READ_ONLY);
+        mdbxc::sync::OrderedElementStateRecord record;
+        if (!store.get(transaction.handle(), first, record) || record.live ||
+            !record.key.empty() || !record.value.empty()) {
+            throw std::runtime_error("ordered element tombstone did not persist");
+        }
+        const std::vector<mdbxc::sync::OrderedElementId> live =
+            store.live_ids_for_key(transaction.handle(), key);
+        if (live.size() != 1u || live[0] != second) {
+            throw std::runtime_error("ordered element live index is incorrect");
+        }
+        transaction.rollback();
+    }
+
+    const std::vector<std::uint8_t> logical =
+        mdbxc::sync::encode_ordered_element_id_logical(second);
+    const std::vector<std::uint8_t> index =
+        mdbxc::sync::encode_ordered_element_id_index(second);
+    if (mdbxc::sync::decode_ordered_element_id_logical(logical) != second ||
+        mdbxc::sync::decode_ordered_element_id_index(index) != second) {
+        throw std::runtime_error("ordered element id codec round trip mismatch");
+    }
+
+    connection->disconnect();
+    cleanup(path);
+}
+
+} // namespace
+
+int main() {
+    test_ordered_element_state_persists_live_and_tombstone_records();
+    return 0;
+}

--- a/tests/test_key_ordered_multi_value_destructive_state.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_state.cpp
@@ -41,6 +41,7 @@ void test_ordered_element_state_persists_live_and_tombstone_records() {
     {
         mdbxc::Transaction transaction =
             connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        store.initialize(transaction.handle());
         first = store.allocate_id(transaction.handle(), origin);
         second = store.allocate_id(transaction.handle(), origin);
         if (first.sequence != 1u || second.sequence != 2u ||
@@ -82,9 +83,91 @@ void test_ordered_element_state_persists_live_and_tombstone_records() {
     cleanup(path);
 }
 
+void test_ordered_element_state_requires_initialized_compatible_dbis() {
+    const std::string path = "test_ordered_element_state_setup.mdbx";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    mdbxc::sync::OrderedElementStateStore missing(
+        connection->env_handle(), "missing_state", "missing_by_key");
+    mdbxc::sync::OrderedElementStateRecord record;
+    mdbxc::sync::OrderedElementId id;
+    id.origin = make_node(0x51u);
+    id.sequence = 1u;
+
+    bool rejected_missing = false;
+    {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::READ_ONLY);
+        try {
+            missing.get(transaction.handle(), id, record);
+        } catch (const std::exception&) {
+            rejected_missing = true;
+        }
+        transaction.rollback();
+    }
+    if (!rejected_missing) {
+        throw std::runtime_error("missing ordered state DBI was treated as empty");
+    }
+
+    {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        MDBX_dbi dbi = 0;
+        const int rc = mdbx_dbi_open(
+            transaction.handle(), "missing_state",
+            static_cast<MDBX_db_flags_t>(0), &dbi);
+        if (rc != MDBX_NOTFOUND) {
+            throw std::runtime_error(
+                "missing ordered state DBI was created by a normal read");
+        }
+        transaction.rollback();
+    }
+
+    {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        MDBX_dbi state = 0;
+        MDBX_dbi by_key = 0;
+        mdbxc::check_mdbx(mdbx_dbi_open(
+            transaction.handle(), "wrong_state", MDBX_CREATE | MDBX_DUPSORT,
+            &state), "wrong ordered state setup failed");
+        mdbxc::check_mdbx(mdbx_dbi_open(
+            transaction.handle(), "wrong_by_key", MDBX_CREATE, &by_key),
+            "wrong ordered index setup failed");
+        transaction.commit();
+    }
+
+    mdbxc::sync::OrderedElementStateStore incompatible(
+        connection->env_handle(), "wrong_state", "wrong_by_key");
+    bool rejected_flags = false;
+    {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        try {
+            incompatible.initialize(transaction.handle());
+        } catch (const std::exception&) {
+            rejected_flags = true;
+        }
+        transaction.rollback();
+    }
+    if (!rejected_flags) {
+        throw std::runtime_error("incompatible ordered state DBI flags accepted");
+    }
+
+    connection->disconnect();
+    cleanup(path);
+}
+
 } // namespace
 
 int main() {
     test_ordered_element_state_persists_live_and_tombstone_records();
+    test_ordered_element_state_requires_initialized_compatible_dbis();
     return 0;
 }

--- a/tests/test_key_ordered_multi_value_destructive_state.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_state.cpp
@@ -1,6 +1,7 @@
 #include <mdbx_containers/sync.hpp>
 
 #include <cstdio>
+#include <cstdint>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -18,6 +19,97 @@ mdbxc::sync::NodeId make_node(std::uint8_t seed) {
         out[i] = static_cast<std::uint8_t>(seed + i);
     }
     return out;
+}
+
+MDBX_val make_raw_val(const std::vector<std::uint8_t>& bytes) {
+    MDBX_val value = {
+        const_cast<std::uint8_t*>(bytes.empty() ? nullptr : &bytes[0]),
+        bytes.size()
+    };
+    return value;
+}
+
+std::vector<std::uint8_t> make_introduced_key(
+        const mdbxc::sync::NodeId& origin) {
+    std::vector<std::uint8_t> key(1u, 0x02u);
+    key.insert(key.end(), origin.begin(), origin.end());
+    return key;
+}
+
+void write_raw_introduced_high_water(
+        const std::shared_ptr<mdbxc::Connection>& connection,
+        const std::string& state_name,
+        const mdbxc::sync::NodeId& origin,
+        std::uint64_t sequence) {
+    mdbxc::Transaction transaction =
+        connection->transaction(mdbxc::TransactionMode::WRITABLE);
+    MDBX_dbi state = 0;
+    mdbxc::check_mdbx(mdbx_dbi_open(
+        transaction.handle(), state_name.c_str(),
+        static_cast<MDBX_db_flags_t>(0), &state),
+        "test state DBI open failed");
+    const std::vector<std::uint8_t> key = make_introduced_key(origin);
+    std::vector<std::uint8_t> value;
+    mdbxc::sync::detail::append_u64_le(value, sequence);
+    MDBX_val raw_key = make_raw_val(key);
+    MDBX_val raw_value = make_raw_val(value);
+    mdbxc::check_mdbx(mdbx_put(transaction.handle(), state, &raw_key,
+                                &raw_value, MDBX_UPSERT),
+                      "test introduced high-water write failed");
+    transaction.commit();
+}
+
+void delete_raw_introduced_high_water(
+        const std::shared_ptr<mdbxc::Connection>& connection,
+        const std::string& state_name,
+        const mdbxc::sync::NodeId& origin) {
+    mdbxc::Transaction transaction =
+        connection->transaction(mdbxc::TransactionMode::WRITABLE);
+    MDBX_dbi state = 0;
+    mdbxc::check_mdbx(mdbx_dbi_open(
+        transaction.handle(), state_name.c_str(),
+        static_cast<MDBX_db_flags_t>(0), &state),
+        "test state DBI open failed");
+    const std::vector<std::uint8_t> key = make_introduced_key(origin);
+    MDBX_val raw_key = make_raw_val(key);
+    mdbxc::check_mdbx(mdbx_del(transaction.handle(), state, &raw_key, nullptr),
+                      "test introduced high-water delete failed");
+    transaction.commit();
+}
+
+void require_high_water_rejected(
+        mdbxc::sync::OrderedElementStateStore& store,
+        const std::shared_ptr<mdbxc::Connection>& connection,
+        const mdbxc::sync::NodeId& origin) {
+    bool verification_rejected = false;
+    {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::READ_ONLY);
+        try {
+            store.verify_existing(transaction.handle());
+        } catch (const std::exception&) {
+            verification_rejected = true;
+        }
+        transaction.rollback();
+    }
+    if (!verification_rejected) {
+        throw std::runtime_error("corrupt introduced high-water passed verification");
+    }
+
+    bool allocation_rejected = false;
+    {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        try {
+            store.allocate_id(transaction.handle(), origin);
+        } catch (const std::exception&) {
+            allocation_rejected = true;
+        }
+        transaction.rollback();
+    }
+    if (!allocation_rejected) {
+        throw std::runtime_error("corrupt introduced high-water allowed allocation");
+    }
 }
 
 void test_ordered_element_state_persists_live_and_tombstone_records() {
@@ -229,11 +321,59 @@ void test_ordered_element_state_survives_reopen() {
     cleanup(path);
 }
 
+void test_ordered_element_state_rejects_corrupt_introduced_high_water() {
+    const std::string path = "test_ordered_element_state_high_water.mdbx";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId origin = make_node(0x71u);
+    const std::vector<std::uint8_t> key(1u, 0xAAu);
+    const std::vector<std::uint8_t> value(1u, 0xBBu);
+    const std::string state_name = "high_water_state";
+    mdbxc::sync::OrderedElementStateStore store(
+        connection->env_handle(), state_name, "high_water_by_key");
+    mdbxc::sync::OrderedElementId id;
+    {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        store.initialize_empty(transaction.handle());
+        id = store.allocate_id(transaction.handle(), origin);
+        store.put_live(transaction.handle(), id, key, value);
+        transaction.commit();
+    }
+
+    delete_raw_introduced_high_water(connection, state_name, origin);
+    require_high_water_rejected(store, connection, origin);
+
+    write_raw_introduced_high_water(connection, state_name, origin, id.sequence);
+    write_raw_introduced_high_water(connection, state_name, origin, id.sequence - 1u);
+    require_high_water_rejected(store, connection, origin);
+
+    write_raw_introduced_high_water(connection, state_name, origin, id.sequence);
+    {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        store.tombstone(transaction.handle(), id);
+        transaction.commit();
+    }
+    write_raw_introduced_high_water(connection, state_name, origin, id.sequence - 1u);
+    require_high_water_rejected(store, connection, origin);
+
+    connection->disconnect();
+    cleanup(path);
+}
+
 } // namespace
 
 int main() {
     test_ordered_element_state_persists_live_and_tombstone_records();
     test_ordered_element_state_requires_initialized_compatible_dbis();
     test_ordered_element_state_survives_reopen();
+    test_ordered_element_state_rejects_corrupt_introduced_high_water();
     return 0;
 }

--- a/tests/test_key_ordered_multi_value_destructive_state.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_state.cpp
@@ -164,10 +164,76 @@ void test_ordered_element_state_requires_initialized_compatible_dbis() {
     cleanup(path);
 }
 
+void test_ordered_element_state_survives_reopen() {
+    const std::string path = "test_ordered_element_state_reopen.mdbx";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const mdbxc::sync::NodeId origin = make_node(0x61u);
+    const std::vector<std::uint8_t> key(1u, 0xBAu);
+    const std::vector<std::uint8_t> value(1u, 0xDCu);
+    mdbxc::sync::OrderedElementId first;
+    mdbxc::sync::OrderedElementId second;
+
+    {
+        const std::shared_ptr<mdbxc::Connection> connection =
+            mdbxc::Connection::create(config);
+        mdbxc::sync::OrderedElementStateStore store(
+            connection->env_handle(), "reopen_state", "reopen_by_key");
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        store.initialize_empty(transaction.handle());
+        first = store.allocate_id(transaction.handle(), origin);
+        second = store.allocate_id(transaction.handle(), origin);
+        store.put_live(transaction.handle(), first, key, value);
+        store.put_live(transaction.handle(), second, key, value);
+        store.tombstone(transaction.handle(), first);
+        transaction.commit();
+        connection->disconnect();
+    }
+
+    {
+        const std::shared_ptr<mdbxc::Connection> connection =
+            mdbxc::Connection::create(config);
+        mdbxc::sync::OrderedElementStateStore store(
+            connection->env_handle(), "reopen_state", "reopen_by_key");
+        {
+            mdbxc::Transaction transaction =
+                connection->transaction(mdbxc::TransactionMode::READ_ONLY);
+            store.verify_existing(transaction.handle());
+            mdbxc::sync::OrderedElementStateRecord record;
+            if (!store.get(transaction.handle(), first, record) || record.live ||
+                !store.get(transaction.handle(), second, record) || !record.live) {
+                throw std::runtime_error(
+                    "ordered element state did not survive environment reopen");
+            }
+            transaction.rollback();
+        }
+        {
+            mdbxc::Transaction transaction =
+                connection->transaction(mdbxc::TransactionMode::WRITABLE);
+            const mdbxc::sync::OrderedElementId third =
+                store.allocate_id(transaction.handle(), origin);
+            if (third.sequence != 3u) {
+                throw std::runtime_error(
+                    "ordered element counter did not survive environment reopen");
+            }
+            transaction.commit();
+        }
+        connection->disconnect();
+    }
+
+    cleanup(path);
+}
+
 } // namespace
 
 int main() {
     test_ordered_element_state_persists_live_and_tombstone_records();
     test_ordered_element_state_requires_initialized_compatible_dbis();
+    test_ordered_element_state_survives_reopen();
     return 0;
 }


### PR DESCRIPTION
## Summary
- add persistent OrderedElementId codecs and state records for destructive ordered logical schema v2
- maintain live/tombstone state and a per-key DUPSORT live index transactionally
- add C++11 regression coverage for allocation, persistence, tombstone and codec round trips

## Validation
- C++11 MinGW: test_key_ordered_multi_value_destructive_state
- C++17 MinGW: test_key_ordered_multi_value_destructive_state
- standalone header syntax checks: C++11/C++17
- git diff --check