### PR TITLE
test(sync): cover destructive ordered replay rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 - Added persistent `OrderedElementId` and state-store primitives for the
-  planned destructive `KeyOrderedMultiValueTable` logical schema v2.
+  initial destructive `KeyOrderedMultiValueTable` logical schema v2.
 - Added a schema-version-2 destructive logical adapter for
   `KeyOrderedMultiValueTable`, with transactional append/erase, durable
   element identity, batch duplicate rejection, and per-key parity checks.
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
   apply through ordered delivery. It preserves repeated values and per-key
   append order for the schema marker's authoritative origin. Its typed capture
   session atomically commits local appends plus an ordered outbox envelope;
-  destructive operations remain deferred.
+  destructive operations use the separate schema-v2 adapter.
 - Restricted `KeyOrderedMultiValueTableLogicalAdapter` to its fixed
   schema-version-1 append payload contract. Future destructive ordered
   semantics require a separate versioned adapter.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -419,8 +419,11 @@ schema version.
 
 The destructive marker has one non-zero `ordered_delivery_origin_node_id`.
 Before allocating an element id, typed capture verifies that the local sync
-`node_id` equals that marker origin. Every received `AppendElement` verifies,
-before adapter mutation, that all three origins are identical:
+`node_id` equals that marker origin. For a received `AppendElement`, the sync
+core first validates `delivery-envelope.origin_node_id` against the marker
+before adapter preflight. Destructive-adapter preflight then validates
+`element-id.origin` against that same marker before mutation. Together these
+checks require all three origins to be identical:
 
 ```text
 element-id.origin == delivery-envelope.origin_node_id
@@ -547,11 +550,12 @@ persisted element sequence. Existing-schema verification, local allocation and
 admission of a new append check this invariant before mutation; a missing or
 lower high-water record is corruption, not an implicit zero value.
 
-For every `AppendElement`, the id origin must equal both the ordered envelope
-origin and the marker's `ordered_delivery_origin_node_id`; this is checked in
-adapter preflight before state or table mutation. `EraseElement` deliberately
-does not impose that admission check: it addresses an already persisted id and
-must remain able to remove legacy elements during a controlled migration.
+For every `AppendElement`, the sync core validates the ordered envelope origin
+against the marker before adapter preflight, and destructive-adapter preflight
+validates the id origin against the marker before state or table mutation.
+`EraseElement` deliberately does not impose that admission check: it addresses
+an already persisted id and must remain able to remove legacy elements during a
+controlled migration.
 
 `element-state` uses ascending bytewise keys. It rejects `MDBX_REVERSEKEY`,
 `MDBX_DUPSORT`, `MDBX_INTEGERKEY`, `MDBX_INTEGERDUP`, `MDBX_REVERSEDUP`, and

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -96,7 +96,7 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
 | `VectorStore` | Supported indirectly | Does not own a separate wire format. Its persistent writes go through `SequenceTable` and `KeyValueTable` member tables. Raw replication requires one authoritative or externally serialized writer per collection. Already-open instances refresh their RAM index lazily after completed remote apply when the connection sync-apply generation changes. |
 | `AnyValueTable` | Not supported in v0.1 | Deferred until heterogeneous value type tags are part of the sync wire format. |
 | `KeyMultiValueTable` | Limited logical adapter | Raw v0.1 capture remains unsupported. `KeyMultiValueTableLogicalAdapter` explicitly captures unordered insert, key erase, all-matching-value erase, and clear under one-writer or causally serialized updates. |
-| `KeyOrderedMultiValueTable` | Append-only logical adapter | `KeyOrderedMultiValueTableLogicalAdapter` captures and applies append-only changes through ordered delivery for the schema marker's one authoritative origin. Destructive operations remain deferred. |
+| `KeyOrderedMultiValueTable` | Ordered logical adapters | Schema v1 remains append-only. Schema v2 provides explicit `AppendElement` and `EraseElement` by immutable id through ordered delivery for one authoritative origin; broad key/value/clear capture remains deferred. |
 | `HashedKeyValueStore` | Not supported in v0.1 | Deferred until hash-index and identity-key mapping semantics are specified. |
 
 Do not add `record_op()` paths for unsupported table types without first
@@ -353,9 +353,9 @@ that operation and uses the same typed capture method. Its capture session owns
 one writable transaction and can atomically commit local appends plus an ordered
 outbox envelope through `commit_to_outbox()`.
 
-#### Planned destructive ordered-history contract
+#### Destructive ordered-history contract
 
-This is a versioned design for a later adapter extension. The existing
+The implemented initial destructive extension is versioned separately. The existing
 append-only `KeyOrderedMultiValueTableLogicalAdapter` is logically schema
 version 1 only and must reject every configured version other than 1. The
 destructive `KeyOrderedMultiValueTableDestructiveLogicalAdapter` is logically
@@ -466,8 +466,8 @@ preflight.
 
 ##### Batch preflight and duplicate identities
 
-Before destructive schema version 2 is implemented, `ILogicalTableAdapter`
-must gain a source-compatible non-pure batch hook:
+Destructive schema version 2 uses the source-compatible non-pure batch hook on
+`ILogicalTableAdapter`:
 
 ```cpp
 virtual LogicalApplyResult preflight_batch(
@@ -512,16 +512,46 @@ of `affected_dbis()`. They are not `_mdbxc_` system DBIs and cannot be shared
 with another logical schema. The marker primary remains the ordered table; the
 marker must contain precisely this canonical three-name set.
 
+Setup calls `SyncEngine::initialize_logical_adapter_schema()` in one writable
+transaction. Without a marker, it requires an empty primary DBI, creates empty
+auxiliary DBIs, and commits the marker. With an existing matching marker, it
+only reopens and validates the existing primary and auxiliary DBIs without
+`MDBX_CREATE`. A missing auxiliary DBI or incompatible persistent flags are
+schema corruption, not an empty state to recreate during setup or delivery.
+Recovery or rebaseline of an existing v2 schema requires a separate explicit
+procedure; rerunning setup is intentionally not a repair operation.
+
+Before constructing a schema-v2 primary table accessor, callers use
+`KeyOrderedMultiValueTableDestructiveLogicalAdapter::open_primary_for_schema()`.
+The helper first reads the persistent marker. It preserves the requested
+`MDBX_CREATE` flag only when the marker is absent; once a matching marker
+exists, it opens the primary without creation. Thus a missing primary DBI
+remains detectable corruption instead of becoming a new empty table. Direct
+`KeyOrderedMultiValueTable` construction remains the ordinary non-schema-bound
+table API and is outside this lifecycle.
+
 `OrderedElementId` has two encodings. Its logical wire encoding is exactly
 `NodeId[16] || sequence-le64`. Its bytewise ordered DBI-key suffix is
 `NodeId[16] || sequence-be64`; the fixed-width `NodeId` bytes precede the
 big-endian sequence so records of one origin retain numeric sequence order.
 The all-zero `NodeId` and `sequence == 0` are invalid. A counter stores the last
 allocated sequence, starts at zero, allocates one through `UINT64_MAX`, and
-fails before mutation on overflow. Remote delivery does not allocate or advance
-the local origin's counter; a baseline migration initializes every origin
-counter to at least the largest assigned id for that origin before the origin is
-allowed to write again.
+fails before mutation on overflow. A separate per-origin introduced high-water
+mark advances with every newly persisted `AppendElement`, remains after a
+tombstone, and ensures new ids are strictly increasing in append order. Local
+allocation uses the larger of its counter and the introduced high-water mark,
+so a later local writer cannot reuse a sequence introduced by remote delivery.
+For every origin that has a persisted Live or Tombstone record, the high-water
+record is mandatory and must be greater than or equal to that origin's largest
+persisted element sequence. Existing-schema verification, local allocation and
+admission of a new append check this invariant before mutation; a missing or
+lower high-water record is corruption, not an implicit zero value.
+
+For every `AppendElement`, the id origin must equal both the ordered envelope
+origin and the marker's `ordered_delivery_origin_node_id`; this is checked in
+adapter preflight before state or table mutation. `EraseElement` deliberately
+does not impose that admission check: it addresses an already persisted id and
+must remain able to remove legacy elements during a controlled migration.
 
 `element-state` uses ascending bytewise keys. It rejects `MDBX_REVERSEKEY`,
 `MDBX_DUPSORT`, `MDBX_INTEGERKEY`, `MDBX_INTEGERDUP`, `MDBX_REVERSEDUP`, and
@@ -531,19 +561,20 @@ reserved key namespace and persistent-layout-v1 values are:
 ```text
 0x00 || NodeId[16]                         -> last-allocated-sequence-le64
 0x01 || NodeId[16] || sequence-be64        -> Live:
-                                                0x01 || logical-key-size-le32
-                                                     || exact-KeyCodec-bytes
-                                                     || logical-value-size-le32
-                                                     || exact-ValueCodec-bytes
-                                                     || local-prefix-be64
-                                             Tombstone:
-                                                0x02
+                                                 0x01 || logical-key-size-le32
+                                                      || exact-KeyCodec-bytes
+                                                      || logical-value-size-le32
+                                                      || exact-ValueCodec-bytes
+                                              Tombstone:
+                                                 0x02
+0x02 || NodeId[16]                         -> introduced-high-water-le64
 ```
 
-The `0x00` counter and `0x01` element namespaces must never be interpreted as
-one another. A counter value must be exactly eight bytes. An element key of any
-other length or tag, a zero node/sequence, a truncated length/value field,
-non-canonical codec bytes, or trailing bytes is corruption and fails closed.
+The `0x00` counter, `0x01` element, and `0x02` introduced-high-water namespaces
+must never be interpreted as one another. Counter and high-water values must be
+exactly eight bytes. An element key of any other length or tag, a zero
+node/sequence, a truncated length/value field, non-canonical codec bytes, or
+trailing bytes is corruption and fails closed.
 Live state stores exactly the canonical logical codec bytes accepted from the
 `AppendElement` payload. Retry equality and the baseline digest compare those
 logical bytes. To validate or mutate the primary DBI, the adapter decodes the
@@ -554,25 +585,22 @@ their only meaning is permanent non-resurrection of the immutable id. Deletion
 metadata, pruning and compaction require a later persistent layout with a
 separately designed global recovery horizon.
 
-`elements-by-key` is a DUPSORT DBI. Its key is the exact canonical serialized
-`KeyT` byte representation used by the primary ordered table; its fixed-format
-duplicate is:
+`elements-by-key` is a DUPSORT DBI. Its key is the exact canonical logical
+`KeyCodec` byte representation. Its fixed-format duplicate is:
 
 ```text
-local-prefix-be64 || NodeId[16] || sequence-be64
+NodeId[16] || sequence-be64
 ```
 
-This makes duplicate enumeration match the table's local presentation order
-without a full-state scan. The DBI must use `MDBX_DUPSORT` with bytewise
-ascending duplicate comparison and must reject `MDBX_INTEGERDUP`,
-`MDBX_REVERSEDUP`, and `MDBX_DUPFIXED`. Its key-comparator flags must exactly
-match the primary table: `MDBX_REVERSEKEY` and validated `MDBX_INTEGERKEY` are
-both inherited when present. Creation/open validates the exact required flags
-through the normal MDBX/ACCEDE path; an existing incompatible DBI is a schema
-error, not a layout to reinterpret. Every index duplicate must be exactly 32
-bytes and contain a non-zero element id.
+For the initial one-origin implementation, the introduced high-water mark
+requires every new append id to be strictly increasing in frame order. Therefore
+bytewise id order is the append order of live elements for one key. The DBI uses
+`MDBX_DUPSORT` with ascending bytewise comparison and rejects incompatible
+duplicate flags. It is a logical index, not a physical mirror of the primary key
+comparator. Every index duplicate is exactly 24 bytes and contains a non-zero
+element id.
 
-After a destructive schema marker is installed, every table mutation must use
+After a destructive schema marker is installed, every local table mutation must use
 the typed adapter session. Mixing direct `KeyOrderedMultiValueTable` mutators
 with the adapter is outside the schema contract. The implementation cannot
 intercept an arbitrary direct raw write at the instant it occurs, but it must
@@ -580,42 +608,51 @@ fail closed before a later destructive mutation can ignore it. For every touched
 key, preflight and post-mutation validation require exact parity:
 
 ```text
-physical duplicate (serialized key, local-prefix, serialized value)
+physical duplicate in current public per-key order
     <=> one Live element-state record whose decoded logical bytes serialize to
-        that key/value and carry the same prefix
-    <=> one elements-by-key duplicate under that serialized key with the same
-        prefix and element id
+        that key/value
+    <=> one elements-by-key duplicate under that canonical logical key with the
+        same element id
 ```
 
+Validation obtains the index side by keyed DUPSORT lookup and the state side by
+a reverse scan of all Live state records for that canonical key; the two exact
+id sets must agree before their values are compared with the physical table.
 An orphan physical row, key-index entry, or Live state record is corruption.
 `clear()` and baseline migration must validate the complete three-DBI parity;
 persistent-layout-v1 does not substitute an unchecked count, generation, or
 hash shortcut. The adapter must never infer or synthesize an element id for a
 raw row during a replicated destructive write.
 
-The table's public representation remains `local-order-prefix || serialized-
-value`. The later implementation must add a narrow table primitive that erases
-one physical duplicate by serialized key plus local-order-prefix. It must not
-implement replicated deletion through `erase_at()` because an index is local and
-can shift after another deletion. An adapter resolves the element through its
-state record, removes that exact local duplicate and the matching key-index
-entry, and changes the state record to a tombstone in the same MDBX transaction.
+The reverse scan is an intentional correctness-first implementation. Its
+per-key cost is linear in all persisted element-state records. A separate
+benchmark-and-bounds follow-up must establish a measured need before adding a
+reverse index or another optimization; this layout must not weaken parity
+validation merely to avoid that scan. High-water integrity validation likewise
+scans the persisted records for one origin before allocation or admission of a
+new id. It remains part of the same benchmark-and-bounds follow-up; no cached
+shortcut may hide durable state corruption.
+
+The initial v2 adapter resolves an element through its persistent state and uses
+the current per-key live-id order to call `erase_at()` inside the same ordered
+delivery transaction. This is valid only for the fixed single-authoritative-
+origin contract: no concurrent writer may shift that order. A future multi-origin
+or baseline-import v2 extension requires a narrow physical-prefix erase primitive
+and a layout revision; it is not implied by this initial adapter.
 
 The versioned logical operations are:
 
 | Operation | Required payload | Apply semantics |
 |-----------|------------------|-----------------|
-| `AppendElement` | Exact schema-v2 payload above | A new id appends once, allocates the replica-local prefix, and persists matching live-state and key-index records. A retry with an existing Live id and byte-identical key/value is a successful no-op after parity validation. The same id with different bytes, or an id already tombstoned, is a permanent conflict. |
-| `EraseElement` | Exact schema-v2 payload above | Delete the exact live occurrence addressed by the state record, remove its key-index record, and persist its tombstone. Replaying an existing tombstone is a successful no-op; an unknown id or a missing physical live record fails closed. |
+| `AppendElement` | Exact schema-v2 payload above | A new id appends once and persists matching live-state and key-index records. An exact committed envelope retry is deduplicated by the delivery layer before adapter callbacks. A later byte-identical append of an already Live id is a successful no-op; a differing payload or a tombstoned id is a permanent conflict. Repeating any `OrderedElementId` within one schema-local batch is malformed and fails during batch preflight. |
+| `EraseElement` | Exact schema-v2 payload above | Delete the exact live occurrence addressed by the state record, remove its key-index record, and persist its tombstone. An exact committed envelope retry is deduplicated before adapter callbacks; an unknown or tombstoned id, or a missing physical live record, fails closed. |
 
 `erase(key, value)`, `erase(key)`, `erase_at(key, index)`, `clear()`, and
-`replace_with()` are not independent broad wire operations in the first
-extension. Typed capture resolves the current local live elements, then emits
-one `EraseElement` for each selected immutable id, in the same ordered frame as
-any replacement `AppendElement` operations. This preserves the current public
-semantics while making every remote deletion addressable. Frame and codec bounds
-remain authoritative: a destructive operation that cannot fit in one bounded
-transaction/frame fails before commit rather than silently becoming partial.
+`replace_with()` are not independent broad wire operations. The initial typed
+capture surface exposes only `append()` and exact `erase(OrderedElementId)`.
+Resolving broad local mutators into bounded `EraseElement` frames is a follow-up
+extension, together with a stronger physical-prefix layout for migration and
+multi-origin histories.
 
 Tombstones are retained indefinitely in the first destructive implementation.
 They must not be pruned by time or by a local outbox acknowledgement. Safe
@@ -660,7 +697,8 @@ id. After the first committed destructive envelope, replacing the marker with
 the append-only version cannot roll back durable element ids or outbox state; it
 requires recovery or re-baselining instead.
 
-Before implementation, add tests for:
+Remaining hardening before this initial v2 adapter can grow into a broader
+destructive surface includes:
 
 - repeated identical values and exact `erase_at` targeting; `erase(key, value)`,
   key erase, clear and replace semantics;
@@ -712,9 +750,9 @@ anchors, see the
   format; deferred until an explicit identity-mapping scheme lands.
 - `KeyMultiValueTable` — DUPSORT duplicate values need the unordered multiset
   model described above before capture can be enabled.
-- `KeyOrderedMultiValueTable` — destructive ordered-history operations remain
-  deferred until the planned persistent element-identity and tombstone contract
-  is implemented and covered by round-trip tests.
+- `KeyOrderedMultiValueTable` — broad destructive local mutators, baseline
+  import, multi-origin history and tombstone compaction remain deferred beyond
+  the implemented single-origin v2 `append` / exact-id `erase` contract.
 - `AnyValueTable` — heterogeneous values need type-tag propagation on the wire.
 - `IdentityProvider` integration in `BaseTable` — declared in v0.1, no
   write path until HashedKeyValueStore.

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
@@ -622,6 +622,12 @@ namespace sync {
                 return LogicalApplyResult::failure(
                     "OrderedElementId is not live");
             }
+            if (decoded.is_append) {
+                ensure_key_parity(txn, decoded.key, decoded.key_bytes);
+            } else {
+                ensure_key_parity(txn, decode_canonical_key(record.key),
+                                  record.key);
+            }
             return LogicalApplyResult::success();
         }
 
@@ -669,10 +675,11 @@ namespace sync {
                                const KeyT& key,
                                const std::vector<std::uint8_t>& key_bytes) const {
             const std::vector<ValueT> values = m_table.find(key, txn);
-            const std::vector<OrderedElementId> ids =
+            std::vector<OrderedElementId> ids =
                 m_state.live_ids_for_key(txn, key_bytes);
             std::vector<OrderedElementId> state_ids =
                 m_state.live_state_ids_for_key(txn, key_bytes);
+            std::sort(ids.begin(), ids.end(), OrderedElementIdLess());
             std::sort(state_ids.begin(), state_ids.end(), OrderedElementIdLess());
             if (values.size() != ids.size() || ids != state_ids) {
                 throw std::runtime_error(

--- a/tests/test_key_ordered_multi_value_destructive_adapter.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_adapter.cpp
@@ -61,6 +61,122 @@ void apply_changes(mdbxc::sync::LogicalTableRegistry& registry,
     }
 }
 
+MDBX_val make_raw_val(const std::vector<std::uint8_t>& bytes) {
+    MDBX_val value = {
+        const_cast<std::uint8_t*>(bytes.empty() ? nullptr : &bytes[0]),
+        bytes.size()
+    };
+    return value;
+}
+
+std::vector<std::uint8_t> make_state_key(
+        const mdbxc::sync::OrderedElementId& id) {
+    std::vector<std::uint8_t> key(1u, 0x01u);
+    const std::vector<std::uint8_t> encoded =
+        mdbxc::sync::encode_ordered_element_id_index(id);
+    key.insert(key.end(), encoded.begin(), encoded.end());
+    return key;
+}
+
+std::vector<std::uint8_t> make_introduced_key(
+        const mdbxc::sync::NodeId& origin) {
+    std::vector<std::uint8_t> key(1u, 0x02u);
+    key.insert(key.end(), origin.begin(), origin.end());
+    return key;
+}
+
+void delete_raw_introduced_high_water(
+        const std::shared_ptr<mdbxc::Connection>& connection,
+        const std::string& state_name,
+        const mdbxc::sync::NodeId& origin) {
+    mdbxc::Transaction transaction =
+        connection->transaction(mdbxc::TransactionMode::WRITABLE);
+    MDBX_dbi state = 0;
+    mdbxc::check_mdbx(mdbx_dbi_open(
+        transaction.handle(), state_name.c_str(),
+        static_cast<MDBX_db_flags_t>(0), &state),
+        "test state DBI open failed");
+    const std::vector<std::uint8_t> key = make_introduced_key(origin);
+    MDBX_val raw_key = make_raw_val(key);
+    mdbxc::check_mdbx(mdbx_del(transaction.handle(), state, &raw_key, nullptr),
+                      "test introduced high-water delete failed");
+    transaction.commit();
+}
+
+void delete_raw_state_record(
+        const std::shared_ptr<mdbxc::Connection>& connection,
+        const std::string& state_name,
+        const mdbxc::sync::OrderedElementId& id) {
+    mdbxc::Transaction transaction =
+        connection->transaction(mdbxc::TransactionMode::WRITABLE);
+    MDBX_dbi state = 0;
+    mdbxc::check_mdbx(mdbx_dbi_open(
+        transaction.handle(), state_name.c_str(),
+        static_cast<MDBX_db_flags_t>(0), &state),
+        "test state DBI open failed");
+    const std::vector<std::uint8_t> key = make_state_key(id);
+    MDBX_val raw_key = make_raw_val(key);
+    mdbxc::check_mdbx(mdbx_del(transaction.handle(), state, &raw_key, nullptr),
+                      "test state record delete failed");
+    transaction.commit();
+}
+
+void insert_raw_index_record(
+        const std::shared_ptr<mdbxc::Connection>& connection,
+        const std::string& by_key_name,
+        const std::vector<std::uint8_t>& key,
+        const mdbxc::sync::OrderedElementId& id) {
+    mdbxc::Transaction transaction =
+        connection->transaction(mdbxc::TransactionMode::WRITABLE);
+    MDBX_dbi by_key = 0;
+    mdbxc::check_mdbx(mdbx_dbi_open(
+        transaction.handle(), by_key_name.c_str(), MDBX_DUPSORT, &by_key),
+        "test state index DBI open failed");
+    const std::vector<std::uint8_t> value =
+        mdbxc::sync::encode_ordered_element_id_index(id);
+    MDBX_val raw_key = make_raw_val(key);
+    MDBX_val raw_value = make_raw_val(value);
+    mdbxc::check_mdbx(mdbx_put(transaction.handle(), by_key,
+                                &raw_key, &raw_value, MDBX_NODUPDATA),
+                      "test state index write failed");
+    transaction.commit();
+}
+
+void delete_raw_index_record(
+        const std::shared_ptr<mdbxc::Connection>& connection,
+        const std::string& by_key_name,
+        const std::vector<std::uint8_t>& key,
+        const mdbxc::sync::OrderedElementId& id) {
+    mdbxc::Transaction transaction =
+        connection->transaction(mdbxc::TransactionMode::WRITABLE);
+    MDBX_dbi by_key = 0;
+    mdbxc::check_mdbx(mdbx_dbi_open(
+        transaction.handle(), by_key_name.c_str(), MDBX_DUPSORT, &by_key),
+        "test state index DBI open failed");
+    const std::vector<std::uint8_t> value =
+        mdbxc::sync::encode_ordered_element_id_index(id);
+    MDBX_val raw_key = make_raw_val(key);
+    MDBX_val raw_value = make_raw_val(value);
+    mdbxc::check_mdbx(mdbx_del(transaction.handle(), by_key,
+                                &raw_key, &raw_value),
+                      "test state index delete failed");
+    transaction.commit();
+}
+
+void drop_named_dbi(const std::shared_ptr<mdbxc::Connection>& connection,
+                    const std::string& name,
+                    MDBX_db_flags_t flags) {
+    mdbxc::Transaction transaction =
+        connection->transaction(mdbxc::TransactionMode::WRITABLE);
+    MDBX_dbi dbi = 0;
+    mdbxc::check_mdbx(mdbx_dbi_open(
+        transaction.handle(), name.c_str(), flags, &dbi),
+        "test named DBI open failed");
+    mdbxc::check_mdbx(mdbx_drop(transaction.handle(), dbi, true),
+                      "test named DBI drop failed");
+    transaction.commit();
+}
+
 void test_destructive_append_erase_and_batch_preflight() {
     const std::string path = "test_key_ordered_multi_value_destructive_adapter.mdbx";
     cleanup(path);
@@ -250,11 +366,683 @@ void test_destructive_capture_coalesces_and_commits_to_outbox() {
     cleanup(path);
 }
 
+void test_ordered_delivery_rolls_back_malformed_v2_change_and_deduplicates() {
+    const std::string path = "test_key_ordered_multi_value_destructive_replay.mdbx";
+    const std::string primary = "ordered_replay_values";
+    const std::string state = "ordered_replay_state";
+    const std::string by_key = "ordered_replay_by_key";
+    const std::string schema = "app.ordered_replay.v2";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId receiver_node = make_node(0x71u);
+    const mdbxc::sync::NodeId origin = make_node(0x81u);
+    const mdbxc::sync::DbId receiver_db = make_node(0xC1u);
+    mdbxc::sync::SyncEngine engine(connection);
+    engine.initialize_local_identity(receiver_node, receiver_db);
+    table_type table(connection, primary);
+    adapter_type adapter(table, schema, state, by_key);
+    engine.initialize_logical_adapter_schema(
+        adapter, make_v2_record(primary, state, by_key, origin));
+    engine.register_logical_adapter(adapter);
+
+    mdbxc::sync::OrderedElementId id;
+    id.origin = origin;
+    id.sequence = 1u;
+    const mdbxc::sync::LogicalChange valid_change =
+        adapter.make_append(id, 17, "seventeen");
+    mdbxc::sync::LogicalDeliveryEnvelope malformed;
+    malformed.destination_db_uuid = receiver_db;
+    malformed.origin_node_id = origin;
+    malformed.origin_sequence = 1u;
+    malformed.frame_id = "ordered-v2-frame-1";
+    malformed.frame.changes.push_back(valid_change);
+    malformed.frame.changes[0].payload.resize(3u);
+
+    const mdbxc::sync::LogicalDeliveryAcknowledgement failed =
+        engine.apply_ordered_logical_delivery_envelope(malformed);
+    if (failed.ok || failed.acknowledged_through != 0u || !table.find(17).empty()) {
+        throw std::runtime_error("malformed v2 delivery changed durable state");
+    }
+
+    mdbxc::sync::LogicalDeliveryEnvelope valid = malformed;
+    valid.frame.changes[0] = valid_change;
+    const mdbxc::sync::LogicalDeliveryAcknowledgement applied =
+        engine.apply_ordered_logical_delivery_envelope(valid);
+    if (!applied.ok || applied.acknowledged_through != 1u ||
+        table.find(17).size() != 1u || table.find(17)[0] != "seventeen") {
+        throw std::runtime_error("valid v2 delivery did not apply after rollback");
+    }
+
+    const mdbxc::sync::LogicalDeliveryAcknowledgement replay =
+        engine.apply_ordered_logical_delivery_envelope(valid);
+    if (!replay.ok || replay.acknowledged_through != 1u ||
+        table.find(17).size() != 1u) {
+        throw std::runtime_error("exact v2 replay was not a no-op");
+    }
+
+    connection->disconnect();
+    cleanup(path);
+}
+
+void test_destructive_preflight_rejects_untracked_physical_value() {
+    const std::string path = "test_key_ordered_multi_value_destructive_parity.mdbx";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const std::string primary = "ordered_parity_values";
+    const std::string state = "ordered_parity_state";
+    const std::string by_key = "ordered_parity_by_key";
+    const std::string schema = "app.ordered_parity.v2";
+    const mdbxc::sync::NodeId origin = make_node(0x91u);
+    table_type table(connection, primary);
+    adapter_type adapter(table, schema, state, by_key);
+    mdbxc::sync::SyncEngine engine(connection);
+    engine.initialize_local_identity(make_node(0x92u), make_node(0x93u));
+    engine.initialize_logical_adapter_schema(
+        adapter, make_v2_record(primary, state, by_key, origin));
+    mdbxc::sync::LogicalTableRegistry registry;
+    registry.register_adapter(&adapter);
+    table.append(5, "raw");
+
+    mdbxc::sync::OrderedElementId id;
+    id.origin = origin;
+    id.sequence = 1u;
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(adapter.make_append(id, 5, "logical"));
+    apply_changes(registry, connection, changes, false);
+    const std::vector<std::string> values = table.find(5);
+    if (values.size() != 1u || values[0] != "raw") {
+        throw std::runtime_error("parity preflight changed raw physical data");
+    }
+
+    connection->disconnect();
+    cleanup(path);
+}
+
+void test_destructive_preflight_rejects_state_index_corruption() {
+    const std::string path = "test_key_ordered_multi_value_destructive_state_parity.mdbx";
+    const std::string primary = "state_parity_values";
+    const std::string state = "state_parity_state";
+    const std::string by_key = "state_parity_by_key";
+    const std::string schema = "app.state_parity.v2";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId origin = make_node(0xA1u);
+    table_type table(connection, primary);
+    adapter_type adapter(table, schema, state, by_key);
+    mdbxc::sync::SyncEngine engine(connection);
+    engine.initialize_local_identity(make_node(0xA2u), make_node(0xA3u));
+    engine.initialize_logical_adapter_schema(
+        adapter, make_v2_record(primary, state, by_key, origin));
+    mdbxc::sync::LogicalTableRegistry registry;
+    registry.register_adapter(&adapter);
+
+    const std::vector<std::uint8_t> key1 = IntKeyCodec::encode(1);
+    const std::vector<std::uint8_t> key2 = IntKeyCodec::encode(2);
+    const std::vector<std::uint8_t> key3 = IntKeyCodec::encode(3);
+    const std::vector<std::uint8_t> key4 = IntKeyCodec::encode(4);
+    const std::vector<std::uint8_t> key5 = IntKeyCodec::encode(5);
+    const std::vector<std::uint8_t> key6 = IntKeyCodec::encode(6);
+    const std::vector<std::uint8_t> value = StringValueCodec::encode("state");
+    mdbxc::sync::OrderedElementId ids[5];
+    for (std::size_t i = 0u; i < 5u; ++i) {
+        ids[i].origin = origin;
+        ids[i].sequence = i + 1u;
+    }
+    {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        adapter.state_store().put_live(transaction.handle(), ids[0], key1, value);
+        adapter.state_store().put_live(transaction.handle(), ids[1], key2, value);
+        adapter.state_store().put_live(transaction.handle(), ids[2], key3, value);
+        adapter.state_store().put_live(transaction.handle(), ids[3], key5, value);
+        adapter.state_store().put_live(transaction.handle(), ids[4], key6, value);
+        adapter.state_store().tombstone(transaction.handle(), ids[2]);
+        transaction.commit();
+    }
+    delete_raw_index_record(connection, by_key, key1, ids[0]);
+    delete_raw_state_record(connection, state, ids[1]);
+    insert_raw_index_record(connection, by_key, key3, ids[2]);
+    insert_raw_index_record(connection, by_key, key4, ids[3]);
+
+    const int keys[5] = { 1, 2, 3, 4, 6 };
+    for (std::size_t i = 0u; i < 5u; ++i) {
+        mdbxc::sync::OrderedElementId candidate;
+        candidate.origin = origin;
+        candidate.sequence = 10u + i;
+        std::vector<mdbxc::sync::LogicalChange> changes;
+        changes.push_back(adapter.make_append(candidate, keys[i], "candidate"));
+        apply_changes(registry, connection, changes, false);
+    }
+    if (!table.empty()) {
+        throw std::runtime_error("state/index corruption changed the table");
+    }
+
+    connection->disconnect();
+    cleanup(path);
+}
+
+void test_ordered_delivery_rejects_missing_auxiliary_dbis() {
+    const int cases[3] = { 0, 1, 2 };
+    for (std::size_t i = 0u; i < 3u; ++i) {
+        const bool drop_state = cases[i] == 0 || cases[i] == 2;
+        const bool drop_index = cases[i] == 1 || cases[i] == 2;
+        const std::string path =
+            std::string("test_key_ordered_multi_value_destructive_missing_") +
+            (cases[i] == 0 ? "state.mdbx" :
+             (cases[i] == 1 ? "index.mdbx" : "both.mdbx"));
+        const std::string primary = "missing_aux_values";
+        const std::string state = "missing_aux_state";
+        const std::string by_key = "missing_aux_by_key";
+        const std::string schema = "app.missing_aux.v2";
+        cleanup(path);
+
+        mdbxc::Config config;
+        config.pathname = path;
+        config.max_dbs = 16;
+        config.no_subdir = true;
+        const std::shared_ptr<mdbxc::Connection> connection =
+            mdbxc::Connection::create(config);
+        const mdbxc::sync::NodeId receiver = make_node(0xB1u);
+        const mdbxc::sync::NodeId origin = make_node(0xC1u);
+        const mdbxc::sync::DbId db_id = make_node(0xD1u);
+        table_type table(connection, primary);
+        adapter_type adapter(table, schema, state, by_key);
+        mdbxc::sync::SyncEngine engine(connection);
+        engine.initialize_local_identity(receiver, db_id);
+        const mdbxc::sync::LogicalSchemaRecord record =
+            make_v2_record(primary, state, by_key, origin);
+        engine.initialize_logical_adapter_schema(adapter, record);
+        engine.register_logical_adapter(adapter);
+        if (drop_state) {
+            drop_named_dbi(connection, state,
+                           static_cast<MDBX_db_flags_t>(0));
+        }
+        if (drop_index) {
+            drop_named_dbi(connection, by_key, MDBX_DUPSORT);
+        }
+
+        mdbxc::sync::OrderedElementId id;
+        id.origin = origin;
+        id.sequence = 1u;
+        mdbxc::sync::LogicalDeliveryEnvelope envelope;
+        envelope.destination_db_uuid = db_id;
+        envelope.origin_node_id = origin;
+        envelope.origin_sequence = 1u;
+        envelope.frame_id = cases[i] == 0 ? "missing-state" :
+                            (cases[i] == 1 ? "missing-index" : "missing-both");
+        envelope.frame.changes.push_back(adapter.make_append(id, 21, "value"));
+        const mdbxc::sync::LogicalDeliveryAcknowledgement failed =
+            engine.apply_ordered_logical_delivery_envelope(envelope);
+        if (failed.ok || !table.empty()) {
+            throw std::runtime_error(
+                "missing destructive auxiliary DBI was treated as empty");
+        }
+
+        bool setup_rejected = false;
+        try {
+            engine.initialize_logical_adapter_schema(adapter, record);
+        } catch (const std::exception&) {
+            setup_rejected = true;
+        }
+        if (!setup_rejected) {
+            throw std::runtime_error(
+                "existing marker recreated a missing auxiliary DBI");
+        }
+
+        const std::string& missing_name = drop_state ? state : by_key;
+        const MDBX_db_flags_t missing_flags =
+            drop_state ? static_cast<MDBX_db_flags_t>(0) : MDBX_DUPSORT;
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        MDBX_dbi missing_dbi = 0;
+        const int rc = mdbx_dbi_open(transaction.handle(), missing_name.c_str(),
+                                     missing_flags, &missing_dbi);
+        transaction.rollback();
+        if (rc != MDBX_NOTFOUND) {
+            throw std::runtime_error(
+                "failed setup recreated a missing destructive auxiliary DBI");
+        }
+
+        connection->disconnect();
+        cleanup(path);
+    }
+}
+
+void test_destructive_schema_setup_requires_empty_primary() {
+    const std::string path = "test_key_ordered_multi_value_destructive_setup.mdbx";
+    const std::string primary = "setup_values";
+    const std::string state = "setup_state";
+    const std::string by_key = "setup_by_key";
+    const std::string schema = "app.setup.v2";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId origin = make_node(0xD1u);
+    table_type table(connection, primary);
+    adapter_type adapter(table, schema, state, by_key);
+    mdbxc::sync::SyncEngine engine(connection);
+    engine.initialize_local_identity(make_node(0xD2u), make_node(0xD3u));
+    table.append(1, "untracked");
+
+    bool rejected = false;
+    try {
+        engine.initialize_logical_adapter_schema(
+            adapter, make_v2_record(primary, state, by_key, origin));
+    } catch (const std::exception&) {
+        rejected = true;
+    }
+    if (!rejected || table.find(1).size() != 1u) {
+        throw std::runtime_error(
+            "destructive schema setup accepted a non-empty primary DBI");
+    }
+
+    connection->disconnect();
+    cleanup(path);
+}
+
+void test_destructive_schema_reopen_rejects_missing_primary() {
+    const std::string path = "test_key_ordered_multi_value_destructive_missing_primary.mdbx";
+    const std::string primary = "missing_primary_values";
+    const std::string state = "missing_primary_state";
+    const std::string by_key = "missing_primary_by_key";
+    const std::string schema = "app.missing_primary.v2";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const mdbxc::sync::NodeId origin = make_node(0xD3u);
+    {
+        const std::shared_ptr<mdbxc::Connection> connection =
+            mdbxc::Connection::create(config);
+        const std::shared_ptr<table_type> table =
+            adapter_type::open_primary_for_schema(connection, schema, primary);
+        adapter_type adapter(*table, schema, state, by_key);
+        mdbxc::sync::SyncEngine engine(connection);
+        engine.initialize_local_identity(make_node(0xD4u), make_node(0xD5u));
+        engine.initialize_logical_adapter_schema(
+            adapter, make_v2_record(primary, state, by_key, origin));
+        drop_named_dbi(connection, primary, static_cast<MDBX_db_flags_t>(0));
+        connection->disconnect();
+    }
+
+    {
+        const std::shared_ptr<mdbxc::Connection> connection =
+            mdbxc::Connection::create(config);
+        bool rejected = false;
+        try {
+            adapter_type::open_primary_for_schema(connection, schema, primary);
+        } catch (const std::exception&) {
+            rejected = true;
+        }
+        if (!rejected) {
+            throw std::runtime_error(
+                "destructive schema reopen recreated a missing primary DBI");
+        }
+
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        MDBX_dbi dbi = 0;
+        const int rc = mdbx_dbi_open(transaction.handle(), primary.c_str(),
+                                     static_cast<MDBX_db_flags_t>(0), &dbi);
+        transaction.rollback();
+        if (rc != MDBX_NOTFOUND) {
+            throw std::runtime_error(
+                "failed destructive schema reopen recreated primary DBI");
+        }
+        connection->disconnect();
+    }
+    cleanup(path);
+}
+
+void test_destructive_preflight_rejects_corrupt_introduced_high_water() {
+    const std::string path = "test_key_ordered_multi_value_destructive_high_water.mdbx";
+    const std::string primary = "high_water_values";
+    const std::string state = "high_water_state";
+    const std::string by_key = "high_water_by_key";
+    const std::string schema = "app.high_water.v2";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId origin = make_node(0xD6u);
+    table_type table(connection, primary);
+    adapter_type adapter(table, schema, state, by_key);
+    mdbxc::sync::SyncEngine engine(connection);
+    engine.initialize_local_identity(make_node(0xD7u), make_node(0xD8u));
+    engine.initialize_logical_adapter_schema(
+        adapter, make_v2_record(primary, state, by_key, origin));
+    mdbxc::sync::LogicalTableRegistry registry;
+    registry.register_adapter(&adapter);
+
+    mdbxc::sync::OrderedElementId id2;
+    id2.origin = origin;
+    id2.sequence = 2u;
+    mdbxc::sync::OrderedElementId id1;
+    id1.origin = origin;
+    id1.sequence = 1u;
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(adapter.make_append(id2, 9, "same"));
+    apply_changes(registry, connection, changes, true);
+
+    delete_raw_introduced_high_water(connection, state, origin);
+    changes.clear();
+    changes.push_back(adapter.make_append(id1, 9, "same"));
+    apply_changes(registry, connection, changes, false);
+    const std::vector<std::string> values = table.find(9);
+    if (values.size() != 1u || values[0] != "same") {
+        throw std::runtime_error(
+            "corrupt introduced high-water changed the physical ordered table");
+    }
+
+    connection->disconnect();
+    cleanup(path);
+}
+
+void test_destructive_ordering_and_duplicate_append_contract() {
+    const std::string path = "test_key_ordered_multi_value_destructive_ordering.mdbx";
+    const std::string primary = "ordering_values";
+    const std::string state = "ordering_state";
+    const std::string by_key = "ordering_by_key";
+    const std::string schema = "app.ordering.v2";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId origin = make_node(0xD4u);
+    table_type table(connection, primary);
+    adapter_type adapter(table, schema, state, by_key);
+    mdbxc::sync::SyncEngine engine(connection);
+    engine.initialize_local_identity(make_node(0xD5u), make_node(0xD6u));
+    engine.initialize_logical_adapter_schema(
+        adapter, make_v2_record(primary, state, by_key, origin));
+    mdbxc::sync::LogicalTableRegistry registry;
+    registry.register_adapter(&adapter);
+
+    mdbxc::sync::OrderedElementId id2;
+    id2.origin = origin;
+    id2.sequence = 2u;
+    mdbxc::sync::OrderedElementId id1;
+    id1.origin = origin;
+    id1.sequence = 1u;
+    mdbxc::sync::OrderedElementId id5;
+    id5.origin = origin;
+    id5.sequence = 5u;
+    mdbxc::sync::OrderedElementId id8;
+    id8.origin = origin;
+    id8.sequence = 8u;
+    mdbxc::sync::OrderedElementId id7;
+    id7.origin = origin;
+    id7.sequence = 7u;
+    mdbxc::sync::OrderedElementId id9;
+    id9.origin = origin;
+    id9.sequence = 9u;
+    mdbxc::sync::OrderedElementId id10;
+    id10.origin = origin;
+    id10.sequence = 10u;
+    mdbxc::sync::OrderedElementId id11;
+    id11.origin = origin;
+    id11.sequence = 11u;
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    changes.push_back(adapter.make_append(id2, 7, "same"));
+    apply_changes(registry, connection, changes, true);
+    changes.clear();
+    changes.push_back(adapter.make_append(id1, 7, "same"));
+    apply_changes(registry, connection, changes, false);
+    if (table.find(7).size() != 1u || table.find(7)[0] != "same") {
+        throw std::runtime_error(
+            "out-of-order ordered element changed the physical table");
+    }
+
+    changes.clear();
+    changes.push_back(adapter.make_append(id5, 7, "five"));
+    apply_changes(registry, connection, changes, true);
+    changes.clear();
+    changes.push_back(adapter.make_append(id8, 7, "eight"));
+    apply_changes(registry, connection, changes, true);
+    changes.clear();
+    changes.push_back(adapter.make_append(id8, 7, "eight"));
+    apply_changes(registry, connection, changes, true);
+    if (table.find(7).size() != 3u) {
+        throw std::runtime_error("idempotent ordered append duplicated a row");
+    }
+
+    changes.clear();
+    changes.push_back(adapter.make_append(id8, 7, "conflict"));
+    apply_changes(registry, connection, changes, false);
+    changes.clear();
+    changes.push_back(adapter.make_erase(id5));
+    apply_changes(registry, connection, changes, true);
+    changes.clear();
+    changes.push_back(adapter.make_append(id5, 7, "five"));
+    apply_changes(registry, connection, changes, false);
+    changes.clear();
+    changes.push_back(adapter.make_append(id7, 7, "seven"));
+    apply_changes(registry, connection, changes, false);
+
+    changes.clear();
+    changes.push_back(adapter.make_append(id9, 7, "nine"));
+    changes.push_back(adapter.make_append(id9, 7, "nine"));
+    apply_changes(registry, connection, changes, false);
+    if (table.find(7).size() != 2u) {
+        throw std::runtime_error("duplicate append in one batch changed a row");
+    }
+
+    changes.clear();
+    changes.push_back(adapter.make_append(id11, 7, "eleven"));
+    changes.push_back(adapter.make_append(id10, 7, "ten"));
+    apply_changes(registry, connection, changes, false);
+    if (table.find(7).size() != 2u) {
+        throw std::runtime_error(
+            "out-of-order destructive batch changed the physical table");
+    }
+
+    {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        const mdbxc::sync::OrderedElementId allocated =
+            adapter.state_store().allocate_id(transaction.handle(), origin);
+        if (allocated.sequence != 9u) {
+            throw std::runtime_error(
+                "local allocator did not advance past remote introduced ids");
+        }
+        transaction.commit();
+    }
+
+    connection->disconnect();
+    cleanup(path);
+}
+
+void test_ordered_delivery_survives_environment_reopen() {
+    const std::string path = "test_key_ordered_multi_value_destructive_delivery_reopen.mdbx";
+    const std::string primary = "delivery_reopen_values";
+    const std::string state = "delivery_reopen_state";
+    const std::string by_key = "delivery_reopen_by_key";
+    const std::string schema = "app.delivery_reopen.v2";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const mdbxc::sync::NodeId receiver = make_node(0xE1u);
+    const mdbxc::sync::NodeId origin = make_node(0xE2u);
+    const mdbxc::sync::DbId db_id = make_node(0xE3u);
+    mdbxc::sync::OrderedElementId id;
+    id.origin = origin;
+    id.sequence = 1u;
+    mdbxc::sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = db_id;
+    envelope.origin_node_id = origin;
+    envelope.origin_sequence = 1u;
+    envelope.frame_id = "ordered-v2-reopen";
+
+    {
+        const std::shared_ptr<mdbxc::Connection> connection =
+            mdbxc::Connection::create(config);
+        table_type table(connection, primary);
+        adapter_type adapter(table, schema, state, by_key);
+        mdbxc::sync::SyncEngine engine(connection);
+        engine.initialize_local_identity(receiver, db_id);
+        engine.initialize_logical_adapter_schema(
+            adapter, make_v2_record(primary, state, by_key, origin));
+        engine.register_logical_adapter(adapter);
+        envelope.frame.changes.push_back(adapter.make_append(id, 42, "persisted"));
+        const mdbxc::sync::LogicalDeliveryAcknowledgement applied =
+            engine.apply_ordered_logical_delivery_envelope(envelope);
+        if (!applied.ok || applied.acknowledged_through != 1u) {
+            throw std::runtime_error("ordered delivery did not commit before reopen");
+        }
+        connection->disconnect();
+    }
+
+    {
+        const std::shared_ptr<mdbxc::Connection> connection =
+            mdbxc::Connection::create(config);
+        table_type table(connection, primary);
+        adapter_type adapter(table, schema, state, by_key);
+        mdbxc::sync::SyncEngine engine(connection);
+        engine.initialize_local_identity(receiver, db_id);
+        engine.initialize_logical_adapter_schema(
+            adapter, make_v2_record(primary, state, by_key, origin));
+        engine.register_logical_adapter(adapter);
+        const mdbxc::sync::LogicalDeliveryAcknowledgement replay =
+            engine.apply_ordered_logical_delivery_envelope(envelope);
+        if (!replay.ok || replay.acknowledged_through != 1u ||
+            table.find(42).size() != 1u) {
+            throw std::runtime_error(
+                "ordered delivery replay was not durable across environment reopen");
+        }
+        {
+            mdbxc::Transaction transaction =
+                connection->transaction(mdbxc::TransactionMode::READ_ONLY);
+            mdbxc::sync::LogicalDeliveryOrderStore order(connection->env_handle());
+            if (order.last_applied(transaction.handle(), origin) != 1u) {
+                throw std::runtime_error(
+                    "ordered delivery frontier did not survive environment reopen");
+            }
+            transaction.rollback();
+        }
+        connection->disconnect();
+    }
+
+    cleanup(path);
+}
+
+void test_ordered_delivery_rejects_incompatible_auxiliary_dbi() {
+    const std::string path = "test_key_ordered_multi_value_destructive_bad_index.mdbx";
+    const std::string primary = "bad_index_values";
+    const std::string state = "bad_index_state";
+    const std::string by_key = "bad_index_by_key";
+    const std::string schema = "app.bad_index.v2";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId receiver = make_node(0xB4u);
+    const mdbxc::sync::NodeId origin = make_node(0xC4u);
+    const mdbxc::sync::DbId db_id = make_node(0xD4u);
+    table_type table(connection, primary);
+    adapter_type adapter(table, schema, state, by_key);
+    mdbxc::sync::SyncEngine engine(connection);
+    engine.initialize_local_identity(receiver, db_id);
+    const mdbxc::sync::LogicalSchemaRecord record =
+        make_v2_record(primary, state, by_key, origin);
+    engine.initialize_logical_adapter_schema(adapter, record);
+    engine.register_logical_adapter(adapter);
+    drop_named_dbi(connection, by_key, MDBX_DUPSORT);
+    {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        MDBX_dbi bad_index = 0;
+        mdbxc::check_mdbx(mdbx_dbi_open(
+            transaction.handle(), by_key.c_str(), MDBX_CREATE, &bad_index),
+            "test incompatible index DBI creation failed");
+        transaction.commit();
+    }
+
+    mdbxc::sync::OrderedElementId id;
+    id.origin = origin;
+    id.sequence = 1u;
+    mdbxc::sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = db_id;
+    envelope.origin_node_id = origin;
+    envelope.origin_sequence = 1u;
+    envelope.frame_id = "bad-index";
+    envelope.frame.changes.push_back(adapter.make_append(id, 22, "value"));
+    const mdbxc::sync::LogicalDeliveryAcknowledgement failed =
+        engine.apply_ordered_logical_delivery_envelope(envelope);
+    if (failed.ok || !table.empty()) {
+        throw std::runtime_error(
+            "incompatible destructive auxiliary DBI was accepted");
+    }
+
+    bool setup_rejected = false;
+    try {
+        engine.initialize_logical_adapter_schema(adapter, record);
+    } catch (const std::exception&) {
+        setup_rejected = true;
+    }
+    if (!setup_rejected) {
+        throw std::runtime_error("incompatible auxiliary DBI passed setup");
+    }
+
+    connection->disconnect();
+    cleanup(path);
+}
+
 } // namespace
 
 int main() {
     test_destructive_append_erase_and_batch_preflight();
     test_destructive_preflight_rejects_foreign_append_id();
     test_destructive_capture_coalesces_and_commits_to_outbox();
+    test_ordered_delivery_rolls_back_malformed_v2_change_and_deduplicates();
+    test_destructive_preflight_rejects_untracked_physical_value();
+    test_destructive_preflight_rejects_state_index_corruption();
+    test_ordered_delivery_rejects_missing_auxiliary_dbis();
+    test_ordered_delivery_rejects_incompatible_auxiliary_dbi();
+    test_destructive_schema_setup_requires_empty_primary();
+    test_destructive_schema_reopen_rejects_missing_primary();
+    test_destructive_preflight_rejects_corrupt_introduced_high_water();
+    test_destructive_ordering_and_duplicate_append_contract();
+    test_ordered_delivery_survives_environment_reopen();
     return 0;
 }

--- a/tests/test_key_ordered_multi_value_destructive_adapter.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_adapter.cpp
@@ -932,8 +932,9 @@ void test_ordered_delivery_survives_environment_reopen() {
     {
         const std::shared_ptr<mdbxc::Connection> connection =
             mdbxc::Connection::create(config);
-        table_type table(connection, primary);
-        adapter_type adapter(table, schema, state, by_key);
+        const std::shared_ptr<table_type> table =
+            adapter_type::open_primary_for_schema(connection, schema, primary);
+        adapter_type adapter(*table, schema, state, by_key);
         mdbxc::sync::SyncEngine engine(connection);
         engine.initialize_local_identity(receiver, db_id);
         engine.initialize_logical_adapter_schema(
@@ -942,7 +943,7 @@ void test_ordered_delivery_survives_environment_reopen() {
         const mdbxc::sync::LogicalDeliveryAcknowledgement replay =
             engine.apply_ordered_logical_delivery_envelope(envelope);
         if (!replay.ok || replay.acknowledged_through != 1u ||
-            table.find(42).size() != 1u) {
+            table->find(42).size() != 1u) {
             throw std::runtime_error(
                 "ordered delivery replay was not durable across environment reopen");
         }


### PR DESCRIPTION
## Summary
- cover malformed schema-v2 payload rollback before physical mutation
- prove the same ordered sequence can apply after the failed attempt
- cover exact retry as a durable no-op
- reject an untracked physical row during adapter preflight, before mutation
- align the published initial-v2 contract with the implemented single-origin surface

## Validation
- C++11 MinGW: test_key_ordered_multi_value_destructive_adapter and test_key_ordered_multi_value_destructive_state
- C++17 MinGW: test_key_ordered_multi_value_destructive_adapter and test_key_ordered_multi_value_destructive_state
- git diff --check