### PR TITLE
feat(sync): capture multivalue reconcile deltas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+
+- Added `KeyMultiValueTable::erase_one()` and schema-v2 logical
+  `EraseOneValue`. Schema v2 typed multivalue capture supports
+  multiplicity-preserving `reconcile()` by publishing exact surplus deletes and
+  missing inserts; schema v1 remains limited to its original operation set.
 - Added bounded `erase_at()`, `erase_value()`, `erase_key()`, and `clear()` selector
   expansion to destructive ordered capture. They resolve canonical logical-codec
   selectors to exact immutable ids before mutation and emit only `EraseElement`

--- a/guides/sync-table-coverage.md
+++ b/guides/sync-table-coverage.md
@@ -20,7 +20,7 @@ values during transport, and remote apply replays the captured physical
 | `SequenceTable<V>` | Supported | `Put`, `Delete`, `ClearTable`; append, `insert_or_assign`, erase, and clear paths are implemented. | Stable `uint64_t` sequence keys and value bytes are replayed. | `test_sync_capture`, `test_sync_replication` |
 | `VectorStore` | Indirectly supported | Captured through its internal `SequenceTable` and `KeyValueTable` members. | The internal table operations are replicated; `VectorStore` has no separate wire type. This raw path requires one authoritative or externally serialized writer per collection. Already-open instances compare `Connection::sync_apply_generation()` and lazily rebuild their RAM index before index-dependent operations after remote apply. A connection apply/read barrier serializes remote `handle_push()` apply commits with cache-backed `VectorStore` operations. Each `VectorStore` instance serializes its own methods; C++17 builds let different readers share the connection read side, while C++11 builds use an exclusive connection mutex fallback. | `test_sync_capture`, `test_sync_replication` |
 | `AnyValueTable<K>` | Deferred | No `ChangeOp` in v0.1. | Not applied by sync as a typed heterogeneous table. | `test_sync_capture` negative coverage |
-| `KeyMultiValueTable<K, V>` | Limited logical adapter | No raw `ChangeOp` in v0.1. | `KeyMultiValueTableLogicalAdapter` explicitly captures unordered insert, key erase, all-matching-value erase, and clear for one writer or causally serialized updates. Raw calls, append, reconcile, range erase, and general multi-writer destructive convergence remain deferred. | `test_key_value_logical_adapter`, `test_sync_capture` negative coverage |
+| `KeyMultiValueTable<K, V>` | Limited logical adapter | No raw `ChangeOp` in v0.1. | Schema v1 explicitly captures unordered insert, key erase, all-matching-value erase, and clear. Schema v2 additionally captures exact-one erase and typed `reconcile()` for one writer or causally serialized updates. Raw calls, append, range erase, and general multi-writer destructive convergence remain deferred. | `test_key_value_logical_adapter`, `test_sync_capture` negative coverage |
 | `KeyOrderedMultiValueTable<K, V>` | Limited ordered logical adapters | No raw `ChangeOp` in v0.1. Schema v1 captures append-only changes; schema v2 captures `AppendElement` and exact `EraseElement` by persistent id. | Both schemas require one authoritative ordered origin and fail closed for direct logical frames or unordered delivery. Schema v2 persists element identity and tombstones, and its typed capture atomically commits local mutations plus an ordered outbox envelope. Bounded `erase_at`, key/value erase, and clear resolve selectors to exact ids before mutation; replace, baseline import, and multi-origin histories remain separately deferred. | `test_key_value_logical_adapter`, `test_key_ordered_multi_value_destructive_state`, `test_key_ordered_multi_value_destructive_adapter` |
 | `HashedKeyValueStore<K, V, H, Layout>` | Deferred | No `ChangeOp` in v0.1. | Hash-index identity and logical-key mapping are deferred. | `test_sync_capture` negative coverage |
 
@@ -104,11 +104,8 @@ unordered multiset model. Repeated identical `(key, value)` pairs preserve
 multiplicity under single-writer or causally serialized updates. Raw v0.1
 capture, bulk/reconcile/range capture, and general concurrent destructive
 updates remain deferred.
-Before adding another `KeyMultiValueTableLogicalAdapter` opcode or capture
-method, expand its malformed-payload regression matrix to cover truncated
-pair payloads, oversized declared lengths, trailing bytes, payload-bearing
-clear, and unknown opcodes. This is deferred coverage work for the next
-logical-adapter extension, not a claim that those operations are supported.
+The adapter rejects truncated pair payloads, oversized declared lengths,
+trailing bytes, payload-bearing clear, and unknown opcodes before mutation.
 The detailed deferred contract lives in
 `include/mdbx_containers/sync/DESIGN.md`: it requires explicit multivalue wire
 sub-operations and receiver-side logical apply helpers before capture can be

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -75,10 +75,11 @@ These table families intentionally emit no `ChangeOp` in v0.1:
 
 - `AnyValueTable`, until a wire-level type tag and compatibility policy is
   specified.
-- raw `KeyMultiValueTable` capture, bulk/reconcile/range operations, and
+- raw `KeyMultiValueTable` capture, bulk/range operations, and
   general multi-writer destructive convergence. The explicit unordered logical
-  adapter covers only insert, key erase, all-matching-value erase, and clear for one writer
-  or causally serialized updates.
+  adapter schema v1 covers insert, key erase, all-matching-value erase, and
+  clear; schema v2 additionally covers exact-one erase and typed `reconcile()`
+  for one writer or causally serialized updates.
 - `KeyOrderedMultiValueTable` raw capture, replace, baseline import, and
   multi-origin histories. Schema v1 remains append-only. Schema v2 supports
   logical `AppendElement` and exact `EraseElement` by persistent element id,
@@ -107,8 +108,9 @@ delivery. The logical core uses the following contracts:
   apply helpers with opt-in typed capture sessions. Neither is connected to
   the transport pull/push path yet; callers own logical frame delivery.
 - `KeyMultiValueTableLogicalAdapter` follows the same explicit logical-frame
-  path for its limited unordered multiset operation set. It does not enable raw
-  `ChangeOp` capture for the table wrapper.
+  path. Schema v1 provides unordered insert, key erase, all-matching-value
+  erase, and clear; schema v2 adds exact-one erase and typed `reconcile()`.
+  It does not enable raw `ChangeOp` capture for the table wrapper.
 - `KeyOrderedMultiValueTableLogicalAdapter` applies schema-v1 append-only
   changes only through ordered delivery for one origin stream.
   `KeyOrderedMultiValueTableDestructiveLogicalAdapter` applies schema-v2

--- a/include/mdbx_containers/KeyMultiValueTable.hpp
+++ b/include/mdbx_containers/KeyMultiValueTable.hpp
@@ -1109,6 +1109,28 @@ namespace mdbxc {
             return erase(key, value, txn.handle());
         }
 
+        /// \brief Removes one matching key-value pair.
+        /// \param key Key to remove from.
+        /// \param value One matching value to remove.
+        /// \param txn Optional transaction handle.
+        /// \return \c true if one pair was removed.
+        /// \details Repeated identical pairs remain stored separately. This
+        /// method removes at most one of them.
+        bool erase_one(const KeyT& key, const ValueT& value,
+                       MDBX_txn* txn = nullptr) {
+            bool removed = false;
+            with_transaction([this, &key, &value, &removed](MDBX_txn* t) {
+                removed = db_erase_one_pair(key, value, t);
+            }, TransactionMode::WRITABLE, txn);
+            return removed;
+        }
+
+        /// \brief Removes one matching key-value pair in an active transaction.
+        bool erase_one(const KeyT& key, const ValueT& value,
+                       const Transaction& txn) {
+            return erase_one(key, value, txn.handle());
+        }
+
         /// \brief Removes all pairs.
         /// \param txn Optional transaction handle.
         void clear(MDBX_txn* txn = nullptr) {
@@ -1972,6 +1994,36 @@ namespace mdbxc {
                 check_mdbx(rc, "Failed to scan duplicate values");
             }
             return removed;
+        }
+
+        bool db_erase_one_pair(const KeyT& key, const ValueT& value,
+                               MDBX_txn* txn) {
+            CursorGuard cursor;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, cursor.out()),
+                       "Failed to open MDBX cursor");
+
+            SerializeScratch sc_key;
+            SerializeScratch sc_value;
+            MDBX_val db_key = serialize_key<Options::safe_integer_key>(key, sc_key);
+            MDBX_val raw_value = make_comparable_value(value, sc_value);
+            MDBX_val db_val;
+            int rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_SET_KEY);
+            if (rc == MDBX_NOTFOUND) {
+                return false;
+            }
+            check_mdbx(rc, "Failed to seek key");
+            while (rc == MDBX_SUCCESS) {
+                if (stored_value_matches(db_val, raw_value)) {
+                    check_mdbx(mdbx_cursor_del(cursor.get(), MDBX_CURRENT),
+                               "Failed to erase duplicate value");
+                    return true;
+                }
+                rc = mdbx_cursor_get(cursor.get(), &db_key, &db_val, MDBX_NEXT_DUP);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "Failed to scan duplicate values");
+            }
+            return false;
         }
 
         void db_clear(MDBX_txn* txn) {

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -95,7 +95,7 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
 | `SequenceTable` | Supported | Captures set/append/delete/clear against stable `uint64_t` record ids. `append()` remains a local single-writer helper; external synchronization is still required for concurrent appenders. |
 | `VectorStore` | Supported indirectly | Does not own a separate wire format. Its persistent writes go through `SequenceTable` and `KeyValueTable` member tables. Raw replication requires one authoritative or externally serialized writer per collection. Already-open instances refresh their RAM index lazily after completed remote apply when the connection sync-apply generation changes. |
 | `AnyValueTable` | Not supported in v0.1 | Deferred until heterogeneous value type tags are part of the sync wire format. |
-| `KeyMultiValueTable` | Limited logical adapter | Raw v0.1 capture remains unsupported. `KeyMultiValueTableLogicalAdapter` explicitly captures unordered insert, key erase, all-matching-value erase, and clear under one-writer or causally serialized updates. |
+| `KeyMultiValueTable` | Limited logical adapter | Raw v0.1 capture remains unsupported. Schema v1 captures unordered insert, key erase, all-matching-value erase, and clear; schema v2 adds exact-one erase and typed `reconcile()` under one-writer or causally serialized updates. |
 | `KeyOrderedMultiValueTable` | Ordered logical adapters | Schema v1 remains append-only. Schema v2 provides explicit `AppendElement` and `EraseElement` by immutable id through ordered delivery for one authoritative origin. Bounded key/index/value/clear capture expands selectors to exact ids. |
 | `HashedKeyValueStore` | Not supported in v0.1 | Deferred until hash-index and identity-key mapping semantics are specified. |
 
@@ -169,7 +169,9 @@ multiset model instead of assuming that a physical key, a stripped value, or a
 locally assigned sequence prefix uniquely identifies one cross-node record.
 
 The first sync design for `KeyMultiValueTable` targets unordered multiset
-preservation under single-writer or causally serialized updates:
+preservation under single-writer or causally serialized updates. Schema v1
+contains `InsertOne`, `EraseKey`, `EraseAllValues`, and `Clear`; schema v2 adds
+`EraseOneValue` and typed `reconcile()`:
 
 ```text
 for every serialized key and serialized public value:
@@ -214,12 +216,15 @@ matching adapter fail closed before mutation through logical schema-marker and
 adapter validation.
 
 The first implementation scope is intentionally smaller than the complete
-model. Its explicit typed capture session supports `InsertOne`, `EraseKey`,
-`EraseAllValues`, and `Clear`. It does not capture raw table calls, `append()`,
-`reconcile()`, `erase_range()`, or `EraseOneValue`. Those paths remain local
-until a later extension can preserve their exact multiset semantics. This is
-not partial raw capture: callers opt into the typed session and only its
-documented methods publish logical changes.
+model. Schema v1 typed capture supports `InsertOne`, `EraseKey`,
+`EraseAllValues`, and `Clear`. Schema v2 additionally supports
+`EraseOneValue` and `reconcile()`. Reconciliation matches canonical logical
+pairs by multiplicity, emits one `EraseOneValue` per surplus occurrence, then
+emits missing `InsertOne` changes in desired-vector order. It does not capture
+raw table calls, `append()`, or `erase_range()`. Those paths remain local until
+a later extension can preserve their exact multiset semantics. This is not
+partial raw capture: callers opt into the typed session and only its documented
+methods publish logical changes.
 
 Implementation phases:
 
@@ -239,8 +244,8 @@ Implementation phases:
    order.
 
 `append()` can be represented as a sequence of `InsertOne` operations in the
-same local batch. `erase(key, value)` should emit `EraseAllValues`.
-`reconcile()` should emit one `EraseOneValue` per surplus occurrence and one
+same local batch. `erase(key, value)` emits `EraseAllValues`. Typed
+`reconcile()` emits one `EraseOneValue` per surplus occurrence and one
 `InsertOne` per missing occurrence so that repeated identical pairs preserve
 their final multiplicity. If a future implementation captures lower-level
 physical deletes during `reconcile()` or range erase, it must copy cursor keys
@@ -860,8 +865,9 @@ anchors, see the
 
 - `HashedKeyValueStore` — internal hash index layout complicates the wire
   format; deferred until an explicit identity-mapping scheme lands.
-- `KeyMultiValueTable` — DUPSORT duplicate values need the unordered multiset
-  model described above before capture can be enabled.
+- `KeyMultiValueTable` — raw capture, `append()`, and range-oriented operations
+  remain deferred beyond the schema-v1/v2 unordered multiset model described
+  above.
 - `KeyOrderedMultiValueTable` — raw capture, `replace_with()`, baseline import,
   multi-origin history and tombstone compaction remain deferred beyond the
   implemented single-origin v2 capture contract. That contract includes

--- a/include/mdbx_containers/sync/adapters/KeyMultiValueTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyMultiValueTableLogicalAdapter.hpp
@@ -27,7 +27,8 @@ namespace sync {
         KeyMultiValueLogicalInsertOne       = 1,
         KeyMultiValueLogicalEraseKey        = 2,
         KeyMultiValueLogicalEraseAllValues  = 3,
-        KeyMultiValueLogicalClear           = 4
+        KeyMultiValueLogicalClear           = 4,
+        KeyMultiValueLogicalEraseOneValue   = 5
     };
 
     /// \brief Logical adapter for an unordered \c KeyMultiValueTable.
@@ -63,9 +64,9 @@ namespace sync {
                 throw std::invalid_argument(
                     "KeyMultiValueTableLogicalAdapter DBI name is empty");
             }
-            if (m_schema_version == 0u) {
+            if (m_schema_version != 1u && m_schema_version != 2u) {
                 throw std::invalid_argument(
-                    "KeyMultiValueTableLogicalAdapter schema version is zero");
+                    "KeyMultiValueTableLogicalAdapter schema version is unsupported");
             }
         }
 
@@ -104,6 +105,13 @@ namespace sync {
                                     key, value);
         }
 
+        LogicalChange make_erase_one_value(const KeyT& key,
+                                            const ValueT& value) const {
+            require_schema_v2();
+            return make_pair_change(KeyMultiValueLogicalEraseOneValue,
+                                    key, value);
+        }
+
         LogicalChange make_clear() const {
             LogicalChange change;
             change.schema = schema_ref();
@@ -114,13 +122,17 @@ namespace sync {
         /// \brief Transaction-bound typed logical capture session.
         /// \details The session owns a writable transaction and suppresses raw
         /// capture for its mutations. It captures only unordered multiset
-        /// operations exposed by this class; direct table calls, bulk
-        /// reconciliation, and range erasure remain local-only operations.
+        /// operations exposed by this class. Direct table calls, bulk table
+        /// APIs, and range erasure remain local-only. Typed schema-v2
+        /// \c reconcile() is captured as exact multiset deltas.
         /// The adapter, table, and connection referenced by the adapter must
         /// outlive the session. An exception after physical mutation, outbox
         /// enqueue, or native commit processing begins requests rollback of
-        /// the transaction and deactivates the session. Preparation or
-        /// encoding failures before transaction mutation leave it active.
+        /// the transaction and deactivates the session. Any failure during
+        /// \c reconcile() planning or application also rolls back and
+        /// deactivates the session, including before its first table mutation.
+        /// Other single-operation preparation or encoding failures before
+        /// mutation leave the session active.
         class LogicalCaptureSession {
         public:
             explicit LogicalCaptureSession(
@@ -197,6 +209,99 @@ namespace sync {
                 }
             }
 
+            bool erase_one(const KeyT& key, const ValueT& value) {
+                ensure_active();
+                const LogicalChange change =
+                    m_adapter.make_erase_one_value(key, value);
+                const std::size_t previous_size = m_pending.size();
+                m_pending.push_back(change);
+                try {
+                    Connection::SyncCaptureSuppressionScope suppress_capture(
+                        *m_adapter.m_table.connection(), m_txn.handle());
+                    const bool removed = m_adapter.m_table.erase_one(
+                        key, value, m_txn.handle());
+                    if (!removed) {
+                        m_pending.resize(previous_size);
+                    }
+                    return removed;
+                } catch (...) {
+                    rollback_and_deactivate();
+                    throw;
+                }
+            }
+
+            void reconcile(const std::vector<typename table_type::value_type>& desired) {
+                ensure_active();
+                try {
+                    m_adapter.require_schema_v2();
+                    const std::vector<typename table_type::value_type> existing =
+                        m_adapter.m_table.retrieve_all_vector(m_txn.handle());
+                    std::vector<LogicalChange> desired_changes;
+                    desired_changes.reserve(desired.size());
+                    std::size_t i = 0u;
+                    for (; i < desired.size(); ++i) {
+                        desired_changes.push_back(m_adapter.make_insert_one(
+                            desired[i].first, desired[i].second));
+                    }
+
+                    std::vector<bool> desired_matched(desired.size(), false);
+                    std::vector<bool> existing_matched(existing.size(), false);
+                    std::vector<ReconcileDelta> plan;
+                    plan.reserve(existing.size() + desired.size());
+                    for (i = 0u; i < existing.size(); ++i) {
+                        const LogicalChange existing_change =
+                            m_adapter.make_insert_one(existing[i].first,
+                                                      existing[i].second);
+                        std::size_t j = 0u;
+                        for (; j < desired.size(); ++j) {
+                            if (!desired_matched[j] &&
+                                existing_change.payload ==
+                                    desired_changes[j].payload) {
+                                desired_matched[j] = true;
+                                existing_matched[i] = true;
+                                break;
+                            }
+                        }
+                    }
+                    for (i = 0u; i < existing.size(); ++i) {
+                        if (!existing_matched[i]) {
+                            plan.push_back(ReconcileDelta(
+                                m_adapter.make_erase_one_value(
+                                    existing[i].first, existing[i].second),
+                                existing[i], true));
+                        }
+                    }
+                    for (i = 0u; i < desired.size(); ++i) {
+                        if (!desired_matched[i]) {
+                            plan.push_back(ReconcileDelta(
+                                desired_changes[i], desired[i], false));
+                        }
+                    }
+
+                    m_pending.reserve(m_pending.size() + plan.size());
+                    for (i = 0u; i < plan.size(); ++i) {
+                        m_pending.push_back(plan[i].change);
+                        Connection::SyncCaptureSuppressionScope suppress_capture(
+                            *m_adapter.m_table.connection(), m_txn.handle());
+                        if (plan[i].erase) {
+                            if (!m_adapter.m_table.erase_one(
+                                    plan[i].pair.first, plan[i].pair.second,
+                                    m_txn.handle())) {
+                                throw std::logic_error(
+                                    "KeyMultiValue reconcile lost a planned pair");
+                            }
+                        } else {
+                            m_adapter.m_table.insert(
+                                plan[i].pair.first, plan[i].pair.second,
+                                m_txn.handle());
+                        }
+                    }
+                } catch (...) {
+                    rollback_and_deactivate();
+                    throw;
+                }
+            }
+
             void clear() {
                 ensure_active();
                 append_then_mutate(m_adapter.make_clear(), [this]() {
@@ -259,6 +364,17 @@ namespace sync {
             }
 
         private:
+            struct ReconcileDelta {
+                ReconcileDelta(const LogicalChange& change_value,
+                               const typename table_type::value_type& pair_value,
+                               bool erase_value)
+                    : change(change_value), pair(pair_value), erase(erase_value) {}
+
+                LogicalChange change;
+                typename table_type::value_type pair;
+                bool erase;
+            };
+
             template<class Mutation>
             void append_then_mutate(const LogicalChange& change,
                                     const Mutation& mutation) {
@@ -335,6 +451,12 @@ namespace sync {
                     const std::pair<KeyT, ValueT> pair =
                         decode_pair(change.payload);
                     (void)m_table.erase(pair.first, pair.second, txn);
+                    return LogicalApplyResult::success();
+                }
+                if (change.opcode == KeyMultiValueLogicalEraseOneValue) {
+                    const std::pair<KeyT, ValueT> pair =
+                        decode_pair(change.payload);
+                    (void)m_table.erase_one(pair.first, pair.second, txn);
                     return LogicalApplyResult::success();
                 }
                 if (change.opcode == KeyMultiValueLogicalClear) {
@@ -452,11 +574,24 @@ namespace sync {
             return std::make_pair(key, value);
         }
 
-        static LogicalApplyResult validate_payload(
-                const LogicalChange& change) {
+        void require_schema_v2() const {
+            if (m_schema_version != 2u) {
+                throw std::logic_error(
+                    "KeyMultiValue exact-one erase requires schema version 2");
+            }
+        }
+
+        LogicalApplyResult validate_payload(
+                const LogicalChange& change) const {
             try {
                 if (change.opcode == KeyMultiValueLogicalInsertOne ||
-                    change.opcode == KeyMultiValueLogicalEraseAllValues) {
+                    change.opcode == KeyMultiValueLogicalEraseAllValues ||
+                    change.opcode == KeyMultiValueLogicalEraseOneValue) {
+                    if (change.opcode == KeyMultiValueLogicalEraseOneValue &&
+                        m_schema_version != 2u) {
+                        return LogicalApplyResult::failure(
+                            "KeyMultiValue exact-one erase requires schema version 2");
+                    }
                     (void)decode_pair(change.payload);
                     return LogicalApplyResult::success();
                 }

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -28,6 +28,28 @@ typedef mdbxc::sync::KeyMultiValueTableLogicalAdapter<
 typedef mdbxc::sync::KeyOrderedMultiValueTableLogicalAdapter<
     int, std::string, IntKeyCodec, StringValueCodec> IntStringOrderedAdapter;
 
+struct LateFailStringCodec {
+    typedef std::string value_type;
+
+    static std::vector<std::uint8_t> encode(const std::string& value) {
+        if (fail_on_value && value == "fail") {
+            throw std::runtime_error("forced late logical codec failure");
+        }
+        return StringValueCodec::encode(value);
+    }
+
+    static std::string decode(const std::vector<std::uint8_t>& bytes) {
+        return StringValueCodec::decode(bytes);
+    }
+
+    static bool fail_on_value;
+};
+
+bool LateFailStringCodec::fail_on_value = false;
+
+typedef mdbxc::sync::KeyMultiValueTableLogicalAdapter<
+    int, std::string, IntKeyCodec, LateFailStringCodec> LateFailMultiAdapter;
+
 static_assert(mdbxc::sync::detail::KeyValueLogicalIntegerLocalSupported<
                   std::int32_t>::value,
               "int32_t local type must be supported by integer codec");
@@ -1892,7 +1914,7 @@ void test_key_multi_value_logical_adapter_applies_multiset_operations() {
     const std::string path =
         "test_key_multi_value_logical_adapter_engine.mdbx";
     const std::string dbi_name = "logical_key_multi_value_engine";
-    const std::string schema_id = "app.logical_key_multi_value_engine.v1";
+    const std::string schema_id = "app.logical_key_multi_value_engine.v2";
     cleanup(path);
 
     mdbxc::Config cfg;
@@ -1904,10 +1926,10 @@ void test_key_multi_value_logical_adapter_applies_multiset_operations() {
     mdbxc::sync::SyncEngine engine(conn);
     engine.initialize_local_identity(make_node(0x4D), make_node(0xD5));
     engine.register_logical_schema(
-        schema_id, make_key_multi_value_record(dbi_name));
+        schema_id, make_key_multi_value_record(dbi_name, 2u));
 
     mdbxc::KeyMultiValueTable<int, std::string> table(conn, dbi_name);
-    IntStringMultiAdapter adapter(table, schema_id);
+    IntStringMultiAdapter adapter(table, schema_id, 2u);
     engine.register_logical_adapter(adapter);
 
     std::vector<mdbxc::sync::LogicalChange> changes;
@@ -1919,6 +1941,13 @@ void test_key_multi_value_logical_adapter_applies_multiset_operations() {
     MDBXC_TEST_ASSERT(result.ok);
     MDBXC_TEST_ASSERT(table.count(7) == 3u);
     MDBXC_TEST_ASSERT(table.count(7, "seven") == 2u);
+    MDBXC_TEST_ASSERT(table.count(7, "other") == 1u);
+
+    changes.clear();
+    changes.push_back(adapter.make_erase_one_value(7, "seven"));
+    result = engine.apply_logical_changes(changes);
+    MDBXC_TEST_ASSERT(result.ok);
+    MDBXC_TEST_ASSERT(table.count(7, "seven") == 1u);
     MDBXC_TEST_ASSERT(table.count(7, "other") == 1u);
 
     changes.clear();
@@ -2010,6 +2039,32 @@ void test_key_multi_value_logical_adapter_rejects_invalid_payload() {
         MDBXC_TEST_ASSERT(table.count(77, "keep") == 1u);
     }
 
+    bool v1_make_rejected = false;
+    try {
+        (void)adapter.make_erase_one_value(77, "keep");
+    } catch (const std::logic_error&) {
+        v1_make_rejected = true;
+    }
+    MDBXC_TEST_ASSERT(v1_make_rejected);
+    IntStringMultiAdapter v2_adapter(
+        table, "app.logical_key_multi_value_malformed.v2", 2u);
+    mdbxc::sync::LogicalChange v1_exact_one =
+        v2_adapter.make_erase_one_value(77, "keep");
+    v1_exact_one.schema = adapter.schema_ref();
+    std::vector<mdbxc::sync::LogicalChange> v1_changes;
+    v1_changes.push_back(v1_exact_one);
+    const mdbxc::sync::LogicalApplyResult v1_result =
+        engine.apply_logical_changes(v1_changes);
+    MDBXC_TEST_ASSERT(!v1_result.ok);
+    MDBXC_TEST_ASSERT(table.count(77, "keep") == 1u);
+
+    std::vector<mdbxc::sync::LogicalChange> v2_changes;
+    v2_changes.push_back(v2_adapter.make_erase_one_value(77, "keep"));
+    const mdbxc::sync::LogicalApplyResult v2_result =
+        engine.apply_logical_changes(v2_changes);
+    MDBXC_TEST_ASSERT(!v2_result.ok);
+    MDBXC_TEST_ASSERT(table.count(77, "keep") == 1u);
+
     conn->disconnect();
     cleanup(path);
 }
@@ -2073,6 +2128,157 @@ void test_key_multi_value_logical_capture_session_commits_typed_writes() {
     }
 
     conn->disconnect();
+    cleanup(path);
+}
+
+void test_key_multi_value_logical_capture_session_reconciles_multiplicity() {
+    const std::string source_path =
+        "test_key_multi_value_logical_adapter_reconcile_source.mdbx";
+    const std::string replica_path =
+        "test_key_multi_value_logical_adapter_reconcile_replica.mdbx";
+    const std::string dbi_name = "logical_key_multi_value_reconcile";
+    const std::string schema_id = "app.logical_key_multi_value_reconcile.v2";
+    cleanup(source_path);
+    cleanup(replica_path);
+
+    mdbxc::Config source_config;
+    source_config.pathname = source_path;
+    source_config.max_dbs = 16;
+    source_config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> source =
+        mdbxc::Connection::create(source_config);
+    mdbxc::Config replica_config = source_config;
+    replica_config.pathname = replica_path;
+    const std::shared_ptr<mdbxc::Connection> replica =
+        mdbxc::Connection::create(replica_config);
+
+    mdbxc::sync::SyncEngine source_engine(source);
+    source_engine.initialize_local_identity(make_node(0x61), make_node(0xE1));
+    source_engine.register_logical_schema(
+        schema_id, make_key_multi_value_record(dbi_name, 2u));
+    mdbxc::sync::SyncEngine replica_engine(replica);
+    replica_engine.initialize_local_identity(make_node(0x62), make_node(0xE2));
+    replica_engine.register_logical_schema(
+        schema_id, make_key_multi_value_record(dbi_name, 2u));
+
+    mdbxc::KeyMultiValueTable<int, std::string> source_table(source, dbi_name);
+    mdbxc::KeyMultiValueTable<int, std::string> replica_table(replica, dbi_name);
+    IntStringMultiAdapter source_adapter(source_table, schema_id, 2u);
+    IntStringMultiAdapter replica_adapter(replica_table, schema_id, 2u);
+    source_engine.register_logical_adapter(source_adapter);
+    replica_engine.register_logical_adapter(replica_adapter);
+
+    source_table.insert(1, "same");
+    source_table.insert(1, "same");
+    source_table.insert(2, "remove");
+    replica_table.insert(1, "same");
+    replica_table.insert(1, "same");
+    replica_table.insert(2, "remove");
+
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    {
+        std::unique_ptr<IntStringMultiAdapter::LogicalCaptureSession> session =
+            source_adapter.begin_capture_session();
+        std::vector<mdbxc::KeyMultiValueTable<int, std::string>::value_type>
+            desired;
+        desired.push_back(std::make_pair(1, std::string("same")));
+        desired.push_back(std::make_pair(1, std::string("other")));
+        desired.push_back(std::make_pair(3, std::string("new")));
+        session->reconcile(desired);
+        session->commit(changes);
+    }
+
+    bool captured_erase_one = false;
+    for (std::size_t i = 0u; i < changes.size(); ++i) {
+        if (changes[i].opcode == mdbxc::sync::KeyMultiValueLogicalEraseOneValue) {
+            captured_erase_one = true;
+        }
+    }
+    MDBXC_TEST_ASSERT(captured_erase_one);
+
+    MDBXC_TEST_ASSERT(source_table.count(1, "same") == 1u);
+    MDBXC_TEST_ASSERT(source_table.count(1, "other") == 1u);
+    MDBXC_TEST_ASSERT(source_table.count(2) == 0u);
+    MDBXC_TEST_ASSERT(source_table.count(3, "new") == 1u);
+    const mdbxc::sync::LogicalApplyResult result =
+        replica_engine.apply_logical_changes(changes);
+    MDBXC_TEST_ASSERT(result.ok);
+    MDBXC_TEST_ASSERT(replica_table.count(1, "same") == 1u);
+    MDBXC_TEST_ASSERT(replica_table.count(1, "other") == 1u);
+    MDBXC_TEST_ASSERT(replica_table.count(2) == 0u);
+    MDBXC_TEST_ASSERT(replica_table.count(3, "new") == 1u);
+
+    {
+        std::unique_ptr<IntStringMultiAdapter::LogicalCaptureSession> session =
+            source_adapter.begin_capture_session();
+        std::vector<mdbxc::KeyMultiValueTable<int, std::string>::value_type>
+            desired;
+        desired.push_back(std::make_pair(1, std::string("same")));
+        desired.push_back(std::make_pair(1, std::string("other")));
+        desired.push_back(std::make_pair(3, std::string("new")));
+        session->reconcile(desired);
+        std::vector<mdbxc::sync::LogicalChange> no_op_changes;
+        session->commit(no_op_changes);
+        MDBXC_TEST_ASSERT(no_op_changes.empty());
+    }
+
+    source->disconnect();
+    replica->disconnect();
+    cleanup(source_path);
+    cleanup(replica_path);
+}
+
+void test_key_multi_value_logical_reconcile_rolls_back_late_codec_failure() {
+    const std::string path =
+        "test_key_multi_value_logical_adapter_reconcile_codec_failure.mdbx";
+    const std::string dbi_name = "logical_key_multi_value_reconcile_failure";
+    const std::string schema_id =
+        "app.logical_key_multi_value_reconcile_failure.v2";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    mdbxc::sync::SyncEngine engine(connection);
+    engine.initialize_local_identity(make_node(0x63), make_node(0xE3));
+    engine.register_logical_schema(
+        schema_id, make_key_multi_value_record(dbi_name, 2u));
+    mdbxc::KeyMultiValueTable<int, std::string> table(connection, dbi_name);
+    LateFailMultiAdapter adapter(table, schema_id, 2u);
+    table.insert(1, "old");
+
+    std::unique_ptr<LateFailMultiAdapter::LogicalCaptureSession> session =
+        adapter.begin_capture_session();
+    std::vector<mdbxc::KeyMultiValueTable<int, std::string>::value_type>
+        desired;
+    desired.push_back(std::make_pair(1, std::string("good")));
+    desired.push_back(std::make_pair(2, std::string("fail")));
+    LateFailStringCodec::fail_on_value = true;
+    bool caught = false;
+    try {
+        session->reconcile(desired);
+    } catch (const std::runtime_error&) {
+        caught = true;
+    }
+    LateFailStringCodec::fail_on_value = false;
+    MDBXC_TEST_ASSERT(caught);
+    MDBXC_TEST_ASSERT(table.count(1, "old") == 1u);
+    MDBXC_TEST_ASSERT(table.count() == 1u);
+    std::vector<mdbxc::sync::LogicalChange> changes;
+    bool commit_rejected = false;
+    try {
+        session->commit(changes);
+    } catch (const std::logic_error&) {
+        commit_rejected = true;
+    }
+    MDBXC_TEST_ASSERT(commit_rejected);
+    MDBXC_TEST_ASSERT(changes.empty());
+    MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(make_node(0xE4)).empty());
+
+    connection->disconnect();
     cleanup(path);
 }
 
@@ -5463,6 +5669,8 @@ int main() {
     test_key_multi_value_logical_adapter_applies_multiset_operations();
     test_key_multi_value_logical_adapter_rejects_invalid_payload();
     test_key_multi_value_logical_capture_session_commits_typed_writes();
+    test_key_multi_value_logical_capture_session_reconciles_multiplicity();
+    test_key_multi_value_logical_reconcile_rolls_back_late_codec_failure();
     test_key_multi_value_logical_capture_session_commits_to_outbox();
     test_key_multi_value_logical_capture_session_rolls_back_on_outbox_failure();
     test_key_multi_value_logical_capture_session_rolls_back_partial_erase();


### PR DESCRIPTION
Adds exact-one multivalue deletion and typed reconcile capture that preserves duplicate multiplicity through logical frames.