### PR TITLE
bench(sync): compare ordered index and reverse scan costs

### DIFF
--- a/benchmarks/README-sync-RU.md
+++ b/benchmarks/README-sync-RU.md
@@ -166,6 +166,17 @@ records. `elapsed_ms` включает открытие read transaction, изм
 добавления index, cache или фиксированного лимита к любому из путей
 корректности.
 
+CSV также содержит отдельные строки `live_ids_for_key_index` и
+`live_state_ids_for_key`: первая измеряет DUPSORT lookup, вторая - полную
+обратную проверку state DBI. `estimated_scanned_records` показывает границу
+работы сценария, а не внутренний счётчик.
+
+Обратная проверка остаётся эталонным fail-closed путём. Будущий trusted
+no-rescan путь должен сохранять этот fallback и документировать доказательство,
+делающее bounded scan безопасным. `BroadEraseBounds::max_scanned_records`
+должен покрывать выбранную операцию; меньший лимит должен приводить к отказу
+до mutation.
+
 Bounded destructive capture теперь использует предварительно проверенные exact
 id на стадии mutation и не повторяет это полное reverse-сканирование для
 каждого выбранного id. Соответствующий regression сохраняет state с большим

--- a/benchmarks/README-sync.md
+++ b/benchmarks/README-sync.md
@@ -155,9 +155,19 @@ The optional positional arguments are `origins`, `elements_per_origin`,
 `tombstones_per_origin` ids of every origin are persisted as Tombstone records;
 the default is zero. CSV rows separately report total, Live, and Tombstone
 element records, the full state-record count, and live DUPSORT index records.
-`elapsed_ms` includes read-transaction open, the measured scan, and rollback.
-Use results from representative workloads before adding an index, cache, or
-fixed limit to either correctness path.
+CSV now has separate rows for `live_ids_for_key_index` and
+`live_state_ids_for_key`. The first measures the DUPSORT lookup; the second
+measures the full reverse validation scan. `estimated_scanned_records` is a
+workload bound, not an internal counter. `elapsed_ms` includes read-transaction
+open, the measured scan, and rollback. Use results from representative
+workloads before adding an index, cache, or fixed limit to either correctness
+path.
+
+The reverse-validation row is intentionally the reference path. Any future
+trusted no-rescan path must retain this path as a fallback and must document
+the proof that makes its bounded scan safe. `BroadEraseBounds::max_scanned_records`
+must be large enough for the selected operation while this validation path is
+enabled; a smaller bound is expected to reject before mutation.
 
 Bounded destructive capture now uses prevalidated exact ids for its mutation
 phase and does not repeat this full reverse scan for every selected id. The

--- a/benchmarks/ordered_destructive_state_benchmark.cpp
+++ b/benchmarks/ordered_destructive_state_benchmark.cpp
@@ -193,6 +193,33 @@ std::uint64_t measure_live_state_reverse_scan(
     return observed;
 }
 
+std::uint64_t measure_live_index_scan(
+        const std::shared_ptr<mdbxc::Connection>& connection,
+        const Scenario& scenario,
+        const mdbxc::sync::OrderedElementStateStore& store,
+        const std::vector<std::uint8_t>& key,
+        double& out_ms) {
+    const std::uint64_t expected = expected_target_ids(scenario);
+    std::uint64_t observed = 0u;
+    const std::chrono::steady_clock::time_point started =
+        std::chrono::steady_clock::now();
+    for (std::uint64_t iteration = 0u;
+         iteration < scenario.iterations; ++iteration) {
+        mdbxc::Transaction transaction =
+            connection->transaction(mdbxc::TransactionMode::READ_ONLY);
+        const std::vector<mdbxc::sync::OrderedElementId> ids =
+            store.live_ids_for_key(transaction.handle(), key);
+        transaction.rollback();
+        if (ids.size() != expected) {
+            throw std::runtime_error(
+                "live index scan returned an unexpected id count");
+        }
+        observed += static_cast<std::uint64_t>(ids.size());
+    }
+    out_ms = elapsed_ms(started);
+    return observed;
+}
+
 void measure_origin_scans(const std::shared_ptr<mdbxc::Connection>& connection,
                           const Scenario& scenario,
                           const mdbxc::sync::OrderedElementStateStore& store,
@@ -226,6 +253,9 @@ void run(const Scenario& scenario) {
     std::vector<mdbxc::sync::NodeId> origins;
     seed_state(connection, scenario, store, origins);
 
+    double index_ms = 0.0;
+    const std::uint64_t matched_index_ids = measure_live_index_scan(
+        connection, scenario, store, make_key(0u), index_ms);
     double reverse_ms = 0.0;
     const std::uint64_t matched_live_ids = measure_live_state_reverse_scan(
         connection, scenario, store, make_key(0u), reverse_ms);
@@ -244,18 +274,26 @@ void run(const Scenario& scenario) {
     std::cout
         << "scan,origins,elements_per_origin,key_count,iterations,element_records,"
         << "live_element_records,tombstone_records,state_records,by_key_records,"
-        << "matched_live_ids,elapsed_ms\n"
-        << "live_state_ids_for_key," << scenario.origins << ','
+        << "estimated_scanned_records,matched_live_ids,elapsed_ms\n"
+        << "live_ids_for_key_index," << scenario.origins << ','
         << scenario.elements_per_origin << ',' << scenario.key_count << ','
         << scenario.iterations << ',' << element_records << ','
         << live_element_records << ',' << tombstone_records << ','
         << state_records << ',' << by_key_records << ','
+        << expected_target_ids(scenario) << ',' << matched_index_ids << ','
+        << index_ms << '\n'
+        << "live_state_ids_for_key," << scenario.origins << ','
+        << scenario.elements_per_origin << ',' << scenario.key_count << ','
+        << scenario.iterations << ',' << element_records << ','
+        << live_element_records << ',' << tombstone_records << ','
+        << state_records << ',' << by_key_records << ',' << state_records << ','
         << matched_live_ids << ',' << reverse_ms << '\n'
         << "verify_introduced_high_water," << scenario.origins << ','
         << scenario.elements_per_origin << ',' << scenario.key_count << ','
         << scenario.iterations << ',' << element_records << ','
         << live_element_records << ',' << tombstone_records << ','
         << state_records << ',' << by_key_records << ','
+        << scenario.elements_per_origin << ','
         << 0u << ',' << origin_ms << '\n';
     connection->disconnect();
 }


### PR DESCRIPTION
## Summary\n- measure DUPSORT lookup and full state reverse-validation separately\n- report estimated scan work in CSV output\n- document the fail-closed fallback and scan-bound contract in EN/RU benchmark guides\n\n## Validation\n- benchmark target builds under MinGW C++11 and C++17\n- representative tombstone-heavy run completed in both modes\n- git diff --check