### PR TITLE
docs(sync): document destructive ordered schema v2

### DIFF
--- a/guides/sync-table-coverage.md
+++ b/guides/sync-table-coverage.md
@@ -21,7 +21,7 @@ values during transport, and remote apply replays the captured physical
 | `VectorStore` | Indirectly supported | Captured through its internal `SequenceTable` and `KeyValueTable` members. | The internal table operations are replicated; `VectorStore` has no separate wire type. This raw path requires one authoritative or externally serialized writer per collection. Already-open instances compare `Connection::sync_apply_generation()` and lazily rebuild their RAM index before index-dependent operations after remote apply. A connection apply/read barrier serializes remote `handle_push()` apply commits with cache-backed `VectorStore` operations. Each `VectorStore` instance serializes its own methods; C++17 builds let different readers share the connection read side, while C++11 builds use an exclusive connection mutex fallback. | `test_sync_capture`, `test_sync_replication` |
 | `AnyValueTable<K>` | Deferred | No `ChangeOp` in v0.1. | Not applied by sync as a typed heterogeneous table. | `test_sync_capture` negative coverage |
 | `KeyMultiValueTable<K, V>` | Limited logical adapter | No raw `ChangeOp` in v0.1. | `KeyMultiValueTableLogicalAdapter` explicitly captures unordered insert, key erase, all-matching-value erase, and clear for one writer or causally serialized updates. Raw calls, append, reconcile, range erase, and general multi-writer destructive convergence remain deferred. | `test_key_value_logical_adapter`, `test_sync_capture` negative coverage |
-| `KeyOrderedMultiValueTable<K, V>` | Limited ordered logical adapter | No raw `ChangeOp` in v0.1. | Append-only logical changes require one ordered origin stream; direct logical frames and unordered delivery fail closed. Typed capture atomically commits local appends plus an ordered outbox envelope; destructive operations remain deferred pending persistent element identity and tombstones. | `test_key_value_logical_adapter` |
+| `KeyOrderedMultiValueTable<K, V>` | Limited ordered logical adapters | No raw `ChangeOp` in v0.1. Schema v1 captures append-only changes; schema v2 captures `AppendElement` and exact `EraseElement` by persistent id. | Both schemas require one authoritative ordered origin and fail closed for direct logical frames or unordered delivery. Schema v2 persists element identity and tombstones, and its typed capture atomically commits local mutations plus an ordered outbox envelope. Broad key/value erase, clear, baseline import, and multi-origin histories remain deferred. | `test_key_value_logical_adapter`, `test_key_ordered_multi_value_destructive_state`, `test_key_ordered_multi_value_destructive_adapter` |
 | `HashedKeyValueStore<K, V, H, Layout>` | Deferred | No `ChangeOp` in v0.1. | Hash-index identity and logical-key mapping are deferred. | `test_sync_capture` negative coverage |
 
 ## Supported Capture Contract
@@ -114,12 +114,15 @@ The detailed deferred contract lives in
 sub-operations and receiver-side logical apply helpers before capture can be
 enabled.
 
-`KeyOrderedMultiValueTable<K, V>` has an append-only ordered logical adapter.
-Malformed ordered pair payloads, active-session destruction rollback, and
-missing, stale, or DBI-mismatched schema markers are covered by the current
-append-only adapter regression tests. A native MDBX commit failure after ordered
-capture preparation remains deferred coverage; the existing pre-commit failure
-test does not model a native commit failure.
+`KeyOrderedMultiValueTable<K, V>` has two ordered logical schemas. Schema v1 is
+append-only. Schema v2 adds `AppendElement` and exact `EraseElement` by a
+persistent `OrderedElementId`, with Live/Tombstone state, per-origin introduced
+high-water integrity, and typed capture that atomically commits the mutation and
+an ordered outbox envelope. Both require one authoritative ordered origin.
+Broad key/value erase, clear, baseline import, multi-origin histories, tombstone
+pruning, and compaction remain deferred. A native MDBX commit failure after
+ordered capture preparation also remains deferred coverage; the existing
+pre-commit failure test does not model a native commit failure.
 
 `AnyValueTable<K>` needs value type-tag propagation or another explicit
 compatibility policy. The current sync wire operation only carries raw value

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -79,9 +79,11 @@ These table families intentionally emit no `ChangeOp` in v0.1:
   general multi-writer destructive convergence. The explicit unordered logical
   adapter covers only insert, key erase, all-matching-value erase, and clear for one writer
   or causally serialized updates.
-- `KeyOrderedMultiValueTable` raw capture and destructive operations. Its
-  append-only logical contract requires one ordered origin stream; adapter,
-  capture, and round-trip support are tracked separately from raw v0.1 sync.
+- `KeyOrderedMultiValueTable` raw capture and broad destructive operations.
+  Schema v1 remains append-only. Schema v2 supports logical `AppendElement`
+  and exact `EraseElement` by persistent element id through one authoritative
+  ordered origin, but key/value erase, clear, baseline import, and multi-origin
+  histories remain deferred.
 - `HashedKeyValueStore`, until the relationship between logical key bytes,
   physical storage keys, and hash-index entries is specified.
 
@@ -89,7 +91,8 @@ Do not add `record_op()` calls to these tables until their wire format and
 round-trip tests exist. A partial capture path is worse than no capture because
 it can make replication appear successful while logical state diverges.
 
-The logical sync scaffolding is preparatory only:
+The raw `handle_push()` transport path remains separate from explicit logical
+delivery. The logical core uses the following contracts:
 
 - `_mdbxc_sync_schema` is a persistent compatibility marker, not an apply path.
 - `LogicalChange` payloads are opaque and are not serialized by the current
@@ -106,13 +109,16 @@ The logical sync scaffolding is preparatory only:
 - `KeyMultiValueTableLogicalAdapter` follows the same explicit logical-frame
   path for its limited unordered multiset operation set. It does not enable raw
   `ChangeOp` capture for the table wrapper.
-- `KeyOrderedMultiValueTableLogicalAdapter` applies append-only logical changes
-  only through ordered delivery for one origin stream. Its typed capture
-  session can atomically commit local appends and an ordered outbox envelope;
-  destructive ordered-table operations remain deferred. Transferring that
-  authoritative origin is an application-coordinated schema-marker cutover;
-  it is not automatic failover and requires old-outbox drain plus replay-marker
-  retention through the chosen retry horizon.
+- `KeyOrderedMultiValueTableLogicalAdapter` applies schema-v1 append-only
+  changes only through ordered delivery for one origin stream.
+  `KeyOrderedMultiValueTableDestructiveLogicalAdapter` applies schema-v2
+  `AppendElement` and exact `EraseElement` changes with persistent element
+  identity and tombstones; its typed capture session atomically commits local
+  mutations and an ordered outbox envelope. Broad destructive mutators remain
+  deferred. Transferring the authoritative origin is an
+  application-coordinated schema-marker cutover; it is not automatic failover
+  and requires old-outbox drain plus replay-marker retention through the chosen
+  retry horizon.
 - Logical delivery replay markers can be pruned through a persisted per-origin
   watermark. The watermark DBI is created lazily on the first pruning call, so
   deployments that use pruning must reserve one additional named-DBI slot in
@@ -144,8 +150,10 @@ tables.
   `SnapshotRequired` as automatically recoverable by sync itself.
 - Define explicit conflict/CRDT semantics before claiming general concurrent
   multi-writer convergence for `KeyMultiValueTable`.
-- Keep `KeyOrderedMultiValueTable<K, V>` append-only until persistent element
-  identity and tombstone semantics are designed for destructive operations.
+- Extend schema-v2 `KeyOrderedMultiValueTable<K, V>` beyond exact element
+  operations only after broad mutators have bounded `EraseElement` frame
+  semantics, plus a persistent-layout design for baseline import and
+  multi-origin histories.
 - Evaluate whether any `KeyMultiValueTable` framing ideas carry over to
   `AnyValueTable` and `HashedKeyValueStore`.
 


### PR DESCRIPTION
Summary: align sync coverage and readiness documentation with the merged schema-v2 destructive ordered adapter. Validation: git diff --check.