### PR TITLE
feat(sync): define validated full snapshot chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Sync: add the validated preparatory `FullSnapshotCodec` boundary for
+  manifest-bearing `seq=0` snapshot chunks. Full-snapshot transport and apply
+  remain explicitly unsupported until continuation and replacement semantics
+  are implemented.
+
 - Added an opt-in transaction-bound ordered key-index proof for trusted
   destructive selector resolution. The default full reverse validation remains
   the fail-closed fallback; trusted selector calls still enforce their bounds

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,6 +457,7 @@ if(MDBXC_BUILD_TESTS)
           mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
         mdbx_containers/sync/ChangeBatch.hpp
         mdbx_containers/sync/ChangeBatchCodec.hpp
+        mdbx_containers/sync/FullSnapshotProtocol.hpp
         mdbx_containers/sync/SyncApplyObserver.hpp
         mdbx_containers/sync/SyncNodeSession.hpp
         mdbx_containers/sync/SyncWorkerGuard.hpp

--- a/include/mdbx_containers/sync.hpp
+++ b/include/mdbx_containers/sync.hpp
@@ -33,6 +33,7 @@
 #include "sync/CodecBounds.hpp"
 #include "sync/ChangeBatch.hpp"
 #include "sync/ChangeBatchCodec.hpp"
+#include "sync/FullSnapshotProtocol.hpp"
 #include "sync/ChangeAccumulator.hpp"
 #include "sync/SyncCaptureScope.hpp"
 #include "sync/cancellation.hpp"

--- a/include/mdbx_containers/sync/CodecBounds.hpp
+++ b/include/mdbx_containers/sync/CodecBounds.hpp
@@ -30,6 +30,10 @@ namespace sync {
             16u * 1024u; ///< Max logical delivery frame id bytes.
         std::uint32_t max_transport_message_bytes =
             128u * 1024u * 1024u; ///< Max encoded transport message bytes.
+        std::uint32_t max_snapshot_id_len = 256u; ///< Max snapshot identity bytes.
+        std::uint32_t max_snapshot_manifest_entries = 10000u; ///< Max DBIs in one snapshot manifest.
+        std::uint32_t max_snapshot_chunk_bytes =
+            128u * 1024u * 1024u; ///< Max encoded full-snapshot chunk bytes.
     };
 
 } // namespace sync

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1479,8 +1479,16 @@ B: applies each page as above
 
 The reserved `seq=0, BATCH_HAS_MORE` full export/import format remains planned
 for v0.1 and is not the current cold-replica implementation.
-`PullRequest::request_full_snapshot=true` is rejected explicitly until that
-format is implemented. In v0.1 this is a sync-level protocol rejection carried
+`FullSnapshotProtocol.hpp` now defines and validates a preparatory chunk
+codec: every chunk carries a source identity, stable `snapshot_id`, chunk
+index, immutable named-user-DBI manifest, and a nested raw batch with `seq=0`.
+The codec is deliberately not wired into `PullRequest::request_full_snapshot`
+yet. The transport path still needs continuation-token validation, cursor
+bootstrap semantics, and an atomic replacement apply path before the flag can
+be accepted.
+`PullRequest::request_full_snapshot=true` is rejected explicitly until the
+transport and replacement apply path are implemented. In v0.1 this is a
+sync-level protocol rejection carried
 as `PullResponse{ok=false, error=..., error_code=UnsupportedFullSnapshot}`; it
 does not produce a transport retry hint because the server returned a valid
 sync response rather than a transport failure.

--- a/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
+++ b/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
@@ -60,6 +60,7 @@ namespace sync {
         static std::vector<std::uint8_t> encode(
                 const FullSnapshotChunk& chunk,
                 const CodecBounds* bounds = nullptr) {
+            bounds = effective_bounds(bounds);
             validate(chunk, bounds);
             const std::vector<std::uint8_t> nested =
                 ChangeBatchCodec::encode(chunk.batch, bounds);
@@ -91,6 +92,7 @@ namespace sync {
         static FullSnapshotChunk decode(
                 const std::vector<std::uint8_t>& encoded,
                 const CodecBounds* bounds = nullptr) {
+            bounds = effective_bounds(bounds);
             validate_encoded_size(encoded, bounds);
             Cursor cursor = make_cursor(encoded);
             check_bytes(cursor, magic(), magic_size());
@@ -138,6 +140,7 @@ namespace sync {
 
         static void validate(const FullSnapshotChunk& chunk,
                              const CodecBounds* bounds = nullptr) {
+            bounds = effective_bounds(bounds);
             if (is_zero_id(chunk.source_node_id) ||
                 is_zero_id(chunk.source_db_uuid)) {
                 throw std::runtime_error(
@@ -146,13 +149,11 @@ namespace sync {
             if (chunk.snapshot_id.empty()) {
                 throw std::invalid_argument("Full snapshot id is empty");
             }
-            if (bounds != nullptr &&
-                chunk.snapshot_id.size() > bounds->max_snapshot_id_len) {
+            if (chunk.snapshot_id.size() > bounds->max_snapshot_id_len) {
                 throw std::length_error(
                     "full snapshot id exceeds max_snapshot_id_len");
             }
-            if (bounds != nullptr &&
-                chunk.manifest.size() > bounds->max_snapshot_manifest_entries) {
+            if (chunk.manifest.size() > bounds->max_snapshot_manifest_entries) {
                 throw std::length_error(
                     "full snapshot manifest exceeds max_snapshot_manifest_entries");
             }
@@ -170,9 +171,7 @@ namespace sync {
                     throw std::invalid_argument(
                         "Full snapshot manifest must be sorted and unique");
                 }
-                if (entry.dbi_name.size() >
-                    (bounds == nullptr ? static_cast<std::size_t>(256u) :
-                        bounds->max_dbi_name_len)) {
+                if (entry.dbi_name.size() > bounds->max_dbi_name_len) {
                     throw std::length_error(
                         "full snapshot manifest DBI name exceeds max_dbi_name_len");
                 }
@@ -191,18 +190,20 @@ namespace sync {
                     "Full snapshot continuation does not match batch flags");
             }
             for (std::size_t i = 0u; i < chunk.batch.ops.size(); ++i) {
-                if (is_reserved_dbi(chunk.batch.ops[i].dbi_name)) {
+                const ChangeOp& op = chunk.batch.ops[i];
+                validate_snapshot_operation(op);
+                if (is_reserved_dbi(op.dbi_name)) {
                     throw std::invalid_argument(
                         "Full snapshot contains a reserved DBI operation");
                 }
                 std::uint32_t manifest_flags = 0u;
                 if (!manifest_entry_flags(chunk.manifest,
-                                          chunk.batch.ops[i].dbi_name,
+                                          op.dbi_name,
                                           manifest_flags)) {
                     throw std::invalid_argument(
                         "Full snapshot operation is outside its manifest");
                 }
-                if (chunk.batch.ops[i].dbi_flags != manifest_flags) {
+                if (op.dbi_flags != manifest_flags) {
                     throw std::invalid_argument(
                         "Full snapshot operation DBI flags differ from manifest");
                 }
@@ -218,6 +219,30 @@ namespace sync {
 
         static bool is_reserved_dbi(const std::string& name) {
             return name.size() >= 7u && name.compare(0u, 7u, "_mdbxc_") == 0;
+        }
+
+        static const CodecBounds* effective_bounds(
+                const CodecBounds* bounds) {
+            static const CodecBounds defaults;
+            return bounds != nullptr ? bounds : &defaults;
+        }
+
+        static void validate_snapshot_operation(const ChangeOp& op) {
+            if (op.op_type != ChangeOpType::Put &&
+                op.op_type != ChangeOpType::ClearTable) {
+                throw std::invalid_argument(
+                    "Full snapshot operation must be Put or ClearTable");
+            }
+            if (op.op_flags != OP_NONE || !op.identity_key.empty() ||
+                !op.revision_key.empty()) {
+                throw std::invalid_argument(
+                    "Full snapshot operation contains non-physical metadata");
+            }
+            if (op.op_type == ChangeOpType::ClearTable &&
+                (!op.storage_key.empty() || !op.value.empty())) {
+                throw std::invalid_argument(
+                    "Full snapshot ClearTable operation contains key or value bytes");
+            }
         }
 
         static bool is_zero_id(const NodeId& id) {
@@ -352,8 +377,7 @@ namespace sync {
         static void validate_encoded_size(
                 const std::vector<std::uint8_t>& encoded,
                 const CodecBounds* bounds) {
-            if (bounds != nullptr &&
-                encoded.size() > bounds->max_snapshot_chunk_bytes) {
+            if (encoded.size() > bounds->max_snapshot_chunk_bytes) {
                 throw std::length_error(
                     "full snapshot chunk exceeds max_snapshot_chunk_bytes");
             }

--- a/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
+++ b/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
@@ -1,0 +1,366 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_FULL_SNAPSHOT_PROTOCOL_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_FULL_SNAPSHOT_PROTOCOL_HPP_INCLUDED
+
+/// \file FullSnapshotProtocol.hpp
+/// \brief Explicit full-snapshot chunk contract and codec.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "ChangeBatchCodec.hpp"
+#include "CodecBounds.hpp"
+#include "common.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief One named user DBI in an immutable snapshot manifest.
+    struct FullSnapshotManifestEntry {
+        std::string dbi_name;
+        std::uint32_t dbi_flags = 0u;
+    };
+
+    /// \brief One chunk of a full database export.
+    /// \details Snapshot chunks are not changelog batches. They carry a
+    /// stable source identity, an immutable manifest, and a nested raw batch
+    /// whose sequence is always zero. A future transport may accept this
+    /// contract only after validating the complete manifest and snapshot
+    /// continuation before any user-DBI mutation.
+    struct FullSnapshotChunk {
+        NodeId source_node_id{};
+        DbId source_db_uuid{};
+        std::string snapshot_id;
+        std::uint64_t chunk_index = 0u;
+        bool has_more = false;
+        std::vector<FullSnapshotManifestEntry> manifest;
+        ChangeBatch batch;
+    };
+
+    /// \brief Strict codec for the reserved full-snapshot wire boundary.
+    /// \details This codec is preparatory. v0.1 pull responders still reject
+    /// \c PullRequest::request_full_snapshot until a transport dispatcher and
+    /// validated replacement apply path are available.
+    class FullSnapshotCodec {
+    public:
+        static const std::uint8_t* magic() {
+            static const std::uint8_t value[8] =
+                { 'M', 'D', 'B', 'X', 'C', 'S', 'N', 'P' };
+            return value;
+        }
+
+        static std::size_t magic_size() { return 8u; }
+        static std::uint16_t codec_version() { return 1u; }
+
+        static std::vector<std::uint8_t> encode(
+                const FullSnapshotChunk& chunk,
+                const CodecBounds* bounds = nullptr) {
+            validate(chunk, bounds);
+            const std::vector<std::uint8_t> nested =
+                ChangeBatchCodec::encode(chunk.batch, bounds);
+            std::vector<std::uint8_t> out;
+            append_bytes(out, magic(), magic_size());
+            detail::append_u16_le(out, codec_version());
+            append_bytes(out, chunk.source_node_id.data(),
+                         chunk.source_node_id.size());
+            append_bytes(out, chunk.source_db_uuid.data(),
+                         chunk.source_db_uuid.size());
+            append_string(out, chunk.snapshot_id);
+            detail::append_u64_le(out, chunk.chunk_index);
+            out.push_back(chunk.has_more ? 1u : 0u);
+            detail::append_u32_le(
+                out, static_cast<std::uint32_t>(chunk.manifest.size()));
+            for (std::size_t i = 0u; i < chunk.manifest.size(); ++i) {
+                append_string(out, chunk.manifest[i].dbi_name);
+                detail::append_u32_le(out, chunk.manifest[i].dbi_flags);
+            }
+            if (nested.size() > (std::numeric_limits<std::uint32_t>::max)()) {
+                throw std::length_error("full snapshot nested batch exceeds u32");
+            }
+            detail::append_u32_le(out, static_cast<std::uint32_t>(nested.size()));
+            append_bytes(out, nested.empty() ? nullptr : &nested[0], nested.size());
+            validate_encoded_size(out, bounds);
+            return out;
+        }
+
+        static FullSnapshotChunk decode(
+                const std::vector<std::uint8_t>& encoded,
+                const CodecBounds* bounds = nullptr) {
+            validate_encoded_size(encoded, bounds);
+            Cursor cursor = make_cursor(encoded);
+            check_bytes(cursor, magic(), magic_size());
+            if (read_u16_le(cursor) != codec_version()) {
+                throw std::runtime_error("Unsupported full snapshot codec version");
+            }
+            FullSnapshotChunk out;
+            read_bytes(cursor, out.source_node_id.data(), out.source_node_id.size());
+            read_bytes(cursor, out.source_db_uuid.data(), out.source_db_uuid.size());
+            out.snapshot_id = read_string(
+                cursor, bounds == nullptr ? 256u : bounds->max_snapshot_id_len,
+                "full snapshot id exceeds max_snapshot_id_len");
+            out.chunk_index = read_u64_le(cursor);
+            const std::uint8_t has_more = read_u8(cursor);
+            if (has_more > 1u) {
+                throw std::runtime_error("Invalid full snapshot continuation flag");
+            }
+            out.has_more = has_more != 0u;
+            const std::uint32_t manifest_count = read_u32_le(cursor);
+            if (bounds != nullptr &&
+                manifest_count > bounds->max_snapshot_manifest_entries) {
+                throw std::length_error(
+                    "full snapshot manifest exceeds max_snapshot_manifest_entries");
+            }
+            out.manifest.resize(manifest_count);
+            for (std::uint32_t i = 0u; i < manifest_count; ++i) {
+                out.manifest[i].dbi_name = read_string(
+                    cursor, bounds == nullptr ? 256u : bounds->max_dbi_name_len,
+                    "full snapshot manifest DBI name exceeds max_dbi_name_len");
+                out.manifest[i].dbi_flags = read_u32_le(cursor);
+            }
+            const std::uint32_t nested_size = read_u32_le(cursor);
+            const std::uint8_t* nested_data = read_pointer(cursor, nested_size);
+            std::vector<std::uint8_t> nested(nested_size);
+            if (nested_size != 0u) {
+                std::memcpy(&nested[0], nested_data, nested_size);
+            }
+            out.batch = ChangeBatchCodec::decode_exact(nested, bounds);
+            if (cursor.pos != cursor.size) {
+                throw std::runtime_error("Trailing bytes after full snapshot chunk");
+            }
+            validate(out, bounds);
+            return out;
+        }
+
+        static void validate(const FullSnapshotChunk& chunk,
+                             const CodecBounds* bounds = nullptr) {
+            if (is_zero_id(chunk.source_node_id) ||
+                is_zero_id(chunk.source_db_uuid)) {
+                throw std::runtime_error(
+                    "Full snapshot source identity is incomplete");
+            }
+            if (chunk.snapshot_id.empty()) {
+                throw std::invalid_argument("Full snapshot id is empty");
+            }
+            if (bounds != nullptr &&
+                chunk.snapshot_id.size() > bounds->max_snapshot_id_len) {
+                throw std::length_error(
+                    "full snapshot id exceeds max_snapshot_id_len");
+            }
+            if (bounds != nullptr &&
+                chunk.manifest.size() > bounds->max_snapshot_manifest_entries) {
+                throw std::length_error(
+                    "full snapshot manifest exceeds max_snapshot_manifest_entries");
+            }
+            if (chunk.manifest.empty()) {
+                throw std::invalid_argument("Full snapshot manifest is empty");
+            }
+            for (std::size_t i = 0u; i < chunk.manifest.size(); ++i) {
+                const FullSnapshotManifestEntry& entry = chunk.manifest[i];
+                if (entry.dbi_name.empty() || is_reserved_dbi(entry.dbi_name)) {
+                    throw std::invalid_argument(
+                        "Full snapshot manifest contains a reserved or empty DBI");
+                }
+                if (i != 0u &&
+                    chunk.manifest[i - 1u].dbi_name >= entry.dbi_name) {
+                    throw std::invalid_argument(
+                        "Full snapshot manifest must be sorted and unique");
+                }
+                if (entry.dbi_name.size() >
+                    (bounds == nullptr ? static_cast<std::size_t>(256u) :
+                        bounds->max_dbi_name_len)) {
+                    throw std::length_error(
+                        "full snapshot manifest DBI name exceeds max_dbi_name_len");
+                }
+            }
+            if (chunk.batch.version != ChangeBatchCodec::batch_version() ||
+                chunk.batch.seq != 0u ||
+                chunk.batch.origin_node_id != chunk.source_node_id) {
+                throw std::invalid_argument(
+                    "Full snapshot batch must use source identity and seq=0");
+            }
+            const std::uint32_t expected_flags =
+                chunk.has_more ? static_cast<std::uint32_t>(BATCH_HAS_MORE) :
+                    static_cast<std::uint32_t>(BATCH_NONE);
+            if (chunk.batch.batch_flags != expected_flags) {
+                throw std::invalid_argument(
+                    "Full snapshot continuation does not match batch flags");
+            }
+            for (std::size_t i = 0u; i < chunk.batch.ops.size(); ++i) {
+                if (is_reserved_dbi(chunk.batch.ops[i].dbi_name)) {
+                    throw std::invalid_argument(
+                        "Full snapshot contains a reserved DBI operation");
+                }
+                std::uint32_t manifest_flags = 0u;
+                if (!manifest_entry_flags(chunk.manifest,
+                                          chunk.batch.ops[i].dbi_name,
+                                          manifest_flags)) {
+                    throw std::invalid_argument(
+                        "Full snapshot operation is outside its manifest");
+                }
+                if (chunk.batch.ops[i].dbi_flags != manifest_flags) {
+                    throw std::invalid_argument(
+                        "Full snapshot operation DBI flags differ from manifest");
+                }
+            }
+        }
+
+    private:
+        struct Cursor {
+            const std::uint8_t* data;
+            std::size_t size;
+            std::size_t pos;
+        };
+
+        static bool is_reserved_dbi(const std::string& name) {
+            return name.size() >= 7u && name.compare(0u, 7u, "_mdbxc_") == 0;
+        }
+
+        static bool is_zero_id(const NodeId& id) {
+            for (std::size_t i = 0u; i < id.size(); ++i) {
+                if (id[i] != 0u) return false;
+            }
+            return true;
+        }
+
+        static bool manifest_entry_flags(
+                const std::vector<FullSnapshotManifestEntry>& manifest,
+                const std::string& name,
+                std::uint32_t& flags) {
+            for (std::size_t i = 0u; i < manifest.size(); ++i) {
+                if (manifest[i].dbi_name == name) {
+                    flags = manifest[i].dbi_flags;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        static void append_bytes(std::vector<std::uint8_t>& out,
+                                 const std::uint8_t* data,
+                                 std::size_t size) {
+            if (size == 0u) return;
+            if (data == nullptr ||
+                size > (std::numeric_limits<std::size_t>::max)() - out.size()) {
+                throw std::length_error("full snapshot size overflow");
+            }
+            const std::size_t old_size = out.size();
+            out.resize(old_size + size);
+            std::memcpy(&out[old_size], data, size);
+        }
+
+        static void append_string(std::vector<std::uint8_t>& out,
+                                  const std::string& value) {
+            if (value.size() > (std::numeric_limits<std::uint32_t>::max)()) {
+                throw std::length_error("full snapshot string exceeds u32");
+            }
+            detail::append_u32_le(out, static_cast<std::uint32_t>(value.size()));
+            append_bytes(out,
+                         value.empty() ? nullptr :
+                             reinterpret_cast<const std::uint8_t*>(value.data()),
+                         value.size());
+        }
+
+        static Cursor make_cursor(const std::vector<std::uint8_t>& encoded) {
+            Cursor out = { encoded.empty() ? nullptr : &encoded[0],
+                           encoded.size(), 0u };
+            return out;
+        }
+
+        static void require(Cursor& cursor, std::size_t size) {
+            if (size > cursor.size - cursor.pos) {
+                throw std::runtime_error("Truncated full snapshot chunk");
+            }
+        }
+
+        static void check_bytes(Cursor& cursor, const std::uint8_t* expected,
+                                std::size_t size) {
+            require(cursor, size);
+            if (std::memcmp(cursor.data + cursor.pos, expected, size) != 0) {
+                throw std::runtime_error("Invalid full snapshot magic");
+            }
+            cursor.pos += size;
+        }
+
+        static std::uint8_t read_u8(Cursor& cursor) {
+            require(cursor, 1u);
+            return cursor.data[cursor.pos++];
+        }
+
+        static std::uint16_t read_u16_le(Cursor& cursor) {
+            require(cursor, 2u);
+            const std::uint16_t out =
+                static_cast<std::uint16_t>(cursor.data[cursor.pos]) |
+                static_cast<std::uint16_t>(cursor.data[cursor.pos + 1u] << 8u);
+            cursor.pos += 2u;
+            return out;
+        }
+
+        static std::uint32_t read_u32_le(Cursor& cursor) {
+            require(cursor, 4u);
+            std::uint32_t out = 0u;
+            for (std::size_t i = 0u; i < 4u; ++i) {
+                out |= static_cast<std::uint32_t>(cursor.data[cursor.pos + i])
+                    << (8u * i);
+            }
+            cursor.pos += 4u;
+            return out;
+        }
+
+        static std::uint64_t read_u64_le(Cursor& cursor) {
+            require(cursor, 8u);
+            std::uint64_t out = 0u;
+            for (std::size_t i = 0u; i < 8u; ++i) {
+                out |= static_cast<std::uint64_t>(cursor.data[cursor.pos + i])
+                    << (8u * i);
+            }
+            cursor.pos += 8u;
+            return out;
+        }
+
+        static const std::uint8_t* read_pointer(Cursor& cursor,
+                                                 std::size_t size) {
+            require(cursor, size);
+            const std::uint8_t* out = cursor.data + cursor.pos;
+            cursor.pos += size;
+            return out;
+        }
+
+        static void read_bytes(Cursor& cursor, std::uint8_t* out,
+                               std::size_t size) {
+            const std::uint8_t* data = read_pointer(cursor, size);
+            if (size != 0u) std::memcpy(out, data, size);
+        }
+
+        static std::string read_string(Cursor& cursor,
+                                       std::size_t max_size,
+                                       const char* error) {
+            const std::uint32_t size = read_u32_le(cursor);
+            if (size > max_size) {
+                throw std::length_error(error);
+            }
+            const std::uint8_t* data = read_pointer(cursor, size);
+            return size == 0u
+                ? std::string()
+                : std::string(reinterpret_cast<const char*>(data), size);
+        }
+
+        static void validate_encoded_size(
+                const std::vector<std::uint8_t>& encoded,
+                const CodecBounds* bounds) {
+            if (bounds != nullptr &&
+                encoded.size() > bounds->max_snapshot_chunk_bytes) {
+                throw std::length_error(
+                    "full snapshot chunk exceeds max_snapshot_chunk_bytes");
+            }
+        }
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_FULL_SNAPSHOT_PROTOCOL_HPP_INCLUDED

--- a/tests/test_full_snapshot_protocol.cpp
+++ b/tests/test_full_snapshot_protocol.cpp
@@ -1,0 +1,127 @@
+#include <mdbx_containers/sync.hpp>
+
+#include "test_assert.hpp"
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+mdbxc::sync::NodeId make_id(std::uint8_t seed) {
+    mdbxc::sync::NodeId out{};
+    for (std::size_t i = 0u; i < out.size(); ++i) {
+        out[i] = static_cast<std::uint8_t>(seed + i);
+    }
+    return out;
+}
+
+mdbxc::sync::FullSnapshotChunk make_chunk() {
+    mdbxc::sync::FullSnapshotChunk out;
+    out.source_node_id = make_id(0x10u);
+    out.source_db_uuid = make_id(0x20u);
+    out.snapshot_id = "snapshot-1";
+    out.chunk_index = 0u;
+    out.has_more = true;
+
+    mdbxc::sync::FullSnapshotManifestEntry manifest_entry;
+    manifest_entry.dbi_name = "documents";
+    manifest_entry.dbi_flags = 0u;
+    out.manifest.push_back(manifest_entry);
+
+    out.batch.origin_node_id = out.source_node_id;
+    out.batch.seq = 0u;
+    out.batch.batch_flags = mdbxc::sync::BATCH_HAS_MORE;
+    mdbxc::sync::ChangeOp op;
+    op.op_type = mdbxc::sync::ChangeOpType::Put;
+    op.dbi_name = "documents";
+    op.storage_key.push_back(0x01u);
+    op.value.push_back(0x02u);
+    out.batch.ops.push_back(op);
+    return out;
+}
+
+template <typename Fn>
+bool throws(Fn fn) {
+    try {
+        fn();
+    } catch (const std::exception&) {
+        return true;
+    }
+    return false;
+}
+
+void test_full_snapshot_round_trip() {
+    const mdbxc::sync::FullSnapshotChunk source = make_chunk();
+    const std::vector<std::uint8_t> encoded =
+        mdbxc::sync::FullSnapshotCodec::encode(source);
+    const mdbxc::sync::FullSnapshotChunk decoded =
+        mdbxc::sync::FullSnapshotCodec::decode(encoded);
+
+    MDBXC_TEST_ASSERT(decoded.source_node_id == source.source_node_id);
+    MDBXC_TEST_ASSERT(decoded.source_db_uuid == source.source_db_uuid);
+    MDBXC_TEST_ASSERT(decoded.snapshot_id == source.snapshot_id);
+    MDBXC_TEST_ASSERT(decoded.chunk_index == 0u);
+    MDBXC_TEST_ASSERT(decoded.has_more);
+    MDBXC_TEST_ASSERT(decoded.manifest.size() == 1u);
+    MDBXC_TEST_ASSERT(decoded.manifest[0].dbi_name == "documents");
+    MDBXC_TEST_ASSERT(decoded.batch.seq == 0u);
+    MDBXC_TEST_ASSERT(decoded.batch.origin_node_id == source.source_node_id);
+    MDBXC_TEST_ASSERT(decoded.batch.ops.size() == 1u);
+}
+
+void test_full_snapshot_rejects_reserved_and_unlisted_dbis() {
+    mdbxc::sync::FullSnapshotChunk reserved = make_chunk();
+    reserved.manifest[0].dbi_name = "_mdbxc_meta";
+    reserved.batch.ops[0].dbi_name = "_mdbxc_meta";
+    MDBXC_TEST_ASSERT(throws([&reserved]() {
+        mdbxc::sync::FullSnapshotCodec::encode(reserved);
+    }));
+
+    mdbxc::sync::FullSnapshotChunk unlisted = make_chunk();
+    unlisted.batch.ops[0].dbi_name = "other";
+    MDBXC_TEST_ASSERT(throws([&unlisted]() {
+        mdbxc::sync::FullSnapshotCodec::encode(unlisted);
+    }));
+
+    mdbxc::sync::FullSnapshotChunk mismatched_flags = make_chunk();
+    mismatched_flags.batch.ops[0].dbi_flags = 1u;
+    MDBXC_TEST_ASSERT(throws([&mismatched_flags]() {
+        mdbxc::sync::FullSnapshotCodec::encode(mismatched_flags);
+    }));
+}
+
+void test_full_snapshot_rejects_wrong_sequence_and_trailing_bytes() {
+    mdbxc::sync::FullSnapshotChunk wrong_sequence = make_chunk();
+    wrong_sequence.batch.seq = 1u;
+    MDBXC_TEST_ASSERT(throws([&wrong_sequence]() {
+        mdbxc::sync::FullSnapshotCodec::encode(wrong_sequence);
+    }));
+
+    const std::vector<std::uint8_t> encoded =
+        mdbxc::sync::FullSnapshotCodec::encode(make_chunk());
+    std::vector<std::uint8_t> trailing = encoded;
+    trailing.push_back(0xFFu);
+    MDBXC_TEST_ASSERT(throws([&trailing]() {
+        mdbxc::sync::FullSnapshotCodec::decode(trailing);
+    }));
+}
+
+void test_full_snapshot_respects_bounds() {
+    mdbxc::sync::CodecBounds bounds;
+    bounds.max_snapshot_id_len = 4u;
+    MDBXC_TEST_ASSERT(throws([&bounds]() {
+        mdbxc::sync::FullSnapshotCodec::encode(make_chunk(), &bounds);
+    }));
+}
+
+} // namespace
+
+int main() {
+    test_full_snapshot_round_trip();
+    test_full_snapshot_rejects_reserved_and_unlisted_dbis();
+    test_full_snapshot_rejects_wrong_sequence_and_trailing_bytes();
+    test_full_snapshot_respects_bounds();
+    return 0;
+}

--- a/tests/test_full_snapshot_protocol.cpp
+++ b/tests/test_full_snapshot_protocol.cpp
@@ -52,6 +52,31 @@ bool throws(Fn fn) {
     return false;
 }
 
+void write_u32_le(std::vector<std::uint8_t>& bytes,
+                  std::size_t offset,
+                  std::uint32_t value) {
+    MDBXC_TEST_ASSERT(offset + 4u <= bytes.size());
+    for (std::size_t i = 0u; i < 4u; ++i) {
+        bytes[offset + i] = static_cast<std::uint8_t>(value >> (8u * i));
+    }
+}
+
+std::size_t manifest_count_offset(
+        const mdbxc::sync::FullSnapshotChunk& chunk) {
+    return mdbxc::sync::FullSnapshotCodec::magic_size() + 2u +
+        chunk.source_node_id.size() + chunk.source_db_uuid.size() + 4u +
+        chunk.snapshot_id.size() + 8u + 1u;
+}
+
+std::size_t nested_batch_offset(
+        const mdbxc::sync::FullSnapshotChunk& chunk) {
+    std::size_t offset = manifest_count_offset(chunk) + 4u;
+    for (std::size_t i = 0u; i < chunk.manifest.size(); ++i) {
+        offset += 4u + chunk.manifest[i].dbi_name.size() + 4u;
+    }
+    return offset + 4u;
+}
+
 void test_full_snapshot_round_trip() {
     const mdbxc::sync::FullSnapshotChunk source = make_chunk();
     const std::vector<std::uint8_t> encoded =
@@ -116,6 +141,68 @@ void test_full_snapshot_respects_bounds() {
     }));
 }
 
+void test_full_snapshot_default_bounds_reject_hostile_counts() {
+    const mdbxc::sync::FullSnapshotChunk source = make_chunk();
+    const std::vector<std::uint8_t> encoded =
+        mdbxc::sync::FullSnapshotCodec::encode(source);
+
+    std::vector<std::uint8_t> oversized_manifest = encoded;
+    write_u32_le(oversized_manifest, manifest_count_offset(source), 10001u);
+    MDBXC_TEST_ASSERT(throws([&oversized_manifest]() {
+        mdbxc::sync::FullSnapshotCodec::decode(oversized_manifest);
+    }));
+
+    const std::size_t nested_offset = nested_batch_offset(source);
+    std::vector<std::uint8_t> oversized_ops = encoded;
+    const std::size_t ops_count_offset = nested_offset +
+        mdbxc::sync::ChangeBatchCodec::magic_size() + 4u + 4u +
+        source.source_node_id.size() + 8u + 8u;
+    write_u32_le(oversized_ops, ops_count_offset, 10001u);
+    MDBXC_TEST_ASSERT(throws([&oversized_ops]() {
+        mdbxc::sync::FullSnapshotCodec::decode(oversized_ops);
+    }));
+
+    std::vector<std::uint8_t> oversized_nested = encoded;
+    write_u32_le(oversized_nested, nested_offset - 4u, 0xFFFFFFFFu);
+    MDBXC_TEST_ASSERT(throws([&oversized_nested]() {
+        mdbxc::sync::FullSnapshotCodec::decode(oversized_nested);
+    }));
+}
+
+void test_full_snapshot_rejects_non_replacement_operations() {
+    mdbxc::sync::FullSnapshotChunk deleted = make_chunk();
+    deleted.batch.ops[0].op_type = mdbxc::sync::ChangeOpType::Delete;
+    MDBXC_TEST_ASSERT(throws([&deleted]() {
+        mdbxc::sync::FullSnapshotCodec::encode(deleted);
+    }));
+
+    mdbxc::sync::FullSnapshotChunk tombstone_put = make_chunk();
+    tombstone_put.batch.ops[0].op_flags = mdbxc::sync::OP_TOMBSTONE;
+    tombstone_put.batch.ops[0].value.clear();
+    MDBXC_TEST_ASSERT(throws([&tombstone_put]() {
+        mdbxc::sync::FullSnapshotCodec::encode(tombstone_put);
+    }));
+
+    mdbxc::sync::FullSnapshotChunk malformed_clear = make_chunk();
+    malformed_clear.batch.ops[0].op_type =
+        mdbxc::sync::ChangeOpType::ClearTable;
+    malformed_clear.batch.ops[0].value.clear();
+    MDBXC_TEST_ASSERT(throws([&malformed_clear]() {
+        mdbxc::sync::FullSnapshotCodec::encode(malformed_clear);
+    }));
+
+    mdbxc::sync::FullSnapshotChunk clear = make_chunk();
+    clear.batch.ops[0].op_type = mdbxc::sync::ChangeOpType::ClearTable;
+    clear.batch.ops[0].storage_key.clear();
+    clear.batch.ops[0].value.clear();
+    const std::vector<std::uint8_t> encoded =
+        mdbxc::sync::FullSnapshotCodec::encode(clear);
+    const mdbxc::sync::FullSnapshotChunk decoded =
+        mdbxc::sync::FullSnapshotCodec::decode(encoded);
+    MDBXC_TEST_ASSERT(decoded.batch.ops[0].op_type ==
+        mdbxc::sync::ChangeOpType::ClearTable);
+}
+
 } // namespace
 
 int main() {
@@ -123,5 +210,7 @@ int main() {
     test_full_snapshot_rejects_reserved_and_unlisted_dbis();
     test_full_snapshot_rejects_wrong_sequence_and_trailing_bytes();
     test_full_snapshot_respects_bounds();
+    test_full_snapshot_default_bounds_reject_hostile_counts();
+    test_full_snapshot_rejects_non_replacement_operations();
     return 0;
 }


### PR DESCRIPTION
## Summary
- add a strict manifest-bearing full-snapshot chunk codec;
- validate source identity, stable snapshot id, seq=0, continuation flags, user-DBI manifest, DBI flags, and codec bounds;
- keep PullRequest::request_full_snapshot explicitly unsupported until transport continuation and atomic replacement apply are implemented.

## Verification
- C++11 MinGW test_full_snapshot_protocol passed;
- standalone FullSnapshotProtocol.hpp target passed;
- C++17 translation-unit compile passed;
- git diff --check passed.