### PR TITLE
feat(sync): capture bounded ordered clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
-- Added bounded `erase_at()`, `erase_value()`, and `erase_key()` selector
+- Added bounded `erase_at()`, `erase_value()`, `erase_key()`, and `clear()` selector
   expansion to destructive ordered capture. They resolve canonical logical-codec
   selectors to exact immutable ids before mutation and emit only `EraseElement`
-  operations; `clear()` remains a separate pending operation.
+  operations.
 - Added persistent `OrderedElementId` and state-store primitives for the
   initial destructive `KeyOrderedMultiValueTable` logical schema v2.
 - Added a schema-version-2 destructive logical adapter for

--- a/include/mdbx_containers/KeyOrderedMultiValueTable.hpp
+++ b/include/mdbx_containers/KeyOrderedMultiValueTable.hpp
@@ -722,6 +722,29 @@ namespace mdbxc {
             }
         }
 
+        template<typename BeforeInspect>
+        void db_collect_entries(std::vector<value_type>& entries,
+                                MDBX_txn* txn,
+                                BeforeInspect before_inspect) const {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()),
+                       "Failed to open MDBX cursor");
+
+            MDBX_val db_key;
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_FIRST);
+            while (rc == MDBX_SUCCESS) {
+                before_inspect();
+                entries.push_back(value_type(
+                    deserialize_key<KeyT>(db_key),
+                    deserialize_value<ValueT>(strip_order(db_val))));
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to read ordered multi-value records");
+            }
+        }
+
         bool db_contains_key(const KeyT& key, MDBX_txn* txn) const {
             SerializeScratch sc_key;
             MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -679,8 +679,10 @@ distinguish potentially broad selectors from `erase(OrderedElementId)`. They
 preserve the corresponding local table semantics: `erase_at()` returns false
 for a missing index, `erase_value()` removes every repeated exact value under
 the key, `erase_key()` removes every value under the key, and `clear()` removes
-every current value. `clear()` validates the complete bounded schema candidate
-set before it creates the first tombstone.
+every current value. `clear()` scans and reconciles the complete bounded
+primary/state/key-index set, validates introduced high-water marks for every
+Live or Tombstone origin, and admits each Live id before it materializes the
+complete candidate set or creates the first tombstone.
 Committing a session with no pending changes retains the existing empty-envelope
 semantics and consumes one ordered delivery sequence.
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -96,7 +96,7 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
 | `VectorStore` | Supported indirectly | Does not own a separate wire format. Its persistent writes go through `SequenceTable` and `KeyValueTable` member tables. Raw replication requires one authoritative or externally serialized writer per collection. Already-open instances refresh their RAM index lazily after completed remote apply when the connection sync-apply generation changes. |
 | `AnyValueTable` | Not supported in v0.1 | Deferred until heterogeneous value type tags are part of the sync wire format. |
 | `KeyMultiValueTable` | Limited logical adapter | Raw v0.1 capture remains unsupported. `KeyMultiValueTableLogicalAdapter` explicitly captures unordered insert, key erase, all-matching-value erase, and clear under one-writer or causally serialized updates. |
-| `KeyOrderedMultiValueTable` | Ordered logical adapters | Schema v1 remains append-only. Schema v2 provides explicit `AppendElement` and `EraseElement` by immutable id through ordered delivery for one authoritative origin. Bounded key/index/value capture expands selectors to exact ids; `clear()` remains a separate pending operation. |
+| `KeyOrderedMultiValueTable` | Ordered logical adapters | Schema v1 remains append-only. Schema v2 provides explicit `AppendElement` and `EraseElement` by immutable id through ordered delivery for one authoritative origin. Bounded key/index/value/clear capture expands selectors to exact ids. |
 | `HashedKeyValueStore` | Not supported in v0.1 | Deferred until hash-index and identity-key mapping semantics are specified. |
 
 Do not add `record_op()` paths for unsupported table types without first
@@ -674,12 +674,13 @@ size_t erase_key(key, const BroadEraseBounds& bounds)
 size_t clear(const BroadEraseBounds& bounds)
 ```
 
-The implemented `erase_at()`, `erase_value()`, and `erase_key()` methods
+The implemented `erase_at()`, `erase_value()`, `erase_key()`, and `clear()` methods
 distinguish potentially broad selectors from `erase(OrderedElementId)`. They
 preserve the corresponding local table semantics: `erase_at()` returns false
 for a missing index, `erase_value()` removes every repeated exact value under
-the key, and `erase_key()` removes every value under the key. `clear()` remains
-pending as a separately bounded complete-schema operation.
+the key, `erase_key()` removes every value under the key, and `clear()` removes
+every current value. `clear()` validates the complete bounded schema candidate
+set before it creates the first tombstone.
 Committing a session with no pending changes retains the existing empty-envelope
 semantics and consumes one ordered delivery sequence.
 

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
@@ -181,6 +181,12 @@ namespace sync {
         std::vector<std::uint8_t> value;
     };
 
+    /// \brief One live state record paired with its immutable identity.
+    struct OrderedLiveElementState {
+        OrderedElementId id;
+        OrderedElementStateRecord record;
+    };
+
     /// \brief Transactional store for destructive ordered element state.
     /// \details The state DBI stores origin allocation counters, introduced
     /// sequence high-water marks, and Live/Tombstone records.
@@ -522,6 +528,64 @@ namespace sync {
                             decode_state_value(raw_value);
                         if (record.live && record.key == key) {
                             out.push_back(id);
+                        }
+                    } else {
+                        throw std::runtime_error(
+                            "Ordered element state key tag is invalid");
+                    }
+                    rc = mdbx_cursor_get(cursor, &raw_key, &raw_value,
+                                         MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "Ordered element state cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return out;
+        }
+
+        /// \brief Scans every Live element state record.
+        /// \details Used by complete-schema selectors such as captured clear
+        /// to establish their candidate set before any mutation begins.
+        std::vector<OrderedLiveElementState> live_state_records(
+                MDBX_txn* txn,
+                OrderedElementCandidateSet* candidates = nullptr) const {
+            txn = checked_txn(
+                txn, "OrderedElementStateStore::live_state_records");
+            const MDBX_dbi state = open_state(txn);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, state, &cursor),
+                       "Ordered element state cursor open failed");
+            std::vector<OrderedLiveElementState> out;
+            try {
+                MDBX_val raw_key;
+                MDBX_val raw_value;
+                int rc = mdbx_cursor_get(cursor, &raw_key, &raw_value,
+                                         MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    inspect_record(candidates);
+                    const std::uint8_t* bytes =
+                        static_cast<const std::uint8_t*>(raw_key.iov_base);
+                    if (bytes == nullptr || raw_key.iov_len == 0u) {
+                        throw std::runtime_error(
+                            "Ordered element state key is invalid");
+                    }
+                    if (bytes[0] == counter_tag() ||
+                        bytes[0] == introduced_tag()) {
+                        if (raw_key.iov_len != 1u + NodeId().size() ||
+                            raw_value.iov_len != 8u) {
+                            throw std::runtime_error(
+                                "Ordered element counter record is corrupt");
+                        }
+                    } else if (bytes[0] == element_tag()) {
+                        OrderedLiveElementState entry;
+                        entry.id = decode_element_key(raw_key);
+                        entry.record = decode_state_value(raw_value);
+                        if (entry.record.live) {
+                            out.push_back(entry);
                         }
                     } else {
                         throw std::runtime_error(

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
@@ -187,6 +187,22 @@ namespace sync {
         OrderedElementStateRecord record;
     };
 
+    /// \brief Full bounded element-state scan used by complete-schema selectors.
+    struct OrderedElementStateScan {
+        std::vector<OrderedLiveElementState> live_records;
+        std::vector<NodeId> element_origins;
+    };
+
+    /// \brief One physical elements-by-key entry.
+    struct OrderedElementKeyIndexEntry {
+        std::vector<std::uint8_t> key;
+        OrderedElementId id;
+
+        bool operator==(const OrderedElementKeyIndexEntry& other) const {
+            return key == other.key && id == other.id;
+        }
+    };
+
     /// \brief Transactional store for destructive ordered element state.
     /// \details The state DBI stores origin allocation counters, introduced
     /// sequence high-water marks, and Live/Tombstone records.
@@ -547,19 +563,20 @@ namespace sync {
             return out;
         }
 
-        /// \brief Scans every Live element state record.
-        /// \details Used by complete-schema selectors such as captured clear
-        /// to establish their candidate set before any mutation begins.
-        std::vector<OrderedLiveElementState> live_state_records(
+        /// \brief Scans every element record and every origin it references.
+        /// \param select_live_candidates When true, each Live id is admitted
+        ///        before its record is materialized in the returned vector.
+        OrderedElementStateScan scan_all_element_records(
                 MDBX_txn* txn,
-                OrderedElementCandidateSet* candidates = nullptr) const {
+                OrderedElementCandidateSet* candidates = nullptr,
+                bool select_live_candidates = false) const {
             txn = checked_txn(
-                txn, "OrderedElementStateStore::live_state_records");
+                txn, "OrderedElementStateStore::scan_all_element_records");
             const MDBX_dbi state = open_state(txn);
             MDBX_cursor* cursor = nullptr;
             check_mdbx(mdbx_cursor_open(txn, state, &cursor),
                        "Ordered element state cursor open failed");
-            std::vector<OrderedLiveElementState> out;
+            OrderedElementStateScan out;
             try {
                 MDBX_val raw_key;
                 MDBX_val raw_value;
@@ -584,8 +601,14 @@ namespace sync {
                         OrderedLiveElementState entry;
                         entry.id = decode_element_key(raw_key);
                         entry.record = decode_state_value(raw_value);
+                        if (!contains_origin(out.element_origins, entry.id.origin)) {
+                            out.element_origins.push_back(entry.id.origin);
+                        }
                         if (entry.record.live) {
-                            out.push_back(entry);
+                            if (select_live_candidates && candidates != nullptr) {
+                                candidates->select(entry.id);
+                            }
+                            out.live_records.push_back(entry);
                         }
                     } else {
                         throw std::runtime_error(
@@ -596,6 +619,42 @@ namespace sync {
                 }
                 if (rc != MDBX_NOTFOUND) {
                     check_mdbx(rc, "Ordered element state cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return out;
+        }
+
+        /// \brief Bounded full scan of the elements-by-key DUPSORT index.
+        std::vector<OrderedElementKeyIndexEntry> key_index_entries(
+                MDBX_txn* txn,
+                OrderedElementCandidateSet* candidates = nullptr) const {
+            txn = checked_txn(
+                txn, "OrderedElementStateStore::key_index_entries");
+            const MDBX_dbi by_key = open_by_key(txn);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, by_key, &cursor),
+                       "Ordered element key index cursor open failed");
+            std::vector<OrderedElementKeyIndexEntry> out;
+            try {
+                MDBX_val raw_key;
+                MDBX_val raw_value;
+                int rc = mdbx_cursor_get(cursor, &raw_key, &raw_value,
+                                         MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    inspect_record(candidates);
+                    OrderedElementKeyIndexEntry entry;
+                    entry.key = copy_bytes(raw_key);
+                    entry.id = decode_index_value(raw_value);
+                    out.push_back(entry);
+                    rc = mdbx_cursor_get(cursor, &raw_key, &raw_value,
+                                         MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "Ordered element key index cursor read failed");
                 }
             } catch (...) {
                 mdbx_cursor_close(cursor);
@@ -625,6 +684,18 @@ namespace sync {
             if (candidates != nullptr) {
                 candidates->inspect_record();
             }
+        }
+
+        static std::vector<std::uint8_t> copy_bytes(const MDBX_val& value) {
+            if (value.iov_len == 0u) {
+                return std::vector<std::uint8_t>();
+            }
+            if (value.iov_base == nullptr) {
+                throw std::runtime_error("Ordered element index key is invalid");
+            }
+            const std::uint8_t* bytes =
+                static_cast<const std::uint8_t*>(value.iov_base);
+            return std::vector<std::uint8_t>(bytes, bytes + value.iov_len);
         }
 
         MDBX_dbi open_by_key(MDBX_txn* txn) const {

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
@@ -336,6 +336,64 @@ namespace sync {
                 }
             }
 
+            /// \brief Resolves and erases every current table element.
+            std::size_t clear(const BroadEraseBounds& bounds) {
+                ensure_active();
+                try {
+                    OrderedElementCandidateSet candidates(bounds);
+                    const std::vector<OrderedLiveElementState> live_records =
+                        m_adapter.m_state.live_state_records(
+                            m_txn.handle(), &candidates);
+                    std::vector<typename table_type::value_type> physical_entries;
+                    m_adapter.m_table.db_collect_entries(
+                        physical_entries, m_txn.handle(),
+                        [&candidates]() {
+                            candidates.inspect_record();
+                        });
+                    if (physical_entries.size() != live_records.size()) {
+                        throw std::runtime_error(
+                            "Ordered destructive table and state counts differ");
+                    }
+                    std::vector<std::vector<std::uint8_t> > keys;
+                    std::vector<std::vector<OrderedElementId> > state_ids;
+                    std::vector<NodeId> origins;
+                    for (std::size_t i = 0u; i < live_records.size(); ++i) {
+                        const std::size_t key_index = find_key_group(
+                            keys, live_records[i].record.key);
+                        if (key_index == keys.size()) {
+                            keys.push_back(live_records[i].record.key);
+                            state_ids.push_back(std::vector<OrderedElementId>());
+                        }
+                        state_ids[key_index].push_back(live_records[i].id);
+                        if (!contains_origin(origins, live_records[i].id.origin)) {
+                            origins.push_back(live_records[i].id.origin);
+                        }
+                    }
+
+                    for (std::size_t i = 0u; i < origins.size(); ++i) {
+                        m_adapter.m_state.verify_introduced_high_water(
+                            m_txn.handle(), origins[i], &candidates);
+                    }
+                    for (std::size_t i = 0u; i < keys.size(); ++i) {
+                        const KeyT key = KeyCodec::decode(keys[i]);
+                        if (KeyCodec::encode(key) != keys[i]) {
+                            throw std::runtime_error(
+                                "Ordered destructive state key is non-canonical");
+                        }
+                        validate_live_key_group(
+                            key, keys[i], state_ids[i], candidates);
+                    }
+
+                    const std::vector<OrderedElementId> ids =
+                        candidates.sorted_ids();
+                    erase_selected(ids, &candidates);
+                    return ids.size();
+                } catch (...) {
+                    rollback_and_deactivate();
+                    throw;
+                }
+            }
+
             /// \brief Commits captured mutations and delivery atomically.
             LogicalDeliveryEnvelope commit_to_outbox(
                     ILogicalDeliveryOutbox& outbox,
@@ -371,6 +429,17 @@ namespace sync {
             }
 
         private:
+            static std::size_t find_key_group(
+                    const std::vector<std::vector<std::uint8_t> >& keys,
+                    const std::vector<std::uint8_t>& key) {
+                for (std::size_t i = 0u; i < keys.size(); ++i) {
+                    if (keys[i] == key) {
+                        return i;
+                    }
+                }
+                return keys.size();
+            }
+
             static bool contains_origin(const std::vector<NodeId>& origins,
                                         const NodeId& origin) {
                 for (std::size_t i = 0u; i < origins.size(); ++i) {
@@ -433,6 +502,45 @@ namespace sync {
                     }
                 }
                 return selected;
+            }
+
+            void validate_live_key_group(
+                    const KeyT& key,
+                    const std::vector<std::uint8_t>& key_bytes,
+                    std::vector<OrderedElementId> expected_ids,
+                    OrderedElementCandidateSet& candidates) const {
+                std::vector<OrderedElementId> index_ids =
+                    m_adapter.m_state.live_ids_for_key(
+                        m_txn.handle(), key_bytes, &candidates);
+                std::sort(index_ids.begin(), index_ids.end(), OrderedElementIdLess());
+                std::sort(expected_ids.begin(), expected_ids.end(),
+                          OrderedElementIdLess());
+                if (index_ids != expected_ids) {
+                    throw std::runtime_error(
+                        "Ordered destructive key index and state records differ");
+                }
+
+                std::vector<ValueT> physical_values;
+                m_adapter.m_table.db_collect_values(
+                    key, physical_values, m_txn.handle(),
+                    [&candidates]() {
+                        candidates.inspect_record();
+                    });
+                if (physical_values.size() != index_ids.size()) {
+                    throw std::runtime_error(
+                        "Ordered destructive table and state counts differ");
+                }
+                for (std::size_t i = 0u; i < index_ids.size(); ++i) {
+                    OrderedElementStateRecord record;
+                    if (!m_adapter.m_state.get(
+                            m_txn.handle(), index_ids[i], record, &candidates) ||
+                        !record.live || record.key != key_bytes ||
+                        record.value != ValueCodec::encode(physical_values[i])) {
+                        throw std::runtime_error(
+                            "Ordered destructive table and state value order differs");
+                    }
+                    candidates.select(index_ids[i]);
+                }
             }
 
             void erase_resolved(const OrderedElementId& id,

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
@@ -341,38 +341,46 @@ namespace sync {
                 ensure_active();
                 try {
                     OrderedElementCandidateSet candidates(bounds);
-                    const std::vector<OrderedLiveElementState> live_records =
-                        m_adapter.m_state.live_state_records(
-                            m_txn.handle(), &candidates);
+                    const OrderedElementStateScan state_scan =
+                        m_adapter.m_state.scan_all_element_records(
+                            m_txn.handle(), &candidates, true);
                     std::vector<typename table_type::value_type> physical_entries;
                     m_adapter.m_table.db_collect_entries(
                         physical_entries, m_txn.handle(),
                         [&candidates]() {
                             candidates.inspect_record();
                         });
-                    if (physical_entries.size() != live_records.size()) {
+                    if (physical_entries.size() != state_scan.live_records.size()) {
                         throw std::runtime_error(
                             "Ordered destructive table and state counts differ");
                     }
+                    const std::vector<OrderedElementKeyIndexEntry> index_entries =
+                        m_adapter.m_state.key_index_entries(
+                            m_txn.handle(), &candidates);
+                    std::vector<OrderedElementKeyIndexEntry> expected_index_entries;
                     std::vector<std::vector<std::uint8_t> > keys;
                     std::vector<std::vector<OrderedElementId> > state_ids;
-                    std::vector<NodeId> origins;
-                    for (std::size_t i = 0u; i < live_records.size(); ++i) {
+                    for (std::size_t i = 0u;
+                         i < state_scan.live_records.size(); ++i) {
                         const std::size_t key_index = find_key_group(
-                            keys, live_records[i].record.key);
+                            keys, state_scan.live_records[i].record.key);
                         if (key_index == keys.size()) {
-                            keys.push_back(live_records[i].record.key);
+                            keys.push_back(state_scan.live_records[i].record.key);
                             state_ids.push_back(std::vector<OrderedElementId>());
                         }
-                        state_ids[key_index].push_back(live_records[i].id);
-                        if (!contains_origin(origins, live_records[i].id.origin)) {
-                            origins.push_back(live_records[i].id.origin);
-                        }
+                        state_ids[key_index].push_back(state_scan.live_records[i].id);
+                        OrderedElementKeyIndexEntry expected;
+                        expected.key = state_scan.live_records[i].record.key;
+                        expected.id = state_scan.live_records[i].id;
+                        expected_index_entries.push_back(expected);
                     }
 
-                    for (std::size_t i = 0u; i < origins.size(); ++i) {
+                    validate_complete_key_index(
+                        index_entries, expected_index_entries);
+                    for (std::size_t i = 0u;
+                         i < state_scan.element_origins.size(); ++i) {
                         m_adapter.m_state.verify_introduced_high_water(
-                            m_txn.handle(), origins[i], &candidates);
+                            m_txn.handle(), state_scan.element_origins[i], &candidates);
                     }
                     for (std::size_t i = 0u; i < keys.size(); ++i) {
                         const KeyT key = KeyCodec::decode(keys[i]);
@@ -450,6 +458,33 @@ namespace sync {
                 return false;
             }
 
+            static bool key_index_entry_less(
+                    const OrderedElementKeyIndexEntry& lhs,
+                    const OrderedElementKeyIndexEntry& rhs) {
+                if (lhs.key != rhs.key) {
+                    return lhs.key < rhs.key;
+                }
+                return OrderedElementIdLess()(lhs.id, rhs.id);
+            }
+
+            static void validate_complete_key_index(
+                    std::vector<OrderedElementKeyIndexEntry> actual,
+                    std::vector<OrderedElementKeyIndexEntry> expected) {
+                for (std::size_t i = 0u; i < actual.size(); ++i) {
+                    const KeyT key = KeyCodec::decode(actual[i].key);
+                    if (KeyCodec::encode(key) != actual[i].key) {
+                        throw std::runtime_error(
+                            "Ordered destructive index key is non-canonical");
+                    }
+                }
+                std::sort(actual.begin(), actual.end(), key_index_entry_less);
+                std::sort(expected.begin(), expected.end(), key_index_entry_less);
+                if (actual != expected) {
+                    throw std::runtime_error(
+                        "Ordered destructive complete key index and state differ");
+                }
+            }
+
             template<typename Selector>
             bool resolve_live_elements(
                     const KeyT& key,
@@ -509,16 +544,8 @@ namespace sync {
                     const std::vector<std::uint8_t>& key_bytes,
                     std::vector<OrderedElementId> expected_ids,
                     OrderedElementCandidateSet& candidates) const {
-                std::vector<OrderedElementId> index_ids =
-                    m_adapter.m_state.live_ids_for_key(
-                        m_txn.handle(), key_bytes, &candidates);
-                std::sort(index_ids.begin(), index_ids.end(), OrderedElementIdLess());
                 std::sort(expected_ids.begin(), expected_ids.end(),
                           OrderedElementIdLess());
-                if (index_ids != expected_ids) {
-                    throw std::runtime_error(
-                        "Ordered destructive key index and state records differ");
-                }
 
                 std::vector<ValueT> physical_values;
                 m_adapter.m_table.db_collect_values(
@@ -526,20 +553,19 @@ namespace sync {
                     [&candidates]() {
                         candidates.inspect_record();
                     });
-                if (physical_values.size() != index_ids.size()) {
+                if (physical_values.size() != expected_ids.size()) {
                     throw std::runtime_error(
                         "Ordered destructive table and state counts differ");
                 }
-                for (std::size_t i = 0u; i < index_ids.size(); ++i) {
+                for (std::size_t i = 0u; i < expected_ids.size(); ++i) {
                     OrderedElementStateRecord record;
                     if (!m_adapter.m_state.get(
-                            m_txn.handle(), index_ids[i], record, &candidates) ||
+                            m_txn.handle(), expected_ids[i], record, &candidates) ||
                         !record.live || record.key != key_bytes ||
                         record.value != ValueCodec::encode(physical_values[i])) {
                         throw std::runtime_error(
                             "Ordered destructive table and state value order differs");
                     }
-                    candidates.select(index_ids[i]);
                 }
             }
 

--- a/tests/test_key_ordered_multi_value_destructive_adapter.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_adapter.cpp
@@ -171,6 +171,25 @@ void insert_raw_index_record(
     transaction.commit();
 }
 
+void insert_raw_index_value(
+        const std::shared_ptr<mdbxc::Connection>& connection,
+        const std::string& by_key_name,
+        const std::vector<std::uint8_t>& key,
+        const std::vector<std::uint8_t>& value) {
+    mdbxc::Transaction transaction =
+        connection->transaction(mdbxc::TransactionMode::WRITABLE);
+    MDBX_dbi by_key = 0;
+    mdbxc::check_mdbx(mdbx_dbi_open(
+        transaction.handle(), by_key_name.c_str(), MDBX_DUPSORT, &by_key),
+        "test state index DBI open failed");
+    MDBX_val raw_key = make_raw_val(key);
+    MDBX_val raw_value = make_raw_val(value);
+    mdbxc::check_mdbx(mdbx_put(transaction.handle(), by_key,
+                                &raw_key, &raw_value, MDBX_NODUPDATA),
+                      "test raw state index write failed");
+    transaction.commit();
+}
+
 void delete_raw_index_record(
         const std::shared_ptr<mdbxc::Connection>& connection,
         const std::string& by_key_name,
@@ -189,6 +208,25 @@ void delete_raw_index_record(
     mdbxc::check_mdbx(mdbx_del(transaction.handle(), by_key,
                                 &raw_key, &raw_value),
                       "test state index delete failed");
+    transaction.commit();
+}
+
+void delete_raw_index_value(
+        const std::shared_ptr<mdbxc::Connection>& connection,
+        const std::string& by_key_name,
+        const std::vector<std::uint8_t>& key,
+        const std::vector<std::uint8_t>& value) {
+    mdbxc::Transaction transaction =
+        connection->transaction(mdbxc::TransactionMode::WRITABLE);
+    MDBX_dbi by_key = 0;
+    mdbxc::check_mdbx(mdbx_dbi_open(
+        transaction.handle(), by_key_name.c_str(), MDBX_DUPSORT, &by_key),
+        "test state index DBI open failed");
+    MDBX_val raw_key = make_raw_val(key);
+    MDBX_val raw_value = make_raw_val(value);
+    mdbxc::check_mdbx(mdbx_del(transaction.handle(), by_key,
+                                &raw_key, &raw_value),
+                      "test raw state index delete failed");
     transaction.commit();
 }
 
@@ -725,6 +763,21 @@ void test_destructive_capture_clears_bounded_tombstone_heavy_table() {
         throw std::runtime_error("ordered clear tombstone fixture is invalid");
     }
 
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        bool rejected = false;
+        try {
+            session->clear({ 1u, 256u });
+        } catch (const std::length_error&) {
+            rejected = true;
+        }
+        if (!rejected || table.count() != 2u) {
+            throw std::runtime_error(
+                "ordered clear selected beyond its candidate limit");
+        }
+    }
+
     const mdbxc::sync::BroadEraseBounds bounds = { 8u, 256u };
     {
         std::unique_ptr<adapter_type::LogicalCaptureSession> session =
@@ -785,6 +838,174 @@ void test_destructive_capture_clears_bounded_tombstone_heavy_table() {
             table.find(5).size() != 1u) {
             throw std::runtime_error(
                 "ordered broad clear accepted untracked physical data");
+        }
+    }
+
+    connection->disconnect();
+    cleanup(path);
+}
+
+void test_destructive_capture_clear_rejects_complete_schema_corruption() {
+    const std::string path =
+        "test_key_ordered_multi_value_destructive_clear_corruption.mdbx";
+    const std::string primary = "ordered_clear_corrupt_values";
+    const std::string state = "ordered_clear_corrupt_state";
+    const std::string by_key = "ordered_clear_corrupt_by_key";
+    const std::string schema = "app.ordered_clear_corrupt.v2";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId origin = make_node(0x66u);
+    const mdbxc::sync::DbId local_db = make_node(0xA6u);
+    mdbxc::sync::SyncEngine engine(connection);
+    engine.initialize_local_identity(origin, local_db);
+    table_type table(connection, primary);
+    adapter_type adapter(table, schema, state, by_key);
+    engine.initialize_logical_adapter_schema(
+        adapter, make_v2_record(primary, state, by_key, origin));
+    const mdbxc::sync::BroadEraseBounds bounds = { 8u, 1024u };
+    const std::vector<std::uint8_t> key = IntKeyCodec::encode(7);
+    mdbxc::sync::OrderedElementId orphan;
+    orphan.origin = origin;
+    orphan.sequence = 1u;
+
+    insert_raw_index_record(connection, by_key, key, orphan);
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        bool rejected = false;
+        try {
+            session->clear(bounds);
+        } catch (const std::runtime_error&) {
+            rejected = true;
+        }
+        if (!rejected || !table.empty()) {
+            throw std::runtime_error("ordered clear accepted orphan key index id");
+        }
+    }
+    delete_raw_index_record(connection, by_key, key, orphan);
+
+    const std::vector<std::uint8_t> malformed_index_value(1u, 0x01u);
+    insert_raw_index_value(
+        connection, by_key, key, malformed_index_value);
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        bool rejected = false;
+        try {
+            session->clear(bounds);
+        } catch (const std::runtime_error&) {
+            rejected = true;
+        }
+        if (!rejected || !table.empty()) {
+            throw std::runtime_error("ordered clear accepted malformed index id");
+        }
+    }
+    delete_raw_index_value(connection, by_key, key, malformed_index_value);
+
+    mdbxc::sync::OrderedElementId tombstone_id;
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        tombstone_id = session->append(8, "tombstone");
+        session->commit_to_outbox(engine, make_node(0xB6u));
+    }
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->erase(tombstone_id);
+        session->commit_to_outbox(engine, make_node(0xB6u));
+    }
+    insert_raw_index_record(
+        connection, by_key, IntKeyCodec::encode(8), tombstone_id);
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        bool rejected = false;
+        try {
+            session->clear(bounds);
+        } catch (const std::runtime_error&) {
+            rejected = true;
+        }
+        if (!rejected || !table.empty()) {
+            throw std::runtime_error("ordered clear accepted tombstone index id");
+        }
+    }
+
+    connection->disconnect();
+    cleanup(path);
+}
+
+void test_destructive_capture_clear_checks_tombstone_only_origin_high_water() {
+    const std::string path =
+        "test_key_ordered_multi_value_destructive_clear_high_water.mdbx";
+    const std::string primary = "ordered_clear_high_water_values";
+    const std::string state = "ordered_clear_high_water_state";
+    const std::string by_key = "ordered_clear_high_water_by_key";
+    const std::string schema = "app.ordered_clear_high_water.v2";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId origin = make_node(0x67u);
+    const mdbxc::sync::NodeId tombstone_origin = make_node(0x77u);
+    const mdbxc::sync::DbId local_db = make_node(0xA7u);
+    const mdbxc::sync::DbId destination = make_node(0xB7u);
+    mdbxc::sync::SyncEngine engine(connection);
+    engine.initialize_local_identity(origin, local_db);
+    table_type table(connection, primary);
+    adapter_type adapter(table, schema, state, by_key);
+    engine.initialize_logical_adapter_schema(
+        adapter, make_v2_record(primary, state, by_key, origin));
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->append(1, "live");
+        session->commit_to_outbox(engine, destination);
+    }
+
+    mdbxc::sync::OrderedElementId tombstone_id;
+    tombstone_id.origin = tombstone_origin;
+    tombstone_id.sequence = 1u;
+    {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        mdbxc::Connection::SyncCaptureSuppressionScope suppress_capture(
+            *connection, transaction.handle());
+        table.append(2, "tombstone", transaction);
+        adapter.state_store().put_live(
+            transaction.handle(), tombstone_id,
+            IntKeyCodec::encode(2), StringValueCodec::encode("tombstone"));
+        if (!table.erase_at(2, 0u, transaction)) {
+            throw std::runtime_error("tombstone-only origin fixture is invalid");
+        }
+        adapter.state_store().tombstone(transaction.handle(), tombstone_id);
+        transaction.commit();
+    }
+    delete_raw_introduced_high_water(connection, state, tombstone_origin);
+
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        bool rejected = false;
+        try {
+            session->clear({ 8u, 1024u });
+        } catch (const std::runtime_error&) {
+            rejected = true;
+        }
+        if (!rejected || table.find(1).size() != 1u ||
+            table.find(1)[0] != "live") {
+            throw std::runtime_error(
+                "ordered clear missed tombstone-only origin high-water corruption");
         }
     }
 
@@ -1465,6 +1686,8 @@ int main() {
     test_destructive_capture_resolves_bounded_broad_erasure();
     test_destructive_capture_bounds_post_selection_mutation_scans();
     test_destructive_capture_clears_bounded_tombstone_heavy_table();
+    test_destructive_capture_clear_rejects_complete_schema_corruption();
+    test_destructive_capture_clear_checks_tombstone_only_origin_high_water();
     test_ordered_delivery_rolls_back_malformed_v2_change_and_deduplicates();
     test_destructive_preflight_rejects_untracked_physical_value();
     test_destructive_preflight_rejects_state_index_corruption();

--- a/tests/test_key_ordered_multi_value_destructive_adapter.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_adapter.cpp
@@ -674,6 +674,124 @@ void test_destructive_capture_bounds_post_selection_mutation_scans() {
     cleanup(path);
 }
 
+void test_destructive_capture_clears_bounded_tombstone_heavy_table() {
+    const std::string path =
+        "test_key_ordered_multi_value_destructive_broad_clear.mdbx";
+    const std::string primary = "ordered_clear_values";
+    const std::string state = "ordered_clear_state";
+    const std::string by_key = "ordered_clear_by_key";
+    const std::string schema = "app.ordered_clear.v2";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId origin = make_node(0x64u);
+    const mdbxc::sync::DbId local_db = make_node(0xA4u);
+    const mdbxc::sync::DbId destination = make_node(0xB4u);
+    mdbxc::sync::SyncEngine engine(connection);
+    engine.initialize_local_identity(origin, local_db);
+    table_type table(connection, primary);
+    adapter_type adapter(table, schema, state, by_key);
+    engine.initialize_logical_adapter_schema(
+        adapter, make_v2_record(primary, state, by_key, origin));
+
+    mdbxc::sync::OrderedElementId first;
+    mdbxc::sync::OrderedElementId second;
+    mdbxc::sync::OrderedElementId third;
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        first = session->append(1, "first");
+        second = session->append(1, "second");
+        third = session->append(2, "third");
+        session->append(2, "fourth");
+        session->append(3, "fifth");
+        session->commit_to_outbox(engine, destination);
+    }
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->erase(first);
+        session->erase(second);
+        session->erase(third);
+        session->commit_to_outbox(engine, destination);
+    }
+    if (table.count() != 2u || table.find(2).size() != 1u ||
+        table.find(3).size() != 1u) {
+        throw std::runtime_error("ordered clear tombstone fixture is invalid");
+    }
+
+    const mdbxc::sync::BroadEraseBounds bounds = { 8u, 256u };
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        if (session->clear(bounds) != 2u) {
+            throw std::runtime_error("ordered broad clear selected the wrong ids");
+        }
+        const mdbxc::sync::LogicalDeliveryEnvelope envelope =
+            session->commit_to_outbox(engine, destination);
+        if (envelope.frame.changes.size() != 2u) {
+            throw std::runtime_error("ordered broad clear emitted the wrong changes");
+        }
+        for (std::size_t i = 0u; i < envelope.frame.changes.size(); ++i) {
+            if (envelope.frame.changes[i].opcode !=
+                mdbxc::sync::KeyOrderedMultiValueDestructiveLogicalErase) {
+                throw std::runtime_error("ordered broad clear emitted a non-erase");
+            }
+        }
+    }
+    if (table.count() != 0u) {
+        throw std::runtime_error("ordered broad clear left a live physical value");
+    }
+
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->append(4, "survives");
+        session->commit_to_outbox(engine, destination);
+    }
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        const mdbxc::sync::BroadEraseBounds no_selection = { 0u, 256u };
+        bool rejected = false;
+        try {
+            session->clear(no_selection);
+        } catch (const std::length_error&) {
+            rejected = true;
+        }
+        const std::vector<std::string> values = table.find(4);
+        if (!rejected || values.size() != 1u || values[0] != "survives") {
+            throw std::runtime_error(
+                "ordered broad clear selection failure did not roll back");
+        }
+    }
+
+    table.append(5, "untracked");
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        bool rejected = false;
+        try {
+            session->clear(bounds);
+        } catch (const std::runtime_error&) {
+            rejected = true;
+        }
+        if (!rejected || table.find(4).size() != 1u ||
+            table.find(5).size() != 1u) {
+            throw std::runtime_error(
+                "ordered broad clear accepted untracked physical data");
+        }
+    }
+
+    connection->disconnect();
+    cleanup(path);
+}
+
 void test_ordered_delivery_rolls_back_malformed_v2_change_and_deduplicates() {
     const std::string path = "test_key_ordered_multi_value_destructive_replay.mdbx";
     const std::string primary = "ordered_replay_values";
@@ -1346,6 +1464,7 @@ int main() {
     test_destructive_capture_rolls_back_injected_native_commit_failure();
     test_destructive_capture_resolves_bounded_broad_erasure();
     test_destructive_capture_bounds_post_selection_mutation_scans();
+    test_destructive_capture_clears_bounded_tombstone_heavy_table();
     test_ordered_delivery_rolls_back_malformed_v2_change_and_deduplicates();
     test_destructive_preflight_rejects_untracked_physical_value();
     test_destructive_preflight_rejects_state_index_corruption();


### PR DESCRIPTION
## Summary
- add bounded schema-v2 clear capture using deterministic exact-id resolution
- validate full primary, state, and key-index parity before any tombstone is written
- cover tombstone-heavy clear, selection-limit rollback, and untracked physical data rejection

## Validation
- 	est_key_ordered_multi_value_destructive_adapter (C++11, C++17)
- 	est_key_ordered_multi_value_destructive_state (C++11, C++17)
- header_sync_umbrella_test (C++11, C++17)