### PR TITLE
feat(sync): export stable full snapshot pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ All notable changes to this project will be documented in this file.
   source-tail, replacement-scope, manifest-version, and continuation fields.
   `PullRequest`/`PullResponse` now carry explicit snapshot session state and
   chunk pages; this changes the unreleased `TransportMessageCodec` wire version
-  from 4 to 5. Source export and replacement apply remain explicitly disabled
-  until their lifecycle implementations land.
+  from 4 to 5. `SyncEngine` can materialize an explicitly configured source
+  manifest into bounded, stable pages. Replacement apply and cursor bootstrap
+  remain disabled until their lifecycle implementations land.
 - Sync: document the authoritative-baseline and multi-origin conflict
   boundary for ordered schema-v2. Baseline import and concurrent multi-writer
   resolution remain design-only and are not exposed as partial APIs.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1535,7 +1535,7 @@ B: applies each page as above
 The reserved `seq=0, BATCH_HAS_MORE` full export/import format is not the
 current cold-replica implementation yet. `FullSnapshotProtocol.hpp` defines and
 validates its chunk codec: every chunk carries a source identity, immutable
-source changelog tail, stable `snapshot_id`, chunk index, replacement scope,
+per-origin replication tail, stable `snapshot_id`, chunk index, replacement scope,
 opaque next-page token, manifest version, immutable named-user-DBI manifest,
 and a nested raw batch with `seq=0`. Transport codec v5 carries the explicit
 session request and one snapshot chunk in `PullResponse`; it rejects mixed
@@ -1601,7 +1601,7 @@ Required protocol properties before enabling the flag:
   ambiguous resume attempts.
 - Metadata bootstrap is separate from user data import. After the snapshot data
   is committed, the receiver records applied cursors consistent with the
-  responder's advertised changelog tail so the next round can continue through
+  responder's advertised replication tail so the next round can continue through
   ordinary incremental pull.
 - Chunk pagination must use the existing pull limits: `max_bytes` as a soft page
   budget and `max_single_batch_bytes` as a hard limit for a single encoded

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1532,23 +1532,26 @@ B: applies each page as above
     -> onward sync is incremental pull-from-have
 ```
 
-The reserved `seq=0, BATCH_HAS_MORE` full export/import format remains planned
-for v0.1 and is not the current cold-replica implementation.
-`FullSnapshotProtocol.hpp` now defines and validates a preparatory chunk
-codec: every chunk carries a source identity, immutable source changelog tail,
-stable `snapshot_id`, chunk index, replacement scope, opaque next-page token,
-manifest version, immutable named-user-DBI manifest, and a nested raw batch
-with `seq=0`. Transport codec v5 carries the explicit session request and one
-snapshot chunk in `PullResponse`; it rejects mixed incremental/snapshot pages
-and malformed session state. `SyncEngine` does not accept the request yet: the
-source-export session, cursor bootstrap semantics, and atomic replacement apply
-path still need to be implemented before the flag can be enabled.
-`PullRequest::request_full_snapshot=true` is rejected explicitly until the
-transport and replacement apply path are implemented. In v0.1 this is a
-sync-level protocol rejection carried
-as `PullResponse{ok=false, error=..., error_code=UnsupportedFullSnapshot}`; it
-does not produce a transport retry hint because the server returned a valid
-sync response rather than a transport failure.
+The reserved `seq=0, BATCH_HAS_MORE` full export/import format is not the
+current cold-replica implementation yet. `FullSnapshotProtocol.hpp` defines and
+validates its chunk codec: every chunk carries a source identity, immutable
+source changelog tail, stable `snapshot_id`, chunk index, replacement scope,
+opaque next-page token, manifest version, immutable named-user-DBI manifest,
+and a nested raw batch with `seq=0`. Transport codec v5 carries the explicit
+session request and one snapshot chunk in `PullResponse`; it rejects mixed
+incremental/snapshot pages and malformed session state.
+
+`SyncEngine` can export an explicit `FullSnapshotExportOptions::manifest`: it
+materializes configured user DBIs in one read transaction, bounds active
+sessions and materialized data, and returns stable pages. An empty source
+manifest returns `SnapshotNotConfigured`; unknown, expired, or mismatched
+continuations or a different requester return `SnapshotSessionInvalid`; bounded
+session capacity returns retryable `SnapshotSessionBusy`.
+
+Snapshot import, applied-cursor bootstrap, and worker fallback are still not
+implemented. Consequently a snapshot export is not yet an automatic recovery
+path for `SnapshotRequired`; callers must not treat source export alone as a
+working replica-replacement workflow.
 If changelog pruning removed entries needed by the requester's cursor,
 `handle_pull()` returns `SnapshotRequired` with no batches. This is also a
 valid sync response, not a transport failure.

--- a/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
+++ b/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
@@ -63,7 +63,10 @@ namespace sync {
         NodeId source_node_id{};
         DbId source_db_uuid{};
         std::string snapshot_id;
-        /// \brief Immutable source changelog tail captured with this snapshot.
+        /// \brief Immutable per-origin replication tail captured with this snapshot.
+        /// \details This is the componentwise maximum of source changelog and
+        /// already-applied remote-origin progress, so a fresh receiver can
+        /// continue incremental pull from every represented origin.
         SyncCursor source_tail;
         std::uint64_t chunk_index = 0u;
         bool has_more = false;

--- a/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
+++ b/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
@@ -6,6 +6,7 @@
 /// \brief Explicit full-snapshot chunk contract and codec.
 
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <limits>
@@ -35,6 +36,21 @@ namespace sync {
     enum class FullSnapshotScope : std::uint8_t {
         ManifestOnly = 0u,
         CompleteUserDatabase = 1u
+    };
+
+    /// \brief Explicit source-side configuration for materialized snapshots.
+    /// \details The engine never scans MainDB to guess named user DBIs. A
+    /// caller declares the exportable DBIs, including empty tables, and bounds
+    /// the one-session materialization before enabling full-snapshot pull.
+    struct FullSnapshotExportOptions {
+        std::vector<FullSnapshotManifestEntry> manifest;
+        FullSnapshotScope replacement_scope = FullSnapshotScope::ManifestOnly;
+        std::uint64_t max_materialized_operations = 1000000u;
+        std::uint64_t max_materialized_bytes =
+            256ULL * 1024ULL * 1024ULL;
+        std::uint32_t max_active_sessions = 4u;
+        std::chrono::seconds session_idle_timeout =
+            std::chrono::seconds(300);
     };
 
     /// \brief One chunk of a full database export.

--- a/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
+++ b/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
@@ -30,18 +30,22 @@ namespace sync {
     };
 
     /// \brief Declares which user-DBI content a snapshot may replace.
-    /// \details \c ManifestOnly preserves receiver-only user DBIs. Complete
-    /// replacement is an explicit receiver opt-in and is not enabled by the
-    /// initial importer.
+    /// \details \c ManifestOnly replaces only manifest DBIs and never
+    /// bootstraps global raw-sync progress. \c CompleteUserDatabase replaces
+    /// every named user DBI and is the only scope that may bootstrap the
+    /// per-origin applied cursor for subsequent incremental replication.
     enum class FullSnapshotScope : std::uint8_t {
         ManifestOnly = 0u,
         CompleteUserDatabase = 1u
     };
 
     /// \brief Explicit source-side configuration for materialized snapshots.
-    /// \details The engine never scans MainDB to guess named user DBIs. A
-    /// caller declares the exportable DBIs, including empty tables, and bounds
-    /// the one-session materialization before enabling full-snapshot pull.
+    /// \details For \c ManifestOnly, c manifest explicitly declares the
+    /// exportable DBIs, including empty tables. For
+    /// \c CompleteUserDatabase, c manifest must be empty: the engine
+    /// enumerates every named non-reserved DBI in MainDB under one read
+    /// transaction. Both modes bound one-session materialization before
+    /// enabling full-snapshot pull.
     struct FullSnapshotExportOptions {
         std::vector<FullSnapshotManifestEntry> manifest;
         FullSnapshotScope replacement_scope = FullSnapshotScope::ManifestOnly;
@@ -56,9 +60,8 @@ namespace sync {
     /// \brief One chunk of a full database export.
     /// \details Snapshot chunks are not changelog batches. They carry a
     /// stable source identity, an immutable manifest, and a nested raw batch
-    /// whose sequence is always zero. A future transport may accept this
-    /// contract only after validating the complete manifest and snapshot
-    /// continuation before any user-DBI mutation.
+    /// whose sequence is always zero. The transport validates the complete
+    /// manifest and snapshot continuation before any user-DBI mutation.
     struct FullSnapshotChunk {
         NodeId source_node_id{};
         DbId source_db_uuid{};
@@ -84,9 +87,8 @@ namespace sync {
 
     /// \brief Strict codec for the explicit full-snapshot wire boundary.
     /// \details Configured sources export bounded snapshot sessions through
-    /// \c PullRequest::request_full_snapshot. The initial receiver accepts
-    /// only \c ManifestOnly pages into a fresh replica and commits the staged
-    /// replacement plan atomically at the final page.
+    /// \c PullRequest::request_full_snapshot. Receivers stage pages and
+    /// commit the validated replacement plan atomically at the final page.
     class FullSnapshotCodec {
     public:
         static const std::uint8_t* magic() {

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -1293,7 +1293,22 @@ namespace sync {
 
         static void validate_full_snapshot_export_options(
                 const FullSnapshotExportOptions& options) {
-            if (options.manifest.empty()) {
+            switch (options.replacement_scope) {
+                case FullSnapshotScope::ManifestOnly:
+                case FullSnapshotScope::CompleteUserDatabase:
+                    break;
+                default:
+                    throw std::invalid_argument(
+                        "invalid full snapshot replacement scope");
+            }
+            if (options.replacement_scope ==
+                    FullSnapshotScope::CompleteUserDatabase &&
+                !options.manifest.empty()) {
+                throw std::invalid_argument(
+                    "complete full snapshot export enumerates its manifest");
+            }
+            if (options.replacement_scope == FullSnapshotScope::ManifestOnly &&
+                options.manifest.empty()) {
                 return;
             }
             if (options.max_materialized_operations == 0u ||
@@ -1302,14 +1317,6 @@ namespace sync {
                 options.session_idle_timeout <= std::chrono::seconds::zero()) {
                 throw std::invalid_argument(
                     "full snapshot export limits must be non-zero");
-            }
-            switch (options.replacement_scope) {
-                case FullSnapshotScope::ManifestOnly:
-                case FullSnapshotScope::CompleteUserDatabase:
-                    break;
-                default:
-                    throw std::invalid_argument(
-                        "invalid full snapshot replacement scope");
             }
             for (std::size_t i = 0u; i < options.manifest.size(); ++i) {
                 const FullSnapshotManifestEntry& entry = options.manifest[i];
@@ -1324,6 +1331,73 @@ namespace sync {
                         "full snapshot manifest must be sorted and unique");
                 }
             }
+        }
+
+        static bool full_snapshot_export_is_configured(
+                const FullSnapshotExportOptions& options) {
+            return options.replacement_scope ==
+                FullSnapshotScope::CompleteUserDatabase ||
+                !options.manifest.empty();
+        }
+
+        std::vector<FullSnapshotManifestEntry>
+        enumerate_complete_snapshot_manifest(MDBX_txn* txn) const {
+            MDBX_dbi main_dbi = 0;
+            check_mdbx(
+                mdbx_dbi_open(
+                    txn, static_cast<const char*>(MDBX_CHK_MAIN),
+                    static_cast<MDBX_db_flags_t>(0), &main_dbi),
+                "full snapshot failed to open MainDB for complete inventory");
+
+            std::vector<FullSnapshotManifestEntry> manifest;
+            MDBX_cursor* raw = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, main_dbi, &raw),
+                       "full snapshot failed to open MainDB cursor");
+            CursorGuard cursor(raw);
+            MDBX_val key;
+            MDBX_val value;
+            int rc = mdbx_cursor_get(raw, &key, &value, MDBX_FIRST);
+            while (rc == MDBX_SUCCESS) {
+                MDBX_dbi dbi = 0;
+                const int open_rc = mdbx_dbi_open2(
+                    txn, &key, MDBX_DB_ACCEDE, &dbi);
+                if (open_rc == MDBX_SUCCESS) {
+                    const char* name_data =
+                        static_cast<const char*>(key.iov_base);
+                    const std::string name(name_data, key.iov_len);
+                    if (!is_reserved_snapshot_dbi(name)) {
+                        unsigned raw_flags = 0u;
+                        check_mdbx(
+                            mdbx_dbi_flags(txn, dbi, &raw_flags),
+                            "full snapshot failed to read complete DBI flags");
+                        FullSnapshotManifestEntry entry;
+                        entry.dbi_name = name;
+                        entry.dbi_flags = persistent_dbi_flags(
+                            static_cast<std::uint32_t>(raw_flags));
+                        manifest.push_back(entry);
+                    }
+                } else if (open_rc != MDBX_INCOMPATIBLE &&
+                           open_rc != MDBX_NOTFOUND) {
+                    check_mdbx(
+                        open_rc,
+                        "full snapshot failed to inspect MainDB entry");
+                }
+                rc = mdbx_cursor_get(raw, &key, &value, MDBX_NEXT);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc,
+                           "full snapshot failed to scan complete DBI inventory");
+            }
+            std::sort(manifest.begin(), manifest.end(),
+                [](const FullSnapshotManifestEntry& left,
+                   const FullSnapshotManifestEntry& right) {
+                    return left.dbi_name < right.dbi_name;
+                });
+            if (manifest.empty()) {
+                throw std::runtime_error(
+                    "complete full snapshot source has no user DBIs");
+            }
+            return manifest;
         }
 
         static std::uint64_t snapshot_materialized_bytes_for(
@@ -1423,7 +1497,6 @@ namespace sync {
                 new FullSnapshotSession());
             session->snapshot_id = snapshot_id;
             session->requester = requester;
-            session->manifest = options.manifest;
             session->replacement_scope = options.replacement_scope;
             session->last_access = std::chrono::steady_clock::now();
 
@@ -1438,18 +1511,26 @@ namespace sync {
                     "full snapshot source identity is not initialized");
             }
 
-            const MDBX_dbi changelog_dbi = open_changelog_ro(txn.handle());
-            session->source_tail = read_applied_cursor(
-                txn.handle(), SyncCursor());
-            if (changelog_dbi != 0) {
-                const std::vector<PullOrigin> origins =
-                    collect_known_origins(txn.handle(), changelog_dbi);
-                SyncCursor changelog_tail;
-                if (!copy_known_tail(origins, changelog_tail)) {
-                    throw std::runtime_error(
-                        "full snapshot source changelog tail is incomplete");
+            session->manifest = options.replacement_scope ==
+                    FullSnapshotScope::CompleteUserDatabase
+                ? enumerate_complete_snapshot_manifest(txn.handle())
+                : options.manifest;
+
+            if (options.replacement_scope ==
+                    FullSnapshotScope::CompleteUserDatabase) {
+                const MDBX_dbi changelog_dbi = open_changelog_ro(txn.handle());
+                session->source_tail = read_applied_cursor(
+                    txn.handle(), SyncCursor());
+                if (changelog_dbi != 0) {
+                    const std::vector<PullOrigin> origins =
+                        collect_known_origins(txn.handle(), changelog_dbi);
+                    SyncCursor changelog_tail;
+                    if (!copy_known_tail(origins, changelog_tail)) {
+                        throw std::runtime_error(
+                            "full snapshot source changelog tail is incomplete");
+                    }
+                    merge_sync_cursor_max(session->source_tail, changelog_tail);
                 }
-                merge_sync_cursor_max(session->source_tail, changelog_tail);
             }
 
             std::uint64_t materialized_bytes = 0u;
@@ -1620,7 +1701,7 @@ namespace sync {
                     std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
                     prune_expired_full_snapshot_sessions_locked();
                     options = m_full_snapshot_options;
-                    if (options.manifest.empty()) {
+                    if (!full_snapshot_export_is_configured(options)) {
                         out.ok = false;
                         out.error = "full snapshot source export is not configured";
                         out.error_code =

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -1341,7 +1341,7 @@ namespace sync {
         }
 
         std::vector<FullSnapshotManifestEntry>
-        enumerate_complete_snapshot_manifest(MDBX_txn* txn) const {
+        enumerate_user_snapshot_manifest(MDBX_txn* txn) const {
             MDBX_dbi main_dbi = 0;
             check_mdbx(
                 mdbx_dbi_open(
@@ -1393,10 +1393,6 @@ namespace sync {
                    const FullSnapshotManifestEntry& right) {
                     return left.dbi_name < right.dbi_name;
                 });
-            if (manifest.empty()) {
-                throw std::runtime_error(
-                    "complete full snapshot source has no user DBIs");
-            }
             return manifest;
         }
 
@@ -1513,8 +1509,14 @@ namespace sync {
 
             session->manifest = options.replacement_scope ==
                     FullSnapshotScope::CompleteUserDatabase
-                ? enumerate_complete_snapshot_manifest(txn.handle())
+                ? enumerate_user_snapshot_manifest(txn.handle())
                 : options.manifest;
+            if (session->replacement_scope ==
+                    FullSnapshotScope::CompleteUserDatabase &&
+                session->manifest.empty()) {
+                throw std::runtime_error(
+                    "complete full snapshot source has no user DBIs");
+            }
 
             if (options.replacement_scope ==
                     FullSnapshotScope::CompleteUserDatabase) {

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -23,10 +23,13 @@
 /// supplied transaction and are therefore valid only for its lifetime.
 
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <map>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -138,17 +141,43 @@ namespace sync {
             bool has_last_seq;
         };
 
+        struct FullSnapshotContinuation {
+            std::size_t next_operation = 0u;
+            std::uint64_t chunk_index = 0u;
+        };
+
+        struct FullSnapshotSession {
+            NodeId source_node_id{};
+            DbId source_db_uuid{};
+            NodeId requester{};
+            std::string snapshot_id;
+            SyncCursor source_tail;
+            FullSnapshotScope replacement_scope =
+                FullSnapshotScope::ManifestOnly;
+            std::vector<FullSnapshotManifestEntry> manifest;
+            std::vector<ChangeOp> operations;
+            std::map<std::string, FullSnapshotContinuation> continuations;
+            std::chrono::steady_clock::time_point last_access;
+            std::mutex mutex;
+        };
+
     public:
         /// \brief Constructs an engine bound to \p conn.
         /// \param conn Shared connection that owns the env and stores.
         /// \param policy Conflict resolution policy (default: \c Reject).
         explicit SyncEngine(std::shared_ptr<Connection> conn,
-                            ConflictPolicy policy = ConflictPolicy::Reject)
-            : m_conn(std::move(conn)), m_policy(policy) {
+                            ConflictPolicy policy = ConflictPolicy::Reject,
+                            const FullSnapshotExportOptions&
+                                full_snapshot_options =
+                                    FullSnapshotExportOptions())
+            : m_conn(std::move(conn)),
+              m_policy(policy),
+              m_full_snapshot_options(full_snapshot_options) {
             if (m_policy == ConflictPolicy::LastWriterWins) {
                 throw std::invalid_argument(
                     "ConflictPolicy::LastWriterWins is not implemented");
             }
+            validate_full_snapshot_export_options(m_full_snapshot_options);
         }
 
         /// \brief Initialises the local \c node_id and \c db_uuid.
@@ -198,6 +227,18 @@ namespace sync {
 
         /// \brief Returns the conflict resolution policy.
         ConflictPolicy policy() const noexcept { return m_policy; }
+
+        /// \brief Replaces the explicit source manifest used for full snapshots.
+        /// \details An empty manifest disables source export. Reconfiguration
+        /// invalidates all in-memory snapshot sessions, so callers must not
+        /// change it while an export is in progress.
+        void set_full_snapshot_export_options(
+                const FullSnapshotExportOptions& options) {
+            validate_full_snapshot_export_options(options);
+            std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
+            m_full_snapshot_options = options;
+            m_full_snapshot_sessions.clear();
+        }
 
         /// \brief Registers or verifies a persistent logical table schema.
         /// \details This is the normal lifecycle entry point for application
@@ -990,8 +1031,8 @@ namespace sync {
             return "unknown";
         }
 
-        /// \brief Handles a pull request: reads the local changelog
-        /// for batches newer than the requester's cursor.
+        /// \brief Handles an incremental pull or explicitly configured
+        /// full-snapshot export request.
         /// \details When \c request.have is empty, replays all retained
         /// changelog batches from seq=1 for all known origins. This is not
         /// a full database snapshot. Non-empty cursors still
@@ -1003,7 +1044,10 @@ namespace sync {
         /// \c request.max_batches or the soft page budget
         /// \c request.max_bytes rather than running out of changelog entries.
         /// A single retained batch may exceed \c max_bytes but is rejected
-        /// when it exceeds \c request.max_single_batch_bytes.
+        /// when it exceeds \c request.max_single_batch_bytes. Full snapshots
+        /// require an empty receiver cursor and an explicit source manifest;
+        /// they materialize stable, bounded source pages, while import remains
+        /// a separate lifecycle operation.
         PullResponse handle_pull(const PullRequest& request) {
             PullResponse out;
             if (!db_id_matches(request.db_id)) {
@@ -1013,11 +1057,7 @@ namespace sync {
                 return out;
             }
             if (request.request_full_snapshot) {
-                out.ok = false;
-                out.error = "PullRequest::request_full_snapshot is not implemented";
-                out.error_code =
-                    SyncResponseErrorCode::UnsupportedFullSnapshot;
-                return out;
+                return handle_full_snapshot_pull(request);
             }
 
             MDBX_txn* txn = nullptr;
@@ -1245,6 +1285,410 @@ namespace sync {
 
             MDBX_cursor* raw;
         };
+
+        static bool is_reserved_snapshot_dbi(const std::string& name) {
+            return name.size() >= 7u &&
+                name.compare(0u, 7u, "_mdbxc_") == 0;
+        }
+
+        static void validate_full_snapshot_export_options(
+                const FullSnapshotExportOptions& options) {
+            if (options.manifest.empty()) {
+                return;
+            }
+            if (options.max_materialized_operations == 0u ||
+                options.max_materialized_bytes == 0u ||
+                options.max_active_sessions == 0u ||
+                options.session_idle_timeout <= std::chrono::seconds::zero()) {
+                throw std::invalid_argument(
+                    "full snapshot export limits must be non-zero");
+            }
+            switch (options.replacement_scope) {
+                case FullSnapshotScope::ManifestOnly:
+                case FullSnapshotScope::CompleteUserDatabase:
+                    break;
+                default:
+                    throw std::invalid_argument(
+                        "invalid full snapshot replacement scope");
+            }
+            for (std::size_t i = 0u; i < options.manifest.size(); ++i) {
+                const FullSnapshotManifestEntry& entry = options.manifest[i];
+                if (entry.dbi_name.empty() ||
+                    is_reserved_snapshot_dbi(entry.dbi_name)) {
+                    throw std::invalid_argument(
+                        "full snapshot manifest contains a reserved or empty DBI");
+                }
+                if (i != 0u &&
+                    options.manifest[i - 1u].dbi_name >= entry.dbi_name) {
+                    throw std::invalid_argument(
+                        "full snapshot manifest must be sorted and unique");
+                }
+            }
+        }
+
+        static std::uint64_t snapshot_materialized_bytes_for(
+                const std::string& dbi_name,
+                const MDBX_val& key,
+                const MDBX_val& value) {
+            const std::uint64_t max =
+                (std::numeric_limits<std::uint64_t>::max)();
+            if (dbi_name.size() > max || key.iov_len > max || value.iov_len > max) {
+                throw std::length_error("full snapshot materialization size overflow");
+            }
+            const std::uint64_t name_size =
+                static_cast<std::uint64_t>(dbi_name.size());
+            const std::uint64_t key_size = static_cast<std::uint64_t>(key.iov_len);
+            const std::uint64_t value_size = static_cast<std::uint64_t>(value.iov_len);
+            const std::uint64_t operation_size =
+                static_cast<std::uint64_t>(sizeof(ChangeOp));
+            if (operation_size > max - name_size ||
+                key_size > max - name_size - operation_size ||
+                value_size > max - name_size - operation_size - key_size) {
+                throw std::length_error("full snapshot materialization size overflow");
+            }
+            return name_size + operation_size + key_size + value_size;
+        }
+
+        static void append_full_snapshot_operation(
+                FullSnapshotSession& session,
+                const FullSnapshotExportOptions& options,
+                const std::string& dbi_name,
+                std::uint32_t dbi_flags,
+                ChangeOpType op_type,
+                const MDBX_val* key,
+                const MDBX_val* value,
+                std::uint64_t& materialized_bytes) {
+            if (static_cast<std::uint64_t>(session.operations.size()) >=
+                options.max_materialized_operations) {
+                throw std::length_error(
+                    "full snapshot exceeds max_materialized_operations");
+            }
+            MDBX_val empty = { nullptr, 0u };
+            const MDBX_val& actual_key = key == nullptr ? empty : *key;
+            const MDBX_val& actual_value = value == nullptr ? empty : *value;
+            const std::uint64_t add = snapshot_materialized_bytes_for(
+                dbi_name, actual_key, actual_value);
+            if (add > options.max_materialized_bytes - materialized_bytes) {
+                throw std::length_error(
+                    "full snapshot exceeds max_materialized_bytes");
+            }
+
+            ChangeOp op;
+            op.op_type = op_type;
+            op.dbi_name = dbi_name;
+            op.dbi_flags = dbi_flags;
+            if (actual_key.iov_len != 0u) {
+                const std::uint8_t* bytes =
+                    static_cast<const std::uint8_t*>(actual_key.iov_base);
+                op.storage_key.assign(bytes, bytes + actual_key.iov_len);
+            }
+            if (actual_value.iov_len != 0u) {
+                const std::uint8_t* bytes =
+                    static_cast<const std::uint8_t*>(actual_value.iov_base);
+                op.value.assign(bytes, bytes + actual_value.iov_len);
+            }
+            session.operations.push_back(std::move(op));
+            materialized_bytes += add;
+        }
+
+        std::string next_full_snapshot_id() {
+            std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
+            ++m_next_full_snapshot_session_id;
+            return std::string("snapshot-") +
+                std::to_string(m_next_full_snapshot_session_id);
+        }
+
+        void prune_expired_full_snapshot_sessions_locked() {
+            const std::chrono::steady_clock::time_point now =
+                std::chrono::steady_clock::now();
+            std::map<std::string,
+                     std::shared_ptr<FullSnapshotSession>>::iterator it =
+                m_full_snapshot_sessions.begin();
+            while (it != m_full_snapshot_sessions.end()) {
+                const std::chrono::steady_clock::duration idle =
+                    now - it->second->last_access;
+                if (idle >= m_full_snapshot_options.session_idle_timeout) {
+                    m_full_snapshot_sessions.erase(it++);
+                } else {
+                    ++it;
+                }
+            }
+        }
+
+        std::shared_ptr<FullSnapshotSession> materialize_full_snapshot(
+                const FullSnapshotExportOptions& options,
+                const std::string& snapshot_id,
+                const NodeId& requester) const {
+            std::shared_ptr<FullSnapshotSession> session(
+                new FullSnapshotSession());
+            session->snapshot_id = snapshot_id;
+            session->requester = requester;
+            session->manifest = options.manifest;
+            session->replacement_scope = options.replacement_scope;
+            session->last_access = std::chrono::steady_clock::now();
+
+            auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
+            MetaStore meta(m_conn->env_handle());
+            meta.open(txn.handle());
+            session->source_node_id = meta.get_node_id(txn.handle());
+            session->source_db_uuid = meta.get_db_uuid(txn.handle());
+            if (compare_node_id(session->source_node_id, NodeId()) == 0 ||
+                compare_node_id(session->source_db_uuid, NodeId()) == 0) {
+                throw std::logic_error(
+                    "full snapshot source identity is not initialized");
+            }
+
+            const MDBX_dbi changelog_dbi = open_changelog_ro(txn.handle());
+            if (changelog_dbi != 0) {
+                const std::vector<PullOrigin> origins =
+                    collect_known_origins(txn.handle(), changelog_dbi);
+                copy_known_tail(origins, session->source_tail);
+            }
+
+            std::uint64_t materialized_bytes = 0u;
+            for (std::size_t i = 0u; i < session->manifest.size(); ++i) {
+                const FullSnapshotManifestEntry& entry = session->manifest[i];
+                MDBX_dbi dbi = 0;
+                const MDBX_db_flags_t open_flags =
+                    static_cast<MDBX_db_flags_t>(
+                        persistent_dbi_flags(entry.dbi_flags));
+                int rc = mdbx_dbi_open(txn.handle(), entry.dbi_name.c_str(),
+                                       open_flags, &dbi);
+                if (rc == MDBX_NOTFOUND) {
+                    throw std::runtime_error(
+                        "full snapshot manifest DBI does not exist: " +
+                        entry.dbi_name);
+                }
+                check_mdbx(rc, "full snapshot failed to open DBI '" +
+                            entry.dbi_name + "'");
+
+                unsigned actual_raw = 0u;
+                check_mdbx(mdbx_dbi_flags(txn.handle(), dbi, &actual_raw),
+                           "full snapshot failed to read DBI flags");
+                const std::uint32_t actual_flags = persistent_dbi_flags(
+                    static_cast<std::uint32_t>(actual_raw));
+                if (actual_flags != entry.dbi_flags) {
+                    throw std::runtime_error(
+                        "full snapshot manifest DBI flags mismatch: " +
+                        entry.dbi_name);
+                }
+
+                append_full_snapshot_operation(*session, options,
+                    entry.dbi_name, actual_flags, ChangeOpType::ClearTable,
+                    nullptr, nullptr, materialized_bytes);
+
+                MDBX_cursor* raw = nullptr;
+                check_mdbx(mdbx_cursor_open(txn.handle(), dbi, &raw),
+                           "full snapshot failed to open DBI cursor");
+                CursorGuard cursor(raw);
+                MDBX_val key;
+                MDBX_val value;
+                rc = mdbx_cursor_get(raw, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    append_full_snapshot_operation(*session, options,
+                        entry.dbi_name, actual_flags, ChangeOpType::Put,
+                        &key, &value, materialized_bytes);
+                    rc = mdbx_cursor_get(raw, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "full snapshot failed to scan DBI '" +
+                               entry.dbi_name + "'");
+                }
+            }
+            return session;
+        }
+
+        static std::string continuation_for(
+                FullSnapshotSession& session,
+                std::size_t next_operation,
+                std::uint64_t next_chunk_index) {
+            std::map<std::string, FullSnapshotContinuation>::const_iterator it =
+                session.continuations.begin();
+            for (; it != session.continuations.end(); ++it) {
+                if (it->second.next_operation == next_operation &&
+                    it->second.chunk_index == next_chunk_index) {
+                    return it->first;
+                }
+            }
+            const std::string token = session.snapshot_id + ":" +
+                std::to_string(next_chunk_index) + ":" +
+                std::to_string(next_operation);
+            FullSnapshotContinuation continuation;
+            continuation.next_operation = next_operation;
+            continuation.chunk_index = next_chunk_index;
+            session.continuations[token] = continuation;
+            return token;
+        }
+
+        static PullResponse make_full_snapshot_page(
+                FullSnapshotSession& session,
+                const PullRequest& request,
+                std::size_t start_operation,
+                std::uint64_t chunk_index) {
+            if (request.max_single_batch_bytes == 0u) {
+                throw std::length_error(
+                    "full snapshot max_single_batch_bytes must be non-zero");
+            }
+            const std::uint64_t hard_limit = request.max_single_batch_bytes;
+            const std::uint64_t soft_limit = request.max_bytes;
+            FullSnapshotChunk chunk;
+            chunk.source_node_id = session.source_node_id;
+            chunk.source_db_uuid = session.source_db_uuid;
+            chunk.snapshot_id = session.snapshot_id;
+            chunk.source_tail = session.source_tail;
+            chunk.chunk_index = chunk_index;
+            chunk.replacement_scope = session.replacement_scope;
+            chunk.manifest = session.manifest;
+            chunk.batch.origin_node_id = session.source_node_id;
+            chunk.batch.seq = 0u;
+            chunk.batch.version = ChangeBatchCodec::batch_version();
+
+            std::size_t next_operation = start_operation;
+            std::vector<std::uint8_t> last_encoded;
+            FullSnapshotChunk last_chunk;
+            while (next_operation < session.operations.size()) {
+                chunk.batch.ops.push_back(session.operations[next_operation]);
+                const std::size_t candidate_next = next_operation + 1u;
+                chunk.has_more = candidate_next < session.operations.size();
+                chunk.continuation = chunk.has_more
+                    ? continuation_for(session, candidate_next, chunk_index + 1u)
+                    : std::string();
+                chunk.batch.batch_flags = chunk.has_more
+                    ? static_cast<std::uint32_t>(BATCH_HAS_MORE)
+                    : static_cast<std::uint32_t>(BATCH_NONE);
+                const std::vector<std::uint8_t> encoded =
+                    FullSnapshotCodec::encode(chunk);
+                if (encoded.size() > hard_limit) {
+                    if (last_encoded.empty()) {
+                        throw std::length_error(
+                            "full snapshot operation exceeds max_single_batch_bytes");
+                    }
+                    break;
+                }
+                if (!last_encoded.empty() && soft_limit != 0u &&
+                    encoded.size() > soft_limit) {
+                    break;
+                }
+                last_chunk = chunk;
+                last_encoded = encoded;
+                next_operation = candidate_next;
+            }
+            if (last_encoded.empty()) {
+                throw std::length_error("full snapshot page contains no operations");
+            }
+
+            PullResponse out;
+            out.ok = true;
+            out.is_full_snapshot = true;
+            out.snapshot_chunk = last_chunk;
+            out.has_more = last_chunk.has_more;
+            out.remote_tail = session.source_tail;
+            out.remote_tail_known = true;
+            return out;
+        }
+
+        PullResponse handle_full_snapshot_pull(const PullRequest& request) {
+            PullResponse out;
+            if (request.full_snapshot_id.empty() !=
+                request.full_snapshot_continuation.empty()) {
+                out.ok = false;
+                out.error =
+                    "full snapshot session id and continuation must both be empty or set";
+                out.error_code = SyncResponseErrorCode::SnapshotSessionInvalid;
+                return out;
+            }
+            if (!request.have.last_seq_by_origin.empty()) {
+                out.ok = false;
+                out.error = "full snapshot requires an empty receiver cursor";
+                out.error_code = SyncResponseErrorCode::SnapshotSessionInvalid;
+                return out;
+            }
+
+            std::shared_ptr<FullSnapshotSession> session;
+            std::size_t start_operation = 0u;
+            std::uint64_t chunk_index = 0u;
+            if (request.full_snapshot_id.empty()) {
+                FullSnapshotExportOptions options;
+                {
+                    std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
+                    prune_expired_full_snapshot_sessions_locked();
+                    options = m_full_snapshot_options;
+                    if (options.manifest.empty()) {
+                        out.ok = false;
+                        out.error = "full snapshot source export is not configured";
+                        out.error_code =
+                            SyncResponseErrorCode::SnapshotNotConfigured;
+                        return out;
+                    }
+                    if (m_full_snapshot_sessions.size() +
+                        m_full_snapshot_creating >= options.max_active_sessions) {
+                        out.ok = false;
+                        out.error = "full snapshot session capacity is exhausted";
+                        out.error_code = SyncResponseErrorCode::SnapshotSessionBusy;
+                        out.error_retryable = true;
+                        return out;
+                    }
+                    ++m_full_snapshot_creating;
+                }
+                try {
+                    session = materialize_full_snapshot(
+                        options, next_full_snapshot_id(), request.requester);
+                } catch (...) {
+                    std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
+                    --m_full_snapshot_creating;
+                    throw;
+                }
+                {
+                    std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
+                    --m_full_snapshot_creating;
+                    prune_expired_full_snapshot_sessions_locked();
+                    m_full_snapshot_sessions[session->snapshot_id] = session;
+                }
+            } else {
+                std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
+                prune_expired_full_snapshot_sessions_locked();
+                std::map<std::string,
+                         std::shared_ptr<FullSnapshotSession>>::const_iterator it =
+                    m_full_snapshot_sessions.find(request.full_snapshot_id);
+                if (it == m_full_snapshot_sessions.end()) {
+                    out.ok = false;
+                    out.error = "full snapshot session is unknown or expired";
+                    out.error_code = SyncResponseErrorCode::SnapshotSessionInvalid;
+                    return out;
+                }
+                session = it->second;
+                session->last_access = std::chrono::steady_clock::now();
+            }
+
+            std::lock_guard<std::mutex> lock(session->mutex);
+            if (compare_node_id(session->requester, request.requester) != 0) {
+                out.ok = false;
+                out.error = "full snapshot requester does not own this session";
+                out.error_code = SyncResponseErrorCode::SnapshotSessionInvalid;
+                return out;
+            }
+            if (!request.full_snapshot_id.empty()) {
+                std::map<std::string, FullSnapshotContinuation>::const_iterator it =
+                    session->continuations.find(request.full_snapshot_continuation);
+                if (it == session->continuations.end()) {
+                    out.ok = false;
+                    out.error = "full snapshot continuation is invalid";
+                    out.error_code = SyncResponseErrorCode::SnapshotSessionInvalid;
+                    return out;
+                }
+                start_operation = it->second.next_operation;
+                chunk_index = it->second.chunk_index;
+            }
+            try {
+                return make_full_snapshot_page(*session, request,
+                                               start_operation, chunk_index);
+            } catch (const std::length_error& e) {
+                out.ok = false;
+                out.error = e.what();
+                out.error_code = SyncResponseErrorCode::BatchTooLarge;
+                return out;
+            }
+        }
 
         /// \brief Returns true when \p request_db_id matches the local
         /// \c db_uuid. A zero \p request_db_id is rejected: callers must
@@ -1981,6 +2425,12 @@ namespace sync {
         std::shared_ptr<Connection> m_conn;
         ConflictPolicy              m_policy;
         LogicalTableRegistry        m_logical_registry;
+        FullSnapshotExportOptions   m_full_snapshot_options;
+        mutable std::mutex          m_full_snapshot_mutex;
+        std::map<std::string, std::shared_ptr<FullSnapshotSession>>
+                                    m_full_snapshot_sessions;
+        std::uint64_t               m_next_full_snapshot_session_id = 0u;
+        std::size_t                  m_full_snapshot_creating = 0u;
     };
 
 } // namespace sync

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -1439,10 +1439,17 @@ namespace sync {
             }
 
             const MDBX_dbi changelog_dbi = open_changelog_ro(txn.handle());
+            session->source_tail = read_applied_cursor(
+                txn.handle(), SyncCursor());
             if (changelog_dbi != 0) {
                 const std::vector<PullOrigin> origins =
                     collect_known_origins(txn.handle(), changelog_dbi);
-                copy_known_tail(origins, session->source_tail);
+                SyncCursor changelog_tail;
+                if (!copy_known_tail(origins, changelog_tail)) {
+                    throw std::runtime_error(
+                        "full snapshot source changelog tail is incomplete");
+                }
+                merge_sync_cursor_max(session->source_tail, changelog_tail);
             }
 
             std::uint64_t materialized_bytes = 0u;
@@ -1657,7 +1664,6 @@ namespace sync {
                     return out;
                 }
                 session = it->second;
-                session->last_access = std::chrono::steady_clock::now();
             }
 
             std::lock_guard<std::mutex> lock(session->mutex);
@@ -1678,6 +1684,21 @@ namespace sync {
                 }
                 start_operation = it->second.next_operation;
                 chunk_index = it->second.chunk_index;
+            }
+            {
+                std::lock_guard<std::mutex> sessions_lock(
+                    m_full_snapshot_mutex);
+                std::map<std::string,
+                         std::shared_ptr<FullSnapshotSession>>::const_iterator it =
+                    m_full_snapshot_sessions.find(session->snapshot_id);
+                if (it == m_full_snapshot_sessions.end() ||
+                    it->second != session) {
+                    out.ok = false;
+                    out.error = "full snapshot session is unknown or expired";
+                    out.error_code = SyncResponseErrorCode::SnapshotSessionInvalid;
+                    return out;
+                }
+                session->last_access = std::chrono::steady_clock::now();
             }
             try {
                 return make_full_snapshot_page(*session, request,
@@ -2160,6 +2181,18 @@ namespace sync {
                     origins[i].last_seq;
             }
             return true;
+        }
+
+        static void merge_sync_cursor_max(SyncCursor& target,
+                                          const SyncCursor& source) {
+            for (std::map<NodeId, std::uint64_t>::const_iterator it =
+                    source.last_seq_by_origin.begin();
+                 it != source.last_seq_by_origin.end(); ++it) {
+                const std::uint64_t current = target.last_seq_for(it->first);
+                if (it->second > current) {
+                    target.last_seq_by_origin[it->first] = it->second;
+                }
+            }
         }
 
         static std::vector<PullOrigin> collect_changelog_origins(MDBX_txn* txn,

--- a/include/mdbx_containers/sync/TransportMessageCodec.hpp
+++ b/include/mdbx_containers/sync/TransportMessageCodec.hpp
@@ -342,6 +342,9 @@ namespace sync {
                 case SyncResponseErrorCode::ApplyConflict:
                 case SyncResponseErrorCode::SnapshotRequired:
                 case SyncResponseErrorCode::BatchTooLarge:
+                case SyncResponseErrorCode::SnapshotNotConfigured:
+                case SyncResponseErrorCode::SnapshotSessionInvalid:
+                case SyncResponseErrorCode::SnapshotSessionBusy:
                     detail::append_u16_le(out,
                         static_cast<std::uint16_t>(code));
                     return;
@@ -514,6 +517,15 @@ namespace sync {
                 case static_cast<std::uint16_t>(
                         SyncResponseErrorCode::BatchTooLarge):
                     return SyncResponseErrorCode::BatchTooLarge;
+                case static_cast<std::uint16_t>(
+                        SyncResponseErrorCode::SnapshotNotConfigured):
+                    return SyncResponseErrorCode::SnapshotNotConfigured;
+                case static_cast<std::uint16_t>(
+                        SyncResponseErrorCode::SnapshotSessionInvalid):
+                    return SyncResponseErrorCode::SnapshotSessionInvalid;
+                case static_cast<std::uint16_t>(
+                        SyncResponseErrorCode::SnapshotSessionBusy):
+                    return SyncResponseErrorCode::SnapshotSessionBusy;
             }
             throw std::runtime_error("Invalid SyncResponseErrorCode");
         }

--- a/include/mdbx_containers/sync/protocol.hpp
+++ b/include/mdbx_containers/sync/protocol.hpp
@@ -30,6 +30,9 @@ namespace sync {
         ApplyConflict           = 3, ///< Push apply failed on a sync conflict.
         SnapshotRequired        = 4, ///< Requested changelog history was pruned.
         BatchTooLarge           = 5, ///< A single retained batch exceeds the requested limit.
+        SnapshotNotConfigured   = 6, ///< Responder has no explicit snapshot export manifest.
+        SnapshotSessionInvalid  = 7, ///< Snapshot session is unknown, expired, or mismatched.
+        SnapshotSessionBusy     = 8, ///< Responder reached its bounded snapshot-session capacity.
     };
 
     /// \brief Returns a stable diagnostic name for a sync response error code.
@@ -48,6 +51,12 @@ namespace sync {
                 return "snapshot_required";
             case SyncResponseErrorCode::BatchTooLarge:
                 return "batch_too_large";
+            case SyncResponseErrorCode::SnapshotNotConfigured:
+                return "snapshot_not_configured";
+            case SyncResponseErrorCode::SnapshotSessionInvalid:
+                return "snapshot_session_invalid";
+            case SyncResponseErrorCode::SnapshotSessionBusy:
+                return "snapshot_session_busy";
         }
         return "unknown";
     }

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1730,6 +1730,49 @@ void test_engine_exports_stable_full_snapshot_pages() {
     cleanup(p);
 }
 
+void test_engine_full_snapshot_tail_includes_applied_origins() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_full_snapshot_applied_tail.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xA7);
+    const sync::NodeId remote_origin = make_node(0xB7);
+    const sync::DbId db_id = make_node(0xD7);
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::FullSnapshotExportOptions options;
+    sync::FullSnapshotManifestEntry entry;
+    entry.dbi_name = "documents";
+    options.manifest.push_back(entry);
+    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
+    engine.initialize_local_identity(source_node, db_id);
+
+    sync::PushRequest pushed;
+    pushed.sender = remote_origin;
+    pushed.db_id = db_id;
+    pushed.batches.push_back(make_raw_batch(remote_origin, 1u,
+                                            "documents", 0x51u));
+    if (!engine.handle_push(pushed).ok) {
+        throw std::runtime_error(
+            "snapshot source did not apply remote origin batch");
+    }
+
+    sync::PullRequest request;
+    request.requester = make_node(0xC7);
+    request.db_id = db_id;
+    request.request_full_snapshot = true;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    const sync::PullResponse response = engine.handle_pull(request);
+    if (!response.ok || !response.is_full_snapshot || response.has_more ||
+        response.snapshot_chunk.source_tail.last_seq_for(remote_origin) != 1u) {
+        throw std::runtime_error(
+            "snapshot source tail omitted an applied remote origin");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 void test_engine_changelog_page_rejects_full_snapshot_request() {
     using namespace mdbxc;
     const std::string p = "test_engine_changelog_full_snapshot_request.mdbx";
@@ -2342,6 +2385,8 @@ int main() {
           &test_engine_rejects_unconfigured_full_snapshot_request },
         { "test_engine_exports_stable_full_snapshot_pages",
           &test_engine_exports_stable_full_snapshot_pages },
+        { "test_engine_full_snapshot_tail_includes_applied_origins",
+          &test_engine_full_snapshot_tail_includes_applied_origins },
         { "test_engine_changelog_page_rejects_full_snapshot_request",
           &test_engine_changelog_page_rejects_full_snapshot_request },
         { "test_engine_pull_reports_snapshot_required_after_prune",

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1740,9 +1740,7 @@ void test_engine_full_snapshot_tail_includes_applied_origins() {
     const sync::DbId db_id = make_node(0xD7);
     std::shared_ptr<Connection> conn = open_env(p);
     sync::FullSnapshotExportOptions options;
-    sync::FullSnapshotManifestEntry entry;
-    entry.dbi_name = "documents";
-    options.manifest.push_back(entry);
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
     sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
     engine.initialize_local_identity(source_node, db_id);
 
@@ -1767,6 +1765,52 @@ void test_engine_full_snapshot_tail_includes_applied_origins() {
         response.snapshot_chunk.source_tail.last_seq_for(remote_origin) != 1u) {
         throw std::runtime_error(
             "snapshot source tail omitted an applied remote origin");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_exports_complete_full_snapshot_inventory() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_complete_full_snapshot_inventory.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xA8);
+    const sync::DbId db_id = make_node(0xD8);
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::FullSnapshotExportOptions options;
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
+    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
+    engine.initialize_local_identity(source_node, db_id);
+    KeyValueTable<std::string, std::string> documents(conn, "documents");
+    KeyValueTable<std::string, std::string> audit(conn, "audit");
+    documents.insert_or_assign("document", "value");
+    audit.insert_or_assign("audit", "value");
+
+    sync::PullRequest request;
+    request.requester = make_node(0xB8);
+    request.db_id = db_id;
+    request.request_full_snapshot = true;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    const sync::PullResponse response = engine.handle_pull(request);
+    if (!response.ok || !response.is_full_snapshot || response.has_more ||
+        response.snapshot_chunk.replacement_scope !=
+            sync::FullSnapshotScope::CompleteUserDatabase ||
+        response.snapshot_chunk.manifest.size() != 2u ||
+        response.snapshot_chunk.manifest[0].dbi_name != "audit" ||
+        response.snapshot_chunk.manifest[1].dbi_name != "documents") {
+        throw std::runtime_error(
+            "complete full snapshot did not inventory all user DBIs");
+    }
+    for (std::size_t i = 0u;
+         i < response.snapshot_chunk.manifest.size(); ++i) {
+        if (response.snapshot_chunk.manifest[i].dbi_name.find("_mdbxc_") ==
+            0u) {
+            throw std::runtime_error(
+                "complete full snapshot exported a reserved DBI");
+        }
     }
 
     conn->disconnect();
@@ -2387,6 +2431,8 @@ int main() {
           &test_engine_exports_stable_full_snapshot_pages },
         { "test_engine_full_snapshot_tail_includes_applied_origins",
           &test_engine_full_snapshot_tail_includes_applied_origins },
+        { "test_engine_exports_complete_full_snapshot_inventory",
+          &test_engine_exports_complete_full_snapshot_inventory },
         { "test_engine_changelog_page_rejects_full_snapshot_request",
           &test_engine_changelog_page_rejects_full_snapshot_request },
         { "test_engine_pull_reports_snapshot_required_after_prune",

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1587,7 +1587,7 @@ void test_engine_handle_pull_wrong_db_id() {
     cleanup(p);
 }
 
-void test_engine_rejects_full_snapshot_request() {
+void test_engine_rejects_unconfigured_full_snapshot_request() {
     using namespace mdbxc;
     const std::string p = "test_engine_full_snapshot_request.mdbx";
     cleanup(p);
@@ -1608,12 +1608,122 @@ void test_engine_rejects_full_snapshot_request() {
     if (!resp.batches.empty()) {
         throw std::runtime_error("full snapshot rejection returned batches");
     }
-    if (resp.error.find("request_full_snapshot") == std::string::npos) {
+    if (resp.error.find("not configured") == std::string::npos) {
         throw std::runtime_error("full snapshot rejection error is not explicit");
     }
-    if (resp.error_code != sync::SyncResponseErrorCode::UnsupportedFullSnapshot ||
+    if (resp.error_code != sync::SyncResponseErrorCode::SnapshotNotConfigured ||
         resp.error_retryable) {
         throw std::runtime_error("full snapshot rejection code incorrect");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_exports_stable_full_snapshot_pages() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_full_snapshot_export.mdbx";
+    cleanup(p);
+
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::FullSnapshotExportOptions options;
+    sync::FullSnapshotManifestEntry entry;
+    entry.dbi_name = "documents";
+    entry.dbi_flags = 0u;
+    options.manifest.push_back(entry);
+    options.max_materialized_operations = 16u;
+    options.max_materialized_bytes = 4096u;
+    options.max_active_sessions = 1u;
+    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
+    const sync::NodeId source_node = make_node(0xA2);
+    const sync::NodeId db_id = make_node(0xD2);
+    engine.initialize_local_identity(source_node, db_id);
+
+    KeyValueTable<std::string, std::string> documents(conn, "documents");
+    documents.insert_or_assign("one", "1");
+    documents.insert_or_assign("two", "2");
+    documents.insert_or_assign("three", "3");
+
+    sync::PullRequest request;
+    request.requester = make_node(0xB2);
+    request.db_id = db_id;
+    request.request_full_snapshot = true;
+    request.max_bytes = 1u;
+    request.max_single_batch_bytes = 8192u;
+
+    sync::PullResponse response = engine.handle_pull(request);
+    if (!response.ok || !response.is_full_snapshot ||
+        !response.batches.empty() || !response.has_more) {
+        throw std::runtime_error("first full snapshot page is invalid");
+    }
+    if (response.snapshot_chunk.chunk_index != 0u ||
+        response.snapshot_chunk.snapshot_id.empty() ||
+        response.snapshot_chunk.continuation.empty() ||
+        response.snapshot_chunk.manifest.size() != 1u ||
+        response.snapshot_chunk.manifest[0].dbi_name != "documents") {
+        throw std::runtime_error("first full snapshot session metadata is invalid");
+    }
+
+    const sync::PullResponse busy = engine.handle_pull(request);
+    if (busy.ok ||
+        busy.error_code != sync::SyncResponseErrorCode::SnapshotSessionBusy ||
+        !busy.error_retryable) {
+        throw std::runtime_error("full snapshot session capacity is not bounded");
+    }
+
+    sync::PullRequest foreign_request = request;
+    foreign_request.requester = make_node(0xC2);
+    foreign_request.full_snapshot_id = response.snapshot_chunk.snapshot_id;
+    foreign_request.full_snapshot_continuation =
+        response.snapshot_chunk.continuation;
+    const sync::PullResponse foreign = engine.handle_pull(foreign_request);
+    if (foreign.ok ||
+        foreign.error_code != sync::SyncResponseErrorCode::SnapshotSessionInvalid) {
+        throw std::runtime_error("full snapshot session accepted a foreign requester");
+    }
+
+    documents.insert_or_assign("late", "not-in-snapshot");
+
+    std::size_t clear_count = 0u;
+    std::size_t put_count = 0u;
+    for (;;) {
+        const std::vector<sync::ChangeOp>& ops = response.snapshot_chunk.batch.ops;
+        for (std::size_t i = 0u; i < ops.size(); ++i) {
+            if (ops[i].op_type == sync::ChangeOpType::ClearTable) {
+                ++clear_count;
+            } else if (ops[i].op_type == sync::ChangeOpType::Put) {
+                ++put_count;
+                const std::string key(ops[i].storage_key.begin(),
+                                      ops[i].storage_key.end());
+                if (key == "late") {
+                    throw std::runtime_error(
+                        "full snapshot included a post-session source write");
+                }
+            } else {
+                throw std::runtime_error("full snapshot contains a non-physical op");
+            }
+        }
+        if (!response.has_more) {
+            break;
+        }
+        request.full_snapshot_id = response.snapshot_chunk.snapshot_id;
+        request.full_snapshot_continuation =
+            response.snapshot_chunk.continuation;
+        response = engine.handle_pull(request);
+        if (!response.ok || !response.is_full_snapshot ||
+            response.snapshot_chunk.snapshot_id != request.full_snapshot_id) {
+            throw std::runtime_error("full snapshot continuation was rejected");
+        }
+    }
+    if (clear_count != 1u || put_count != 3u) {
+        throw std::runtime_error("full snapshot materialization has wrong content");
+    }
+
+    request.full_snapshot_continuation = "foreign-token";
+    const sync::PullResponse invalid = engine.handle_pull(request);
+    if (invalid.ok ||
+        invalid.error_code != sync::SyncResponseErrorCode::SnapshotSessionInvalid) {
+        throw std::runtime_error("invalid full snapshot continuation was accepted");
     }
 
     conn->disconnect();
@@ -2228,8 +2338,10 @@ int main() {
           &test_sync_apply_observer_reports_clear_and_delete_dbi_names },
         { "test_engine_push_multi_batch_gap_cursor",&test_engine_push_multi_batch_gap_reports_persistent_cursor },
         { "test_engine_handle_pull_wrong_db_id",&test_engine_handle_pull_wrong_db_id },
-        { "test_engine_rejects_full_snapshot_request",
-          &test_engine_rejects_full_snapshot_request },
+        { "test_engine_rejects_unconfigured_full_snapshot_request",
+          &test_engine_rejects_unconfigured_full_snapshot_request },
+        { "test_engine_exports_stable_full_snapshot_pages",
+          &test_engine_exports_stable_full_snapshot_pages },
         { "test_engine_changelog_page_rejects_full_snapshot_request",
           &test_engine_changelog_page_rejects_full_snapshot_request },
         { "test_engine_pull_reports_snapshot_required_after_prune",


### PR DESCRIPTION
## Summary
- materialize an explicit user-DBI snapshot manifest in one source read transaction
- serve bounded, requester-bound continuation pages without holding a reader transaction
- cap materialized data and active/idle sessions

## Validation
- C++11/C++17 MinGW: sync engine, snapshot codec, and transport codec tests
- standalone FullSnapshotProtocol and TransportMessageCodec headers