### PR TITLE
feat(sync): capture bounded ordered broad erasure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,10 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
-- Documented the future bounded broad-erasure contract for destructive ordered
-  capture. Key/value selectors and clear use canonical logical-codec bytes and
-  must resolve a complete candidate- and scan-bounded set of immutable element
-  ids before mutation while emitting only exact `EraseElement` operations;
-  implementation remains deferred.
+- Added bounded `erase_at()`, `erase_value()`, and `erase_key()` selector
+  expansion to destructive ordered capture. They resolve canonical logical-codec
+  selectors to exact immutable ids before mutation and emit only `EraseElement`
+  operations; `clear()` remains a separate pending operation.
 - Added persistent `OrderedElementId` and state-store primitives for the
   initial destructive `KeyOrderedMultiValueTable` logical schema v2.
 - Added a schema-version-2 destructive logical adapter for

--- a/include/mdbx_containers/KeyOrderedMultiValueTable.hpp
+++ b/include/mdbx_containers/KeyOrderedMultiValueTable.hpp
@@ -16,6 +16,12 @@
 
 namespace mdbxc {
 
+    namespace sync {
+        template<class KeyT, class ValueT, class KeyCodec, class ValueCodec,
+                 class Options>
+        class KeyOrderedMultiValueTableDestructiveLogicalAdapter;
+    }
+
     /// \class KeyOrderedMultiValueTable
     /// \ingroup mdbxc_tables
     /// \brief Multi-value table where value order is part of the contract.
@@ -36,9 +42,10 @@ namespace mdbxc {
     /// significant and reconciliation by unordered multiset semantics is desired.
     ///
     /// \note Sync v0.1 emits no raw \c ChangeOp for this wrapper. The opt-in
-    ///       \c KeyOrderedMultiValueTableLogicalAdapter instead captures only
-    ///       append history through one ordered logical-delivery origin;
-    ///       destructive operations remain local-only.
+    ///       schema-v1 logical adapter captures append history only. The
+    ///       separate schema-v2 destructive logical adapter captures exact
+    ///       element erasures, including bounded local selector expansion,
+    ///       through one authoritative ordered-delivery origin.
     ///
     /// \note \c MDBX_DB_ACCEDE is accepted only for DBIs created with a
     ///       compatible \c KeyOrderedMultiValueTable storage contract: the same
@@ -46,6 +53,9 @@ namespace mdbxc {
     ///       duplicate values encoded with this table's internal order prefix.
     template<class KeyT, class ValueT, class Options = DefaultTableOptions>
     class KeyOrderedMultiValueTable final : public BaseTable {
+        template<class, class, class, class, class>
+        friend class sync::KeyOrderedMultiValueTableDestructiveLogicalAdapter;
+
     public:
         typedef std::pair<KeyT, ValueT> value_type;
 
@@ -677,6 +687,33 @@ namespace mdbxc {
             }
             check_mdbx(rc, "Failed to seek key");
             while (rc == MDBX_SUCCESS) {
+                values.push_back(deserialize_value<ValueT>(strip_order(db_val)));
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT_DUP);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to read ordered duplicate values");
+            }
+        }
+
+        template<typename BeforeInspect>
+        void db_collect_values(const KeyT& key,
+                               std::vector<ValueT>& values,
+                               MDBX_txn* txn,
+                               BeforeInspect before_inspect) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()),
+                       "Failed to open MDBX cursor");
+
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_KEY);
+            if (rc == MDBX_NOTFOUND) {
+                return;
+            }
+            check_mdbx(rc, "Failed to seek key");
+            while (rc == MDBX_SUCCESS) {
+                before_inspect();
                 values.push_back(deserialize_value<ValueT>(strip_order(db_val)));
                 rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT_DUP);
             }

--- a/include/mdbx_containers/KeyOrderedMultiValueTable.hpp
+++ b/include/mdbx_containers/KeyOrderedMultiValueTable.hpp
@@ -851,6 +851,40 @@ namespace mdbxc {
             return false;
         }
 
+        template<typename BeforeInspect>
+        bool db_erase_at(const KeyT& key,
+                         std::size_t index,
+                         MDBX_txn* txn,
+                         BeforeInspect before_inspect) {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()),
+                       "Failed to open MDBX cursor");
+
+            SerializeScratch sc_key;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_KEY);
+            if (rc == MDBX_NOTFOUND) {
+                return false;
+            }
+            check_mdbx(rc, "Failed to seek key");
+            std::size_t current = 0u;
+            while (rc == MDBX_SUCCESS) {
+                before_inspect();
+                if (current == index) {
+                    check_mdbx(mdbx_cursor_del(cursor.get(), MDBX_CURRENT),
+                               "Failed to erase ordered duplicate by index");
+                    return true;
+                }
+                ++current;
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT_DUP);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to scan ordered duplicate values");
+            }
+            return false;
+        }
+
         void db_clear(MDBX_txn* txn) {
             check_mdbx(mdbx_drop(txn, m_dbi, 0), "Failed to clear ordered multi-value table");
         }

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -96,7 +96,7 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
 | `VectorStore` | Supported indirectly | Does not own a separate wire format. Its persistent writes go through `SequenceTable` and `KeyValueTable` member tables. Raw replication requires one authoritative or externally serialized writer per collection. Already-open instances refresh their RAM index lazily after completed remote apply when the connection sync-apply generation changes. |
 | `AnyValueTable` | Not supported in v0.1 | Deferred until heterogeneous value type tags are part of the sync wire format. |
 | `KeyMultiValueTable` | Limited logical adapter | Raw v0.1 capture remains unsupported. `KeyMultiValueTableLogicalAdapter` explicitly captures unordered insert, key erase, all-matching-value erase, and clear under one-writer or causally serialized updates. |
-| `KeyOrderedMultiValueTable` | Ordered logical adapters | Schema v1 remains append-only. Schema v2 provides explicit `AppendElement` and `EraseElement` by immutable id through ordered delivery for one authoritative origin. Broad key/value/clear capture has a bounded exact-id expansion design but remains unimplemented. |
+| `KeyOrderedMultiValueTable` | Ordered logical adapters | Schema v1 remains append-only. Schema v2 provides explicit `AppendElement` and `EraseElement` by immutable id through ordered delivery for one authoritative origin. Bounded key/index/value capture expands selectors to exact ids; `clear()` remains a separate pending operation. |
 | `HashedKeyValueStore` | Not supported in v0.1 | Deferred until hash-index and identity-key mapping semantics are specified. |
 
 Do not add `record_op()` paths for unsupported table types without first
@@ -660,7 +660,7 @@ opcodes.
 
 ##### Bounded broad local erasure contract
 
-The planned typed capture-session API is:
+The typed capture-session API is:
 
 ```text
 struct BroadEraseBounds {
@@ -674,11 +674,12 @@ size_t erase_key(key, const BroadEraseBounds& bounds)
 size_t clear(const BroadEraseBounds& bounds)
 ```
 
-These methods are not implemented yet. Their names distinguish the potentially
-broad selectors from `erase(OrderedElementId)`. They preserve the corresponding
-local table semantics: `erase_at()` returns false for a missing index,
-`erase_value()` removes every repeated exact value under the key, `erase_key()`
-removes every value under the key, and `clear()` removes every live element.
+The implemented `erase_at()`, `erase_value()`, and `erase_key()` methods
+distinguish potentially broad selectors from `erase(OrderedElementId)`. They
+preserve the corresponding local table semantics: `erase_at()` returns false
+for a missing index, `erase_value()` removes every repeated exact value under
+the key, and `erase_key()` removes every value under the key. `clear()` remains
+pending as a separately bounded complete-schema operation.
 Committing a session with no pending changes retains the existing empty-envelope
 semantics and consumes one ordered delivery sequence.
 

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
@@ -268,7 +268,8 @@ namespace sync {
         /// admitting a lower id that would disagree with DUPSORT id order.
         void verify_introduced_high_water(
                 MDBX_txn* txn,
-                const NodeId& origin) const {
+                const NodeId& origin,
+                OrderedElementCandidateSet* candidates = nullptr) const {
             txn = checked_txn(
                 txn, "OrderedElementStateStore::verify_introduced_high_water");
             if (compare_node_id(origin, make_zero_node()) == 0) {
@@ -286,6 +287,7 @@ namespace sync {
                 int rc = mdbx_cursor_get(cursor, &raw_key, &raw_value,
                                          MDBX_SET_RANGE);
                 while (rc == MDBX_SUCCESS && has_prefix(raw_key, prefix)) {
+                    inspect_record(candidates);
                     const OrderedElementId id = decode_element_key(raw_key);
                     decode_state_value(raw_value);
                     if (id.sequence > highest_persisted) {
@@ -306,6 +308,7 @@ namespace sync {
 
             if (highest_persisted == 0u) return;
             std::uint64_t introduced = 0u;
+            inspect_record(candidates);
             if (!read_sequence_if_present(
                     txn, state, make_introduced_key(origin), introduced,
                     "Ordered element introduced high-water mark") ||
@@ -436,7 +439,8 @@ namespace sync {
 
         std::vector<OrderedElementId> live_ids_for_key(
                 MDBX_txn* txn,
-                const std::vector<std::uint8_t>& key) const {
+                const std::vector<std::uint8_t>& key,
+                OrderedElementCandidateSet* candidates = nullptr) const {
             txn = checked_txn(txn, "OrderedElementStateStore::live_ids_for_key");
             const MDBX_dbi by_key = open_by_key(txn);
             MDBX_cursor* cursor = nullptr;
@@ -448,8 +452,10 @@ namespace sync {
                 MDBX_val raw_value;
                 int rc = mdbx_cursor_get(cursor, &raw_key, &raw_value, MDBX_SET_KEY);
                 while (rc == MDBX_SUCCESS) {
+                    inspect_record(candidates);
                     const OrderedElementId id = decode_index_value(raw_value);
                     OrderedElementStateRecord record;
+                    inspect_record(candidates);
                     if (!get(txn, id, record)) {
                         throw std::runtime_error(
                             "Ordered element key index references missing state");
@@ -477,7 +483,8 @@ namespace sync {
         /// \details Used to detect state entries missing from the DUPSORT index.
         std::vector<OrderedElementId> live_state_ids_for_key(
                 MDBX_txn* txn,
-                const std::vector<std::uint8_t>& key) const {
+                const std::vector<std::uint8_t>& key,
+                OrderedElementCandidateSet* candidates = nullptr) const {
             txn = checked_txn(
                 txn, "OrderedElementStateStore::live_state_ids_for_key");
             const MDBX_dbi state = open_state(txn);
@@ -491,6 +498,7 @@ namespace sync {
                 int rc = mdbx_cursor_get(cursor, &raw_key, &raw_value,
                                          MDBX_FIRST);
                 while (rc == MDBX_SUCCESS) {
+                    inspect_record(candidates);
                     const std::uint8_t* bytes =
                         static_cast<const std::uint8_t*>(raw_key.iov_base);
                     if (bytes == nullptr || raw_key.iov_len == 0u) {
@@ -543,6 +551,12 @@ namespace sync {
         MDBX_dbi open_state(MDBX_txn* txn) const {
             return open_named_existing(txn, m_state_dbi_name,
                                        static_cast<MDBX_db_flags_t>(0));
+        }
+
+        static void inspect_record(OrderedElementCandidateSet* candidates) {
+            if (candidates != nullptr) {
+                candidates->inspect_record();
+            }
         }
 
         MDBX_dbi open_by_key(MDBX_txn* txn) const {

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
@@ -308,10 +308,9 @@ namespace sync {
 
             if (highest_persisted == 0u) return;
             std::uint64_t introduced = 0u;
-            inspect_record(candidates);
             if (!read_sequence_if_present(
                     txn, state, make_introduced_key(origin), introduced,
-                    "Ordered element introduced high-water mark") ||
+                    "Ordered element introduced high-water mark", candidates) ||
                 introduced < highest_persisted) {
                 throw std::runtime_error(
                     "Ordered element introduced high-water mark is corrupt");
@@ -370,11 +369,13 @@ namespace sync {
                            "Ordered element introduced high-water write failed");
         }
 
-        void tombstone(MDBX_txn* txn, const OrderedElementId& id) const {
+        void tombstone(MDBX_txn* txn,
+                       const OrderedElementId& id,
+                       OrderedElementCandidateSet* candidates = nullptr) const {
             txn = checked_txn(txn, "OrderedElementStateStore::tombstone");
             require_id(id);
             OrderedElementStateRecord record;
-            if (!get(txn, id, record)) {
+            if (!get(txn, id, record, candidates)) {
                 throw std::runtime_error("Ordered element id is missing");
             }
             if (!record.live) {
@@ -400,11 +401,13 @@ namespace sync {
         /// \brief Removes a newly allocated live element without a tombstone.
         /// \details Used when one local typed capture session coalesces its own
         /// append and erase. The origin counter remains advanced.
-        void erase_live(MDBX_txn* txn, const OrderedElementId& id) const {
+        void erase_live(MDBX_txn* txn,
+                        const OrderedElementId& id,
+                        OrderedElementCandidateSet* candidates = nullptr) const {
             txn = checked_txn(txn, "OrderedElementStateStore::erase_live");
             require_id(id);
             OrderedElementStateRecord record;
-            if (!get(txn, id, record) || !record.live) {
+            if (!get(txn, id, record, candidates) || !record.live) {
                 throw std::runtime_error("Ordered live element is missing");
             }
             const MDBX_dbi state = open_state(txn);
@@ -423,7 +426,8 @@ namespace sync {
 
         bool get(MDBX_txn* txn,
                  const OrderedElementId& id,
-                 OrderedElementStateRecord& out) const {
+                 OrderedElementStateRecord& out,
+                 OrderedElementCandidateSet* candidates = nullptr) const {
             txn = checked_txn(txn, "OrderedElementStateStore::get");
             require_id(id);
             const MDBX_dbi state = open_state(txn);
@@ -433,6 +437,7 @@ namespace sync {
             const int rc = mdbx_get(txn, state, &raw_key, &raw_value);
             if (rc == MDBX_NOTFOUND) return false;
             check_mdbx(rc, "Ordered element state read failed");
+            inspect_record(candidates);
             out = decode_state_value(raw_value);
             return true;
         }
@@ -455,8 +460,7 @@ namespace sync {
                     inspect_record(candidates);
                     const OrderedElementId id = decode_index_value(raw_value);
                     OrderedElementStateRecord record;
-                    inspect_record(candidates);
-                    if (!get(txn, id, record)) {
+                    if (!get(txn, id, record, candidates)) {
                         throw std::runtime_error(
                             "Ordered element key index references missing state");
                     }
@@ -682,12 +686,14 @@ namespace sync {
                 MDBX_dbi dbi,
                 const std::vector<std::uint8_t>& key,
                 std::uint64_t& out,
-                const char* context) {
+                const char* context,
+                OrderedElementCandidateSet* candidates = nullptr) {
             MDBX_val raw_key = make_val(key);
             MDBX_val raw_value;
             const int rc = mdbx_get(txn, dbi, &raw_key, &raw_value);
             if (rc == MDBX_NOTFOUND) return false;
             check_mdbx(rc, context);
+            inspect_record(candidates);
             if (raw_value.iov_len != 8u || raw_value.iov_base == nullptr) {
                 throw std::runtime_error(std::string(context) + " is corrupt");
             }

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
@@ -278,6 +278,74 @@ namespace sync {
                 }
             }
 
+            /// \brief Resolves and erases one current per-key append position.
+            bool erase_at(const KeyT& key,
+                          std::size_t index,
+                          const BroadEraseBounds& bounds) {
+                ensure_active();
+                try {
+                    OrderedElementCandidateSet candidates(bounds);
+                    const bool found = resolve_live_elements(
+                        key, candidates,
+                        [index](std::size_t current,
+                                const OrderedElementStateRecord&) {
+                            return current == index;
+                        });
+                    if (!found) return false;
+                    erase_selected(candidates.sorted_ids());
+                    return true;
+                } catch (...) {
+                    rollback_and_deactivate();
+                    throw;
+                }
+            }
+
+            /// \brief Resolves and erases all canonical value matches under a key.
+            std::size_t erase_value(const KeyT& key,
+                                    const ValueT& value,
+                                    const BroadEraseBounds& bounds) {
+                ensure_active();
+                try {
+                    const std::vector<std::uint8_t> value_bytes =
+                        ValueCodec::encode(value);
+                    OrderedElementCandidateSet candidates(bounds);
+                    resolve_live_elements(
+                        key, candidates,
+                        [&value_bytes](std::size_t,
+                                       const OrderedElementStateRecord& record) {
+                            return record.value == value_bytes;
+                        });
+                    const std::vector<OrderedElementId> ids =
+                        candidates.sorted_ids();
+                    erase_selected(ids);
+                    return ids.size();
+                } catch (...) {
+                    rollback_and_deactivate();
+                    throw;
+                }
+            }
+
+            /// \brief Resolves and erases all current values under a key.
+            std::size_t erase_key(const KeyT& key,
+                                  const BroadEraseBounds& bounds) {
+                ensure_active();
+                try {
+                    OrderedElementCandidateSet candidates(bounds);
+                    resolve_live_elements(
+                        key, candidates,
+                        [](std::size_t, const OrderedElementStateRecord&) {
+                            return true;
+                        });
+                    const std::vector<OrderedElementId> ids =
+                        candidates.sorted_ids();
+                    erase_selected(ids);
+                    return ids.size();
+                } catch (...) {
+                    rollback_and_deactivate();
+                    throw;
+                }
+            }
+
             /// \brief Commits captured mutations and delivery atomically.
             LogicalDeliveryEnvelope commit_to_outbox(
                     ILogicalDeliveryOutbox& outbox,
@@ -313,6 +381,77 @@ namespace sync {
             }
 
         private:
+            static bool contains_origin(const std::vector<NodeId>& origins,
+                                        const NodeId& origin) {
+                for (std::size_t i = 0u; i < origins.size(); ++i) {
+                    if (compare_node_id(origins[i], origin) == 0) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            template<typename Selector>
+            bool resolve_live_elements(
+                    const KeyT& key,
+                    OrderedElementCandidateSet& candidates,
+                    Selector select) const {
+                const std::vector<std::uint8_t> key_bytes = KeyCodec::encode(key);
+                std::vector<OrderedElementId> index_ids =
+                    m_adapter.m_state.live_ids_for_key(
+                        m_txn.handle(), key_bytes, &candidates);
+                std::vector<OrderedElementId> state_ids =
+                    m_adapter.m_state.live_state_ids_for_key(
+                        m_txn.handle(), key_bytes, &candidates);
+                std::sort(index_ids.begin(), index_ids.end(), OrderedElementIdLess());
+                std::sort(state_ids.begin(), state_ids.end(), OrderedElementIdLess());
+                if (index_ids != state_ids) {
+                    throw std::runtime_error(
+                        "Ordered destructive key index and state records differ");
+                }
+
+                std::vector<ValueT> physical_values;
+                m_adapter.m_table.db_collect_values(
+                    key, physical_values, m_txn.handle(),
+                    [&candidates]() {
+                        candidates.inspect_record();
+                    });
+                if (physical_values.size() != index_ids.size()) {
+                    throw std::runtime_error(
+                        "Ordered destructive table and state counts differ");
+                }
+
+                std::vector<NodeId> verified_origins;
+                bool selected = false;
+                for (std::size_t i = 0u; i < index_ids.size(); ++i) {
+                    if (!contains_origin(verified_origins, index_ids[i].origin)) {
+                        m_adapter.m_state.verify_introduced_high_water(
+                            m_txn.handle(), index_ids[i].origin, &candidates);
+                        verified_origins.push_back(index_ids[i].origin);
+                    }
+                    candidates.inspect_record();
+                    OrderedElementStateRecord record;
+                    if (!m_adapter.m_state.get(
+                            m_txn.handle(), index_ids[i], record) ||
+                        !record.live || record.key != key_bytes ||
+                        record.value != ValueCodec::encode(physical_values[i])) {
+                        throw std::runtime_error(
+                            "Ordered destructive table and state value order differs");
+                    }
+                    if (select(i, record)) {
+                        candidates.select(index_ids[i]);
+                        selected = true;
+                    }
+                }
+                return selected;
+            }
+
+            void erase_selected(const std::vector<OrderedElementId>& ids) {
+                for (std::size_t i = 0u; i < ids.size(); ++i) {
+                    erase(ids[i]);
+                }
+            }
+
             std::size_t find_pending_append(const OrderedElementId& id) const {
                 for (std::size_t i = 0u; i < m_pending.size(); ++i) {
                     if (m_pending[i].opcode ==

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
@@ -261,17 +261,7 @@ namespace sync {
             void erase(const OrderedElementId& id) {
                 ensure_active();
                 try {
-                    Connection::SyncCaptureSuppressionScope suppress_capture(
-                        *m_adapter.m_table.connection(), m_txn.handle());
-                    const std::size_t pending_index = find_pending_append(id);
-                    if (pending_index != m_pending.size()) {
-                        m_adapter.erase_live_element(m_txn.handle(), id, false);
-                        m_pending.erase(m_pending.begin() +
-                            static_cast<std::ptrdiff_t>(pending_index));
-                    } else {
-                        m_adapter.erase_live_element(m_txn.handle(), id, true);
-                        m_pending.push_back(m_adapter.make_erase(id));
-                    }
+                    erase_resolved(id, nullptr);
                 } catch (...) {
                     rollback_and_deactivate();
                     throw;
@@ -292,7 +282,7 @@ namespace sync {
                             return current == index;
                         });
                     if (!found) return false;
-                    erase_selected(candidates.sorted_ids());
+                    erase_selected(candidates.sorted_ids(), &candidates);
                     return true;
                 } catch (...) {
                     rollback_and_deactivate();
@@ -317,7 +307,7 @@ namespace sync {
                         });
                     const std::vector<OrderedElementId> ids =
                         candidates.sorted_ids();
-                    erase_selected(ids);
+                    erase_selected(ids, &candidates);
                     return ids.size();
                 } catch (...) {
                     rollback_and_deactivate();
@@ -338,7 +328,7 @@ namespace sync {
                         });
                     const std::vector<OrderedElementId> ids =
                         candidates.sorted_ids();
-                    erase_selected(ids);
+                    erase_selected(ids, &candidates);
                     return ids.size();
                 } catch (...) {
                     rollback_and_deactivate();
@@ -429,10 +419,9 @@ namespace sync {
                             m_txn.handle(), index_ids[i].origin, &candidates);
                         verified_origins.push_back(index_ids[i].origin);
                     }
-                    candidates.inspect_record();
                     OrderedElementStateRecord record;
                     if (!m_adapter.m_state.get(
-                            m_txn.handle(), index_ids[i], record) ||
+                            m_txn.handle(), index_ids[i], record, &candidates) ||
                         !record.live || record.key != key_bytes ||
                         record.value != ValueCodec::encode(physical_values[i])) {
                         throw std::runtime_error(
@@ -446,9 +435,27 @@ namespace sync {
                 return selected;
             }
 
-            void erase_selected(const std::vector<OrderedElementId>& ids) {
+            void erase_resolved(const OrderedElementId& id,
+                                OrderedElementCandidateSet* candidates) {
+                Connection::SyncCaptureSuppressionScope suppress_capture(
+                    *m_adapter.m_table.connection(), m_txn.handle());
+                const std::size_t pending_index = find_pending_append(id);
+                if (pending_index != m_pending.size()) {
+                    m_adapter.erase_live_element(
+                        m_txn.handle(), id, false, candidates);
+                    m_pending.erase(m_pending.begin() +
+                        static_cast<std::ptrdiff_t>(pending_index));
+                } else {
+                    m_adapter.erase_live_element(
+                        m_txn.handle(), id, true, candidates);
+                    m_pending.push_back(m_adapter.make_erase(id));
+                }
+            }
+
+            void erase_selected(const std::vector<OrderedElementId>& ids,
+                                OrderedElementCandidateSet* candidates) {
                 for (std::size_t i = 0u; i < ids.size(); ++i) {
-                    erase(ids[i]);
+                    erase_resolved(ids[i], candidates);
                 }
             }
 
@@ -784,14 +791,15 @@ namespace sync {
 
         void erase_live_element(MDBX_txn* txn,
                                 const OrderedElementId& id,
-                                bool preserve_tombstone) const {
+                                bool preserve_tombstone,
+                                OrderedElementCandidateSet* candidates = nullptr) const {
             OrderedElementStateRecord record;
-            if (!m_state.get(txn, id, record) || !record.live) {
+            if (!m_state.get(txn, id, record, candidates) || !record.live) {
                 throw std::runtime_error("Ordered element is not live");
             }
             const KeyT key = decode_canonical_key(record.key);
             const std::vector<OrderedElementId> ids =
-                m_state.live_ids_for_key(txn, record.key);
+                m_state.live_ids_for_key(txn, record.key, candidates);
             std::size_t index = ids.size();
             for (std::size_t i = 0u; i < ids.size(); ++i) {
                 if (ids[i] == id) {
@@ -799,25 +807,48 @@ namespace sync {
                     break;
                 }
             }
-            if (index == ids.size() || !m_table.erase_at(key, index, txn)) {
+            if (index == ids.size()) {
+                throw std::runtime_error("Ordered element key index is missing id");
+            }
+            bool erased = false;
+            if (candidates == nullptr) {
+                erased = m_table.erase_at(key, index, txn);
+            } else {
+                erased = m_table.db_erase_at(
+                    key, index, txn,
+                    [candidates]() {
+                        candidates->inspect_record();
+                    });
+            }
+            if (!erased) {
                 throw std::runtime_error("Ordered element physical value is missing");
             }
             if (preserve_tombstone) {
-                m_state.tombstone(txn, id);
+                m_state.tombstone(txn, id, candidates);
             } else {
-                m_state.erase_live(txn, id);
+                m_state.erase_live(txn, id, candidates);
             }
-            ensure_key_parity(txn, key, record.key);
+            ensure_key_parity(txn, key, record.key, candidates);
         }
 
         void ensure_key_parity(MDBX_txn* txn,
                                const KeyT& key,
-                               const std::vector<std::uint8_t>& key_bytes) const {
-            const std::vector<ValueT> values = m_table.find(key, txn);
+                               const std::vector<std::uint8_t>& key_bytes,
+                               OrderedElementCandidateSet* candidates = nullptr) const {
+            std::vector<ValueT> values;
+            if (candidates == nullptr) {
+                values = m_table.find(key, txn);
+            } else {
+                m_table.db_collect_values(
+                    key, values, txn,
+                    [candidates]() {
+                        candidates->inspect_record();
+                    });
+            }
             std::vector<OrderedElementId> ids =
-                m_state.live_ids_for_key(txn, key_bytes);
+                m_state.live_ids_for_key(txn, key_bytes, candidates);
             std::vector<OrderedElementId> state_ids =
-                m_state.live_state_ids_for_key(txn, key_bytes);
+                m_state.live_state_ids_for_key(txn, key_bytes, candidates);
             std::sort(ids.begin(), ids.end(), OrderedElementIdLess());
             std::sort(state_ids.begin(), state_ids.end(), OrderedElementIdLess());
             if (values.size() != ids.size() || ids != state_ids) {
@@ -826,7 +857,7 @@ namespace sync {
             }
             for (std::size_t i = 0u; i < ids.size(); ++i) {
                 OrderedElementStateRecord record;
-                if (!m_state.get(txn, ids[i], record) || !record.live ||
+                if (!m_state.get(txn, ids[i], record, candidates) || !record.live ||
                     record.key != key_bytes ||
                     record.value != ValueCodec::encode(values[i])) {
                     throw std::runtime_error(

--- a/tests/test_key_ordered_multi_value_destructive_adapter.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_adapter.cpp
@@ -595,6 +595,85 @@ void test_destructive_capture_resolves_bounded_broad_erasure() {
     cleanup(path);
 }
 
+void test_destructive_capture_bounds_post_selection_mutation_scans() {
+    const std::string path =
+        "test_key_ordered_multi_value_destructive_mutation_bounds.mdbx";
+    const std::string primary = "ordered_mutation_bound_values";
+    const std::string state = "ordered_mutation_bound_state";
+    const std::string by_key = "ordered_mutation_bound_by_key";
+    const std::string schema = "app.ordered_mutation_bound.v2";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId origin = make_node(0x65u);
+    const mdbxc::sync::DbId local_db = make_node(0xA5u);
+    const mdbxc::sync::DbId destination = make_node(0xB5u);
+    mdbxc::sync::SyncEngine engine(connection);
+    engine.initialize_local_identity(origin, local_db);
+    table_type table(connection, primary);
+    adapter_type adapter(table, schema, state, by_key);
+    engine.initialize_logical_adapter_schema(
+        adapter, make_v2_record(primary, state, by_key, origin));
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->append(1, "first");
+        session->append(1, "second");
+        session->commit_to_outbox(engine, destination);
+    }
+
+    std::size_t selection_limit = 0u;
+    bool selection_found = false;
+    for (std::size_t limit = 0u; limit < 256u; ++limit) {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        try {
+            if (session->erase_at(1, 99u, { 2u, limit })) {
+                throw std::runtime_error("missing ordered index was selected");
+            }
+            selection_limit = limit;
+            selection_found = true;
+            break;
+        } catch (const std::length_error&) {
+        }
+    }
+    if (!selection_found) {
+        throw std::runtime_error("could not establish ordered selection bound");
+    }
+
+    std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+        adapter.begin_capture_session();
+    bool rejected = false;
+    try {
+        session->erase_at(1, 0u, { 2u, selection_limit });
+    } catch (const std::length_error&) {
+        rejected = true;
+    }
+    if (!rejected || table.find(1).size() != 2u ||
+        table.find(1)[0] != "first" || table.find(1)[1] != "second") {
+        throw std::runtime_error(
+            "post-selection scan limit did not roll back ordered erasure");
+    }
+    bool reuse_rejected = false;
+    try {
+        session->erase_at(1, 0u, { 2u, 256u });
+    } catch (const std::logic_error&) {
+        reuse_rejected = true;
+    }
+    if (!reuse_rejected) {
+        throw std::runtime_error(
+            "post-selection scan-limit failure left capture active");
+    }
+
+    connection->disconnect();
+    cleanup(path);
+}
+
 void test_ordered_delivery_rolls_back_malformed_v2_change_and_deduplicates() {
     const std::string path = "test_key_ordered_multi_value_destructive_replay.mdbx";
     const std::string primary = "ordered_replay_values";
@@ -1266,6 +1345,7 @@ int main() {
     test_destructive_capture_coalesces_and_commits_to_outbox();
     test_destructive_capture_rolls_back_injected_native_commit_failure();
     test_destructive_capture_resolves_bounded_broad_erasure();
+    test_destructive_capture_bounds_post_selection_mutation_scans();
     test_ordered_delivery_rolls_back_malformed_v2_change_and_deduplicates();
     test_destructive_preflight_rejects_untracked_physical_value();
     test_destructive_preflight_rejects_state_index_corruption();

--- a/tests/test_key_ordered_multi_value_destructive_adapter.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_adapter.cpp
@@ -475,6 +475,126 @@ void test_destructive_capture_rolls_back_injected_native_commit_failure() {
     cleanup(path);
 }
 
+void test_destructive_capture_resolves_bounded_broad_erasure() {
+    const std::string path =
+        "test_key_ordered_multi_value_destructive_broad_erasure.mdbx";
+    const std::string primary = "ordered_broad_values";
+    const std::string state = "ordered_broad_state";
+    const std::string by_key = "ordered_broad_by_key";
+    const std::string schema = "app.ordered_broad.v2";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId origin = make_node(0x63u);
+    const mdbxc::sync::DbId local_db = make_node(0xA3u);
+    const mdbxc::sync::DbId destination = make_node(0xB3u);
+    mdbxc::sync::SyncEngine engine(connection);
+    engine.initialize_local_identity(origin, local_db);
+    table_type table(connection, primary);
+    adapter_type adapter(table, schema, state, by_key);
+    engine.initialize_logical_adapter_schema(
+        adapter, make_v2_record(primary, state, by_key, origin));
+
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->append(1, "first");
+        session->append(1, "same");
+        session->append(1, "same");
+        session->append(2, "other");
+        session->commit_to_outbox(engine, destination);
+    }
+
+    const mdbxc::sync::BroadEraseBounds bounds = { 4u, 64u };
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        if (!session->erase_at(1, 1u, bounds) ||
+            session->erase_value(1, "same", bounds) != 1u ||
+            session->erase_key(2, bounds) != 1u) {
+            throw std::runtime_error("bounded broad erasure selection is incorrect");
+        }
+        const mdbxc::sync::LogicalDeliveryEnvelope envelope =
+            session->commit_to_outbox(engine, destination);
+        if (envelope.frame.changes.size() != 3u) {
+            throw std::runtime_error("broad erasure did not emit exact erase changes");
+        }
+        for (std::size_t i = 0u; i < envelope.frame.changes.size(); ++i) {
+            if (envelope.frame.changes[i].opcode !=
+                mdbxc::sync::KeyOrderedMultiValueDestructiveLogicalErase) {
+                throw std::runtime_error("broad erasure emitted a non-exact opcode");
+            }
+        }
+    }
+    if (table.find(1).size() != 1u || table.find(1)[0] != "first" ||
+        !table.find(2).empty()) {
+        throw std::runtime_error("bounded broad erasure changed the wrong values");
+    }
+
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        const mdbxc::sync::BroadEraseBounds no_selection = { 0u, 64u };
+        bool rejected = false;
+        try {
+            session->erase_key(1, no_selection);
+        } catch (const std::length_error&) {
+            rejected = true;
+        }
+        const std::vector<std::string> values = table.find(1);
+        if (!rejected || values.size() != 1u || values[0] != "first") {
+            throw std::runtime_error(
+                "broad selection-limit failure did not roll back the session");
+        }
+    }
+
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        const mdbxc::sync::BroadEraseBounds no_scan = { 4u, 0u };
+        bool rejected = false;
+        try {
+            session->erase_at(99, 0u, no_scan);
+        } catch (const std::length_error&) {
+            rejected = true;
+        }
+        const std::vector<std::string> values = table.find(1);
+        if (!rejected || values.size() != 1u || values[0] != "first") {
+            throw std::runtime_error(
+                "broad scan-limit failure did not roll back the session");
+        }
+    }
+
+    if (table.find(1).size() != 1u || table.find(1)[0] != "first") {
+        throw std::runtime_error("failed broad erasure changed durable table state");
+    }
+
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->append(3, "transient");
+        if (session->erase_value(3, "transient", bounds) != 1u ||
+            session->pending_size() != 0u) {
+            throw std::runtime_error(
+                "broad erasure did not coalesce a pending append");
+        }
+        const mdbxc::sync::LogicalDeliveryEnvelope envelope =
+            session->commit_to_outbox(engine, destination);
+        if (!envelope.frame.changes.empty() || !table.find(3).empty()) {
+            throw std::runtime_error(
+                "coalesced broad erasure leaked a physical or logical record");
+        }
+    }
+
+    connection->disconnect();
+    cleanup(path);
+}
+
 void test_ordered_delivery_rolls_back_malformed_v2_change_and_deduplicates() {
     const std::string path = "test_key_ordered_multi_value_destructive_replay.mdbx";
     const std::string primary = "ordered_replay_values";
@@ -1145,6 +1265,7 @@ int main() {
     test_destructive_preflight_rejects_foreign_append_id();
     test_destructive_capture_coalesces_and_commits_to_outbox();
     test_destructive_capture_rolls_back_injected_native_commit_failure();
+    test_destructive_capture_resolves_bounded_broad_erasure();
     test_ordered_delivery_rolls_back_malformed_v2_change_and_deduplicates();
     test_destructive_preflight_rejects_untracked_physical_value();
     test_destructive_preflight_rejects_state_index_corruption();

--- a/tests/test_key_ordered_multi_value_destructive_state.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_state.cpp
@@ -499,6 +499,68 @@ void test_ordered_element_state_rejects_malformed_records_in_origin_scan() {
     cleanup(path);
 }
 
+void test_ordered_element_state_accounts_bounded_high_water_point_read() {
+    const std::string path = "test_ordered_element_state_bounded_high_water.mdbx";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId origin = make_node(0xB1u);
+    const std::vector<std::uint8_t> key(1u, 0xAAu);
+    const std::vector<std::uint8_t> value(1u, 0xBBu);
+    mdbxc::sync::OrderedElementStateStore store(
+        connection->env_handle(), "bounded_high_water_state",
+        "bounded_high_water_by_key");
+    {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        store.initialize_empty(transaction.handle());
+        const mdbxc::sync::OrderedElementId id =
+            store.allocate_id(transaction.handle(), origin);
+        store.put_live(transaction.handle(), id, key, value);
+        transaction.commit();
+    }
+
+    {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::READ_ONLY);
+        const mdbxc::sync::BroadEraseBounds bounds = { 1u, 2u };
+        mdbxc::sync::OrderedElementCandidateSet candidates(bounds);
+        store.verify_introduced_high_water(
+            transaction.handle(), origin, &candidates);
+        if (candidates.scanned_records() != 2u) {
+            throw std::runtime_error(
+                "bounded high-water accounting did not count point read");
+        }
+        transaction.rollback();
+    }
+    {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::READ_ONLY);
+        const mdbxc::sync::BroadEraseBounds bounds = { 1u, 1u };
+        mdbxc::sync::OrderedElementCandidateSet candidates(bounds);
+        bool rejected = false;
+        try {
+            store.verify_introduced_high_water(
+                transaction.handle(), origin, &candidates);
+        } catch (const std::length_error&) {
+            rejected = true;
+        }
+        transaction.rollback();
+        if (!rejected) {
+            throw std::runtime_error(
+                "bounded high-water point read exceeded no scan limit");
+        }
+    }
+
+    connection->disconnect();
+    cleanup(path);
+}
+
 void test_broad_erase_candidate_set_enforces_bounds_and_order() {
     const mdbxc::sync::NodeId first_origin = make_node(0x11u);
     const mdbxc::sync::NodeId second_origin = make_node(0x21u);
@@ -558,6 +620,7 @@ int main() {
     test_ordered_element_state_rejects_corrupt_introduced_high_water();
     test_ordered_element_state_rejects_second_origin_high_water_corruption();
     test_ordered_element_state_rejects_malformed_records_in_origin_scan();
+    test_ordered_element_state_accounts_bounded_high_water_point_read();
     test_broad_erase_candidate_set_enforces_bounds_and_order();
     return 0;
 }


### PR DESCRIPTION
## Summary
- add bounded schema-v2 capture selectors for ordered erase-at, erase-value, and erase-key
- validate authoritative table, state, and index parity before mutation
- keep clear as a separate follow-up for complete-schema selection and rollback coverage

## Validation
- 	est_key_ordered_multi_value_destructive_adapter (C++11, C++17)
- 	est_key_ordered_multi_value_destructive_state (C++11, C++17)