### PR TITLE
feat(sync): define full snapshot session transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-- Sync: add the validated preparatory `FullSnapshotCodec` boundary for
-  manifest-bearing `seq=0` snapshot chunks. Full-snapshot transport and apply
-  remain explicitly unsupported until continuation and replacement semantics
-  are implemented.
+- Sync: extend the preparatory `FullSnapshotCodec` boundary with immutable
+  source-tail, replacement-scope, manifest-version, and continuation fields.
+  `PullRequest`/`PullResponse` now carry explicit snapshot session state and
+  chunk pages; this changes the unreleased `TransportMessageCodec` wire version
+  from 4 to 5. Source export and replacement apply remain explicitly disabled
+  until their lifecycle implementations land.
 - Sync: document the authoritative-baseline and multi-origin conflict
   boundary for ordered schema-v2. Baseline import and concurrent multi-writer
   resolution remain design-only and are not exposed as partial APIs.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1407,7 +1407,7 @@ payload itself.
 Locked contract:
 
 - Magic: 8 bytes `MDBXCPRT`.
-- Version: u16 little-endian, currently `4`.
+- Version: u16 little-endian, currently `5`.
 - Message type: u8 (`1=PullRequest`, `2=PullResponse`, `3=PushRequest`,
   `4=PushResponse`).
 - Message flags: u32 little-endian, currently zero. Unknown non-zero flags are
@@ -1420,6 +1420,12 @@ Locked contract:
 - `PullResponse` carries both `remote_have` (responder applied cursor) and
   optional `remote_tail` (responder changelog tail) so receivers can report
   catch-up progress without changing pagination semantics.
+- Full-snapshot pull pages use the same `PullRequest`/`PullResponse` envelope,
+  but are explicit: a request has `request_full_snapshot=true`; the first page
+  has empty `full_snapshot_id` and `full_snapshot_continuation`; later requests
+  repeat both opaque values exactly. A response with `is_full_snapshot=true`
+  contains one length-prefixed `FullSnapshotCodec` chunk and no incremental
+  batches. Its `has_more` value must equal the chunk continuation flag.
 - `PullRequest::max_bytes` is a soft page budget. A responder may return one
   retained changelog batch whose encoded size exceeds `max_bytes` when that
   batch is the next required batch. `PullRequest::max_single_batch_bytes` is
@@ -1529,12 +1535,14 @@ B: applies each page as above
 The reserved `seq=0, BATCH_HAS_MORE` full export/import format remains planned
 for v0.1 and is not the current cold-replica implementation.
 `FullSnapshotProtocol.hpp` now defines and validates a preparatory chunk
-codec: every chunk carries a source identity, stable `snapshot_id`, chunk
-index, immutable named-user-DBI manifest, and a nested raw batch with `seq=0`.
-The codec is deliberately not wired into `PullRequest::request_full_snapshot`
-yet. The transport path still needs continuation-token validation, cursor
-bootstrap semantics, and an atomic replacement apply path before the flag can
-be accepted.
+codec: every chunk carries a source identity, immutable source changelog tail,
+stable `snapshot_id`, chunk index, replacement scope, opaque next-page token,
+manifest version, immutable named-user-DBI manifest, and a nested raw batch
+with `seq=0`. Transport codec v5 carries the explicit session request and one
+snapshot chunk in `PullResponse`; it rejects mixed incremental/snapshot pages
+and malformed session state. `SyncEngine` does not accept the request yet: the
+source-export session, cursor bootstrap semantics, and atomic replacement apply
+path still need to be implemented before the flag can be enabled.
 `PullRequest::request_full_snapshot=true` is rejected explicitly until the
 transport and replacement apply path are implemented. In v0.1 this is a
 sync-level protocol rejection carried

--- a/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
+++ b/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
@@ -63,10 +63,11 @@ namespace sync {
         ChangeBatch batch;
     };
 
-    /// \brief Strict codec for the reserved full-snapshot wire boundary.
-    /// \details This codec is preparatory. v0.1 pull responders still reject
-    /// \c PullRequest::request_full_snapshot until a transport dispatcher and
-    /// validated replacement apply path are available.
+    /// \brief Strict codec for the explicit full-snapshot wire boundary.
+    /// \details Configured sources export bounded snapshot sessions through
+    /// \c PullRequest::request_full_snapshot. The initial receiver accepts
+    /// only \c ManifestOnly pages into a fresh replica and commits the staged
+    /// replacement plan atomically at the final page.
     class FullSnapshotCodec {
     public:
         static const std::uint8_t* magic() {
@@ -233,6 +234,10 @@ namespace sync {
             if (chunk.batch.batch_flags != expected_flags) {
                 throw std::invalid_argument(
                     "Full snapshot continuation does not match batch flags");
+            }
+            if (chunk.batch.ops.empty()) {
+                throw std::invalid_argument(
+                    "Full snapshot chunk must contain at least one operation");
             }
             for (std::size_t i = 0u; i < chunk.batch.ops.size(); ++i) {
                 const ChangeOp& op = chunk.batch.ops[i];

--- a/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
+++ b/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <map>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -16,6 +17,7 @@
 #include "ChangeBatchCodec.hpp"
 #include "CodecBounds.hpp"
 #include "common.hpp"
+#include "SyncCursor.hpp"
 
 namespace mdbxc {
 namespace sync {
@@ -24,6 +26,15 @@ namespace sync {
     struct FullSnapshotManifestEntry {
         std::string dbi_name;
         std::uint32_t dbi_flags = 0u;
+    };
+
+    /// \brief Declares which user-DBI content a snapshot may replace.
+    /// \details \c ManifestOnly preserves receiver-only user DBIs. Complete
+    /// replacement is an explicit receiver opt-in and is not enabled by the
+    /// initial importer.
+    enum class FullSnapshotScope : std::uint8_t {
+        ManifestOnly = 0u,
+        CompleteUserDatabase = 1u
     };
 
     /// \brief One chunk of a full database export.
@@ -36,8 +47,18 @@ namespace sync {
         NodeId source_node_id{};
         DbId source_db_uuid{};
         std::string snapshot_id;
+        /// \brief Immutable source changelog tail captured with this snapshot.
+        SyncCursor source_tail;
         std::uint64_t chunk_index = 0u;
         bool has_more = false;
+        /// \brief Explicit replacement scope for the receiver.
+        FullSnapshotScope replacement_scope = FullSnapshotScope::ManifestOnly;
+        /// \brief Opaque token that requests the immediate next chunk.
+        /// \details Non-empty exactly when \c has_more is true. Callers return
+        /// this value unchanged in PullRequest::full_snapshot_continuation.
+        std::string continuation;
+        /// \brief Version of the immutable manifest contract.
+        std::uint32_t manifest_version = 1u;
         std::vector<FullSnapshotManifestEntry> manifest;
         ChangeBatch batch;
     };
@@ -55,7 +76,7 @@ namespace sync {
         }
 
         static std::size_t magic_size() { return 8u; }
-        static std::uint16_t codec_version() { return 1u; }
+        static std::uint16_t codec_version() { return 2u; }
 
         static std::vector<std::uint8_t> encode(
                 const FullSnapshotChunk& chunk,
@@ -72,8 +93,12 @@ namespace sync {
             append_bytes(out, chunk.source_db_uuid.data(),
                          chunk.source_db_uuid.size());
             append_string(out, chunk.snapshot_id);
+            append_cursor(out, chunk.source_tail, bounds);
             detail::append_u64_le(out, chunk.chunk_index);
             out.push_back(chunk.has_more ? 1u : 0u);
+            append_scope(out, chunk.replacement_scope);
+            append_string(out, chunk.continuation);
+            detail::append_u32_le(out, chunk.manifest_version);
             detail::append_u32_le(
                 out, static_cast<std::uint32_t>(chunk.manifest.size()));
             for (std::size_t i = 0u; i < chunk.manifest.size(); ++i) {
@@ -105,12 +130,18 @@ namespace sync {
             out.snapshot_id = read_string(
                 cursor, bounds == nullptr ? 256u : bounds->max_snapshot_id_len,
                 "full snapshot id exceeds max_snapshot_id_len");
+            out.source_tail = read_cursor(cursor, bounds);
             out.chunk_index = read_u64_le(cursor);
             const std::uint8_t has_more = read_u8(cursor);
             if (has_more > 1u) {
                 throw std::runtime_error("Invalid full snapshot continuation flag");
             }
             out.has_more = has_more != 0u;
+            out.replacement_scope = read_scope(cursor);
+            out.continuation = read_string(
+                cursor, bounds == nullptr ? 256u : bounds->max_snapshot_id_len,
+                "full snapshot continuation exceeds max_snapshot_id_len");
+            out.manifest_version = read_u32_le(cursor);
             const std::uint32_t manifest_count = read_u32_le(cursor);
             if (bounds != nullptr &&
                 manifest_count > bounds->max_snapshot_manifest_entries) {
@@ -153,6 +184,20 @@ namespace sync {
                 throw std::length_error(
                     "full snapshot id exceeds max_snapshot_id_len");
             }
+            if (chunk.continuation.size() > bounds->max_snapshot_id_len) {
+                throw std::length_error(
+                    "full snapshot continuation exceeds max_snapshot_id_len");
+            }
+            if (chunk.has_more != !chunk.continuation.empty()) {
+                throw std::invalid_argument(
+                    "Full snapshot continuation does not match has_more");
+            }
+            if (chunk.manifest_version != 1u) {
+                throw std::invalid_argument(
+                    "Unsupported full snapshot manifest version");
+            }
+            validate_scope(chunk.replacement_scope);
+            validate_cursor(chunk.source_tail, bounds);
             if (chunk.manifest.size() > bounds->max_snapshot_manifest_entries) {
                 throw std::length_error(
                     "full snapshot manifest exceeds max_snapshot_manifest_entries");
@@ -263,6 +308,78 @@ namespace sync {
                 }
             }
             return false;
+        }
+
+        static void validate_scope(FullSnapshotScope scope) {
+            switch (scope) {
+                case FullSnapshotScope::ManifestOnly:
+                case FullSnapshotScope::CompleteUserDatabase:
+                    return;
+            }
+            throw std::invalid_argument("Invalid full snapshot replacement scope");
+        }
+
+        static void append_scope(std::vector<std::uint8_t>& out,
+                                 FullSnapshotScope scope) {
+            validate_scope(scope);
+            out.push_back(static_cast<std::uint8_t>(scope));
+        }
+
+        static FullSnapshotScope read_scope(Cursor& cursor) {
+            const std::uint8_t raw = read_u8(cursor);
+            switch (raw) {
+                case static_cast<std::uint8_t>(FullSnapshotScope::ManifestOnly):
+                    return FullSnapshotScope::ManifestOnly;
+                case static_cast<std::uint8_t>(
+                        FullSnapshotScope::CompleteUserDatabase):
+                    return FullSnapshotScope::CompleteUserDatabase;
+                default:
+                    throw std::runtime_error(
+                        "Invalid full snapshot replacement scope");
+            }
+        }
+
+        static void append_cursor(std::vector<std::uint8_t>& out,
+                                  const SyncCursor& value,
+                                  const CodecBounds* bounds) {
+            validate_cursor(value, bounds);
+            detail::append_u32_le(
+                out, static_cast<std::uint32_t>(value.last_seq_by_origin.size()));
+            std::map<NodeId, std::uint64_t>::const_iterator it =
+                value.last_seq_by_origin.begin();
+            for (; it != value.last_seq_by_origin.end(); ++it) {
+                append_bytes(out, it->first.data(), it->first.size());
+                detail::append_u64_le(out, it->second);
+            }
+        }
+
+        static SyncCursor read_cursor(Cursor& cursor, const CodecBounds* bounds) {
+            const std::uint32_t count = read_u32_le(cursor);
+            if (count > bounds->max_cursor_origins) {
+                throw std::length_error(
+                    "full snapshot tail exceeds max_cursor_origins");
+            }
+            SyncCursor out;
+            for (std::uint32_t i = 0u; i < count; ++i) {
+                NodeId origin{};
+                read_bytes(cursor, origin.data(), origin.size());
+                const std::uint64_t sequence = read_u64_le(cursor);
+                if (out.last_seq_by_origin.find(origin) !=
+                    out.last_seq_by_origin.end()) {
+                    throw std::runtime_error(
+                        "Duplicate origin in full snapshot tail");
+                }
+                out.last_seq_by_origin[origin] = sequence;
+            }
+            return out;
+        }
+
+        static void validate_cursor(const SyncCursor& value,
+                                    const CodecBounds* bounds) {
+            if (value.last_seq_by_origin.size() > bounds->max_cursor_origins) {
+                throw std::length_error(
+                    "full snapshot tail exceeds max_cursor_origins");
+            }
         }
 
         static void append_bytes(std::vector<std::uint8_t>& out,

--- a/include/mdbx_containers/sync/TransportMessageCodec.hpp
+++ b/include/mdbx_containers/sync/TransportMessageCodec.hpp
@@ -8,7 +8,7 @@
 /// Envelope layout for all messages:
 /// \code
 ///   magic             "MDBXCPRT"   8 bytes
-///   codec_version     u16 le       = 4
+///   codec_version     u16 le       = 5
 ///   message_type      u8           1=pull request, 2=pull response,
 ///                                  3=push request, 4=push response
 ///   message_flags     u32 le       = 0 in v0.1
@@ -61,7 +61,7 @@ namespace sync {
         static std::size_t magic_size() { return 8; }
 
         /// \brief Supported transport codec version.
-        static std::uint16_t codec_version() { return 4; }
+        static std::uint16_t codec_version() { return 5; }
 
         /// \brief Reads the message type from a transport envelope.
         /// \details Validates magic, codec version, and mandatory flags but
@@ -87,6 +87,9 @@ namespace sync {
             detail::append_u64_le(out, request.max_batches);
             detail::append_u64_le(out, request.max_bytes);
             append_bool(out, request.request_full_snapshot);
+            validate_pull_request_snapshot(request, bounds);
+            append_snapshot_token(out, request.full_snapshot_id, bounds);
+            append_snapshot_token(out, request.full_snapshot_continuation, bounds);
             detail::append_u64_le(out, request.max_single_batch_bytes);
             validate_message_size(out, bounds);
             return out;
@@ -104,6 +107,11 @@ namespace sync {
             append_bool(out, response.remote_tail_known);
             append_batches(out, response.batches, bounds);
             append_bool(out, response.has_more);
+            validate_pull_response_snapshot(response, bounds);
+            append_bool(out, response.is_full_snapshot);
+            if (response.is_full_snapshot) {
+                append_snapshot_chunk(out, response.snapshot_chunk, bounds);
+            }
             append_bool(out, response.ok);
             append_string(out, response.error, bounds);
             append_response_error_code(out, response.error_code);
@@ -156,7 +164,10 @@ namespace sync {
             request.max_batches = read_u64_le(cur);
             request.max_bytes = read_u64_le(cur);
             request.request_full_snapshot = read_bool(cur);
+            request.full_snapshot_id = read_snapshot_token(cur, bounds);
+            request.full_snapshot_continuation = read_snapshot_token(cur, bounds);
             request.max_single_batch_bytes = read_u64_le(cur);
+            validate_pull_request_snapshot(request, bounds);
             check_consumed(cur);
             return request;
         }
@@ -174,11 +185,16 @@ namespace sync {
             response.remote_tail_known = read_bool(cur);
             response.batches = read_batches(cur, bounds);
             response.has_more = read_bool(cur);
+            response.is_full_snapshot = read_bool(cur);
+            if (response.is_full_snapshot) {
+                response.snapshot_chunk = read_snapshot_chunk(cur, bounds);
+            }
             response.ok = read_bool(cur);
             response.error = read_string(cur, bounds);
             response.error_code = read_response_error_code(cur);
             response.error_retryable = read_bool(cur);
             check_consumed(cur);
+            validate_pull_response_snapshot(response, bounds);
             return response;
         }
 
@@ -394,6 +410,34 @@ namespace sync {
             }
         }
 
+        static void append_snapshot_token(std::vector<std::uint8_t>& out,
+                                          const std::string& value,
+                                          const CodecBounds* bounds) {
+            if (value.size() > bounds->max_snapshot_id_len) {
+                throw std::length_error(
+                    "snapshot token exceeds max_snapshot_id_len");
+            }
+            append_u32_size(out, value.size(),
+                            "snapshot token length exceeds u32");
+            if (!value.empty()) {
+                append_bytes(out,
+                             reinterpret_cast<const std::uint8_t*>(value.data()),
+                             value.size());
+            }
+        }
+
+        static void append_snapshot_chunk(
+                std::vector<std::uint8_t>& out,
+                const FullSnapshotChunk& chunk,
+                const CodecBounds* bounds) {
+            const std::vector<std::uint8_t> encoded =
+                FullSnapshotCodec::encode(chunk, bounds);
+            append_u32_size(out, encoded.size(),
+                            "full snapshot chunk length exceeds u32");
+            append_bytes(out, encoded.empty() ? nullptr : &encoded[0],
+                         encoded.size());
+        }
+
         static void append_batches(std::vector<std::uint8_t>& out,
                                    const std::vector<ChangeBatch>& batches,
                                    const CodecBounds* bounds) {
@@ -536,6 +580,80 @@ namespace sync {
             }
             const std::uint8_t* bytes = read_bytes(cur, len);
             return std::string(reinterpret_cast<const char*>(bytes), len);
+        }
+
+        static std::string read_snapshot_token(Cursor& cur,
+                                               const CodecBounds* bounds) {
+            const std::uint32_t len = read_u32_le(cur);
+            if (len > bounds->max_snapshot_id_len) {
+                throw std::length_error(
+                    "snapshot token exceeds max_snapshot_id_len");
+            }
+            if (len == 0u) {
+                return std::string();
+            }
+            const std::uint8_t* bytes = read_bytes(cur, len);
+            return std::string(reinterpret_cast<const char*>(bytes), len);
+        }
+
+        static FullSnapshotChunk read_snapshot_chunk(
+                Cursor& cur,
+                const CodecBounds* bounds) {
+            const std::uint32_t len = read_u32_le(cur);
+            if (len > bounds->max_snapshot_chunk_bytes) {
+                throw std::length_error(
+                    "full snapshot chunk exceeds max_snapshot_chunk_bytes");
+            }
+            const std::uint8_t* bytes = read_bytes(cur, len);
+            std::vector<std::uint8_t> encoded(len);
+            if (len != 0u) {
+                std::memcpy(&encoded[0], bytes, len);
+            }
+            return FullSnapshotCodec::decode(encoded, bounds);
+        }
+
+        static void validate_pull_request_snapshot(
+                const PullRequest& request,
+                const CodecBounds* bounds) {
+            if (request.full_snapshot_id.size() > bounds->max_snapshot_id_len ||
+                request.full_snapshot_continuation.size() >
+                    bounds->max_snapshot_id_len) {
+                throw std::length_error(
+                    "snapshot token exceeds max_snapshot_id_len");
+            }
+            if (!request.request_full_snapshot &&
+                (!request.full_snapshot_id.empty() ||
+                 !request.full_snapshot_continuation.empty())) {
+                throw std::invalid_argument(
+                    "incremental pull contains full snapshot session state");
+            }
+            if (request.request_full_snapshot &&
+                (request.full_snapshot_id.empty() !=
+                 request.full_snapshot_continuation.empty())) {
+                throw std::invalid_argument(
+                    "full snapshot session id and continuation must both be empty or set");
+            }
+        }
+
+        static void validate_pull_response_snapshot(
+                const PullResponse& response,
+                const CodecBounds* bounds) {
+            if (!response.is_full_snapshot) {
+                return;
+            }
+            if (!response.batches.empty()) {
+                throw std::invalid_argument(
+                    "full snapshot response also contains incremental batches");
+            }
+            if (!response.ok) {
+                throw std::invalid_argument(
+                    "failed pull response contains a full snapshot chunk");
+            }
+            FullSnapshotCodec::validate(response.snapshot_chunk, bounds);
+            if (response.has_more != response.snapshot_chunk.has_more) {
+                throw std::invalid_argument(
+                    "pull and full snapshot continuation flags differ");
+            }
         }
 
         static std::vector<ChangeBatch> read_batches(

--- a/include/mdbx_containers/sync/protocol.hpp
+++ b/include/mdbx_containers/sync/protocol.hpp
@@ -12,6 +12,7 @@
 #include "ChangeBatch.hpp"
 #include "cancellation.hpp"
 #include "common.hpp"
+#include "FullSnapshotProtocol.hpp"
 #include "SyncCursor.hpp"
 
 namespace mdbxc {
@@ -62,9 +63,15 @@ namespace sync {
         /// returned alone when it does not exceed \c max_single_batch_bytes.
         std::uint64_t max_bytes   = 4ULL * 1024ULL * 1024ULL;
         /// \brief Requests a full snapshot instead of an incremental delta.
-        /// \details Reserved for a future snapshot protocol. v0.1
-        /// \c SyncEngine responders reject this request explicitly.
+        /// \details The first snapshot request has both session fields empty.
+        /// Later pages repeat the server-issued id and continuation unchanged.
+        /// Responders that have not yet implemented export reject this mode
+        /// explicitly rather than treating it as changelog replay.
         bool         request_full_snapshot = false;
+        /// \brief Opaque id of an already-open full snapshot session.
+        std::string  full_snapshot_id;
+        /// \brief Opaque token for the immediate next snapshot chunk.
+        std::string  full_snapshot_continuation;
         /// \brief Cooperative cancellation token for this transport call.
         /// \details Optional; default-constructed tokens never cancel.
         /// Transports may poll it while waiting on interruptible operations.
@@ -87,6 +94,11 @@ namespace sync {
         bool                     remote_tail_known = false;
         std::vector<ChangeBatch> batches;
         bool                     has_more = false;
+        /// \brief True only when this response carries one full snapshot chunk.
+        /// \details Snapshot pages never also carry incremental batches. When
+        /// set, \c has_more must equal \c snapshot_chunk.has_more.
+        bool                     is_full_snapshot = false;
+        FullSnapshotChunk        snapshot_chunk;
         bool                     ok       = true;
         std::string              error;
         /// \brief Optional machine-readable sync-level error code.

--- a/tests/test_full_snapshot_protocol.cpp
+++ b/tests/test_full_snapshot_protocol.cpp
@@ -355,6 +355,12 @@ void test_full_snapshot_session_contract() {
     MDBXC_TEST_ASSERT(throws([&bounds]() {
         mdbxc::sync::FullSnapshotCodec::encode(make_chunk(), &bounds);
     }));
+
+    mdbxc::sync::FullSnapshotChunk empty = make_chunk();
+    empty.batch.ops.clear();
+    MDBXC_TEST_ASSERT(throws([&empty]() {
+        mdbxc::sync::FullSnapshotCodec::encode(empty);
+    }));
 }
 
 } // namespace

--- a/tests/test_full_snapshot_protocol.cpp
+++ b/tests/test_full_snapshot_protocol.cpp
@@ -22,8 +22,10 @@ mdbxc::sync::FullSnapshotChunk make_chunk() {
     out.source_node_id = make_id(0x10u);
     out.source_db_uuid = make_id(0x20u);
     out.snapshot_id = "snapshot-1";
+    out.source_tail.last_seq_by_origin[make_id(0x10u)] = 7u;
     out.chunk_index = 0u;
     out.has_more = true;
+    out.continuation = "next-0";
 
     mdbxc::sync::FullSnapshotManifestEntry manifest_entry;
     manifest_entry.dbi_name = "documents";
@@ -65,7 +67,10 @@ std::size_t manifest_count_offset(
         const mdbxc::sync::FullSnapshotChunk& chunk) {
     return mdbxc::sync::FullSnapshotCodec::magic_size() + 2u +
         chunk.source_node_id.size() + chunk.source_db_uuid.size() + 4u +
-        chunk.snapshot_id.size() + 8u + 1u;
+        chunk.snapshot_id.size() + 4u +
+        chunk.source_tail.last_seq_by_origin.size() *
+            (chunk.source_node_id.size() + 8u) +
+        8u + 1u + 1u + 4u + chunk.continuation.size() + 4u;
 }
 
 std::size_t nested_batch_offset(
@@ -87,8 +92,13 @@ void test_full_snapshot_round_trip() {
     MDBXC_TEST_ASSERT(decoded.source_node_id == source.source_node_id);
     MDBXC_TEST_ASSERT(decoded.source_db_uuid == source.source_db_uuid);
     MDBXC_TEST_ASSERT(decoded.snapshot_id == source.snapshot_id);
+    MDBXC_TEST_ASSERT(decoded.source_tail.last_seq_for(make_id(0x10u)) == 7u);
     MDBXC_TEST_ASSERT(decoded.chunk_index == 0u);
     MDBXC_TEST_ASSERT(decoded.has_more);
+    MDBXC_TEST_ASSERT(decoded.continuation == "next-0");
+    MDBXC_TEST_ASSERT(decoded.replacement_scope ==
+        mdbxc::sync::FullSnapshotScope::ManifestOnly);
+    MDBXC_TEST_ASSERT(decoded.manifest_version == 1u);
     MDBXC_TEST_ASSERT(decoded.manifest.size() == 1u);
     MDBXC_TEST_ASSERT(decoded.manifest[0].dbi_name == "documents");
     MDBXC_TEST_ASSERT(decoded.batch.seq == 0u);
@@ -263,7 +273,7 @@ void test_full_snapshot_manifest_boundary_and_malformed_input() {
     }));
 
     std::vector<std::uint8_t> unknown_version = encoded;
-    unknown_version[8u] = 2u;
+    unknown_version[8u] = 3u;
     unknown_version[9u] = 0u;
     MDBXC_TEST_ASSERT(throws([&unknown_version]() {
         mdbxc::sync::FullSnapshotCodec::decode(unknown_version);
@@ -309,6 +319,44 @@ void test_full_snapshot_rejects_incomplete_identity_and_manifest() {
     }));
 }
 
+void test_full_snapshot_session_contract() {
+    mdbxc::sync::FullSnapshotChunk final_chunk = make_chunk();
+    final_chunk.has_more = false;
+    final_chunk.continuation.clear();
+    final_chunk.batch.batch_flags = mdbxc::sync::BATCH_NONE;
+    const std::vector<std::uint8_t> encoded =
+        mdbxc::sync::FullSnapshotCodec::encode(final_chunk);
+    const mdbxc::sync::FullSnapshotChunk decoded =
+        mdbxc::sync::FullSnapshotCodec::decode(encoded);
+    MDBXC_TEST_ASSERT(!decoded.has_more);
+    MDBXC_TEST_ASSERT(decoded.continuation.empty());
+
+    mdbxc::sync::FullSnapshotChunk missing_token = make_chunk();
+    missing_token.continuation.clear();
+    MDBXC_TEST_ASSERT(throws([&missing_token]() {
+        mdbxc::sync::FullSnapshotCodec::encode(missing_token);
+    }));
+
+    mdbxc::sync::FullSnapshotChunk stale_token = final_chunk;
+    stale_token.continuation = "not-allowed";
+    MDBXC_TEST_ASSERT(throws([&stale_token]() {
+        mdbxc::sync::FullSnapshotCodec::encode(stale_token);
+    }));
+
+    mdbxc::sync::FullSnapshotChunk invalid_scope = make_chunk();
+    invalid_scope.replacement_scope =
+        static_cast<mdbxc::sync::FullSnapshotScope>(9u);
+    MDBXC_TEST_ASSERT(throws([&invalid_scope]() {
+        mdbxc::sync::FullSnapshotCodec::encode(invalid_scope);
+    }));
+
+    mdbxc::sync::CodecBounds bounds;
+    bounds.max_cursor_origins = 0u;
+    MDBXC_TEST_ASSERT(throws([&bounds]() {
+        mdbxc::sync::FullSnapshotCodec::encode(make_chunk(), &bounds);
+    }));
+}
+
 } // namespace
 
 int main() {
@@ -321,5 +369,6 @@ int main() {
     test_full_snapshot_rejects_non_replacement_operations();
     test_full_snapshot_manifest_boundary_and_malformed_input();
     test_full_snapshot_rejects_incomplete_identity_and_manifest();
+    test_full_snapshot_session_contract();
     return 0;
 }

--- a/tests/test_transport_codec.cpp
+++ b/tests/test_transport_codec.cpp
@@ -31,6 +31,26 @@ mdbxc::sync::ChangeBatch make_batch(std::uint8_t seed, std::uint64_t seq) {
     return batch;
 }
 
+mdbxc::sync::FullSnapshotChunk make_snapshot_chunk() {
+    using namespace mdbxc::sync;
+    FullSnapshotChunk chunk;
+    chunk.source_node_id = make_node(0x50);
+    chunk.source_db_uuid = make_node(0x70);
+    chunk.snapshot_id = "snapshot-session";
+    chunk.source_tail.last_seq_by_origin[chunk.source_node_id] = 11u;
+    chunk.chunk_index = 0u;
+    chunk.has_more = true;
+    chunk.continuation = "next-page";
+    FullSnapshotManifestEntry entry;
+    entry.dbi_name = "documents";
+    chunk.manifest.push_back(entry);
+    chunk.batch = make_batch(0x50, 0u);
+    chunk.batch.origin_node_id = chunk.source_node_id;
+    chunk.batch.batch_flags = BATCH_HAS_MORE;
+    chunk.batch.ops[0].dbi_name = "documents";
+    return chunk;
+}
+
 template<class Fn>
 void expect_throw(const std::string& label, Fn&& fn) {
     bool caught = false;
@@ -60,6 +80,8 @@ void test_pull_request_roundtrip() {
     request.max_batches = 17;
     request.max_bytes = 4096;
     request.request_full_snapshot = true;
+    request.full_snapshot_id = "snapshot-session";
+    request.full_snapshot_continuation = "next-page";
     request.max_single_batch_bytes = 8192;
     CancellationSource source;
     request.cancel_token = source.token();
@@ -83,10 +105,50 @@ void test_pull_request_roundtrip() {
                  "PullRequest max_bytes mismatch");
     require_true(decoded.request_full_snapshot,
                  "PullRequest full snapshot mismatch");
+    require_true(decoded.full_snapshot_id == request.full_snapshot_id,
+                 "PullRequest full snapshot id mismatch");
+    require_true(decoded.full_snapshot_continuation ==
+                     request.full_snapshot_continuation,
+                 "PullRequest full snapshot continuation mismatch");
     require_true(decoded.max_single_batch_bytes == 8192,
                  "PullRequest max_single_batch_bytes mismatch");
     require_true(!decoded.cancel_token.can_be_cancelled(),
                  "PullRequest cancel token must not be serialized");
+}
+
+void test_full_snapshot_pull_response_roundtrip() {
+    using namespace mdbxc::sync;
+    PullResponse response;
+    response.is_full_snapshot = true;
+    response.snapshot_chunk = make_snapshot_chunk();
+    response.has_more = true;
+    response.remote_tail_known = true;
+    response.remote_tail = response.snapshot_chunk.source_tail;
+
+    const std::vector<std::uint8_t> bytes =
+        TransportMessageCodec::encode_pull_response(response);
+    const PullResponse decoded =
+        TransportMessageCodec::decode_pull_response(bytes);
+
+    require_true(decoded.is_full_snapshot,
+                 "PullResponse full snapshot flag mismatch");
+    require_true(decoded.batches.empty(),
+                 "PullResponse full snapshot has incremental batches");
+    require_true(decoded.has_more && decoded.snapshot_chunk.has_more,
+                 "PullResponse full snapshot continuation mismatch");
+    require_true(decoded.snapshot_chunk.snapshot_id == "snapshot-session",
+                 "PullResponse full snapshot id mismatch");
+    require_true(decoded.snapshot_chunk.continuation == "next-page",
+                 "PullResponse full snapshot token mismatch");
+    require_true(decoded.snapshot_chunk.source_tail.last_seq_for(
+                     make_node(0x50)) == 11u,
+                 "PullResponse full snapshot tail mismatch");
+
+    expect_throw("mixed pull response", [response] {
+        PullResponse invalid = response;
+        invalid.batches.push_back(make_batch(0x50, 1u));
+        (void)TransportMessageCodec::encode_pull_response(invalid);
+    });
 }
 
 void test_pull_response_roundtrip() {
@@ -320,6 +382,19 @@ void test_bounds_rejections() {
         PullRequest request;
         (void)TransportMessageCodec::encode_pull_request(request, &bounds);
     });
+
+    expect_throw("incremental pull snapshot state", [] {
+        PullRequest request;
+        request.full_snapshot_id = "unexpected";
+        (void)TransportMessageCodec::encode_pull_request(request);
+    });
+
+    expect_throw("partial snapshot session state", [] {
+        PullRequest request;
+        request.request_full_snapshot = true;
+        request.full_snapshot_id = "session";
+        (void)TransportMessageCodec::encode_pull_request(request);
+    });
 }
 
 void test_response_error_code_rejections() {
@@ -352,7 +427,7 @@ void test_golden_header_shape() {
         require_true(bytes[i] == expected_magic[i],
                      "TransportMessageCodec magic mismatch");
     }
-    require_true(bytes[8] == 4u && bytes[9] == 0u,
+    require_true(bytes[8] == 5u && bytes[9] == 0u,
                  "TransportMessageCodec version mismatch");
     require_true(bytes[10] == 1u,
                  "TransportMessageCodec pull request type mismatch");
@@ -366,6 +441,7 @@ void test_golden_header_shape() {
 int main() {
     test_pull_request_roundtrip();
     test_pull_response_roundtrip();
+    test_full_snapshot_pull_response_roundtrip();
     test_push_request_roundtrip();
     test_push_response_roundtrip();
     test_peek_message_type();


### PR DESCRIPTION
## Summary
- define explicit full-snapshot session state in pull DTOs
- carry immutable source-tail, continuation, scope, and manifest version in snapshot chunks
- bump unreleased transport codec to v5 with strict snapshot/incremental separation

## Validation
- C++11/C++17 MinGW: full-snapshot and transport codec/boundary tests
- standalone FullSnapshotProtocol and TransportMessageCodec headers