### PR TITLE
bench(sync): add tombstone state scenarios

### DIFF
--- a/benchmarks/README-sync-RU.md
+++ b/benchmarks/README-sync-RU.md
@@ -153,13 +153,15 @@ tmp/build-bench/bin/benchmarks/sync_tick_hub_benchmark \
 cmake --build tmp/build-bench --target ordered_destructive_state_benchmark
 tmp/build-bench/bin/benchmarks/ordered_destructive_state_benchmark
 tmp/build-bench/bin/benchmarks/ordered_destructive_state_benchmark \
-    16 512 32 100
+    16 512 32 100 384
 ```
 
 Необязательные позиционные аргументы: `origins`, `elements_per_origin`,
-`key_count` и `iterations`. CSV отдельно содержит `element_records` и
-`state_records`; второе значение включает allocation counter и introduced
-high-water record каждого origin. `elapsed_ms` включает открытие read
-transaction, измеряемое сканирование и rollback. Результаты representative
-workloads нужны до добавления index, cache или фиксированного лимита к любому
-из путей корректности.
+`key_count`, `iterations` и `tombstones_per_origin`. Первые
+`tombstones_per_origin` id каждого origin сохраняются как Tombstone records;
+по умолчанию значение равно нулю. CSV отдельно содержит общее число, Live и
+Tombstone element records, полное число state records и Live DUPSORT index
+records. `elapsed_ms` включает открытие read transaction, измеряемое
+сканирование и rollback. Результаты representative workloads нужны до
+добавления index, cache или фиксированного лимита к любому из путей
+корректности.

--- a/benchmarks/README-sync.md
+++ b/benchmarks/README-sync.md
@@ -147,12 +147,14 @@ Use identical arguments and build settings when comparing revisions:
 cmake --build tmp/build-bench --target ordered_destructive_state_benchmark
 tmp/build-bench/bin/benchmarks/ordered_destructive_state_benchmark
 tmp/build-bench/bin/benchmarks/ordered_destructive_state_benchmark \
-    16 512 32 100
+    16 512 32 100 384
 ```
 
 The optional positional arguments are `origins`, `elements_per_origin`,
-`key_count`, and `iterations`. CSV rows separately report `element_records` and
-`state_records`; the latter includes the allocation counter and introduced
-high-water record for each origin. `elapsed_ms` includes read-transaction open,
-the measured scan, and rollback. Use results from representative workloads
-before adding an index, cache, or fixed limit to either correctness path.
+`key_count`, `iterations`, and `tombstones_per_origin`. The first
+`tombstones_per_origin` ids of every origin are persisted as Tombstone records;
+the default is zero. CSV rows separately report total, Live, and Tombstone
+element records, the full state-record count, and live DUPSORT index records.
+`elapsed_ms` includes read-transaction open, the measured scan, and rollback.
+Use results from representative workloads before adding an index, cache, or
+fixed limit to either correctness path.

--- a/benchmarks/ordered_destructive_state_benchmark.cpp
+++ b/benchmarks/ordered_destructive_state_benchmark.cpp
@@ -23,6 +23,7 @@ struct Scenario {
     std::uint64_t elements_per_origin;
     std::uint64_t key_count;
     std::uint64_t iterations;
+    std::uint64_t tombstones_per_origin;
 };
 
 struct CleanupGuard {
@@ -65,16 +66,22 @@ Scenario parse_scenario(int argc, char** argv) {
     scenario.elements_per_origin = 64u;
     scenario.key_count = 8u;
     scenario.iterations = 50u;
+    scenario.tombstones_per_origin = 0u;
     if (argc == 1) return scenario;
-    if (argc != 5) {
+    if (argc != 5 && argc != 6) {
         throw std::invalid_argument(
             "usage: ordered_destructive_state_benchmark "
-            "[origins elements_per_origin key_count iterations]");
+            "[origins elements_per_origin key_count iterations "
+            "[tombstones_per_origin]]");
     }
     scenario.origins = parse_u64(argv[1], "origins");
     scenario.elements_per_origin = parse_u64(argv[2], "elements_per_origin");
     scenario.key_count = parse_u64(argv[3], "key_count");
     scenario.iterations = parse_u64(argv[4], "iterations");
+    if (argc == 6) {
+        scenario.tombstones_per_origin =
+            parse_u64(argv[5], "tombstones_per_origin");
+    }
     return scenario;
 }
 
@@ -86,6 +93,10 @@ void validate_scenario(const Scenario& scenario) {
     if (scenario.origins > 200u || scenario.elements_per_origin > 4096u ||
         scenario.key_count > 1024u || scenario.iterations > 100000u) {
         throw std::invalid_argument("benchmark arguments exceed manual safety bounds");
+    }
+    if (scenario.tombstones_per_origin > scenario.elements_per_origin) {
+        throw std::invalid_argument(
+            "tombstones_per_origin exceeds elements_per_origin");
     }
 }
 
@@ -111,9 +122,14 @@ double elapsed_ms(const std::chrono::steady_clock::time_point& started) {
 }
 
 std::uint64_t expected_target_ids(const Scenario& scenario) {
-    const std::uint64_t per_origin =
-        scenario.elements_per_origin / scenario.key_count +
-        (scenario.elements_per_origin % scenario.key_count == 0u ? 0u : 1u);
+    std::uint64_t per_origin = 0u;
+    for (std::uint64_t element_index = scenario.tombstones_per_origin;
+         element_index < scenario.elements_per_origin;
+         ++element_index) {
+        if (element_index % scenario.key_count == 0u) {
+            ++per_origin;
+        }
+    }
     return per_origin * scenario.origins;
 }
 
@@ -130,6 +146,7 @@ void seed_state(const std::shared_ptr<mdbxc::Connection>& connection,
         const mdbxc::sync::NodeId origin =
             make_node(static_cast<std::uint8_t>(origin_index + 1u));
         origins.push_back(origin);
+        std::vector<mdbxc::sync::OrderedElementId> ids;
         for (std::uint64_t element_index = 0u;
              element_index < scenario.elements_per_origin;
              ++element_index) {
@@ -138,6 +155,13 @@ void seed_state(const std::shared_ptr<mdbxc::Connection>& connection,
             store.put_live(transaction.handle(), id,
                            make_key(element_index % scenario.key_count),
                            make_value(origin_index, element_index));
+            ids.push_back(id);
+        }
+        for (std::uint64_t tombstone_index = 0u;
+             tombstone_index < scenario.tombstones_per_origin;
+             ++tombstone_index) {
+            store.tombstone(
+                transaction.handle(), ids[static_cast<std::size_t>(tombstone_index)]);
         }
     }
     transaction.commit();
@@ -210,20 +234,28 @@ void run(const Scenario& scenario) {
 
     const std::uint64_t element_records =
         scenario.origins * scenario.elements_per_origin;
+    const std::uint64_t tombstone_records =
+        scenario.origins * scenario.tombstones_per_origin;
+    const std::uint64_t live_element_records =
+        element_records - tombstone_records;
     const std::uint64_t state_records =
         scenario.origins * (scenario.elements_per_origin + 2u);
+    const std::uint64_t by_key_records = live_element_records;
     std::cout
         << "scan,origins,elements_per_origin,key_count,iterations,element_records,"
-        << "state_records,matched_live_ids,elapsed_ms\n"
+        << "live_element_records,tombstone_records,state_records,by_key_records,"
+        << "matched_live_ids,elapsed_ms\n"
         << "live_state_ids_for_key," << scenario.origins << ','
         << scenario.elements_per_origin << ',' << scenario.key_count << ','
         << scenario.iterations << ',' << element_records << ','
-        << state_records << ','
+        << live_element_records << ',' << tombstone_records << ','
+        << state_records << ',' << by_key_records << ','
         << matched_live_ids << ',' << reverse_ms << '\n'
         << "verify_introduced_high_water," << scenario.origins << ','
         << scenario.elements_per_origin << ',' << scenario.key_count << ','
         << scenario.iterations << ',' << element_records << ','
-        << state_records << ','
+        << live_element_records << ',' << tombstone_records << ','
+        << state_records << ',' << by_key_records << ','
         << 0u << ',' << origin_ms << '\n';
     connection->disconnect();
 }

--- a/guides/build-and-test.md
+++ b/guides/build-and-test.md
@@ -161,8 +161,8 @@ parameters, CSV columns, and measurement guidelines.
 `ordered_destructive_state_benchmark` is a separate manual CSV baseline for the
 full destructive ordered-state reverse scan and per-origin high-water scan. It
 accepts optional positional `origins elements_per_origin key_count iterations`
-arguments; use it before proposing a cache, index, or bound for those
-correctness paths.
+arguments plus optional `tombstones_per_origin`; use it before proposing a
+cache, index, or bound for those correctness paths.
 The benchmark supports named presets:
 
 ```bash


### PR DESCRIPTION
## Summary
- seed optional tombstone-heavy ordered-state scenarios
- report Live, Tombstone, state, and DUPSORT index record counts in CSV

## Validation
- MinGW C++11 build and run: ordered_destructive_state_benchmark 2 8 2 3 4
- MinGW C++17 build and run: ordered_destructive_state_benchmark 2 8 2 3 4