### PR TITLE
test(sync): harden full snapshot codec boundaries

### DIFF
--- a/include/mdbx_containers/sync/ChangeBatchCodec.hpp
+++ b/include/mdbx_containers/sync/ChangeBatchCodec.hpp
@@ -145,6 +145,12 @@ namespace sync {
                                  op.revision_key.size());
                 }
             }
+            if (bounds != nullptr &&
+                out.size() > static_cast<std::size_t>(
+                    bounds->max_batch_total_bytes)) {
+                throw std::length_error(
+                    "encoded change batch exceeds max_batch_total_bytes");
+            }
             return out;
         }
 

--- a/tests/test_codec_bounds.cpp
+++ b/tests/test_codec_bounds.cpp
@@ -89,6 +89,42 @@ void test_too_many_ops() {
     });
 }
 
+void test_batch_total_size_boundary() {
+    using namespace mdbxc::sync;
+    ChangeBatch batch;
+    ChangeOp op;
+    op.op_type = ChangeOpType::Put;
+    op.dbi_name = "t";
+    op.storage_key = { 0x01 };
+    op.value = { 0x02 };
+    batch.ops.push_back(op);
+
+    const std::vector<std::uint8_t> unbounded =
+        ChangeBatchCodec::encode(batch);
+    CodecBounds exact;
+    exact.max_batch_total_bytes =
+        static_cast<std::uint32_t>(unbounded.size());
+    const std::vector<std::uint8_t> encoded =
+        ChangeBatchCodec::encode(batch, &exact);
+    if (encoded != unbounded ||
+        ChangeBatchCodec::decode_exact(encoded, &exact).ops.size() != 1u) {
+        throw std::runtime_error("exact batch total size bound was rejected");
+    }
+
+    CodecBounds too_small = exact;
+    --too_small.max_batch_total_bytes;
+    bool rejected = false;
+    try {
+        (void)ChangeBatchCodec::encode(batch, &too_small);
+    } catch (const std::length_error&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error(
+            "encoded batch exceeded max_batch_total_bytes");
+    }
+}
+
 } // namespace
 
 int main() {
@@ -96,5 +132,6 @@ int main() {
     test_oversize_storage_key();
     test_oversize_value();
     test_too_many_ops();
+    test_batch_total_size_boundary();
     return 0;
 }

--- a/tests/test_full_snapshot_protocol.cpp
+++ b/tests/test_full_snapshot_protocol.cpp
@@ -147,6 +147,32 @@ void test_full_snapshot_respects_bounds() {
     }));
 }
 
+void test_full_snapshot_respects_nested_batch_total_bound() {
+    const mdbxc::sync::FullSnapshotChunk source = make_chunk();
+    const std::vector<std::uint8_t> nested =
+        mdbxc::sync::ChangeBatchCodec::encode(source.batch);
+
+    mdbxc::sync::CodecBounds exact;
+    exact.max_batch_total_bytes =
+        static_cast<std::uint32_t>(nested.size());
+    exact.max_snapshot_chunk_bytes = 1024u * 1024u;
+    const std::vector<std::uint8_t> encoded =
+        mdbxc::sync::FullSnapshotCodec::encode(source, &exact);
+    MDBXC_TEST_ASSERT(
+        mdbxc::sync::FullSnapshotCodec::decode(encoded, &exact).
+            batch.ops.size() == 1u);
+
+    mdbxc::sync::CodecBounds too_small = exact;
+    --too_small.max_batch_total_bytes;
+    bool rejected = false;
+    try {
+        (void)mdbxc::sync::FullSnapshotCodec::encode(source, &too_small);
+    } catch (const std::length_error&) {
+        rejected = true;
+    }
+    MDBXC_TEST_ASSERT(rejected);
+}
+
 void test_full_snapshot_default_bounds_reject_hostile_counts() {
     const mdbxc::sync::FullSnapshotChunk source = make_chunk();
     const std::vector<std::uint8_t> encoded =
@@ -290,6 +316,7 @@ int main() {
     test_full_snapshot_rejects_reserved_and_unlisted_dbis();
     test_full_snapshot_rejects_wrong_sequence_and_trailing_bytes();
     test_full_snapshot_respects_bounds();
+    test_full_snapshot_respects_nested_batch_total_bound();
     test_full_snapshot_default_bounds_reject_hostile_counts();
     test_full_snapshot_rejects_non_replacement_operations();
     test_full_snapshot_manifest_boundary_and_malformed_input();

--- a/tests/test_full_snapshot_protocol.cpp
+++ b/tests/test_full_snapshot_protocol.cpp
@@ -131,6 +131,12 @@ void test_full_snapshot_rejects_wrong_sequence_and_trailing_bytes() {
     MDBXC_TEST_ASSERT(throws([&trailing]() {
         mdbxc::sync::FullSnapshotCodec::decode(trailing);
     }));
+
+    mdbxc::sync::FullSnapshotChunk mismatched_continuation = make_chunk();
+    mismatched_continuation.has_more = false;
+    MDBXC_TEST_ASSERT(throws([&mismatched_continuation]() {
+        mdbxc::sync::FullSnapshotCodec::encode(mismatched_continuation);
+    }));
 }
 
 void test_full_snapshot_respects_bounds() {
@@ -166,6 +172,12 @@ void test_full_snapshot_default_bounds_reject_hostile_counts() {
     write_u32_le(oversized_nested, nested_offset - 4u, 0xFFFFFFFFu);
     MDBXC_TEST_ASSERT(throws([&oversized_nested]() {
         mdbxc::sync::FullSnapshotCodec::decode(oversized_nested);
+    }));
+
+    std::vector<std::uint8_t> invalid_continuation = encoded;
+    invalid_continuation[manifest_count_offset(source) - 1u] = 2u;
+    MDBXC_TEST_ASSERT(throws([&invalid_continuation]() {
+        mdbxc::sync::FullSnapshotCodec::decode(invalid_continuation);
     }));
 }
 
@@ -203,6 +215,74 @@ void test_full_snapshot_rejects_non_replacement_operations() {
         mdbxc::sync::ChangeOpType::ClearTable);
 }
 
+void test_full_snapshot_manifest_boundary_and_malformed_input() {
+    mdbxc::sync::CodecBounds exact_bounds;
+    exact_bounds.max_snapshot_manifest_entries = 1u;
+    const std::vector<std::uint8_t> encoded =
+        mdbxc::sync::FullSnapshotCodec::encode(make_chunk(), &exact_bounds);
+    const mdbxc::sync::FullSnapshotChunk decoded =
+        mdbxc::sync::FullSnapshotCodec::decode(encoded, &exact_bounds);
+    MDBXC_TEST_ASSERT(decoded.manifest.size() == 1u);
+
+    mdbxc::sync::CodecBounds zero_bounds;
+    zero_bounds.max_snapshot_manifest_entries = 0u;
+    MDBXC_TEST_ASSERT(throws([&zero_bounds]() {
+        mdbxc::sync::FullSnapshotCodec::encode(make_chunk(), &zero_bounds);
+    }));
+
+    std::vector<std::uint8_t> truncated = encoded;
+    truncated.resize(truncated.size() - 1u);
+    MDBXC_TEST_ASSERT(throws([&truncated]() {
+        mdbxc::sync::FullSnapshotCodec::decode(truncated);
+    }));
+
+    std::vector<std::uint8_t> unknown_version = encoded;
+    unknown_version[8u] = 2u;
+    unknown_version[9u] = 0u;
+    MDBXC_TEST_ASSERT(throws([&unknown_version]() {
+        mdbxc::sync::FullSnapshotCodec::decode(unknown_version);
+    }));
+
+    mdbxc::sync::CodecBounds exact_size;
+    exact_size.max_snapshot_chunk_bytes =
+        static_cast<std::uint32_t>(encoded.size());
+    MDBXC_TEST_ASSERT(
+        mdbxc::sync::FullSnapshotCodec::decode(encoded, &exact_size).
+            batch.ops.size() == 1u);
+    std::vector<std::uint8_t> oversized_chunk = encoded;
+    oversized_chunk.push_back(0u);
+    MDBXC_TEST_ASSERT(throws([&oversized_chunk, &exact_size]() {
+        mdbxc::sync::FullSnapshotCodec::decode(oversized_chunk, &exact_size);
+    }));
+}
+
+void test_full_snapshot_rejects_incomplete_identity_and_manifest() {
+    mdbxc::sync::FullSnapshotChunk zero_source = make_chunk();
+    zero_source.source_node_id = mdbxc::sync::make_zero_node();
+    zero_source.batch.origin_node_id = zero_source.source_node_id;
+    MDBXC_TEST_ASSERT(throws([&zero_source]() {
+        mdbxc::sync::FullSnapshotCodec::encode(zero_source);
+    }));
+
+    mdbxc::sync::FullSnapshotChunk empty_snapshot_id = make_chunk();
+    empty_snapshot_id.snapshot_id.clear();
+    MDBXC_TEST_ASSERT(throws([&empty_snapshot_id]() {
+        mdbxc::sync::FullSnapshotCodec::encode(empty_snapshot_id);
+    }));
+
+    mdbxc::sync::FullSnapshotChunk duplicate_manifest = make_chunk();
+    duplicate_manifest.manifest.push_back(duplicate_manifest.manifest[0]);
+    MDBXC_TEST_ASSERT(throws([&duplicate_manifest]() {
+        mdbxc::sync::FullSnapshotCodec::encode(duplicate_manifest);
+    }));
+
+    mdbxc::sync::FullSnapshotChunk oversized_key = make_chunk();
+    oversized_key.batch.ops[0].storage_key.resize(16u * 1024u + 1u, 0u);
+    MDBXC_TEST_ASSERT(throws([&oversized_key]() {
+        mdbxc::sync::FullSnapshotCodec::encode(oversized_key);
+    }));
+}
+
 } // namespace
 
 int main() {
@@ -212,5 +292,7 @@ int main() {
     test_full_snapshot_respects_bounds();
     test_full_snapshot_default_bounds_reject_hostile_counts();
     test_full_snapshot_rejects_non_replacement_operations();
+    test_full_snapshot_manifest_boundary_and_malformed_input();
+    test_full_snapshot_rejects_incomplete_identity_and_manifest();
     return 0;
 }


### PR DESCRIPTION
## Summary\n- cover exact snapshot manifest-entry bounds\n- reject zero-entry bounds, truncated chunks, and unknown codec versions\n- keep full-snapshot transport/apply unsupported; this is codec-only regression coverage\n\n## Validation\n- C++11 direct test build and run\n- C++17 direct test build and run\n- git diff --check\n\nStacked on #281.