### PR TITLE
bench(sync): correct ordered scan accounting

### DIFF
--- a/benchmarks/README-sync-RU.md
+++ b/benchmarks/README-sync-RU.md
@@ -166,20 +166,25 @@ records. `elapsed_ms` включает открытие read transaction, изм
 добавления index, cache или фиксированного лимита к любому из путей
 корректности.
 
-CSV также содержит отдельные строки `live_ids_for_key_index` и
-`live_state_ids_for_key`: первая измеряет DUPSORT lookup, вторая - полную
-обратную проверку state DBI. `estimated_scanned_records` показывает границу
-работы сценария, а не внутренний счётчик.
+CSV также содержит отдельные строки `live_ids_for_key_index`,
+`live_state_ids_for_key` и `verify_introduced_high_water`. Поле
+`estimated_scanned_records_per_iteration` показывает оценку числа прочитанных
+records за одну итерацию соответствующей строки, а не внутренний счётчик.
+Для index path учитываются одна DUPSORT-запись и одно чтение state на каждый
+matching id; reverse path учитывает полный scan state DBI; high-water path
+учитывает records элементов каждого origin и его introduced high-water marker.
+`matched_live_ids` накапливается за все `iterations`.
 
-Обратная проверка остаётся эталонным fail-closed путём. Будущий trusted
-no-rescan путь должен сохранять этот fallback и документировать доказательство,
-делающее bounded scan безопасным. `BroadEraseBounds::max_scanned_records`
-должен покрывать выбранную операцию; меньший лимит должен приводить к отказу
-до mutation.
+Обратная проверка остаётся эталонным fail-closed путём. Proof-based trusted
+selector path уже реализован как явный opt-in: он может повторно использовать
+полный transaction-bound proof, но обязан сохранять этот fallback и проверки
+physical/state records. `BroadEraseBounds::max_scanned_records` должен
+покрывать выбранную операцию в обычном validation path; меньший лимит должен
+приводить к отказу до mutation.
 
 Bounded destructive capture теперь использует предварительно проверенные exact
 id на стадии mutation и не повторяет это полное reverse-сканирование для
 каждого выбранного id. Соответствующий regression сохраняет state с большим
-числом tombstone и одним Live element при намеренно жёстком scan budget;
-используйте этот benchmark для сравнения более крупных распределений state и
-tombstone перед изменением trusted path.
+числом tombstone и одним Live element при намеренно жёстком scan budget.
+Используйте этот benchmark для сравнения более крупных распределений state и
+tombstone перед изменением scan- или proof-контракта.

--- a/benchmarks/README-sync.md
+++ b/benchmarks/README-sync.md
@@ -157,20 +157,28 @@ the default is zero. CSV rows separately report total, Live, and Tombstone
 element records, the full state-record count, and live DUPSORT index records.
 CSV now has separate rows for `live_ids_for_key_index` and
 `live_state_ids_for_key`. The first measures the DUPSORT lookup; the second
-measures the full reverse validation scan. `estimated_scanned_records` is a
-workload bound, not an internal counter. `elapsed_ms` includes read-transaction
-open, the measured scan, and rollback. Use results from representative
-workloads before adding an index, cache, or fixed limit to either correctness
-path.
+measures the full reverse validation scan. The
+`verify_introduced_high_water` row measures the per-origin integrity scan.
+`estimated_scanned_records_per_iteration` is the estimated record work for one
+iteration of that row, not an internal counter. The index estimate includes
+one DUPSORT record and one state point read per matching id; the reverse
+estimate includes the complete state scan; the high-water estimate includes
+each origin's element records and its introduced high-water record.
+`matched_live_ids` is cumulative across all `iterations`. `elapsed_ms` includes
+read-transaction open, the measured scan, and rollback. Use results from
+representative workloads before adding an index, cache, or fixed limit to
+either correctness path.
 
-The reverse-validation row is intentionally the reference path. Any future
-trusted no-rescan path must retain this path as a fallback and must document
-the proof that makes its bounded scan safe. `BroadEraseBounds::max_scanned_records`
-must be large enough for the selected operation while this validation path is
-enabled; a smaller bound is expected to reject before mutation.
+The reverse-validation row is intentionally the reference path. The
+proof-based trusted selector path is implemented as an explicit opt-in: it may
+reuse a complete transaction-bound validation proof, but must retain this row
+as its fail-closed fallback and keep the physical/state point checks. A
+`BroadEraseBounds::max_scanned_records` value must be large enough for the
+selected operation while the ordinary validation path is enabled; a smaller
+bound is expected to reject before mutation.
 
 Bounded destructive capture now uses prevalidated exact ids for its mutation
 phase and does not repeat this full reverse scan for every selected id. The
 corresponding regression retains a tombstone-heavy state with one Live element
-and a deliberately tight scan budget; use this benchmark to compare larger
-state and tombstone distributions before changing that trusted path.
+and a deliberately tight scan budget. Use this benchmark to compare larger
+state and tombstone distributions before changing the scan or proof contract.

--- a/benchmarks/ordered_destructive_state_benchmark.cpp
+++ b/benchmarks/ordered_destructive_state_benchmark.cpp
@@ -271,29 +271,35 @@ void run(const Scenario& scenario) {
     const std::uint64_t state_records =
         scenario.origins * (scenario.elements_per_origin + 2u);
     const std::uint64_t by_key_records = live_element_records;
+    const std::uint64_t index_records_per_iteration =
+        expected_target_ids(scenario) * 2u;
+    const std::uint64_t reverse_records_per_iteration = state_records;
+    const std::uint64_t high_water_records_per_iteration =
+        scenario.origins * (scenario.elements_per_origin + 1u);
     std::cout
         << "scan,origins,elements_per_origin,key_count,iterations,element_records,"
         << "live_element_records,tombstone_records,state_records,by_key_records,"
-        << "estimated_scanned_records,matched_live_ids,elapsed_ms\n"
+        << "estimated_scanned_records_per_iteration,matched_live_ids,elapsed_ms\n"
         << "live_ids_for_key_index," << scenario.origins << ','
         << scenario.elements_per_origin << ',' << scenario.key_count << ','
         << scenario.iterations << ',' << element_records << ','
         << live_element_records << ',' << tombstone_records << ','
         << state_records << ',' << by_key_records << ','
-        << expected_target_ids(scenario) << ',' << matched_index_ids << ','
+        << index_records_per_iteration << ',' << matched_index_ids << ','
         << index_ms << '\n'
         << "live_state_ids_for_key," << scenario.origins << ','
         << scenario.elements_per_origin << ',' << scenario.key_count << ','
         << scenario.iterations << ',' << element_records << ','
         << live_element_records << ',' << tombstone_records << ','
-        << state_records << ',' << by_key_records << ',' << state_records << ','
+        << state_records << ',' << by_key_records << ','
+        << reverse_records_per_iteration << ','
         << matched_live_ids << ',' << reverse_ms << '\n'
         << "verify_introduced_high_water," << scenario.origins << ','
         << scenario.elements_per_origin << ',' << scenario.key_count << ','
         << scenario.iterations << ',' << element_records << ','
         << live_element_records << ',' << tombstone_records << ','
         << state_records << ',' << by_key_records << ','
-        << scenario.elements_per_origin << ','
+        << high_water_records_per_iteration << ','
         << 0u << ',' << origin_ms << '\n';
     connection->disconnect();
 }


### PR DESCRIPTION
Corrects ordered destructive benchmark per-iteration record estimates for index, reverse-state, and high-water paths. Clarifies cumulative output and documents the implemented proof-based trusted selector fallback in English and Russian benchmark guides.