### PR TITLE
feat(sync): add bounded ordered erase selection

### DIFF
--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
@@ -5,6 +5,7 @@
 /// \file KeyOrderedMultiValueDestructiveState.hpp
 /// \brief Persistent state primitives for destructive ordered logical schemas.
 
+#include <algorithm>
 #include <cstddef>
 #include <cstring>
 #include <cstdint>
@@ -49,6 +50,74 @@ namespace sync {
             return compared < 0 ||
                    (compared == 0 && lhs.sequence < rhs.sequence);
         }
+    };
+
+    /// \brief Explicit bounds for destructive broad local erasure.
+    /// \details Every persisted primary, state, or key-index record must be
+    /// counted before it is decoded or otherwise inspected. Selected ids are
+    /// counted before they are materialized in the candidate set.
+    struct BroadEraseBounds {
+        std::size_t max_selected_elements;
+        std::size_t max_scanned_records;
+    };
+
+    /// \brief Bounded, deterministic candidate set for exact element erasure.
+    /// \details Broad selectors resolve to immutable ids before mutating the
+    /// table. This helper centralizes both limits and canonical id ordering so
+    /// every selector has the same rollback boundary.
+    class OrderedElementCandidateSet {
+    public:
+        explicit OrderedElementCandidateSet(const BroadEraseBounds& bounds)
+            : m_bounds(bounds),
+              m_scanned_records(0u) {}
+
+        /// \brief Accounts for one record before decoding or inspecting it.
+        void inspect_record() {
+            if (m_scanned_records >= m_bounds.max_scanned_records) {
+                throw std::length_error(
+                    "Ordered destructive broad erase scan limit exceeded");
+            }
+            ++m_scanned_records;
+        }
+
+        /// \brief Adds one resolved immutable id before later mutation.
+        void select(const OrderedElementId& id) {
+            if (!is_valid_ordered_element_id(id)) {
+                throw std::invalid_argument(
+                    "Ordered destructive broad erase id is invalid");
+            }
+            if (m_ids.size() >= m_bounds.max_selected_elements) {
+                throw std::length_error(
+                    "Ordered destructive broad erase selection limit exceeded");
+            }
+            m_ids.push_back(id);
+        }
+
+        std::size_t scanned_records() const {
+            return m_scanned_records;
+        }
+
+        std::size_t selected_size() const {
+            return m_ids.size();
+        }
+
+        /// \brief Returns ids in canonical origin/sequence order.
+        std::vector<OrderedElementId> sorted_ids() const {
+            std::vector<OrderedElementId> out = m_ids;
+            std::sort(out.begin(), out.end(), OrderedElementIdLess());
+            for (std::size_t i = 1u; i < out.size(); ++i) {
+                if (out[i - 1u] == out[i]) {
+                    throw std::runtime_error(
+                        "Ordered destructive broad erase resolved a duplicate id");
+                }
+            }
+            return out;
+        }
+
+    private:
+        BroadEraseBounds m_bounds;
+        std::size_t m_scanned_records;
+        std::vector<OrderedElementId> m_ids;
     };
 
     /// \brief Encodes an id for logical payloads: node bytes plus LE sequence.

--- a/tests/test_key_ordered_multi_value_destructive_state.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_state.cpp
@@ -499,6 +499,56 @@ void test_ordered_element_state_rejects_malformed_records_in_origin_scan() {
     cleanup(path);
 }
 
+void test_broad_erase_candidate_set_enforces_bounds_and_order() {
+    const mdbxc::sync::NodeId first_origin = make_node(0x11u);
+    const mdbxc::sync::NodeId second_origin = make_node(0x21u);
+    mdbxc::sync::OrderedElementId first;
+    first.origin = first_origin;
+    first.sequence = 2u;
+    mdbxc::sync::OrderedElementId second;
+    second.origin = first_origin;
+    second.sequence = 1u;
+    mdbxc::sync::OrderedElementId third;
+    third.origin = second_origin;
+    third.sequence = 1u;
+
+    const mdbxc::sync::BroadEraseBounds bounds = { 2u, 2u };
+    mdbxc::sync::OrderedElementCandidateSet candidates(bounds);
+    candidates.inspect_record();
+    candidates.inspect_record();
+    if (candidates.scanned_records() != 2u) {
+        throw std::runtime_error("broad erase scan accounting is incorrect");
+    }
+
+    bool scan_rejected = false;
+    try {
+        candidates.inspect_record();
+    } catch (const std::length_error&) {
+        scan_rejected = true;
+    }
+    if (!scan_rejected) {
+        throw std::runtime_error("broad erase scan limit was not enforced");
+    }
+
+    candidates.select(first);
+    candidates.select(second);
+    const std::vector<mdbxc::sync::OrderedElementId> ordered =
+        candidates.sorted_ids();
+    if (ordered.size() != 2u || ordered[0] != second || ordered[1] != first) {
+        throw std::runtime_error("broad erase candidates are not canonical ordered");
+    }
+
+    bool selection_rejected = false;
+    try {
+        candidates.select(third);
+    } catch (const std::length_error&) {
+        selection_rejected = true;
+    }
+    if (!selection_rejected) {
+        throw std::runtime_error("broad erase selection limit was not enforced");
+    }
+}
+
 } // namespace
 
 int main() {
@@ -508,5 +558,6 @@ int main() {
     test_ordered_element_state_rejects_corrupt_introduced_high_water();
     test_ordered_element_state_rejects_second_origin_high_water_corruption();
     test_ordered_element_state_rejects_malformed_records_in_origin_scan();
+    test_broad_erase_candidate_set_enforces_bounds_and_order();
     return 0;
 }


### PR DESCRIPTION
Adds the shared C++11 selection primitive for destructive ordered broad erasure.\n\nIt enforces explicit scan and candidate limits before decoding or materializing records, and returns immutable ids in canonical origin/sequence order.\n\nValidation: focused destructive-state test on MinGW C++11 and C++17.