### PR TITLE
test(sync): cover destructive ordered state corruption

### DIFF
--- a/tests/test_key_ordered_multi_value_destructive_state.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_state.cpp
@@ -36,6 +36,35 @@ std::vector<std::uint8_t> make_introduced_key(
     return key;
 }
 
+std::vector<std::uint8_t> make_element_key(
+        const mdbxc::sync::OrderedElementId& id) {
+    std::vector<std::uint8_t> key(1u, 0x01u);
+    const std::vector<std::uint8_t> encoded =
+        mdbxc::sync::encode_ordered_element_id_index(id);
+    key.insert(key.end(), encoded.begin(), encoded.end());
+    return key;
+}
+
+void write_raw_state_record(
+        const std::shared_ptr<mdbxc::Connection>& connection,
+        const std::string& state_name,
+        const std::vector<std::uint8_t>& key,
+        const std::vector<std::uint8_t>& value) {
+    mdbxc::Transaction transaction =
+        connection->transaction(mdbxc::TransactionMode::WRITABLE);
+    MDBX_dbi state = 0;
+    mdbxc::check_mdbx(mdbx_dbi_open(
+        transaction.handle(), state_name.c_str(),
+        static_cast<MDBX_db_flags_t>(0), &state),
+        "test state DBI open failed");
+    MDBX_val raw_key = make_raw_val(key);
+    MDBX_val raw_value = make_raw_val(value);
+    mdbxc::check_mdbx(mdbx_put(transaction.handle(), state, &raw_key,
+                                &raw_value, MDBX_UPSERT),
+                      "test state record write failed");
+    transaction.commit();
+}
+
 void write_raw_introduced_high_water(
         const std::shared_ptr<mdbxc::Connection>& connection,
         const std::string& state_name,
@@ -109,6 +138,24 @@ void require_high_water_rejected(
     }
     if (!allocation_rejected) {
         throw std::runtime_error("corrupt introduced high-water allowed allocation");
+    }
+}
+
+void require_origin_scan_rejected(
+        mdbxc::sync::OrderedElementStateStore& store,
+        const std::shared_ptr<mdbxc::Connection>& connection,
+        const mdbxc::sync::NodeId& origin) {
+    bool rejected = false;
+    mdbxc::Transaction transaction =
+        connection->transaction(mdbxc::TransactionMode::READ_ONLY);
+    try {
+        store.verify_introduced_high_water(transaction.handle(), origin);
+    } catch (const std::exception&) {
+        rejected = true;
+    }
+    transaction.rollback();
+    if (!rejected) {
+        throw std::runtime_error("corrupt ordered element origin scan passed");
     }
 }
 
@@ -368,6 +415,90 @@ void test_ordered_element_state_rejects_corrupt_introduced_high_water() {
     cleanup(path);
 }
 
+void test_ordered_element_state_rejects_second_origin_high_water_corruption() {
+    const std::string path = "test_ordered_element_state_second_origin_high_water.mdbx";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId first_origin = make_node(0x72u);
+    const mdbxc::sync::NodeId second_origin = make_node(0x82u);
+    const std::vector<std::uint8_t> key(1u, 0xAAu);
+    const std::vector<std::uint8_t> value(1u, 0xBBu);
+    const std::string state_name = "second_origin_high_water_state";
+    mdbxc::sync::OrderedElementStateStore store(
+        connection->env_handle(), state_name, "second_origin_high_water_by_key");
+    mdbxc::sync::OrderedElementId second_id;
+    {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        store.initialize_empty(transaction.handle());
+        const mdbxc::sync::OrderedElementId first_id =
+            store.allocate_id(transaction.handle(), first_origin);
+        second_id = store.allocate_id(transaction.handle(), second_origin);
+        store.put_live(transaction.handle(), first_id, key, value);
+        store.put_live(transaction.handle(), second_id, key, value);
+        transaction.commit();
+    }
+
+    delete_raw_introduced_high_water(connection, state_name, second_origin);
+    require_high_water_rejected(store, connection, second_origin);
+
+    write_raw_introduced_high_water(
+        connection, state_name, second_origin, second_id.sequence);
+    write_raw_introduced_high_water(
+        connection, state_name, second_origin, second_id.sequence - 1u);
+    require_high_water_rejected(store, connection, second_origin);
+
+    connection->disconnect();
+    cleanup(path);
+}
+
+void test_ordered_element_state_rejects_malformed_records_in_origin_scan() {
+    const std::string path = "test_ordered_element_state_malformed_origin_scan.mdbx";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId malformed_key_origin = make_node(0x91u);
+    const mdbxc::sync::NodeId malformed_value_origin = make_node(0xA1u);
+    const std::string state_name = "malformed_origin_scan_state";
+    mdbxc::sync::OrderedElementStateStore store(
+        connection->env_handle(), state_name, "malformed_origin_scan_by_key");
+    {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        store.initialize_empty(transaction.handle());
+        transaction.commit();
+    }
+
+    std::vector<std::uint8_t> malformed_key(1u, 0x01u);
+    malformed_key.insert(malformed_key.end(), malformed_key_origin.begin(),
+                         malformed_key_origin.end());
+    write_raw_state_record(
+        connection, state_name, malformed_key, std::vector<std::uint8_t>(1u, 0x02u));
+    require_origin_scan_rejected(store, connection, malformed_key_origin);
+
+    mdbxc::sync::OrderedElementId malformed_value_id;
+    malformed_value_id.origin = malformed_value_origin;
+    malformed_value_id.sequence = 1u;
+    write_raw_state_record(connection, state_name,
+                           make_element_key(malformed_value_id),
+                           std::vector<std::uint8_t>(1u, 0x7Fu));
+    require_origin_scan_rejected(store, connection, malformed_value_origin);
+
+    connection->disconnect();
+    cleanup(path);
+}
+
 } // namespace
 
 int main() {
@@ -375,5 +506,7 @@ int main() {
     test_ordered_element_state_requires_initialized_compatible_dbis();
     test_ordered_element_state_survives_reopen();
     test_ordered_element_state_rejects_corrupt_introduced_high_water();
+    test_ordered_element_state_rejects_second_origin_high_water_corruption();
+    test_ordered_element_state_rejects_malformed_records_in_origin_scan();
     return 0;
 }


### PR DESCRIPTION
## Summary
- cover introduced high-water corruption for a second origin
- cover malformed state keys and values inside per-origin scans

## Validation
- MinGW C++11 target test_key_ordered_multi_value_destructive_state
- MinGW C++17 target test_key_ordered_multi_value_destructive_state