### PR TITLE
fix(sync): discard capture after commit error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,6 +515,14 @@ if(MDBXC_BUILD_TESTS)
         mdbxc_add_test_target(${test_name} ${test_file})
     endforeach()
 
+    # This test alone exposes the header-only transaction commit-failure seam.
+    # Production and all other test targets always call mdbx_txn_commit directly.
+    if(TARGET test_key_ordered_multi_value_destructive_adapter)
+        target_compile_definitions(
+            test_key_ordered_multi_value_destructive_adapter PRIVATE
+            MDBXC_TEST_INJECT_TRANSACTION_COMMIT_FAILURE=1)
+    endif()
+
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
             ((CMAKE_CXX_COMPILER_ID MATCHES "Clang") AND
              NOT CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC"))

--- a/guides/sync-table-coverage.md
+++ b/guides/sync-table-coverage.md
@@ -120,9 +120,12 @@ persistent `OrderedElementId`, with Live/Tombstone state, per-origin introduced
 high-water integrity, and typed capture that atomically commits the mutation and
 an ordered outbox envelope. Both require one authoritative ordered origin.
 Broad key/value erase, clear, baseline import, multi-origin histories, tombstone
-pruning, and compaction remain deferred. A native MDBX commit failure after
-ordered capture preparation also remains deferred coverage; the existing
-pre-commit failure test does not model a native commit failure.
+pruning, and compaction remain deferred. The transaction wrapper's native
+commit-error cleanup path has deterministic test-only coverage after ordered
+capture preparation: the injected path aborts the native handle before
+returning an MDBX error, notifies the attached capture sink of the discard, and
+requires the physical table, state, and outbox to all roll back. This is not a
+claim of real storage-I/O fault injection.
 
 `AnyValueTable<K>` needs value type-tag propagation or another explicit
 compatibility policy. The current sync wire operation only carries raw value

--- a/include/mdbx_containers/common/Connection.hpp
+++ b/include/mdbx_containers/common/Connection.hpp
@@ -59,6 +59,10 @@ namespace mdbxc {
 #   if MDBXC_SYNC_ENABLED
     public:
         void on_pre_commit(MDBX_txn* txn) override;
+        /// \brief Clears capture state using \p txn only as an identity token.
+        /// \details The MDBX transaction may already be terminated after a
+        /// native commit error. This method and the attached sink must not
+        /// dereference \p txn or pass it to MDBX.
         void on_discard(MDBX_txn* txn) noexcept override;
 #   endif
     private:

--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -506,6 +506,8 @@ namespace mdbxc {
 
     inline void Connection::on_discard(MDBX_txn* txn) noexcept {
         try {
+            // txn is an identity token here. A terminal commit error may have
+            // already invalidated the native handle.
             clear_sync_capture_failed(txn);
             sync::ISyncCaptureSink* sink = sync_capture();
             if (sink != nullptr) {

--- a/include/mdbx_containers/common/Transaction.ipp
+++ b/include/mdbx_containers/common/Transaction.ipp
@@ -1,5 +1,30 @@
 namespace mdbxc {
 
+#if defined(MDBXC_TEST_INJECT_TRANSACTION_COMMIT_FAILURE)
+    namespace detail {
+
+        inline int& injected_transaction_commit_result_for_test() {
+            static int result = MDBX_SUCCESS;
+            return result;
+        }
+
+        /// Test-only seam for exercising the post-native-commit error path.
+        inline void fail_next_transaction_commit_for_test(int result) {
+            assert(result != MDBX_SUCCESS &&
+                   result != MDBX_THREAD_MISMATCH &&
+                   "The injected commit result must terminate the transaction");
+            injected_transaction_commit_result_for_test() = result;
+        }
+
+        inline int take_injected_transaction_commit_result_for_test() {
+            int& result = injected_transaction_commit_result_for_test();
+            const int injected = result;
+            result = MDBX_SUCCESS;
+            return injected;
+        }
+    } // namespace detail
+#endif
+
     inline Transaction::Transaction(TransactionTracker* registry, MDBX_env* env, TransactionMode mode)
         : m_registry(registry), m_env(env), m_mode(mode) {
         begin();
@@ -141,11 +166,37 @@ namespace mdbxc {
             m_registry->on_pre_commit(txn);
 #           endif
 
-            const int rc = mdbx_txn_commit(txn);
+            int rc = MDBX_SUCCESS;
+#           if defined(MDBXC_TEST_INJECT_TRANSACTION_COMMIT_FAILURE)
+            rc = detail::take_injected_transaction_commit_result_for_test();
+            if (rc != MDBX_SUCCESS) {
+                // MDBX commit errors consume the transaction handle. Abort the
+                // injected transaction first so wrapper cleanup sees the same
+                // terminated-handle lifecycle without simulating storage I/O.
+                const int abort_rc = mdbx_txn_abort(txn);
+                assert((abort_rc == MDBX_SUCCESS ||
+                        abort_rc == MDBX_THREAD_MISMATCH) &&
+                       "mdbx_txn_abort() failed in injected commit failure");
+                (void)abort_rc;
+            } else {
+                rc = mdbx_txn_commit(txn);
+            }
+#           else
+            rc = mdbx_txn_commit(txn);
+#           endif
 
             if (rc == MDBX_THREAD_MISMATCH) {
                 check_mdbx(rc, "Failed to commit writable transaction");
             }
+
+#           if MDBXC_SYNC_ENABLED
+            if (rc != MDBX_SUCCESS) {
+                // A terminal native commit error aborts the transaction.
+                // Notify capture sinks before dropping the consumed handle so
+                // txn-pointer keyed pending state cannot leak into reuse.
+                m_registry->on_discard(txn);
+            }
+#           endif
 
             // MDBX_SUCCESS or any other error: the native handle is already
             // terminated (or we threw above for THREAD_MISMATCH). Null the

--- a/include/mdbx_containers/common/TransactionTracker.hpp
+++ b/include/mdbx_containers/common/TransactionTracker.hpp
@@ -91,8 +91,11 @@ namespace mdbxc {
 
         /// \brief Discard hook for sync capture.
         /// \details Called by \c Transaction::release / \c rollback paths
-        /// when a write transaction is aborted. Default is no-op; \c Connection
-        /// forwards to the attached \c ISyncCaptureSink.
+        /// before a write transaction is aborted, and after a terminal native
+        /// commit error has already terminated it. \p txn is an opaque identity
+        /// token only; implementations must not dereference it or pass it to
+        /// MDBX. Default is no-op; \c Connection forwards to the attached
+        /// \c ISyncCaptureSink.
         virtual void on_discard(MDBX_txn* txn) noexcept {
             (void)txn;
         }

--- a/include/mdbx_containers/sync/ISyncCaptureSink.hpp
+++ b/include/mdbx_containers/sync/ISyncCaptureSink.hpp
@@ -83,11 +83,16 @@ namespace sync {
         virtual void flush_in_txn(MDBX_txn* txn) = 0;
 
         /// \brief Discards any pending ops recorded for a transaction that
-        /// is about to be aborted or rolled back.
-        /// \param txn The about-to-be-aborted write transaction.
+        /// was or is being aborted.
+        /// \param txn Opaque identity token for the discarded transaction.
         /// \details Default implementation is a no-op; overrides drop the
         /// pending ops so the next transaction on the same thread (or the
         /// next MDBX_txn* address if the allocator reuses it) starts clean.
+        /// On explicit rollback or destructor cleanup, \p txn may still name
+        /// an active transaction immediately before \c mdbx_txn_abort(). On a
+        /// terminal native commit error, MDBX has already terminated it.
+        /// Implementations may compare or use the pointer value as a map key,
+        /// but must not dereference it or pass it to any MDBX API.
         virtual void discard_txn(MDBX_txn* txn) noexcept {
             (void)txn;
         }

--- a/tests/test_key_ordered_multi_value_destructive_adapter.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_adapter.cpp
@@ -1,6 +1,7 @@
 #include <mdbx_containers/sync.hpp>
 
 #include <cstdio>
+#include <map>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -13,6 +14,34 @@ typedef mdbxc::sync::KeyValueLogicalStringCodec<std::string> StringValueCodec;
 typedef mdbxc::KeyOrderedMultiValueTable<int, std::string> table_type;
 typedef mdbxc::sync::KeyOrderedMultiValueTableDestructiveLogicalAdapter<
     int, std::string, IntKeyCodec, StringValueCodec> adapter_type;
+
+class CommitFailureCaptureSink : public mdbxc::sync::ISyncCaptureSink {
+public:
+    CommitFailureCaptureSink()
+        : flush_calls(0u), discard_calls(0u) {}
+
+    void record_change(
+            MDBX_txn*,
+            const std::string&,
+            mdbxc::sync::ChangeOpType,
+            std::uint32_t,
+            const std::vector<std::uint8_t>&,
+            const std::vector<std::uint8_t>&) override {}
+
+    void flush_in_txn(MDBX_txn* txn) override {
+        ++flush_calls;
+        pending[txn] = 1u;
+    }
+
+    void discard_txn(MDBX_txn* txn) noexcept override {
+        ++discard_calls;
+        pending.erase(txn);
+    }
+
+    std::map<MDBX_txn*, std::size_t> pending;
+    std::size_t flush_calls;
+    std::size_t discard_calls;
+};
 
 void cleanup(const std::string& path) {
     std::remove(path.c_str());
@@ -360,6 +389,86 @@ void test_destructive_capture_coalesces_and_commits_to_outbox() {
     }
     if (table.find(9).size() != 1u || table.find(9)[0] != "durable") {
         throw std::runtime_error("durable local ordered value is missing");
+    }
+
+    connection->disconnect();
+    cleanup(path);
+}
+
+void test_destructive_capture_rolls_back_injected_native_commit_failure() {
+    const std::string path =
+        "test_key_ordered_multi_value_destructive_native_commit_failure.mdbx";
+    const std::string primary = "ordered_commit_failure_values";
+    const std::string state = "ordered_commit_failure_state";
+    const std::string by_key = "ordered_commit_failure_by_key";
+    const std::string schema = "app.ordered_commit_failure.v2";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId origin = make_node(0x62u);
+    const mdbxc::sync::DbId local_db = make_node(0xA2u);
+    const mdbxc::sync::DbId destination = make_node(0xB2u);
+    mdbxc::sync::SyncEngine engine(connection);
+    engine.initialize_local_identity(origin, local_db);
+    table_type table(connection, primary);
+    adapter_type adapter(table, schema, state, by_key);
+    engine.initialize_logical_adapter_schema(
+        adapter, make_v2_record(primary, state, by_key, origin));
+    CommitFailureCaptureSink capture_sink;
+    {
+        mdbxc::sync::SyncCaptureScope capture_scope(connection, capture_sink);
+        std::unique_ptr<adapter_type::LogicalCaptureSession> failed_session =
+            adapter.begin_capture_session();
+        const mdbxc::sync::OrderedElementId failed_id =
+            failed_session->append(10, "discarded");
+        if (failed_id.sequence != 1u || failed_session->pending_size() != 1u) {
+            throw std::runtime_error("commit-failure capture setup is incorrect");
+        }
+
+        mdbxc::detail::fail_next_transaction_commit_for_test(MDBX_MAP_FULL);
+        bool commit_failed = false;
+        try {
+            failed_session->commit_to_outbox(engine, destination);
+        } catch (const mdbxc::MdbxException&) {
+            commit_failed = true;
+        }
+        if (!commit_failed || failed_session->pending_size() != 0u ||
+            capture_sink.flush_calls != 1u ||
+            capture_sink.discard_calls != 1u ||
+            !capture_sink.pending.empty()) {
+            throw std::runtime_error(
+                "native commit failure did not deactivate destructive capture");
+        }
+
+        bool reuse_rejected = false;
+        try {
+            failed_session->append(10, "must-not-append");
+        } catch (const std::logic_error&) {
+            reuse_rejected = true;
+        }
+        if (!reuse_rejected || !table.find(10).empty() ||
+            !engine.pending_logical_deliveries(destination).empty()) {
+            throw std::runtime_error(
+                "native commit failure leaked destructive capture state");
+        }
+    }
+
+    std::unique_ptr<adapter_type::LogicalCaptureSession> clean_session =
+        adapter.begin_capture_session();
+    const mdbxc::sync::OrderedElementId clean_id =
+        clean_session->append(10, "committed");
+    const mdbxc::sync::LogicalDeliveryEnvelope envelope =
+        clean_session->commit_to_outbox(engine, destination);
+    if (clean_id.sequence != 1u || envelope.origin_sequence != 1u ||
+        table.find(10).size() != 1u || table.find(10)[0] != "committed" ||
+        engine.pending_logical_deliveries(destination).size() != 1u) {
+        throw std::runtime_error(
+            "native commit failure did not roll back table, state, and outbox");
     }
 
     connection->disconnect();
@@ -1035,6 +1144,7 @@ int main() {
     test_destructive_append_erase_and_batch_preflight();
     test_destructive_preflight_rejects_foreign_append_id();
     test_destructive_capture_coalesces_and_commits_to_outbox();
+    test_destructive_capture_rolls_back_injected_native_commit_failure();
     test_ordered_delivery_rolls_back_malformed_v2_change_and_deduplicates();
     test_destructive_preflight_rejects_untracked_physical_value();
     test_destructive_preflight_rejects_state_index_corruption();


### PR DESCRIPTION
## Summary

- notify the attached capture sink when a terminal native commit error aborts and consumes a writable transaction
- define `discard_txn()` / `on_discard()` transaction pointers as opaque identity tokens that must never be dereferenced or passed back to MDBX
- add a compile-time, test-only transaction commit-error seam for the ordered destructive adapter test
- verify pointer-keyed pending-state removal, primary table rollback, persistent v2 state rollback, outbox rollback, session deactivation, and a clean sequence-1 retry
- document that this covers the wrapper error path and is not real storage-I/O fault injection

## Validation

- MinGW Debug C++11: `test_key_ordered_multi_value_destructive_adapter`, `header_sync_umbrella_test`
- MinGW Debug C++17: `test_key_ordered_multi_value_destructive_adapter`, `header_sync_umbrella_test`
- C++11/C++17 transaction and sync-capture regressions on the parent implementation
- `git diff --check`