### PR TITLE
feat(sync): add bounded ordered replace_with capture

### DIFF
--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -792,10 +792,13 @@ may derive ids from raw physical rows, skip tombstone creation, or publish a
 partial frame. Receiver apply remains unchanged because it sees only exact
 `EraseElement` operations.
 
-`replace_with()` is not part of this contract. It needs a separately bounded
-combined plan for removals, new id allocation, repeated input values, and final
-per-key order. Baseline import, multi-origin histories, physical-prefix
-optimization, and tombstone pruning likewise remain separate extensions.
+`replace_with()` is implemented for the single-authoritative-origin schema-v2
+capture session. It first validates the complete desired vector, then expands
+the replacement into exact `EraseElement` and `AppendElement` changes with
+fresh immutable ids in one transaction. Its existing-state and desired-size
+bounds are mandatory; no replacement-specific wire opcode is introduced.
+Baseline import, multi-origin histories, physical-prefix optimization, and
+tombstone pruning likewise remain separate extensions.
 
 Implementation acceptance requires C++11/C++17 coverage for empty and non-empty
 selectors under a zero selected-element budget; exact scan-budget success and

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -793,10 +793,12 @@ partial frame. Receiver apply remains unchanged because it sees only exact
 `EraseElement` operations.
 
 `replace_with()` is implemented for the single-authoritative-origin schema-v2
-capture session. It first validates the complete desired vector, then expands
-the replacement into exact `EraseElement` and `AppendElement` changes with
-fresh immutable ids in one transaction. Its existing-state and desired-size
-bounds are mandatory; no replacement-specific wire opcode is introduced.
+capture session. It first prepares canonical logical bytes, fresh immutable
+ids, and exact `AppendElement` payloads, then resolves the complete old live
+set under one cumulative existing-state bound. It applies the exact
+`EraseElement` and prepared `AppendElement` changes without rescanning the
+complete state. Its existing-state and desired-size bounds are mandatory; no
+replacement-specific wire opcode is introduced.
 Baseline import, multi-origin histories, physical-prefix optimization, and
 tombstone pruning likewise remain separate extensions.
 

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
@@ -289,6 +289,7 @@ namespace sync {
             return out;
         }
 
+    private:
         /// \brief Plans consecutive fresh ids without mutating persistent state.
         /// \details The caller must commit the returned range only after all
         /// replacement preparation has succeeded. When \p high_water_verified
@@ -315,8 +316,10 @@ namespace sync {
             const std::uint64_t introduced = highest_introduced(txn, origin);
             const std::uint64_t previous = allocated > introduced ?
                 allocated : introduced;
-            if (count > static_cast<std::size_t>(
-                    (std::numeric_limits<std::uint64_t>::max)() - previous)) {
+            const std::uint64_t maximum =
+                (std::numeric_limits<std::uint64_t>::max)();
+            if (count > static_cast<std::size_t>(maximum) ||
+                previous > maximum - static_cast<std::uint64_t>(count)) {
                 throw std::overflow_error("Ordered element counter overflow");
             }
             std::vector<OrderedElementId> ids;
@@ -347,6 +350,8 @@ namespace sync {
             write_sequence(txn, state, make_introduced_key(origin), last_sequence,
                            "Ordered element introduced high-water write failed");
         }
+
+    public:
 
         const std::string& state_dbi_name() const {
             return m_state_dbi_name;

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
@@ -68,6 +68,10 @@ namespace sync {
     };
 
     /// \brief Bounds for a destructive ordered replacement.
+    /// \details \c existing bounds every persisted state, primary, and index
+    /// inspection needed to validate and erase the old live set. The desired
+    /// limit bounds prepared replacement memory, fresh ids, and exact append
+    /// changes before the first mutation.
     struct ReplaceWithBounds {
         BroadEraseBounds existing;
         std::size_t max_replacement_elements;
@@ -285,6 +289,65 @@ namespace sync {
             return out;
         }
 
+        /// \brief Plans consecutive fresh ids without mutating persistent state.
+        /// \details The caller must commit the returned range only after all
+        /// replacement preparation has succeeded. When \p high_water_verified
+        /// is true, the caller has already checked this origin while validating
+        /// the complete replacement state in the same transaction.
+        std::vector<OrderedElementId> plan_id_range(
+                MDBX_txn* txn,
+                const NodeId& origin,
+                std::size_t count,
+                bool high_water_verified,
+                OrderedElementCandidateSet* candidates = nullptr) const {
+            txn = checked_txn(
+                txn, "OrderedElementStateStore::plan_id_range");
+            if (compare_node_id(origin, make_zero_node()) == 0) {
+                throw std::invalid_argument("Ordered element origin is zero");
+            }
+            if (count == 0u) return std::vector<OrderedElementId>();
+            if (!high_water_verified) {
+                verify_introduced_high_water(txn, origin, candidates);
+            }
+            const MDBX_dbi state = open_state(txn);
+            const std::uint64_t allocated = read_sequence(
+                txn, state, make_counter_key(origin), "Ordered element counter");
+            const std::uint64_t introduced = highest_introduced(txn, origin);
+            const std::uint64_t previous = allocated > introduced ?
+                allocated : introduced;
+            if (count > static_cast<std::size_t>(
+                    (std::numeric_limits<std::uint64_t>::max)() - previous)) {
+                throw std::overflow_error("Ordered element counter overflow");
+            }
+            std::vector<OrderedElementId> ids;
+            ids.reserve(count);
+            for (std::size_t i = 0u; i < count; ++i) {
+                OrderedElementId id;
+                id.origin = origin;
+                id.sequence = previous + static_cast<std::uint64_t>(i) + 1u;
+                ids.push_back(id);
+            }
+            return ids;
+        }
+
+        /// \brief Commits a prevalidated allocation range after its Live rows exist.
+        void commit_id_range(MDBX_txn* txn,
+                             const NodeId& origin,
+                             std::uint64_t last_sequence) const {
+            txn = checked_txn(
+                txn, "OrderedElementStateStore::commit_id_range");
+            if (compare_node_id(origin, make_zero_node()) == 0 ||
+                last_sequence == 0u) {
+                throw std::invalid_argument(
+                    "Ordered element allocation range is invalid");
+            }
+            const MDBX_dbi state = open_state(txn);
+            write_sequence(txn, state, make_counter_key(origin), last_sequence,
+                           "Ordered element counter write failed");
+            write_sequence(txn, state, make_introduced_key(origin), last_sequence,
+                           "Ordered element introduced high-water write failed");
+        }
+
         const std::string& state_dbi_name() const {
             return m_state_dbi_name;
         }
@@ -457,6 +520,36 @@ namespace sync {
         }
 
     private:
+        /// \brief Writes one already validated Live row without rescanning state.
+        /// \details Used only by the replacement path after it has reserved a
+        /// consecutive id range and validated the complete existing state.
+        void put_live_prevalidated(
+                MDBX_txn* txn,
+                const OrderedElementId& id,
+                const std::vector<std::uint8_t>& key,
+                const std::vector<std::uint8_t>& value) const {
+            txn = checked_txn(
+                txn, "OrderedElementStateStore::put_live_prevalidated");
+            require_id(id);
+            const MDBX_dbi state = open_state(txn);
+            const MDBX_dbi by_key = open_by_key(txn);
+            const std::vector<std::uint8_t> state_key = make_element_key(id);
+            const std::vector<std::uint8_t> state_value = make_live_value(key, value);
+            MDBX_val raw_state_key = make_val(state_key);
+            MDBX_val raw_state_value = make_val(state_value);
+            check_mdbx(mdbx_put(txn, state, &raw_state_key, &raw_state_value,
+                                MDBX_NOOVERWRITE),
+                       "Ordered prevalidated element state write failed");
+
+            const std::vector<std::uint8_t> index_value =
+                encode_ordered_element_id_index(id);
+            MDBX_val raw_key = make_val(key);
+            MDBX_val raw_index_value = make_val(index_value);
+            check_mdbx(mdbx_put(txn, by_key, &raw_key, &raw_index_value,
+                                MDBX_NODUPDATA),
+                       "Ordered prevalidated element key index write failed");
+        }
+
         /// \brief Converts a prevalidated Live record to a tombstone.
         /// \details The caller must have verified the record, its key-index
         /// entry, and its physical primary row in the same transaction.

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueDestructiveState.hpp
@@ -67,6 +67,12 @@ namespace sync {
         std::size_t max_scanned_records;
     };
 
+    /// \brief Bounds for a destructive ordered replacement.
+    struct ReplaceWithBounds {
+        BroadEraseBounds existing;
+        std::size_t max_replacement_elements;
+    };
+
     /// \brief Bounded, deterministic candidate set for exact element erasure.
     /// \details Broad selectors resolve to immutable ids before mutating the
     /// table. This helper centralizes both limits and canonical id ordering so

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
@@ -188,6 +188,7 @@ namespace sync {
             return change;
         }
 
+    private:
         LogicalChange make_append_prepared(
                 const OrderedElementId& id,
                 const std::vector<std::uint8_t>& key_bytes,
@@ -198,6 +199,8 @@ namespace sync {
             encode_append_bytes(id, key_bytes, value_bytes, change.payload);
             return change;
         }
+
+    public:
 
         LogicalChange make_erase(const OrderedElementId& id) const {
             LogicalChange change;

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
@@ -188,6 +188,17 @@ namespace sync {
             return change;
         }
 
+        LogicalChange make_append_prepared(
+                const OrderedElementId& id,
+                const std::vector<std::uint8_t>& key_bytes,
+                const std::vector<std::uint8_t>& value_bytes) const {
+            LogicalChange change;
+            change.schema = schema_ref();
+            change.opcode = KeyOrderedMultiValueDestructiveLogicalAppend;
+            encode_append_bytes(id, key_bytes, value_bytes, change.payload);
+            return change;
+        }
+
         LogicalChange make_erase(const OrderedElementId& id) const {
             LogicalChange change;
             change.schema = schema_ref();
@@ -203,6 +214,22 @@ namespace sync {
         /// of the same new id coalesces to no frame operation while its
         /// allocated counter remains monotonic.
         class LogicalCaptureSession {
+        private:
+            struct ClearPlan {
+                std::vector<OrderedElementId> ids;
+                std::vector<NodeId> element_origins;
+            };
+
+            struct PreparedReplacementAppend {
+                const typename table_type::value_type* source;
+                OrderedElementId id;
+                std::vector<std::uint8_t> key_bytes;
+                std::vector<std::uint8_t> value_bytes;
+                LogicalChange change;
+
+                PreparedReplacementAppend() : source(nullptr) {}
+            };
+
         public:
             explicit LogicalCaptureSession(
                     const KeyOrderedMultiValueTableDestructiveLogicalAdapter& adapter)
@@ -451,61 +478,9 @@ namespace sync {
                 ensure_active();
                 try {
                     OrderedElementCandidateSet candidates(bounds);
-                    const OrderedElementStateScan state_scan =
-                        m_adapter.m_state.scan_all_element_records(
-                            m_txn.handle(), &candidates, true);
-                    std::vector<typename table_type::value_type> physical_entries;
-                    m_adapter.m_table.db_collect_entries(
-                        physical_entries, m_txn.handle(),
-                        [&candidates]() {
-                            candidates.inspect_record();
-                        });
-                    if (physical_entries.size() != state_scan.live_records.size()) {
-                        throw std::runtime_error(
-                            "Ordered destructive table and state counts differ");
-                    }
-                    const std::vector<OrderedElementKeyIndexEntry> index_entries =
-                        m_adapter.m_state.key_index_entries(
-                            m_txn.handle(), &candidates);
-                    std::vector<OrderedElementKeyIndexEntry> expected_index_entries;
-                    std::vector<std::vector<std::uint8_t> > keys;
-                    std::vector<std::vector<OrderedElementId> > state_ids;
-                    for (std::size_t i = 0u;
-                         i < state_scan.live_records.size(); ++i) {
-                        const std::size_t key_index = find_key_group(
-                            keys, state_scan.live_records[i].record.key);
-                        if (key_index == keys.size()) {
-                            keys.push_back(state_scan.live_records[i].record.key);
-                            state_ids.push_back(std::vector<OrderedElementId>());
-                        }
-                        state_ids[key_index].push_back(state_scan.live_records[i].id);
-                        OrderedElementKeyIndexEntry expected;
-                        expected.key = state_scan.live_records[i].record.key;
-                        expected.id = state_scan.live_records[i].id;
-                        expected_index_entries.push_back(expected);
-                    }
-
-                    validate_complete_key_index(
-                        index_entries, expected_index_entries);
-                    for (std::size_t i = 0u;
-                         i < state_scan.element_origins.size(); ++i) {
-                        m_adapter.m_state.verify_introduced_high_water(
-                            m_txn.handle(), state_scan.element_origins[i], &candidates);
-                    }
-                    for (std::size_t i = 0u; i < keys.size(); ++i) {
-                        const KeyT key = KeyCodec::decode(keys[i]);
-                        if (KeyCodec::encode(key) != keys[i]) {
-                            throw std::runtime_error(
-                                "Ordered destructive state key is non-canonical");
-                        }
-                        validate_live_key_group(
-                            key, keys[i], state_ids[i], candidates);
-                    }
-
-                    const std::vector<OrderedElementId> ids =
-                        candidates.sorted_ids();
-                    erase_selected(ids, &candidates);
-                    return ids.size();
+                    const ClearPlan plan = prepare_clear(candidates);
+                    erase_selected(plan.ids, &candidates);
+                    return plan.ids.size();
                 } catch (...) {
                     rollback_and_deactivate();
                     throw;
@@ -513,12 +488,13 @@ namespace sync {
             }
 
             /// \brief Replaces the complete live set with desired occurrences.
-            /// \details All desired keys and values are encoded before the
-            /// first physical mutation. Existing live occurrences are then
-            /// erased exactly and desired occurrences are appended with fresh
-            /// immutable ids. The operation is single-origin schema-v2
-            /// capture; it introduces no new wire opcode and remains bounded
-            /// by both the existing-state and replacement limits.
+            /// \details The operation prepares canonical logical bytes, fresh
+            /// immutable ids, and exact append changes before its first
+            /// physical mutation. Existing live occurrences are then erased
+            /// exactly and the prepared occurrences are appended without
+            /// rescanning the complete state. The operation is single-origin
+            /// schema-v2 capture; it introduces no new wire opcode and remains
+            /// bounded by both the existing-state and replacement limits.
             void replace_with(
                     const std::vector<typename table_type::value_type>& desired,
                     const ReplaceWithBounds& bounds) {
@@ -528,23 +504,57 @@ namespace sync {
                         throw std::length_error(
                             "Ordered destructive replacement limit exceeded");
                     }
+
+                    std::vector<PreparedReplacementAppend> prepared;
+                    prepared.reserve(desired.size());
                     for (std::size_t i = 0u; i < desired.size(); ++i) {
-                        const std::vector<std::uint8_t> key_bytes =
+                        PreparedReplacementAppend entry;
+                        entry.source = &desired[i];
+                        entry.key_bytes =
                             KeyCodec::encode(desired[i].first);
-                        const std::vector<std::uint8_t> value_bytes =
+                        entry.value_bytes =
                             ValueCodec::encode(desired[i].second);
-                        if (KeyCodec::encode(KeyCodec::decode(key_bytes)) !=
-                                key_bytes ||
-                            ValueCodec::encode(ValueCodec::decode(value_bytes)) !=
-                                value_bytes) {
+                        if (KeyCodec::encode(KeyCodec::decode(entry.key_bytes)) !=
+                                entry.key_bytes ||
+                            ValueCodec::encode(ValueCodec::decode(entry.value_bytes)) !=
+                                entry.value_bytes) {
                             throw std::runtime_error(
                                 "Ordered destructive replacement value is non-canonical");
                         }
+                        prepared.push_back(std::move(entry));
                     }
 
-                    clear(bounds.existing);
-                    for (std::size_t i = 0u; i < desired.size(); ++i) {
-                        append(desired[i].first, desired[i].second);
+                    OrderedElementCandidateSet candidates(bounds.existing);
+                    const ClearPlan clear_plan = prepare_clear(candidates);
+                    const std::vector<OrderedElementId> ids =
+                        m_adapter.m_state.plan_id_range(
+                            m_txn.handle(), m_origin, prepared.size(),
+                            contains_origin(clear_plan.element_origins, m_origin),
+                            &candidates);
+                    for (std::size_t i = 0u; i < prepared.size(); ++i) {
+                        prepared[i].id = ids[i];
+                        prepared[i].change = m_adapter.make_append_prepared(
+                            prepared[i].id, prepared[i].key_bytes,
+                            prepared[i].value_bytes);
+                    }
+
+                    reserve_replacement_pending(
+                        clear_plan.ids.size(), prepared.size());
+                    erase_selected(clear_plan.ids, &candidates);
+
+                    Connection::SyncCaptureSuppressionScope suppress_capture(
+                        *m_adapter.m_table.connection(), m_txn.handle());
+                    for (std::size_t i = 0u; i < prepared.size(); ++i) {
+                        m_adapter.append_live_element_prevalidated(
+                            m_txn.handle(), prepared[i].id,
+                            prepared[i].source->first, prepared[i].source->second,
+                            prepared[i].key_bytes, prepared[i].value_bytes);
+                        m_pending.push_back(std::move(prepared[i].change));
+                    }
+                    if (!ids.empty()) {
+                        m_adapter.m_state.commit_id_range(
+                            m_txn.handle(), m_origin, ids.back().sequence);
+                        ++m_mutation_revision;
                     }
                 } catch (...) {
                     rollback_and_deactivate();
@@ -587,6 +597,77 @@ namespace sync {
             }
 
         private:
+            ClearPlan prepare_clear(OrderedElementCandidateSet& candidates) const {
+                const OrderedElementStateScan state_scan =
+                    m_adapter.m_state.scan_all_element_records(
+                        m_txn.handle(), &candidates, true);
+                std::vector<typename table_type::value_type> physical_entries;
+                m_adapter.m_table.db_collect_entries(
+                    physical_entries, m_txn.handle(),
+                    [&candidates]() {
+                        candidates.inspect_record();
+                    });
+                if (physical_entries.size() != state_scan.live_records.size()) {
+                    throw std::runtime_error(
+                        "Ordered destructive table and state counts differ");
+                }
+                const std::vector<OrderedElementKeyIndexEntry> index_entries =
+                    m_adapter.m_state.key_index_entries(
+                        m_txn.handle(), &candidates);
+                std::vector<OrderedElementKeyIndexEntry> expected_index_entries;
+                std::vector<std::vector<std::uint8_t> > keys;
+                std::vector<std::vector<OrderedElementId> > state_ids;
+                for (std::size_t i = 0u;
+                     i < state_scan.live_records.size(); ++i) {
+                    const std::size_t key_index = find_key_group(
+                        keys, state_scan.live_records[i].record.key);
+                    if (key_index == keys.size()) {
+                        keys.push_back(state_scan.live_records[i].record.key);
+                        state_ids.push_back(std::vector<OrderedElementId>());
+                    }
+                    state_ids[key_index].push_back(state_scan.live_records[i].id);
+                    OrderedElementKeyIndexEntry expected;
+                    expected.key = state_scan.live_records[i].record.key;
+                    expected.id = state_scan.live_records[i].id;
+                    expected_index_entries.push_back(expected);
+                }
+
+                validate_complete_key_index(index_entries, expected_index_entries);
+                for (std::size_t i = 0u;
+                     i < state_scan.element_origins.size(); ++i) {
+                    m_adapter.m_state.verify_introduced_high_water(
+                        m_txn.handle(), state_scan.element_origins[i], &candidates);
+                }
+                for (std::size_t i = 0u; i < keys.size(); ++i) {
+                    const KeyT key = KeyCodec::decode(keys[i]);
+                    if (KeyCodec::encode(key) != keys[i]) {
+                        throw std::runtime_error(
+                            "Ordered destructive state key is non-canonical");
+                    }
+                    validate_live_key_group(
+                        key, keys[i], state_ids[i], candidates);
+                }
+
+                ClearPlan plan;
+                plan.ids = candidates.sorted_ids();
+                plan.element_origins = state_scan.element_origins;
+                return plan;
+            }
+
+            void reserve_replacement_pending(
+                    std::size_t erased_count,
+                    std::size_t appended_count) {
+                const std::size_t maximum =
+                    (std::numeric_limits<std::size_t>::max)();
+                if (erased_count > maximum - appended_count ||
+                    erased_count + appended_count > maximum - m_pending.size()) {
+                    throw std::length_error(
+                        "Ordered destructive replacement pending frame is too large");
+                }
+                m_pending.reserve(
+                    m_pending.size() + erased_count + appended_count);
+            }
+
             static std::size_t find_key_group(
                     const std::vector<std::vector<std::uint8_t> >& keys,
                     const std::vector<std::uint8_t>& key) {
@@ -1097,9 +1178,18 @@ namespace sync {
                                   const KeyT& key,
                                   const ValueT& value,
                                   std::vector<std::uint8_t>& out) {
+            encode_append_bytes(id, KeyCodec::encode(key), ValueCodec::encode(value),
+                                out);
+        }
+
+        static void encode_append_bytes(
+                const OrderedElementId& id,
+                const std::vector<std::uint8_t>& key_bytes,
+                const std::vector<std::uint8_t>& value_bytes,
+                std::vector<std::uint8_t>& out) {
             out = encode_ordered_element_id_logical(id);
-            append_blob(out, KeyCodec::encode(key));
-            append_blob(out, ValueCodec::encode(value));
+            append_blob(out, key_bytes);
+            append_blob(out, value_bytes);
         }
 
         static DecodedChange decode_change(const LogicalChange& change) {
@@ -1187,6 +1277,17 @@ namespace sync {
             m_table.append(key, value, txn);
             m_state.put_live(txn, id, key_bytes, value_bytes);
             ensure_key_parity(txn, key, key_bytes);
+        }
+
+        void append_live_element_prevalidated(
+                MDBX_txn* txn,
+                const OrderedElementId& id,
+                const KeyT& key,
+                const ValueT& value,
+                const std::vector<std::uint8_t>& key_bytes,
+                const std::vector<std::uint8_t>& value_bytes) const {
+            m_table.append(key, value, txn);
+            m_state.put_live_prevalidated(txn, id, key_bytes, value_bytes);
         }
 
         void erase_live_element(MDBX_txn* txn,

--- a/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
@@ -512,6 +512,46 @@ namespace sync {
                 }
             }
 
+            /// \brief Replaces the complete live set with desired occurrences.
+            /// \details All desired keys and values are encoded before the
+            /// first physical mutation. Existing live occurrences are then
+            /// erased exactly and desired occurrences are appended with fresh
+            /// immutable ids. The operation is single-origin schema-v2
+            /// capture; it introduces no new wire opcode and remains bounded
+            /// by both the existing-state and replacement limits.
+            void replace_with(
+                    const std::vector<typename table_type::value_type>& desired,
+                    const ReplaceWithBounds& bounds) {
+                ensure_active();
+                try {
+                    if (desired.size() > bounds.max_replacement_elements) {
+                        throw std::length_error(
+                            "Ordered destructive replacement limit exceeded");
+                    }
+                    for (std::size_t i = 0u; i < desired.size(); ++i) {
+                        const std::vector<std::uint8_t> key_bytes =
+                            KeyCodec::encode(desired[i].first);
+                        const std::vector<std::uint8_t> value_bytes =
+                            ValueCodec::encode(desired[i].second);
+                        if (KeyCodec::encode(KeyCodec::decode(key_bytes)) !=
+                                key_bytes ||
+                            ValueCodec::encode(ValueCodec::decode(value_bytes)) !=
+                                value_bytes) {
+                            throw std::runtime_error(
+                                "Ordered destructive replacement value is non-canonical");
+                        }
+                    }
+
+                    clear(bounds.existing);
+                    for (std::size_t i = 0u; i < desired.size(); ++i) {
+                        append(desired[i].first, desired[i].second);
+                    }
+                } catch (...) {
+                    rollback_and_deactivate();
+                    throw;
+                }
+            }
+
             /// \brief Commits captured mutations and delivery atomically.
             LogicalDeliveryEnvelope commit_to_outbox(
                     ILogicalDeliveryOutbox& outbox,

--- a/tests/test_key_ordered_multi_value_destructive_adapter.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_adapter.cpp
@@ -2067,6 +2067,80 @@ void test_ordered_delivery_rejects_incompatible_auxiliary_dbi() {
     cleanup(path);
 }
 
+void test_destructive_capture_replaces_bounded_live_set() {
+    const std::string path = "test_key_ordered_multi_value_destructive_replace.mdbx";
+    const std::string primary = "ordered_replace_values";
+    const std::string state = "ordered_replace_state";
+    const std::string by_key = "ordered_replace_by_key";
+    const std::string schema = "app.ordered_replace.v2";
+    cleanup(path);
+
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 16;
+    config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::sync::NodeId origin = make_node(0xE8u);
+    const mdbxc::sync::DbId local_db = make_node(0xF8u);
+    const mdbxc::sync::DbId destination = make_node(0x08u);
+    mdbxc::sync::SyncEngine engine(connection);
+    engine.initialize_local_identity(origin, local_db);
+    table_type table(connection, primary);
+    adapter_type adapter(table, schema, state, by_key);
+    engine.initialize_logical_adapter_schema(
+        adapter, make_v2_record(primary, state, by_key, origin));
+
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->append(1, "old");
+        session->commit_to_outbox(engine, destination);
+    }
+    {
+        std::vector<table_type::value_type> desired;
+        desired.push_back(table_type::value_type(3, "new"));
+        desired.push_back(table_type::value_type(3, "new"));
+        const mdbxc::sync::ReplaceWithBounds bounds =
+            { { 8u, 256u }, 4u };
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->replace_with(desired, bounds);
+        if (session->pending_size() != 3u || !table.find(1).empty() ||
+            table.find(3).size() != 2u) {
+            throw std::runtime_error(
+                "bounded destructive replacement produced wrong local state");
+        }
+        session->commit_to_outbox(engine, destination);
+    }
+    if (table.find(3).size() != 2u || table.find(3)[0] != "new" ||
+        table.find(3)[1] != "new") {
+        throw std::runtime_error(
+            "bounded destructive replacement did not preserve duplicates");
+    }
+
+    bool bound_rejected = false;
+    try {
+        std::vector<table_type::value_type> too_many;
+        too_many.push_back(table_type::value_type(4, "rejected"));
+        const mdbxc::sync::ReplaceWithBounds no_replacement =
+            { { 8u, 256u }, 0u };
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->replace_with(too_many, no_replacement);
+    } catch (const std::length_error&) {
+        bound_rejected = true;
+    }
+    if (!bound_rejected || table.find(3).size() != 2u ||
+        !table.find(4).empty()) {
+        throw std::runtime_error(
+            "bounded destructive replacement did not fail closed");
+    }
+
+    connection->disconnect();
+    cleanup(path);
+}
+
 } // namespace
 
 int main() {
@@ -2094,5 +2168,6 @@ int main() {
     test_destructive_preflight_rejects_corrupt_introduced_high_water();
     test_destructive_ordering_and_duplicate_append_contract();
     test_ordered_delivery_survives_environment_reopen();
+    test_destructive_capture_replaces_bounded_live_set();
     return 0;
 }

--- a/tests/test_key_ordered_multi_value_destructive_adapter.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_adapter.cpp
@@ -2101,20 +2101,22 @@ void test_destructive_capture_replaces_bounded_live_set() {
         std::vector<table_type::value_type> desired;
         desired.push_back(table_type::value_type(3, "new"));
         desired.push_back(table_type::value_type(3, "new"));
+        desired.push_back(table_type::value_type(4, "other"));
         const mdbxc::sync::ReplaceWithBounds bounds =
             { { 8u, 256u }, 4u };
         std::unique_ptr<adapter_type::LogicalCaptureSession> session =
             adapter.begin_capture_session();
         session->replace_with(desired, bounds);
-        if (session->pending_size() != 3u || !table.find(1).empty() ||
-            table.find(3).size() != 2u) {
+        if (session->pending_size() != 4u || !table.find(1).empty() ||
+            table.find(3).size() != 2u || table.find(4).size() != 1u) {
             throw std::runtime_error(
                 "bounded destructive replacement produced wrong local state");
         }
         session->commit_to_outbox(engine, destination);
     }
     if (table.find(3).size() != 2u || table.find(3)[0] != "new" ||
-        table.find(3)[1] != "new") {
+        table.find(3)[1] != "new" || table.find(4).size() != 1u ||
+        table.find(4)[0] != "other") {
         throw std::runtime_error(
             "bounded destructive replacement did not preserve duplicates");
     }
@@ -2132,9 +2134,34 @@ void test_destructive_capture_replaces_bounded_live_set() {
         bound_rejected = true;
     }
     if (!bound_rejected || table.find(3).size() != 2u ||
-        !table.find(4).empty()) {
+        table.find(4).size() != 1u) {
         throw std::runtime_error(
             "bounded destructive replacement did not fail closed");
+    }
+
+    {
+        const std::vector<table_type::value_type> empty;
+        const mdbxc::sync::ReplaceWithBounds bounds =
+            { { 8u, 256u }, 0u };
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->replace_with(empty, bounds);
+        if (session->pending_size() != 3u || !table.empty()) {
+            throw std::runtime_error(
+                "empty destructive replacement did not capture exact erases");
+        }
+        session->commit_to_outbox(engine, destination);
+    }
+
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            adapter.begin_capture_session();
+        session->append(5, "after-replace");
+        session->commit_to_outbox(engine, destination);
+    }
+    if (table.find(5).size() != 1u || table.find(5)[0] != "after-replace") {
+        throw std::runtime_error(
+            "destructive replacement did not preserve future id allocation");
     }
 
     connection->disconnect();

--- a/tests/test_key_ordered_multi_value_destructive_adapter.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_adapter.cpp
@@ -2168,6 +2168,98 @@ void test_destructive_capture_replaces_bounded_live_set() {
     cleanup(path);
 }
 
+void test_destructive_replacement_round_trips_to_replica() {
+    const std::string source_path =
+        "test_key_ordered_multi_value_destructive_replace_source.mdbx";
+    const std::string replica_path =
+        "test_key_ordered_multi_value_destructive_replace_replica.mdbx";
+    const std::string primary = "ordered_replace_round_trip_values";
+    const std::string state = "ordered_replace_round_trip_state";
+    const std::string by_key = "ordered_replace_round_trip_by_key";
+    const std::string schema = "app.ordered_replace.round_trip.v2";
+    cleanup(source_path);
+    cleanup(replica_path);
+
+    mdbxc::Config source_config;
+    source_config.pathname = source_path;
+    source_config.max_dbs = 16;
+    source_config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> source_connection =
+        mdbxc::Connection::create(source_config);
+
+    mdbxc::Config replica_config;
+    replica_config.pathname = replica_path;
+    replica_config.max_dbs = 16;
+    replica_config.no_subdir = true;
+    const std::shared_ptr<mdbxc::Connection> replica_connection =
+        mdbxc::Connection::create(replica_config);
+
+    const mdbxc::sync::NodeId origin = make_node(0xD9u);
+    const mdbxc::sync::DbId source_db = make_node(0xE9u);
+    const mdbxc::sync::DbId replica_db = make_node(0xF9u);
+    const mdbxc::sync::LogicalSchemaRecord schema_record =
+        make_v2_record(primary, state, by_key, origin);
+
+    mdbxc::sync::SyncEngine source_engine(source_connection);
+    source_engine.initialize_local_identity(origin, source_db);
+    table_type source_table(source_connection, primary);
+    adapter_type source_adapter(source_table, schema, state, by_key);
+    source_engine.initialize_logical_adapter_schema(source_adapter, schema_record);
+
+    mdbxc::sync::SyncEngine replica_engine(replica_connection);
+    replica_engine.initialize_local_identity(make_node(0xEAu), replica_db);
+    table_type replica_table(replica_connection, primary);
+    adapter_type replica_adapter(replica_table, schema, state, by_key);
+    replica_engine.initialize_logical_adapter_schema(replica_adapter, schema_record);
+    replica_engine.register_logical_adapter(replica_adapter);
+
+    mdbxc::sync::LogicalDeliveryEnvelope initial;
+    {
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            source_adapter.begin_capture_session();
+        session->append(1, "old");
+        initial = session->commit_to_outbox(source_engine, replica_db);
+    }
+    const mdbxc::sync::LogicalDeliveryAcknowledgement initial_ack =
+        replica_engine.apply_ordered_logical_delivery_envelope(initial);
+    if (!initial_ack.ok || initial_ack.acknowledged_through != 1u ||
+        replica_table.find(1).size() != 1u ||
+        replica_table.find(1)[0] != "old") {
+        throw std::runtime_error(
+            "initial destructive ordered delivery did not reach replica");
+    }
+
+    mdbxc::sync::LogicalDeliveryEnvelope replacement;
+    {
+        std::vector<table_type::value_type> desired;
+        desired.push_back(table_type::value_type(3, "new"));
+        desired.push_back(table_type::value_type(3, "new"));
+        desired.push_back(table_type::value_type(4, "other"));
+        const mdbxc::sync::ReplaceWithBounds bounds = { { 8u, 256u }, 4u };
+        std::unique_ptr<adapter_type::LogicalCaptureSession> session =
+            source_adapter.begin_capture_session();
+        session->replace_with(desired, bounds);
+        replacement = session->commit_to_outbox(source_engine, replica_db);
+    }
+    const mdbxc::sync::LogicalDeliveryAcknowledgement replacement_ack =
+        replica_engine.apply_ordered_logical_delivery_envelope(replacement);
+    if (!replacement_ack.ok || replacement_ack.acknowledged_through != 2u ||
+        !replica_table.find(1).empty() ||
+        replica_table.find(3).size() != 2u ||
+        replica_table.find(3)[0] != "new" ||
+        replica_table.find(3)[1] != "new" ||
+        replica_table.find(4).size() != 1u ||
+        replica_table.find(4)[0] != "other") {
+        throw std::runtime_error(
+            "bounded destructive replacement did not round trip to replica");
+    }
+
+    source_connection->disconnect();
+    replica_connection->disconnect();
+    cleanup(source_path);
+    cleanup(replica_path);
+}
+
 } // namespace
 
 int main() {
@@ -2196,5 +2288,6 @@ int main() {
     test_destructive_ordering_and_duplicate_append_contract();
     test_ordered_delivery_survives_environment_reopen();
     test_destructive_capture_replaces_bounded_live_set();
+    test_destructive_replacement_round_trips_to_replica();
     return 0;
 }


### PR DESCRIPTION
## Summary
- add single-origin schema-v2 replace_with capture;
- validate all desired key/value encodings before mutation;
- expand replacement into exact erase/append logical changes with separate existing-state and desired-size bounds;
- preserve duplicate desired values and fail closed on bound violations.

## Verification
- C++11 MinGW destructive adapter regression passed;
- git diff --check passed.