### PR TITLE
docs(sync): align ordered v2 capture status

### DIFF
--- a/guides/sync-table-coverage.md
+++ b/guides/sync-table-coverage.md
@@ -21,7 +21,7 @@ values during transport, and remote apply replays the captured physical
 | `VectorStore` | Indirectly supported | Captured through its internal `SequenceTable` and `KeyValueTable` members. | The internal table operations are replicated; `VectorStore` has no separate wire type. This raw path requires one authoritative or externally serialized writer per collection. Already-open instances compare `Connection::sync_apply_generation()` and lazily rebuild their RAM index before index-dependent operations after remote apply. A connection apply/read barrier serializes remote `handle_push()` apply commits with cache-backed `VectorStore` operations. Each `VectorStore` instance serializes its own methods; C++17 builds let different readers share the connection read side, while C++11 builds use an exclusive connection mutex fallback. | `test_sync_capture`, `test_sync_replication` |
 | `AnyValueTable<K>` | Deferred | No `ChangeOp` in v0.1. | Not applied by sync as a typed heterogeneous table. | `test_sync_capture` negative coverage |
 | `KeyMultiValueTable<K, V>` | Limited logical adapter | No raw `ChangeOp` in v0.1. | `KeyMultiValueTableLogicalAdapter` explicitly captures unordered insert, key erase, all-matching-value erase, and clear for one writer or causally serialized updates. Raw calls, append, reconcile, range erase, and general multi-writer destructive convergence remain deferred. | `test_key_value_logical_adapter`, `test_sync_capture` negative coverage |
-| `KeyOrderedMultiValueTable<K, V>` | Limited ordered logical adapters | No raw `ChangeOp` in v0.1. Schema v1 captures append-only changes; schema v2 captures `AppendElement` and exact `EraseElement` by persistent id. | Both schemas require one authoritative ordered origin and fail closed for direct logical frames or unordered delivery. Schema v2 persists element identity and tombstones, and its typed capture atomically commits local mutations plus an ordered outbox envelope. Broad key/value erase and clear have a documented bounded exact-id expansion contract but are not implemented; replace, baseline import, and multi-origin histories remain separately deferred. | `test_key_value_logical_adapter`, `test_key_ordered_multi_value_destructive_state`, `test_key_ordered_multi_value_destructive_adapter` |
+| `KeyOrderedMultiValueTable<K, V>` | Limited ordered logical adapters | No raw `ChangeOp` in v0.1. Schema v1 captures append-only changes; schema v2 captures `AppendElement` and exact `EraseElement` by persistent id. | Both schemas require one authoritative ordered origin and fail closed for direct logical frames or unordered delivery. Schema v2 persists element identity and tombstones, and its typed capture atomically commits local mutations plus an ordered outbox envelope. Bounded `erase_at`, key/value erase, and clear resolve selectors to exact ids before mutation; replace, baseline import, and multi-origin histories remain separately deferred. | `test_key_value_logical_adapter`, `test_key_ordered_multi_value_destructive_state`, `test_key_ordered_multi_value_destructive_adapter` |
 | `HashedKeyValueStore<K, V, H, Layout>` | Deferred | No `ChangeOp` in v0.1. | Hash-index identity and logical-key mapping are deferred. | `test_sync_capture` negative coverage |
 
 ## Supported Capture Contract
@@ -119,12 +119,12 @@ append-only. Schema v2 adds `AppendElement` and exact `EraseElement` by a
 persistent `OrderedElementId`, with Live/Tombstone state, per-origin introduced
 high-water integrity, and typed capture that atomically commits the mutation and
 an ordered outbox envelope. Both require one authoritative ordered origin.
-Broad key/value erase and clear have a design-only contract with separate
-candidate-expansion and inspected-record budgets. It expands a complete
+Bounded `erase_at`, key/value erase, and clear expand a complete
 canonical-codec selector result into deterministic exact-id operations before
-mutation; no broad wire opcode or capture method is implemented. Replace,
-baseline import, multi-origin histories, tombstone pruning, and compaction
-remain deferred. The transaction wrapper's native
+mutation. Candidate-expansion and inspected-record budgets apply to the entire
+operation, including remaining mutation-time reads. Replace, baseline import,
+multi-origin histories, tombstone pruning, and compaction remain deferred. The
+transaction wrapper's native
 commit-error cleanup path has deterministic test-only coverage after ordered
 capture preparation: the injected path aborts the native handle before
 returning an MDBX error, notifies the attached capture sink of the discard, and

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -79,11 +79,11 @@ These table families intentionally emit no `ChangeOp` in v0.1:
   general multi-writer destructive convergence. The explicit unordered logical
   adapter covers only insert, key erase, all-matching-value erase, and clear for one writer
   or causally serialized updates.
-- `KeyOrderedMultiValueTable` raw capture and broad destructive operations.
-  Schema v1 remains append-only. Schema v2 supports logical `AppendElement`
-  and exact `EraseElement` by persistent element id through one authoritative
-  ordered origin, but key/value erase, clear, baseline import, and multi-origin
-  histories remain deferred.
+- `KeyOrderedMultiValueTable` raw capture, replace, baseline import, and
+  multi-origin histories. Schema v1 remains append-only. Schema v2 supports
+  logical `AppendElement` and exact `EraseElement` by persistent element id,
+  plus bounded `erase_at`, key/value erase, and clear capture through one
+  authoritative ordered origin.
 - `HashedKeyValueStore`, until the relationship between logical key bytes,
   physical storage keys, and hash-index entries is specified.
 
@@ -114,11 +114,11 @@ delivery. The logical core uses the following contracts:
   `KeyOrderedMultiValueTableDestructiveLogicalAdapter` applies schema-v2
   `AppendElement` and exact `EraseElement` changes with persistent element
   identity and tombstones; its typed capture session atomically commits local
-  mutations and an ordered outbox envelope. Broad key/value erase and clear
-  have a design-only contract with separate candidate and inspected-record
-  bounds plus canonical logical-codec selector semantics; their capture
-  methods remain unimplemented. Replace and other broad state construction
-  remain separately deferred. Transferring the authoritative origin is an
+  mutations and an ordered outbox envelope. Bounded `erase_at`, key/value
+  erase, and clear capture resolve canonical logical-codec selectors to exact
+  ids with separate candidate and inspected-record bounds. Replace and other
+  broad state construction remain separately deferred. Transferring the
+  authoritative origin is an
   application-coordinated schema-marker cutover; it is not automatic failover
   and requires old-outbox drain plus replay-marker retention through the chosen
   retry horizon.
@@ -153,10 +153,8 @@ tables.
   `SnapshotRequired` as automatically recoverable by sync itself.
 - Define explicit conflict/CRDT semantics before claiming general concurrent
   multi-writer convergence for `KeyMultiValueTable`.
-- Implement schema-v2 broad key/value erase and clear only through the
-  documented selector-to-`EraseElement` contract with independent candidate
-  and inspected-record budgets. Design `replace_with()`, baseline import, and
-  multi-origin histories separately; none is implied by bounded erasure.
+- Design `replace_with()`, baseline import, and multi-origin histories for
+  schema v2 separately; none is implied by the implemented bounded erasure.
 - Evaluate whether any `KeyMultiValueTable` framing ideas carry over to
   `AnyValueTable` and `HashedKeyValueStore`.
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -862,9 +862,10 @@ anchors, see the
   format; deferred until an explicit identity-mapping scheme lands.
 - `KeyMultiValueTable` — DUPSORT duplicate values need the unordered multiset
   model described above before capture can be enabled.
-- `KeyOrderedMultiValueTable` — broad destructive local mutators, baseline
-  import, multi-origin history and tombstone compaction remain deferred beyond
-  the implemented single-origin v2 `append` / exact-id `erase` contract.
+- `KeyOrderedMultiValueTable` — raw capture, `replace_with()`, baseline import,
+  multi-origin history and tombstone compaction remain deferred beyond the
+  implemented single-origin v2 capture contract. That contract includes
+  bounded `erase_at`, key/value erase, and clear, each expanded to exact ids.
 - `AnyValueTable` — heterogeneous values need type-tag propagation on the wire.
 - `IdentityProvider` integration in `BaseTable` — declared in v0.1, no
   write path until HashedKeyValueStore.


### PR DESCRIPTION
Aligns sync readiness and coverage documentation with the implemented bounded schema-v2 ordered erase and clear capture.