### PR TITLE
perf(sync): reuse trusted ordered erase resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
   expansion to destructive ordered capture. They resolve canonical logical-codec
   selectors to exact immutable ids before mutation and emit only `EraseElement`
   operations.
+- Reused prevalidated bounded ordered candidates during mutation, avoiding a
+  repeated full state scan after every selected exact erase while preserving one
+  scan budget for remaining primary, index, and state reads.
 - Added persistent `OrderedElementId` and state-store primitives for the
   initial destructive `KeyOrderedMultiValueTable` logical schema v2.
 - Added a schema-version-2 destructive logical adapter for

--- a/benchmarks/README-sync-RU.md
+++ b/benchmarks/README-sync-RU.md
@@ -165,3 +165,10 @@ records. `elapsed_ms` включает открытие read transaction, изм
 сканирование и rollback. Результаты representative workloads нужны до
 добавления index, cache или фиксированного лимита к любому из путей
 корректности.
+
+Bounded destructive capture теперь использует предварительно проверенные exact
+id на стадии mutation и не повторяет это полное reverse-сканирование для
+каждого выбранного id. Соответствующий regression сохраняет state с большим
+числом tombstone и одним Live element при намеренно жёстком scan budget;
+используйте этот benchmark для сравнения более крупных распределений state и
+tombstone перед изменением trusted path.

--- a/benchmarks/README-sync.md
+++ b/benchmarks/README-sync.md
@@ -158,3 +158,9 @@ element records, the full state-record count, and live DUPSORT index records.
 `elapsed_ms` includes read-transaction open, the measured scan, and rollback.
 Use results from representative workloads before adding an index, cache, or
 fixed limit to either correctness path.
+
+Bounded destructive capture now uses prevalidated exact ids for its mutation
+phase and does not repeat this full reverse scan for every selected id. The
+corresponding regression retains a tombstone-heavy state with one Live element
+and a deliberately tight scan budget; use this benchmark to compare larger
+state and tombstone distributions before changing that trusted path.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -683,6 +683,11 @@ every current value. `clear()` scans and reconciles the complete bounded
 primary/state/key-index set, validates introduced high-water marks for every
 Live or Tombstone origin, and admits each Live id before it materializes the
 complete candidate set or creates the first tombstone.
+
+After that prevalidation, bounded selector mutation reuses resolved key/id
+metadata and deletes positions in descending per-key order. It does not repeat
+the full reverse state scan after each id. Physical cursor reads and all state
+or index point reads remain part of the same `max_scanned_records` budget.
 Committing a session with no pending changes retains the existing empty-envelope
 semantics and consumes one ordered delivery sequence.
 

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
@@ -23,6 +23,11 @@
 namespace mdbxc {
 namespace sync {
 
+    template<class KeyT, class ValueT,
+             class KeyCodec, class ValueCodec,
+             class Options>
+    class KeyOrderedMultiValueTableDestructiveLogicalAdapter;
+
     /// \brief Immutable identity of one destructive ordered-table element.
     struct OrderedElementId {
         NodeId origin = make_zero_node();
@@ -210,6 +215,9 @@ namespace sync {
     /// Every public operation participates in the caller-owned transaction.
     class OrderedElementStateStore {
     public:
+        template<class, class, class, class, class>
+        friend class KeyOrderedMultiValueTableDestructiveLogicalAdapter;
+
         OrderedElementStateStore(MDBX_env* env,
                                  const std::string& state_dbi_name,
                                  const std::string& by_key_dbi_name)
@@ -420,6 +428,36 @@ namespace sync {
                        "Ordered element key index tombstone delete failed");
         }
 
+    private:
+        /// \brief Converts a prevalidated Live record to a tombstone.
+        /// \details The caller must have verified the record, its key-index
+        /// entry, and its physical primary row in the same transaction.
+        void tombstone_prevalidated(
+                MDBX_txn* txn,
+                const OrderedElementId& id,
+                const std::vector<std::uint8_t>& key) const {
+            txn = checked_txn(
+                txn, "OrderedElementStateStore::tombstone_prevalidated");
+            require_id(id);
+            const MDBX_dbi state = open_state(txn);
+            const std::vector<std::uint8_t> state_key = make_element_key(id);
+            const std::vector<std::uint8_t> tombstone_value(1u, tombstone_tag());
+            MDBX_val raw_state_key = make_val(state_key);
+            MDBX_val raw_state_value = make_val(tombstone_value);
+            check_mdbx(mdbx_put(txn, state, &raw_state_key, &raw_state_value,
+                                MDBX_UPSERT),
+                       "Ordered prevalidated tombstone write failed");
+
+            const MDBX_dbi by_key = open_by_key(txn);
+            const std::vector<std::uint8_t> index_value =
+                encode_ordered_element_id_index(id);
+            MDBX_val raw_index_key = make_val(key);
+            MDBX_val raw_index_value = make_val(index_value);
+            check_mdbx(mdbx_del(txn, by_key, &raw_index_key, &raw_index_value),
+                       "Ordered prevalidated key index delete failed");
+        }
+
+    public:
         /// \brief Removes a newly allocated live element without a tombstone.
         /// \details Used when one local typed capture session coalesces its own
         /// append and erase. The origin counter remains advanced.
@@ -446,6 +484,32 @@ namespace sync {
                        "Ordered element state erase failed");
         }
 
+    private:
+        /// \brief Erases a prevalidated newly allocated Live record.
+        /// \details Used when trusted broad resolution coalesces a pending
+        /// local append. The origin allocation counter remains advanced.
+        void erase_live_prevalidated(
+                MDBX_txn* txn,
+                const OrderedElementId& id,
+                const std::vector<std::uint8_t>& key) const {
+            txn = checked_txn(
+                txn, "OrderedElementStateStore::erase_live_prevalidated");
+            require_id(id);
+            const MDBX_dbi state = open_state(txn);
+            const MDBX_dbi by_key = open_by_key(txn);
+            const std::vector<std::uint8_t> state_key = make_element_key(id);
+            const std::vector<std::uint8_t> index_value =
+                encode_ordered_element_id_index(id);
+            MDBX_val raw_state_key = make_val(state_key);
+            MDBX_val raw_index_key = make_val(key);
+            MDBX_val raw_index_value = make_val(index_value);
+            check_mdbx(mdbx_del(txn, by_key, &raw_index_key, &raw_index_value),
+                       "Ordered prevalidated key index erase failed");
+            check_mdbx(mdbx_del(txn, state, &raw_state_key, nullptr),
+                       "Ordered prevalidated state erase failed");
+        }
+
+    public:
         bool get(MDBX_txn* txn,
                  const OrderedElementId& id,
                  OrderedElementStateRecord& out,

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
@@ -586,10 +586,102 @@ namespace sync {
                 }
             }
 
+            struct TrustedErase {
+                OrderedElementId id;
+                std::vector<std::uint8_t> key;
+                std::size_t physical_index;
+            };
+
+            static bool trusted_erase_position_descending(
+                    const TrustedErase& lhs,
+                    const TrustedErase& rhs) {
+                return lhs.physical_index > rhs.physical_index;
+            }
+
+            static bool trusted_erase_id_less(const TrustedErase& lhs,
+                                              const TrustedErase& rhs) {
+                return OrderedElementIdLess()(lhs.id, rhs.id);
+            }
+
             void erase_selected(const std::vector<OrderedElementId>& ids,
                                 OrderedElementCandidateSet* candidates) {
+                if (candidates == nullptr) {
+                    throw std::logic_error(
+                        "Trusted ordered erasure requires bounded prevalidation");
+                }
+                std::vector<TrustedErase> resolved;
+                std::vector<std::vector<std::uint8_t> > keys;
                 for (std::size_t i = 0u; i < ids.size(); ++i) {
-                    erase_resolved(ids[i], candidates);
+                    OrderedElementStateRecord record;
+                    if (!m_adapter.m_state.get(
+                            m_txn.handle(), ids[i], record, candidates) ||
+                        !record.live) {
+                        throw std::runtime_error(
+                            "Prevalidated ordered element is not live");
+                    }
+                    TrustedErase entry;
+                    entry.id = ids[i];
+                    entry.key = record.key;
+                    entry.physical_index = 0u;
+                    resolved.push_back(entry);
+                    if (find_key_group(keys, record.key) == keys.size()) {
+                        keys.push_back(record.key);
+                    }
+                }
+
+                Connection::SyncCaptureSuppressionScope suppress_capture(
+                    *m_adapter.m_table.connection(), m_txn.handle());
+                for (std::size_t key_index = 0u;
+                     key_index < keys.size(); ++key_index) {
+                    const KeyT key = decode_canonical_key(keys[key_index]);
+                    const std::vector<OrderedElementId> live_ids =
+                        m_adapter.m_state.live_ids_for_key(
+                            m_txn.handle(), keys[key_index], candidates);
+                    std::vector<TrustedErase> group;
+                    for (std::size_t i = 0u; i < resolved.size(); ++i) {
+                        if (resolved[i].key != keys[key_index]) continue;
+                        std::size_t position = live_ids.size();
+                        for (std::size_t j = 0u; j < live_ids.size(); ++j) {
+                            if (live_ids[j] == resolved[i].id) {
+                                position = j;
+                                break;
+                            }
+                        }
+                        if (position == live_ids.size()) {
+                            throw std::runtime_error(
+                                "Prevalidated ordered element index is missing id");
+                        }
+                        resolved[i].physical_index = position;
+                        group.push_back(resolved[i]);
+                    }
+                    std::sort(group.begin(), group.end(),
+                              trusted_erase_position_descending);
+                    for (std::size_t i = 0u; i < group.size(); ++i) {
+                        if (!m_adapter.m_table.db_erase_at(
+                                key, group[i].physical_index, m_txn.handle(),
+                                [candidates]() {
+                                    candidates->inspect_record();
+                                })) {
+                            throw std::runtime_error(
+                                "Prevalidated ordered element physical value is missing");
+                        }
+                    }
+                }
+
+                std::sort(resolved.begin(), resolved.end(), trusted_erase_id_less);
+                for (std::size_t i = 0u; i < resolved.size(); ++i) {
+                    const std::size_t pending_index =
+                        find_pending_append(resolved[i].id);
+                    if (pending_index != m_pending.size()) {
+                        m_adapter.m_state.erase_live_prevalidated(
+                            m_txn.handle(), resolved[i].id, resolved[i].key);
+                        m_pending.erase(m_pending.begin() +
+                            static_cast<std::ptrdiff_t>(pending_index));
+                    } else {
+                        m_adapter.m_state.tombstone_prevalidated(
+                            m_txn.handle(), resolved[i].id, resolved[i].key);
+                        m_pending.push_back(m_adapter.make_erase(resolved[i].id));
+                    }
                 }
             }
 

--- a/tests/test_key_ordered_multi_value_destructive_adapter.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_adapter.cpp
@@ -615,6 +615,33 @@ void test_destructive_capture_resolves_bounded_broad_erasure() {
     {
         std::unique_ptr<adapter_type::LogicalCaptureSession> session =
             adapter.begin_capture_session();
+        session->append(1, "same");
+        session->append(1, "middle");
+        session->append(1, "same");
+        session->append(1, "last");
+        session->commit_to_outbox(engine, destination);
+    }
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        if (session->erase_value(1, "same", bounds) != 2u) {
+            throw std::runtime_error(
+                "broad erasure did not select every repeated value");
+        }
+        session->commit_to_outbox(engine, destination);
+    }
+    {
+        const std::vector<std::string> values = table.find(1);
+        if (values.size() != 3u || values[0] != "first" ||
+            values[1] != "middle" || values[2] != "last") {
+            throw std::runtime_error(
+                "broad erasure shifted surviving duplicate positions");
+        }
+    }
+
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
         session->append(3, "transient");
         if (session->erase_value(3, "transient", bounds) != 1u ||
             session->pending_size() != 0u) {

--- a/tests/test_key_ordered_multi_value_destructive_adapter.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_adapter.cpp
@@ -1013,6 +1013,67 @@ void test_destructive_capture_clear_checks_tombstone_only_origin_high_water() {
     cleanup(path);
 }
 
+void test_destructive_capture_trusted_clear_avoids_repeated_state_scans() {
+    const std::string path =
+        "test_key_ordered_multi_value_destructive_trusted_clear.mdbx";
+    const std::string primary = "ordered_trusted_clear_values";
+    const std::string state = "ordered_trusted_clear_state";
+    const std::string by_key = "ordered_trusted_clear_by_key";
+    const std::string schema = "app.ordered_trusted_clear.v2";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId origin = make_node(0x68u);
+    const mdbxc::sync::DbId local_db = make_node(0xA8u);
+    const mdbxc::sync::DbId destination = make_node(0xB8u);
+    mdbxc::sync::SyncEngine engine(connection);
+    engine.initialize_local_identity(origin, local_db);
+    table_type table(connection, primary);
+    adapter_type adapter(table, schema, state, by_key);
+    engine.initialize_logical_adapter_schema(
+        adapter, make_v2_record(primary, state, by_key, origin));
+
+    std::vector<mdbxc::sync::OrderedElementId> ids;
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        for (std::size_t i = 0u; i < 64u; ++i) {
+            ids.push_back(session->append(1, "value"));
+        }
+        session->commit_to_outbox(engine, destination);
+    }
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        for (std::size_t i = 0u; i + 1u < ids.size(); ++i) {
+            session->erase(ids[i]);
+        }
+        session->commit_to_outbox(engine, destination);
+    }
+
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        const mdbxc::sync::BroadEraseBounds bounds = { 1u, 160u };
+        if (session->clear(bounds) != 1u) {
+            throw std::runtime_error("trusted ordered clear selected the wrong id");
+        }
+        session->commit_to_outbox(engine, destination);
+    }
+    if (!table.empty()) {
+        throw std::runtime_error(
+            "trusted ordered clear did not remove the final live value");
+    }
+
+    connection->disconnect();
+    cleanup(path);
+}
+
 void test_ordered_delivery_rolls_back_malformed_v2_change_and_deduplicates() {
     const std::string path = "test_key_ordered_multi_value_destructive_replay.mdbx";
     const std::string primary = "ordered_replay_values";
@@ -1688,6 +1749,7 @@ int main() {
     test_destructive_capture_clears_bounded_tombstone_heavy_table();
     test_destructive_capture_clear_rejects_complete_schema_corruption();
     test_destructive_capture_clear_checks_tombstone_only_origin_high_water();
+    test_destructive_capture_trusted_clear_avoids_repeated_state_scans();
     test_ordered_delivery_rolls_back_malformed_v2_change_and_deduplicates();
     test_destructive_preflight_rejects_untracked_physical_value();
     test_destructive_preflight_rejects_state_index_corruption();


### PR DESCRIPTION
## Summary
- reuse bounded prevalidated ids and per-key positions during broad destructive mutation
- avoid a full reverse state scan after every exact erase
- keep physical cursor and state/index point reads within the same scan budget
- document the tombstone-heavy bounds baseline

## Validation
- 	est_key_ordered_multi_value_destructive_adapter (C++11, C++17)
- header_sync_umbrella_test (C++11, C++17)