### PR TITLE
perf(sync): add transaction-bound ordered index proofs

### DIFF
--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
@@ -208,6 +208,23 @@ namespace sync {
         }
     };
 
+    /// \brief A transaction-bound proof that state and key index agree.
+    /// \details The proof is issued by a destructive capture session after a
+    /// complete state/index validation. It is only valid for that session,
+    /// transaction, key, and mutation revision; callers must not persist it or
+    /// reuse it after another capture mutation.
+    struct OrderedElementKeyIndexProof {
+    private:
+        template<class, class, class, class, class>
+        friend class KeyOrderedMultiValueTableDestructiveLogicalAdapter;
+
+        MDBX_txn* transaction = nullptr;
+        const void* owner_session = nullptr;
+        std::size_t mutation_revision = 0u;
+        std::vector<std::uint8_t> key;
+        std::vector<OrderedElementId> ids;
+    };
+
     /// \brief Transactional store for destructive ordered element state.
     /// \details The state DBI stores origin allocation counters, introduced
     /// sequence high-water marks, and Live/Tombstone records.
@@ -625,6 +642,27 @@ namespace sync {
             }
             mdbx_cursor_close(cursor);
             return out;
+        }
+
+        /// \brief Validates and returns the complete live id set for a key.
+        /// \details This is the fail-closed reference path. It compares the
+        /// DUPSORT index with a full state reverse scan before returning ids
+        /// that a caller may bind into a short-lived proof.
+        std::vector<OrderedElementId> validate_live_ids_for_key(
+                MDBX_txn* txn,
+                const std::vector<std::uint8_t>& key,
+                OrderedElementCandidateSet* candidates = nullptr) const {
+            std::vector<OrderedElementId> index_ids =
+                live_ids_for_key(txn, key, candidates);
+            std::vector<OrderedElementId> state_ids =
+                live_state_ids_for_key(txn, key, candidates);
+            std::sort(index_ids.begin(), index_ids.end(), OrderedElementIdLess());
+            std::sort(state_ids.begin(), state_ids.end(), OrderedElementIdLess());
+            if (index_ids != state_ids) {
+                throw std::runtime_error(
+                    "Ordered destructive key index and state records differ");
+            }
+            return index_ids;
         }
 
         /// \brief Scans every element record and every origin it references.

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
@@ -209,7 +209,8 @@ namespace sync {
                 : m_adapter(adapter),
                   m_txn(adapter.m_table.connection()->transaction(
                       TransactionMode::WRITABLE)),
-                  m_active(true) {
+                  m_active(true),
+                  m_mutation_revision(0u) {
                 const LogicalApplyResult marker_result =
                     validate_logical_adapter_marker(
                         m_txn.handle(), adapter.m_table.connection()->env_handle(),
@@ -250,6 +251,7 @@ namespace sync {
                         *m_adapter.m_table.connection(), m_txn.handle());
                     m_adapter.append_live_element(m_txn.handle(), id, key, value);
                     m_pending.push_back(m_adapter.make_append(id, key, value));
+                    ++m_mutation_revision;
                     return id;
                 } catch (...) {
                     rollback_and_deactivate();
@@ -262,6 +264,34 @@ namespace sync {
                 ensure_active();
                 try {
                     erase_resolved(id, nullptr);
+                    ++m_mutation_revision;
+                } catch (...) {
+                    rollback_and_deactivate();
+                    throw;
+                }
+            }
+
+            /// \brief Validates one key and returns a transaction-bound proof.
+            /// \details The proof enables the explicit trusted selector
+            /// overloads below to skip their second full state reverse scan.
+            /// It becomes invalid after any capture mutation, rollback, or
+            /// commit and must be used only with this session.
+            OrderedElementKeyIndexProof validate_key_index(
+                    const KeyT& key,
+                    const BroadEraseBounds& bounds) {
+                ensure_active();
+                try {
+                    const std::vector<std::uint8_t> key_bytes =
+                        KeyCodec::encode(key);
+                    OrderedElementCandidateSet candidates(bounds);
+                    OrderedElementKeyIndexProof proof;
+                    proof.transaction = m_txn.handle();
+                    proof.owner_session = this;
+                    proof.mutation_revision = m_mutation_revision;
+                    proof.key = key_bytes;
+                    proof.ids = m_adapter.m_state.validate_live_ids_for_key(
+                        m_txn.handle(), key_bytes, &candidates);
+                    return proof;
                 } catch (...) {
                     rollback_and_deactivate();
                     throw;
@@ -323,6 +353,83 @@ namespace sync {
                     OrderedElementCandidateSet candidates(bounds);
                     resolve_live_elements(
                         key, candidates,
+                        [](std::size_t, const OrderedElementStateRecord&) {
+                            return true;
+                        });
+                    const std::vector<OrderedElementId> ids =
+                        candidates.sorted_ids();
+                    erase_selected(ids, &candidates);
+                    return ids.size();
+                } catch (...) {
+                    rollback_and_deactivate();
+                    throw;
+                }
+            }
+
+            /// \brief Erases one per-key position using a validated proof.
+            /// \details Unlike erase_at(), this opt-in path does not repeat
+            /// the full reverse scan. The proof must come from
+            /// validate_key_index() on this unchanged session.
+            bool erase_at_trusted(
+                    const KeyT& key,
+                    std::size_t index,
+                    const OrderedElementKeyIndexProof& proof,
+                    const BroadEraseBounds& bounds) {
+                ensure_active();
+                try {
+                    OrderedElementCandidateSet candidates(bounds);
+                    const bool found = resolve_live_elements_trusted(
+                        key, proof, candidates,
+                        [index](std::size_t current,
+                                const OrderedElementStateRecord&) {
+                            return current == index;
+                        });
+                    if (!found) return false;
+                    erase_selected(candidates.sorted_ids(), &candidates);
+                    return true;
+                } catch (...) {
+                    rollback_and_deactivate();
+                    throw;
+                }
+            }
+
+            /// \brief Erases matching values using a validated proof.
+            std::size_t erase_value_trusted(
+                    const KeyT& key,
+                    const ValueT& value,
+                    const OrderedElementKeyIndexProof& proof,
+                    const BroadEraseBounds& bounds) {
+                ensure_active();
+                try {
+                    const std::vector<std::uint8_t> value_bytes =
+                        ValueCodec::encode(value);
+                    OrderedElementCandidateSet candidates(bounds);
+                    resolve_live_elements_trusted(
+                        key, proof, candidates,
+                        [&value_bytes](std::size_t,
+                                       const OrderedElementStateRecord& record) {
+                            return record.value == value_bytes;
+                        });
+                    const std::vector<OrderedElementId> ids =
+                        candidates.sorted_ids();
+                    erase_selected(ids, &candidates);
+                    return ids.size();
+                } catch (...) {
+                    rollback_and_deactivate();
+                    throw;
+                }
+            }
+
+            /// \brief Erases all values under a key using a validated proof.
+            std::size_t erase_key_trusted(
+                    const KeyT& key,
+                    const OrderedElementKeyIndexProof& proof,
+                    const BroadEraseBounds& bounds) {
+                ensure_active();
+                try {
+                    OrderedElementCandidateSet candidates(bounds);
+                    resolve_live_elements_trusted(
+                        key, proof, candidates,
                         [](std::size_t, const OrderedElementStateRecord&) {
                             return true;
                         });
@@ -491,18 +598,38 @@ namespace sync {
                     OrderedElementCandidateSet& candidates,
                     Selector select) const {
                 const std::vector<std::uint8_t> key_bytes = KeyCodec::encode(key);
-                std::vector<OrderedElementId> index_ids =
-                    m_adapter.m_state.live_ids_for_key(
+                const std::vector<OrderedElementId> index_ids =
+                    m_adapter.m_state.validate_live_ids_for_key(
                         m_txn.handle(), key_bytes, &candidates);
-                std::vector<OrderedElementId> state_ids =
-                    m_adapter.m_state.live_state_ids_for_key(
-                        m_txn.handle(), key_bytes, &candidates);
-                std::sort(index_ids.begin(), index_ids.end(), OrderedElementIdLess());
-                std::sort(state_ids.begin(), state_ids.end(), OrderedElementIdLess());
-                if (index_ids != state_ids) {
-                    throw std::runtime_error(
-                        "Ordered destructive key index and state records differ");
+                return resolve_live_elements_from_ids(
+                    key, key_bytes, index_ids, candidates, select);
+            }
+
+            template<typename Selector>
+            bool resolve_live_elements_trusted(
+                    const KeyT& key,
+                    const OrderedElementKeyIndexProof& proof,
+                    OrderedElementCandidateSet& candidates,
+                    Selector select) const {
+                const std::vector<std::uint8_t> key_bytes = KeyCodec::encode(key);
+                if (proof.owner_session != this ||
+                    proof.transaction != m_txn.handle() ||
+                    proof.mutation_revision != m_mutation_revision ||
+                    proof.key != key_bytes) {
+                    throw std::logic_error(
+                        "Ordered key index proof is stale or belongs to another session");
                 }
+                return resolve_live_elements_from_ids(
+                    key, key_bytes, proof.ids, candidates, select);
+            }
+
+            template<typename Selector>
+            bool resolve_live_elements_from_ids(
+                    const KeyT& key,
+                    const std::vector<std::uint8_t>& key_bytes,
+                    const std::vector<OrderedElementId>& index_ids,
+                    OrderedElementCandidateSet& candidates,
+                    Selector select) const {
 
                 std::vector<ValueT> physical_values;
                 m_adapter.m_table.db_collect_values(
@@ -683,6 +810,7 @@ namespace sync {
                         m_pending.push_back(m_adapter.make_erase(resolved[i].id));
                     }
                 }
+                ++m_mutation_revision;
             }
 
             std::size_t find_pending_append(const OrderedElementId& id) const {
@@ -720,6 +848,7 @@ namespace sync {
             NodeId m_origin;
             std::vector<LogicalChange> m_pending;
             bool m_active;
+            std::size_t m_mutation_revision;
         };
 
         std::unique_ptr<LogicalCaptureSession> begin_capture_session() const & {

--- a/tests/test_key_ordered_multi_value_destructive_adapter.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_adapter.cpp
@@ -1101,6 +1101,98 @@ void test_destructive_capture_trusted_clear_avoids_repeated_state_scans() {
     cleanup(path);
 }
 
+void test_destructive_capture_uses_transaction_bound_key_index_proof() {
+    const std::string path =
+        "test_key_ordered_multi_value_destructive_key_index_proof.mdbx";
+    const std::string primary = "ordered_proof_values";
+    const std::string state = "ordered_proof_state";
+    const std::string by_key = "ordered_proof_by_key";
+    const std::string schema = "app.ordered_proof.v2";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId origin = make_node(0x69u);
+    const mdbxc::sync::DbId local_db = make_node(0xA9u);
+    const mdbxc::sync::DbId destination = make_node(0xB9u);
+    mdbxc::sync::SyncEngine engine(connection);
+    engine.initialize_local_identity(origin, local_db);
+    table_type table(connection, primary);
+    adapter_type adapter(table, schema, state, by_key);
+    engine.initialize_logical_adapter_schema(
+        adapter, make_v2_record(primary, state, by_key, origin));
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->append(1, "first");
+        session->append(1, "second");
+        session->append(1, "third");
+        session->commit_to_outbox(engine, destination);
+    }
+
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        bool default_rejected = false;
+        try {
+            (void)session->erase_value(1, "second", { 3u, 24u });
+        } catch (const std::length_error&) {
+            default_rejected = true;
+        }
+        if (!default_rejected || table.find(1).size() != 3u) {
+            throw std::runtime_error(
+                "default ordered selector did not enforce reverse-scan budget");
+        }
+    }
+
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        const mdbxc::sync::OrderedElementKeyIndexProof proof =
+            session->validate_key_index(1, { 3u, 32u });
+        if (session->erase_value_trusted(1, "second", proof, { 3u, 24u }) != 1u) {
+            throw std::runtime_error(
+                "trusted ordered selector removed the wrong number of values");
+        }
+        session->commit_to_outbox(engine, destination);
+    }
+    const std::vector<std::string> remaining = table.find(1);
+    if (remaining.size() != 2u || remaining[0] != "first" ||
+        remaining[1] != "third") {
+        throw std::runtime_error(
+            "trusted ordered selector changed the wrong physical values");
+    }
+
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        const mdbxc::sync::OrderedElementKeyIndexProof proof =
+            session->validate_key_index(1, { 3u, 32u });
+        session->append(1, "new");
+        bool stale_rejected = false;
+        try {
+            (void)session->erase_key_trusted(1, proof, { 3u, 32u });
+        } catch (const std::logic_error&) {
+            stale_rejected = true;
+        }
+        if (!stale_rejected) {
+            throw std::runtime_error(
+                "ordered key index proof survived a capture mutation");
+        }
+    }
+    if (table.find(1).size() != 2u) {
+        throw std::runtime_error(
+            "stale ordered key index proof changed the table");
+    }
+
+    connection->disconnect();
+    cleanup(path);
+}
+
 void test_ordered_delivery_rolls_back_malformed_v2_change_and_deduplicates() {
     const std::string path = "test_key_ordered_multi_value_destructive_replay.mdbx";
     const std::string primary = "ordered_replay_values";
@@ -1777,6 +1869,7 @@ int main() {
     test_destructive_capture_clear_rejects_complete_schema_corruption();
     test_destructive_capture_clear_checks_tombstone_only_origin_high_water();
     test_destructive_capture_trusted_clear_avoids_repeated_state_scans();
+    test_destructive_capture_uses_transaction_bound_key_index_proof();
     test_ordered_delivery_rolls_back_malformed_v2_change_and_deduplicates();
     test_destructive_preflight_rejects_untracked_physical_value();
     test_destructive_preflight_rejects_state_index_corruption();


### PR DESCRIPTION
## Summary\n- centralize fail-closed state/index validation\n- expose a session-bound proof for the same MDBX transaction and mutation revision\n- add explicit trusted erase selectors that skip a repeated reverse scan\n- retain the ordinary full-scan selectors as the default fallback\n\n## Validation\n- test_key_ordered_multi_value_destructive_adapter under MinGW C++11/C++17\n- git diff --check