### PR TITLE
feat(sync): import fresh full snapshot replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ All notable changes to this project will be documented in this file.
   `PullRequest`/`PullResponse` now carry explicit snapshot session state and
   chunk pages; this changes the unreleased `TransportMessageCodec` wire version
   from 4 to 5. `SyncEngine` can materialize an explicitly configured source
-  manifest into bounded, stable pages. Replacement apply and cursor bootstrap
-  remain disabled until their lifecycle implementations land.
+  manifest into bounded, stable pages. `SyncEngine` now also stages explicit
+  `ManifestOnly` pages in bounded memory and atomically imports them only into
+  a fresh replica, bootstrapping `_mdbxc_applied` from the immutable source
+  tail. Worker fallback, persisted importer resume, and complete-database
+  replacement remain deferred.
 - Sync: document the authoritative-baseline and multi-origin conflict
   boundary for ordered schema-v2. Baseline import and concurrent multi-writer
   resolution remain design-only and are not exposed as partial APIs.

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -212,24 +212,25 @@ Operational rules:
   for future logical-key conflict resolution, but `SyncEngine` rejects it until
   timestamp/version-based apply semantics exist. `time_unix_ns` is metadata,
   not a reliable conflict authority. `Custom` is deferred to v0.2.
-- `PullRequest::request_full_snapshot=true` is reserved for the future
-  full export/import protocol. v0.1 responders reject it as
-  `PullResponse{ok=false, error=..., error_code=UnsupportedFullSnapshot}`.
-  This is a sync-level protocol rejection, not a transport retry hint. Code
+- `PullRequest::request_full_snapshot=true` starts an explicit source session
+  only when `SyncEngine` has a non-empty `FullSnapshotExportOptions::manifest`.
+  Otherwise it returns
+  `PullResponse{ok=false, error_code=SnapshotNotConfigured}`. The manual
+  receiver path accepts only bounded `ManifestOnly` chunks into a fresh
+  replica; worker-driven fallback and persisted resume remain deferred. Code
   that needs machine classification should inspect `SyncResponseErrorCode`
   instead of parsing the human-readable `error` string.
 - Pull from a cursor older than retained changelog history fails as
   `PullResponse{ok=false, error_code=SnapshotRequired}`. The response carries no
   batches because applying a later retained batch would produce a sequence gap
-  on the receiver. Until a snapshot protocol is implemented, the caller must
-  provision a fresh replica or use an out-of-band snapshot.
-- The deferred full snapshot protocol is specified in
-  `include/mdbx_containers/sync/DESIGN.md`. It must stay separate from
-  changelog replay: snapshot chunks need explicit framing, user-DBI-only apply
-  rules, a stable `snapshot_id`, an immutable manifest/tail from one source read
-  view, continuation-token validation, cursor bootstrap semantics, and
-  interruption behavior before `PullRequest::request_full_snapshot=true` can be
-  accepted.
+  on the receiver. A caller can explicitly drive the bounded fresh-replica
+  snapshot session, but sync workers do not yet turn this response into an
+  automatic fallback.
+- Full snapshot implementation notes are in
+  `include/mdbx_containers/sync/DESIGN.md`. The manual importer remains separate
+  from changelog replay: it accepts user-DBI-only chunks with an immutable
+  `snapshot_id`, manifest/tail, and continuation sequence, then commits the
+  replacement and cursor bootstrap atomically only at the final page.
 - `PushResponse::error_retryable` describes sync-level recovery. Sequence gaps
   are retryable after the receiver catches up from its persistent applied
   cursor; DBI name/flag conflicts, reserved DBI writes, and unsupported

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -161,8 +161,10 @@ tables.
 - Extend `KeyMultiValueTable` logical capture only after every added bulk or
   reconcile operation has explicit multiset replay semantics and round-trip
   coverage. Raw capture remains disabled.
-- Implement the deferred full snapshot protocol before treating
-  `SnapshotRequired` as automatically recoverable by sync itself.
+- Integrate worker fallback, persisted importer resume, and explicit complete
+  replacement before treating `SnapshotRequired` as automatically recoverable
+  by sync itself. The current manual importer accepts only fresh-replica
+  `ManifestOnly` sessions.
 - Define explicit conflict/CRDT semantics before claiming general concurrent
   multi-writer convergence for `KeyMultiValueTable`.
 - Design baseline import and multi-origin histories for schema v2 separately;

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1033,9 +1033,10 @@ key, which is why `seq` is big-endian in the key.
 Pull detects when `request.have + 1` is older than the earliest retained
 changelog record for a known origin and returns
 `PullResponse{ok=false, error_code=SnapshotRequired}` instead of streaming a
-later non-contiguous batch. Until the reserved full snapshot protocol exists,
-callers must provision a fresh replica or use an application-defined snapshot
-outside sync v0.1.
+later non-contiguous batch. The initial full snapshot importer requires a
+fresh replica and an explicit caller-driven session; worker fallback is not
+implemented, so applications may still provision a fresh replica or use an
+application-defined snapshot outside sync v0.1.
 
 ### `_mdbxc_origins` (OriginIndexStore)
 
@@ -1436,8 +1437,8 @@ Locked contract:
   classification is available. `error_retryable` describes protocol-level
   recovery, not blind replay of the identical request: for example a
   `SequenceGap` apply conflict is retryable after the caller catches up from a
-  fresher cursor, while DBI flag conflicts and unsupported full snapshots are
-  permanent until the caller changes behavior. `SnapshotRequired` means the
+  fresher cursor, while DBI flag conflicts and an unconfigured snapshot source
+  are permanent until the caller changes behavior. `SnapshotRequired` means the
   requested changelog range was pruned and cannot be recovered through
   incremental pull. `BatchTooLarge` means a retained changelog entry exceeds
   the requester's hard per-batch limit and is permanent until the requester
@@ -1532,14 +1533,14 @@ B: applies each page as above
     -> onward sync is incremental pull-from-have
 ```
 
-The reserved `seq=0, BATCH_HAS_MORE` full export/import format is not the
-current cold-replica implementation yet. `FullSnapshotProtocol.hpp` defines and
-validates its chunk codec: every chunk carries a source identity, immutable
-per-origin replication tail, stable `snapshot_id`, chunk index, replacement scope,
-opaque next-page token, manifest version, immutable named-user-DBI manifest,
-and a nested raw batch with `seq=0`. Transport codec v5 carries the explicit
-session request and one snapshot chunk in `PullResponse`; it rejects mixed
-incremental/snapshot pages and malformed session state.
+The reserved `seq=0, BATCH_HAS_MORE` full snapshot format is separate from
+retained changelog replay. `FullSnapshotProtocol.hpp` defines and validates its
+chunk codec: every chunk carries a source identity, immutable per-origin
+replication tail, stable `snapshot_id`, chunk index, replacement scope, opaque next-page
+token, manifest version, immutable named-user-DBI manifest, and a nested raw
+batch with `seq=0`. Transport codec v5 carries the explicit session request and
+one snapshot chunk in `PullResponse`; it rejects mixed incremental/snapshot
+pages and malformed session state.
 
 `SyncEngine` can export an explicit `FullSnapshotExportOptions::manifest`: it
 materializes configured user DBIs in one read transaction, bounds active
@@ -1548,10 +1549,20 @@ manifest returns `SnapshotNotConfigured`; unknown, expired, or mismatched
 continuations or a different requester return `SnapshotSessionInvalid`; bounded
 session capacity returns retryable `SnapshotSessionBusy`.
 
-Snapshot import, applied-cursor bootstrap, and worker fallback are still not
-implemented. Consequently a snapshot export is not yet an automatic recovery
-path for `SnapshotRequired`; callers must not treat source export alone as a
-working replica-replacement workflow.
+`SyncEngine::apply_full_snapshot_chunk()` implements the first manual receiver
+path for `ManifestOnly` snapshots. It stages all pages in bounded process memory
+and validates immutable page-zero metadata on every continuation. Only the
+final page opens a write transaction: it requires zero local changelog sequence,
+an empty applied cursor, and empty manifest DBIs, then applies the staged
+`ClearTable` / `Put` plan and writes the advertised source tail to
+`_mdbxc_applied` atomically. Any interruption, malformed continuation, bound
+failure, or non-fresh target fails before a user-DBI commit. Existing
+receiver-only DBIs outside the manifest remain untouched.
+
+Worker fallback from `SnapshotRequired`, persisted importer restart state, and
+`CompleteUserDatabase` replacement are still not implemented. Consequently a
+snapshot request is not yet an automatic recovery path; a caller must drive the
+source session and the manual importer explicitly.
 If changelog pruning removed entries needed by the requester's cursor,
 `handle_pull()` returns `SnapshotRequired` with no batches. This is also a
 valid sync response, not a transport failure.
@@ -1559,15 +1570,16 @@ valid sync response, not a transport failure.
 sync-level response errors through round results, stage events, and status
 snapshots without treating them as permanent transport failures.
 
-### Deferred full snapshot protocol
+### Remaining full snapshot work
 
-The future full snapshot protocol must be explicit rather than another spelling
-of retained changelog replay. The reserved request shape is
+The full snapshot protocol is explicit rather than another spelling of retained
+changelog replay. The reserved request shape is
 `PullRequest::request_full_snapshot=true`; responders that implement it should
 return snapshot chunks only when the caller requested that mode, never as an
 implicit fallback from a normal incremental pull.
 
-Required protocol properties before enabling the flag:
+The implemented source session and fresh-replica importer preserve these
+properties. The remaining worker and resume work must preserve them too:
 
 - A full snapshot export is a named snapshot session. The first response must
   return an opaque `snapshot_id` and all later pages must present the same id;

--- a/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
+++ b/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
@@ -57,6 +57,22 @@ namespace sync {
             std::chrono::seconds(300);
     };
 
+    /// \brief Receiver-side bounds for one staged full snapshot import.
+    /// \details The initial importer keeps pages only in process memory until
+    /// the final page. These bounds prevent a peer from accumulating an
+    /// unbounded replacement plan before the one atomic destination commit.
+    struct FullSnapshotImportOptions {
+        std::uint64_t max_staged_operations = 1000000u;
+        std::uint64_t max_staged_bytes =
+            256ULL * 1024ULL * 1024ULL;
+    };
+
+    /// \brief Progress returned after accepting one full snapshot chunk.
+    struct FullSnapshotImportResult {
+        bool completed = false;
+        std::uint64_t next_chunk_index = 0u;
+    };
+
     /// \brief One chunk of a full database export.
     /// \details Snapshot chunks are not changelog batches. They carry a
     /// stable source identity, an immutable manifest, and a nested raw batch

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -1953,10 +1953,23 @@ namespace sync {
             }
         }
 
-        static void require_fresh_full_snapshot_target(
+        static bool full_snapshot_manifest_flags(
+                const std::vector<FullSnapshotManifestEntry>& manifest,
+                const std::string& name,
+                std::uint32_t& flags) {
+            for (std::size_t i = 0u; i < manifest.size(); ++i) {
+                if (manifest[i].dbi_name == name) {
+                    flags = manifest[i].dbi_flags;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        void require_fresh_full_snapshot_target(
                 MDBX_txn* txn,
                 MetaStore& meta,
-                const FullSnapshotImportSession& session) {
+                const FullSnapshotImportSession& session) const {
             if (compare_node_id(meta.get_db_uuid(txn),
                                 session.source_db_uuid) != 0) {
                 throw std::invalid_argument(
@@ -1971,6 +1984,12 @@ namespace sync {
                 throw std::logic_error(
                     "full snapshot source and destination node identities match");
             }
+            if (session.replacement_scope ==
+                    FullSnapshotScope::CompleteUserDatabase &&
+                session.source_tail.last_seq_for(local_node_id) != 0u) {
+                throw std::logic_error(
+                    "full snapshot destination node identity appears in source tail");
+            }
             if (meta.get_local_seq(txn) != 0u) {
                 throw std::logic_error(
                     "full snapshot destination has local changelog history");
@@ -1979,6 +1998,24 @@ namespace sync {
             if (!read_applied_cursor(txn, applied).last_seq_by_origin.empty()) {
                 throw std::logic_error(
                     "full snapshot destination has an applied cursor");
+            }
+
+            if (session.replacement_scope ==
+                    FullSnapshotScope::CompleteUserDatabase) {
+                const std::vector<FullSnapshotManifestEntry> destination =
+                    enumerate_user_snapshot_manifest(txn);
+                for (std::size_t i = 0u; i < destination.size(); ++i) {
+                    std::uint32_t manifest_flags = 0u;
+                    if (!full_snapshot_manifest_flags(
+                            session.manifest, destination[i].dbi_name,
+                            manifest_flags) ||
+                        manifest_flags != destination[i].dbi_flags) {
+                        throw std::logic_error(
+                            "complete full snapshot destination has a user DBI "
+                            "outside the source manifest: " +
+                            destination[i].dbi_name);
+                    }
+                }
             }
 
             for (std::size_t i = 0u; i < session.manifest.size(); ++i) {
@@ -2018,9 +2055,11 @@ namespace sync {
                 const FullSnapshotChunk& chunk,
                 Connection::SyncApplyNotification& notification,
                 bool& notification_ready) {
-            if (chunk.replacement_scope != FullSnapshotScope::ManifestOnly) {
+            if (chunk.replacement_scope != FullSnapshotScope::ManifestOnly &&
+                chunk.replacement_scope !=
+                    FullSnapshotScope::CompleteUserDatabase) {
                 throw std::invalid_argument(
-                    "full snapshot importer supports ManifestOnly replacement only");
+                    "full snapshot importer received an unsupported replacement scope");
             }
             if (!m_full_snapshot_import_session) {
                 if (chunk.chunk_index != 0u) {
@@ -2079,13 +2118,16 @@ namespace sync {
                     apply_one_op(txn.handle(), session.operations[i], dbi_cache);
                 }
 
-                AppliedStore applied(m_conn->env_handle());
-                applied.open(txn.handle());
-                for (std::map<NodeId, std::uint64_t>::const_iterator it =
-                        session.source_tail.last_seq_by_origin.begin();
-                     it != session.source_tail.last_seq_by_origin.end(); ++it) {
-                    applied.set_last_applied_seq(txn.handle(), it->first,
-                                                 it->second);
+                if (session.replacement_scope ==
+                        FullSnapshotScope::CompleteUserDatabase) {
+                    AppliedStore applied(m_conn->env_handle());
+                    applied.open(txn.handle());
+                    for (std::map<NodeId, std::uint64_t>::const_iterator it =
+                            session.source_tail.last_seq_by_origin.begin();
+                         it != session.source_tail.last_seq_by_origin.end(); ++it) {
+                        applied.set_last_applied_seq(txn.handle(), it->first,
+                                                     it->second);
+                    }
                 }
                 txn.commit();
                 result.completed = true;

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -161,6 +161,20 @@ namespace sync {
             std::mutex mutex;
         };
 
+        struct FullSnapshotImportSession {
+            NodeId source_node_id{};
+            DbId source_db_uuid{};
+            std::string snapshot_id;
+            SyncCursor source_tail;
+            FullSnapshotScope replacement_scope =
+                FullSnapshotScope::ManifestOnly;
+            std::uint32_t manifest_version = 0u;
+            std::vector<FullSnapshotManifestEntry> manifest;
+            std::uint64_t next_chunk_index = 0u;
+            std::uint64_t staged_bytes = 0u;
+            std::vector<ChangeOp> operations;
+        };
+
     public:
         /// \brief Constructs an engine bound to \p conn.
         /// \param conn Shared connection that owns the env and stores.
@@ -238,6 +252,45 @@ namespace sync {
             std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
             m_full_snapshot_options = options;
             m_full_snapshot_sessions.clear();
+        }
+
+        /// \brief Replaces the bounds for in-memory full snapshot import staging.
+        /// \details Reconfiguration discards an incomplete import because its
+        /// pending pages were never durable and must not outlive their bounds.
+        void set_full_snapshot_import_options(
+                const FullSnapshotImportOptions& options) {
+            validate_full_snapshot_import_options(options);
+            std::lock_guard<std::mutex> lock(m_full_snapshot_import_mutex);
+            m_full_snapshot_import_options = options;
+            m_full_snapshot_import_session.reset();
+        }
+
+        /// \brief Stages or atomically applies one full snapshot chunk.
+        /// \details Only \c ManifestOnly replacement is currently accepted.
+        /// Every page is validated against immutable metadata from page zero.
+        /// No destination user DBI changes before the final page; that page
+        /// verifies a fresh manifest target, applies the complete staged plan,
+        /// and bootstraps the applied cursor in one write transaction.
+        FullSnapshotImportResult apply_full_snapshot_chunk(
+                const FullSnapshotChunk& chunk) {
+            FullSnapshotCodec::validate(chunk);
+            FullSnapshotImportResult result;
+            Connection::SyncApplyNotification notification;
+            {
+                std::lock_guard<std::mutex> lock(
+                    m_full_snapshot_import_mutex);
+                try {
+                    result = apply_full_snapshot_chunk_locked(chunk,
+                                                              notification);
+                } catch (...) {
+                    m_full_snapshot_import_session.reset();
+                    throw;
+                }
+            }
+            if (result.completed) {
+                m_conn->notify_sync_apply_observers(notification);
+            }
+            return result;
         }
 
         /// \brief Registers or verifies a persistent logical table schema.
@@ -1794,6 +1847,181 @@ namespace sync {
             }
         }
 
+        static bool full_snapshot_metadata_matches(
+                const FullSnapshotImportSession& session,
+                const FullSnapshotChunk& chunk) {
+            return compare_node_id(session.source_node_id,
+                                   chunk.source_node_id) == 0 &&
+                compare_node_id(session.source_db_uuid,
+                                chunk.source_db_uuid) == 0 &&
+                session.snapshot_id == chunk.snapshot_id &&
+                session.source_tail.last_seq_by_origin ==
+                    chunk.source_tail.last_seq_by_origin &&
+                session.replacement_scope == chunk.replacement_scope &&
+                session.manifest_version == chunk.manifest_version &&
+                full_snapshot_manifest_equal(session.manifest, chunk.manifest);
+        }
+
+        void append_full_snapshot_import_chunk(
+                FullSnapshotImportSession& session,
+                const FullSnapshotChunk& chunk) const {
+            const std::uint64_t operation_count =
+                static_cast<std::uint64_t>(session.operations.size());
+            const std::uint64_t incoming_count =
+                static_cast<std::uint64_t>(chunk.batch.ops.size());
+            if (operation_count >
+                    m_full_snapshot_import_options.max_staged_operations ||
+                incoming_count >
+                    m_full_snapshot_import_options.max_staged_operations -
+                        operation_count) {
+                throw std::length_error(
+                    "full snapshot import exceeds max_staged_operations");
+            }
+
+            std::uint64_t additional_bytes = 0u;
+            for (std::size_t i = 0u; i < chunk.batch.ops.size(); ++i) {
+                const std::uint64_t operation_bytes =
+                    full_snapshot_operation_bytes(chunk.batch.ops[i]);
+                if (operation_bytes >
+                        m_full_snapshot_import_options.max_staged_bytes -
+                            session.staged_bytes - additional_bytes) {
+                    throw std::length_error(
+                        "full snapshot import exceeds max_staged_bytes");
+                }
+                additional_bytes += operation_bytes;
+            }
+            session.operations.insert(session.operations.end(),
+                                      chunk.batch.ops.begin(),
+                                      chunk.batch.ops.end());
+            session.staged_bytes += additional_bytes;
+        }
+
+        static void require_fresh_full_snapshot_target(
+                MDBX_txn* txn,
+                MetaStore& meta,
+                const FullSnapshotImportSession& session) {
+            if (compare_node_id(meta.get_db_uuid(txn),
+                                session.source_db_uuid) != 0) {
+                throw std::invalid_argument(
+                    "full snapshot source db_uuid does not match destination");
+            }
+            if (meta.get_local_seq(txn) != 0u) {
+                throw std::logic_error(
+                    "full snapshot destination has local changelog history");
+            }
+            SyncCursor applied;
+            if (!read_applied_cursor(txn, applied).last_seq_by_origin.empty()) {
+                throw std::logic_error(
+                    "full snapshot destination has an applied cursor");
+            }
+
+            for (std::size_t i = 0u; i < session.manifest.size(); ++i) {
+                const FullSnapshotManifestEntry& entry = session.manifest[i];
+                MDBX_dbi dbi = 0;
+                int error_code = MDBX_SUCCESS;
+                if (!open_existing_user_dbi(txn, entry.dbi_name,
+                                            entry.dbi_flags, dbi,
+                                            error_code)) {
+                    throw std::runtime_error(
+                        "full snapshot destination DBI flags mismatch: " +
+                        entry.dbi_name);
+                }
+                if (dbi == 0) continue;
+
+                unsigned actual_raw = 0u;
+                check_mdbx(mdbx_dbi_flags(txn, dbi, &actual_raw),
+                           "full snapshot failed to read destination DBI flags");
+                if (persistent_dbi_flags(static_cast<std::uint32_t>(actual_raw)) !=
+                    entry.dbi_flags) {
+                    throw std::runtime_error(
+                        "full snapshot destination DBI flags mismatch: " +
+                        entry.dbi_name);
+                }
+                MDBX_stat stat;
+                check_mdbx(mdbx_dbi_stat(txn, dbi, &stat, sizeof(stat)),
+                           "full snapshot failed to inspect destination DBI");
+                if (stat.ms_entries != 0u) {
+                    throw std::logic_error(
+                        "full snapshot destination DBI is not empty: " +
+                        entry.dbi_name);
+                }
+            }
+        }
+
+        FullSnapshotImportResult apply_full_snapshot_chunk_locked(
+                const FullSnapshotChunk& chunk,
+                Connection::SyncApplyNotification& notification) {
+            if (chunk.replacement_scope != FullSnapshotScope::ManifestOnly) {
+                throw std::invalid_argument(
+                    "full snapshot importer supports ManifestOnly replacement only");
+            }
+            if (!m_full_snapshot_import_session) {
+                if (chunk.chunk_index != 0u) {
+                    throw std::invalid_argument(
+                        "full snapshot import must begin at chunk zero");
+                }
+                std::unique_ptr<FullSnapshotImportSession> session(
+                    new FullSnapshotImportSession());
+                session->source_node_id = chunk.source_node_id;
+                session->source_db_uuid = chunk.source_db_uuid;
+                session->snapshot_id = chunk.snapshot_id;
+                session->source_tail = chunk.source_tail;
+                session->replacement_scope = chunk.replacement_scope;
+                session->manifest_version = chunk.manifest_version;
+                session->manifest = chunk.manifest;
+                m_full_snapshot_import_session = std::move(session);
+            }
+
+            FullSnapshotImportSession& session =
+                *m_full_snapshot_import_session;
+            if (chunk.chunk_index != session.next_chunk_index ||
+                !full_snapshot_metadata_matches(session, chunk)) {
+                throw std::invalid_argument(
+                    "full snapshot chunk does not match the active import session");
+            }
+            append_full_snapshot_import_chunk(session, chunk);
+            ++session.next_chunk_index;
+
+            FullSnapshotImportResult result;
+            result.next_chunk_index = session.next_chunk_index;
+            if (chunk.has_more) return result;
+
+            {
+                const Connection::SyncApplyWriteGuard sync_apply_guard =
+                    m_conn->sync_apply_write_guard();
+                auto txn = m_conn->transaction(TransactionMode::WRITABLE);
+                MetaStore meta(m_conn->env_handle());
+                meta.open(txn.handle());
+                require_fresh_full_snapshot_target(txn.handle(), meta, session);
+
+                std::unordered_map<std::string, MDBX_dbi> dbi_cache;
+                for (std::size_t i = 0u; i < session.operations.size(); ++i) {
+                    apply_one_op(txn.handle(), session.operations[i], dbi_cache);
+                }
+
+                AppliedStore applied(m_conn->env_handle());
+                applied.open(txn.handle());
+                for (std::map<NodeId, std::uint64_t>::const_iterator it =
+                        session.source_tail.last_seq_by_origin.begin();
+                     it != session.source_tail.last_seq_by_origin.end(); ++it) {
+                    applied.set_last_applied_seq(txn.handle(), it->first,
+                                                 it->second);
+                }
+                txn.commit();
+
+                std::vector<std::string> affected_dbi_names;
+                for (std::size_t i = 0u; i < session.manifest.size(); ++i) {
+                    add_unique_dbi_name(affected_dbi_names,
+                                        session.manifest[i].dbi_name);
+                }
+                notification = m_conn->mark_sync_apply_committed(
+                    1u, session.operations.size(), affected_dbi_names);
+            }
+            m_full_snapshot_import_session.reset();
+            result.completed = true;
+            return result;
+        }
+
         /// \brief Returns true when \p request_db_id matches the local
         /// \c db_uuid. A zero \p request_db_id is rejected: callers must
         /// know the database identity before issuing pull/push requests.
@@ -1996,6 +2224,47 @@ namespace sync {
 
         static std::uint32_t persistent_dbi_flags(std::uint32_t dbi_flags) {
             return dbi_flags & persistent_dbi_flags_mask();
+        }
+
+        static void validate_full_snapshot_import_options(
+                const FullSnapshotImportOptions& options) {
+            if (options.max_staged_operations == 0u ||
+                options.max_staged_bytes == 0u) {
+                throw std::invalid_argument(
+                    "full snapshot import bounds must be non-zero");
+            }
+        }
+
+        static bool full_snapshot_manifest_equal(
+                const std::vector<FullSnapshotManifestEntry>& lhs,
+                const std::vector<FullSnapshotManifestEntry>& rhs) {
+            if (lhs.size() != rhs.size()) return false;
+            for (std::size_t i = 0u; i < lhs.size(); ++i) {
+                if (lhs[i].dbi_name != rhs[i].dbi_name ||
+                    lhs[i].dbi_flags != rhs[i].dbi_flags) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        static std::uint64_t full_snapshot_operation_bytes(
+                const ChangeOp& op) {
+            const std::uint64_t fixed =
+                static_cast<std::uint64_t>(sizeof(ChangeOp));
+            const std::uint64_t name =
+                static_cast<std::uint64_t>(op.dbi_name.size());
+            const std::uint64_t key =
+                static_cast<std::uint64_t>(op.storage_key.size());
+            const std::uint64_t value =
+                static_cast<std::uint64_t>(op.value.size());
+            if (name > (std::numeric_limits<std::uint64_t>::max)() - fixed ||
+                key > (std::numeric_limits<std::uint64_t>::max)() - fixed - name ||
+                value > (std::numeric_limits<std::uint64_t>::max)() - fixed - name - key) {
+                throw std::length_error(
+                    "full snapshot operation size overflow");
+            }
+            return fixed + name + key + value;
         }
 
         struct BatchDbiFlags {
@@ -2547,6 +2816,10 @@ namespace sync {
                                     m_full_snapshot_sessions;
         std::uint64_t               m_next_full_snapshot_session_id = 0u;
         std::size_t                  m_full_snapshot_creating = 0u;
+        FullSnapshotImportOptions    m_full_snapshot_import_options;
+        mutable std::mutex           m_full_snapshot_import_mutex;
+        std::unique_ptr<FullSnapshotImportSession>
+                                    m_full_snapshot_import_session;
     };
 
 } // namespace sync

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -162,6 +162,12 @@ namespace sync {
         };
 
         struct FullSnapshotImportSession {
+            enum class ReplacementState {
+                NotSeen,
+                Cleared,
+                ReceivingPuts
+            };
+
             NodeId source_node_id{};
             DbId source_db_uuid{};
             std::string snapshot_id;
@@ -173,6 +179,7 @@ namespace sync {
             std::uint64_t next_chunk_index = 0u;
             std::uint64_t staged_bytes = 0u;
             std::vector<ChangeOp> operations;
+            std::map<std::string, ReplacementState> replacement_state;
         };
 
     public:
@@ -276,18 +283,20 @@ namespace sync {
             FullSnapshotCodec::validate(chunk);
             FullSnapshotImportResult result;
             Connection::SyncApplyNotification notification;
+            bool notification_ready = false;
             {
                 std::lock_guard<std::mutex> lock(
                     m_full_snapshot_import_mutex);
                 try {
                     result = apply_full_snapshot_chunk_locked(chunk,
-                                                              notification);
+                                                              notification,
+                                                              notification_ready);
                 } catch (...) {
                     m_full_snapshot_import_session.reset();
                     throw;
                 }
             }
-            if (result.completed) {
+            if (result.completed && notification_ready) {
                 m_conn->notify_sync_apply_observers(notification);
             }
             return result;
@@ -1865,6 +1874,38 @@ namespace sync {
         void append_full_snapshot_import_chunk(
                 FullSnapshotImportSession& session,
                 const FullSnapshotChunk& chunk) const {
+            std::map<std::string, FullSnapshotImportSession::ReplacementState>
+                replacement_state = session.replacement_state;
+            for (std::size_t i = 0u; i < chunk.batch.ops.size(); ++i) {
+                const ChangeOp& op = chunk.batch.ops[i];
+                std::map<std::string,
+                         FullSnapshotImportSession::ReplacementState>::iterator
+                    state = replacement_state.find(op.dbi_name);
+                if (state == replacement_state.end()) {
+                    throw std::invalid_argument(
+                        "full snapshot operation is outside the replacement plan");
+                }
+                if (op.op_type == ChangeOpType::ClearTable) {
+                    if (state->second !=
+                        FullSnapshotImportSession::ReplacementState::NotSeen) {
+                        throw std::invalid_argument(
+                            "full snapshot replacement DBI was cleared twice");
+                    }
+                    state->second =
+                        FullSnapshotImportSession::ReplacementState::Cleared;
+                } else if (op.op_type == ChangeOpType::Put) {
+                    if (state->second ==
+                        FullSnapshotImportSession::ReplacementState::NotSeen) {
+                        throw std::invalid_argument(
+                            "full snapshot Put precedes its replacement clear");
+                    }
+                    state->second =
+                        FullSnapshotImportSession::ReplacementState::ReceivingPuts;
+                } else {
+                    throw std::invalid_argument(
+                        "full snapshot replacement operation is unsupported");
+                }
+            }
             const std::uint64_t operation_count =
                 static_cast<std::uint64_t>(session.operations.size());
             const std::uint64_t incoming_count =
@@ -1894,6 +1935,22 @@ namespace sync {
                                       chunk.batch.ops.begin(),
                                       chunk.batch.ops.end());
             session.staged_bytes += additional_bytes;
+            session.replacement_state.swap(replacement_state);
+        }
+
+        static void require_complete_full_snapshot_replacement_plan(
+                const FullSnapshotImportSession& session) {
+            for (std::map<std::string,
+                          FullSnapshotImportSession::ReplacementState>::const_iterator
+                    it = session.replacement_state.begin();
+                 it != session.replacement_state.end(); ++it) {
+                if (it->second ==
+                    FullSnapshotImportSession::ReplacementState::NotSeen) {
+                    throw std::invalid_argument(
+                        "full snapshot replacement plan omits manifest DBI: " +
+                        it->first);
+                }
+            }
         }
 
         static void require_fresh_full_snapshot_target(
@@ -1904,6 +1961,15 @@ namespace sync {
                                 session.source_db_uuid) != 0) {
                 throw std::invalid_argument(
                     "full snapshot source db_uuid does not match destination");
+            }
+            const NodeId local_node_id = meta.get_node_id(txn);
+            if (is_zero_sync_id(local_node_id)) {
+                throw std::logic_error(
+                    "full snapshot destination node identity is not initialized");
+            }
+            if (compare_node_id(local_node_id, session.source_node_id) == 0) {
+                throw std::logic_error(
+                    "full snapshot source and destination node identities match");
             }
             if (meta.get_local_seq(txn) != 0u) {
                 throw std::logic_error(
@@ -1950,7 +2016,8 @@ namespace sync {
 
         FullSnapshotImportResult apply_full_snapshot_chunk_locked(
                 const FullSnapshotChunk& chunk,
-                Connection::SyncApplyNotification& notification) {
+                Connection::SyncApplyNotification& notification,
+                bool& notification_ready) {
             if (chunk.replacement_scope != FullSnapshotScope::ManifestOnly) {
                 throw std::invalid_argument(
                     "full snapshot importer supports ManifestOnly replacement only");
@@ -1969,6 +2036,10 @@ namespace sync {
                 session->replacement_scope = chunk.replacement_scope;
                 session->manifest_version = chunk.manifest_version;
                 session->manifest = chunk.manifest;
+                for (std::size_t i = 0u; i < session->manifest.size(); ++i) {
+                    session->replacement_state[session->manifest[i].dbi_name] =
+                        FullSnapshotImportSession::ReplacementState::NotSeen;
+                }
                 m_full_snapshot_import_session = std::move(session);
             }
 
@@ -1986,6 +2057,8 @@ namespace sync {
             result.next_chunk_index = session.next_chunk_index;
             if (chunk.has_more) return result;
 
+            require_complete_full_snapshot_replacement_plan(session);
+
             {
                 const Connection::SyncApplyWriteGuard sync_apply_guard =
                     m_conn->sync_apply_write_guard();
@@ -1993,6 +2066,13 @@ namespace sync {
                 MetaStore meta(m_conn->env_handle());
                 meta.open(txn.handle());
                 require_fresh_full_snapshot_target(txn.handle(), meta, session);
+
+                std::vector<std::string> affected_dbi_names;
+                for (std::size_t i = 0u; i < session.manifest.size(); ++i) {
+                    add_unique_dbi_name(affected_dbi_names,
+                                        session.manifest[i].dbi_name);
+                }
+                const std::size_t applied_operations = session.operations.size();
 
                 std::unordered_map<std::string, MDBX_dbi> dbi_cache;
                 for (std::size_t i = 0u; i < session.operations.size(); ++i) {
@@ -2008,17 +2088,16 @@ namespace sync {
                                                  it->second);
                 }
                 txn.commit();
-
-                std::vector<std::string> affected_dbi_names;
-                for (std::size_t i = 0u; i < session.manifest.size(); ++i) {
-                    add_unique_dbi_name(affected_dbi_names,
-                                        session.manifest[i].dbi_name);
+                result.completed = true;
+                m_full_snapshot_import_session.reset();
+                try {
+                    notification = m_conn->mark_sync_apply_committed(
+                        1u, applied_operations, affected_dbi_names);
+                    notification_ready = true;
+                } catch (...) {
+                    // Native commit is durable; observer bookkeeping is best effort.
                 }
-                notification = m_conn->mark_sync_apply_committed(
-                    1u, session.operations.size(), affected_dbi_names);
             }
-            m_full_snapshot_import_session.reset();
-            result.completed = true;
             return result;
         }
 

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1730,86 +1730,281 @@ void test_engine_exports_stable_full_snapshot_pages() {
     cleanup(p);
 }
 
-void test_engine_full_snapshot_tail_includes_applied_origins() {
+mdbxc::sync::FullSnapshotChunk make_import_chunk(
+        const mdbxc::sync::NodeId& source_node,
+        const mdbxc::sync::DbId& db_id,
+        const std::string& snapshot_id,
+        std::uint64_t chunk_index,
+        bool has_more) {
+    mdbxc::sync::FullSnapshotChunk chunk;
+    chunk.source_node_id = source_node;
+    chunk.source_db_uuid = db_id;
+    chunk.snapshot_id = snapshot_id;
+    chunk.chunk_index = chunk_index;
+    chunk.has_more = has_more;
+    chunk.continuation = has_more ? "next" : std::string();
+    mdbxc::sync::FullSnapshotManifestEntry entry;
+    entry.dbi_name = "documents";
+    entry.dbi_flags = 0u;
+    chunk.manifest.push_back(entry);
+    chunk.batch.origin_node_id = source_node;
+    chunk.batch.version = mdbxc::sync::ChangeBatchCodec::batch_version();
+    chunk.batch.seq = 0u;
+    chunk.batch.batch_flags = has_more
+        ? static_cast<std::uint32_t>(mdbxc::sync::BATCH_HAS_MORE)
+        : static_cast<std::uint32_t>(mdbxc::sync::BATCH_NONE);
+    return chunk;
+}
+
+void append_import_put(mdbxc::sync::FullSnapshotChunk& chunk,
+                       const std::string& key,
+                       const std::string& value) {
+    mdbxc::sync::ChangeOp op;
+    op.op_type = mdbxc::sync::ChangeOpType::Put;
+    op.dbi_name = "documents";
+    op.storage_key.assign(key.begin(), key.end());
+    op.value.assign(value.begin(), value.end());
+    chunk.batch.ops.push_back(op);
+}
+
+void append_import_clear(mdbxc::sync::FullSnapshotChunk& chunk) {
+    mdbxc::sync::ChangeOp op;
+    op.op_type = mdbxc::sync::ChangeOpType::ClearTable;
+    op.dbi_name = "documents";
+    chunk.batch.ops.push_back(op);
+}
+
+void test_engine_imports_full_snapshot_and_bootstraps_cursor() {
     using namespace mdbxc;
-    const std::string p = "test_engine_full_snapshot_applied_tail.mdbx";
-    cleanup(p);
+    const std::string source_path = "test_engine_full_snapshot_source.mdbx";
+    const std::string replica_path = "test_engine_full_snapshot_replica.mdbx";
+    cleanup(source_path);
+    cleanup(replica_path);
 
-    const sync::NodeId source_node = make_node(0xA7);
-    const sync::NodeId remote_origin = make_node(0xB7);
-    const sync::DbId db_id = make_node(0xD7);
-    std::shared_ptr<Connection> conn = open_env(p);
+    const sync::NodeId source_node = make_node(0xA3);
+    const sync::NodeId replica_node = make_node(0xB3);
+    const sync::DbId db_id = make_node(0xD3);
     sync::FullSnapshotExportOptions options;
-    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
-    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
-    engine.initialize_local_identity(source_node, db_id);
+    sync::FullSnapshotManifestEntry entry;
+    entry.dbi_name = "documents";
+    options.manifest.push_back(entry);
+    options.max_materialized_operations = 16u;
+    options.max_materialized_bytes = 4096u;
 
-    sync::PushRequest pushed;
-    pushed.sender = remote_origin;
-    pushed.db_id = db_id;
-    pushed.batches.push_back(make_raw_batch(remote_origin, 1u,
-                                            "documents", 0x51u));
-    if (!engine.handle_push(pushed).ok) {
-        throw std::runtime_error(
-            "snapshot source did not apply remote origin batch");
+    std::shared_ptr<Connection> source_conn = open_env(source_path);
+    sync::SyncEngine source(source_conn, sync::ConflictPolicy::Reject, options);
+    source.initialize_local_identity(source_node, db_id);
+    KeyValueTable<std::string, std::string> source_documents(
+        source_conn, "documents");
+    source_documents.insert_or_assign("one", "1");
+    source_documents.insert_or_assign("two", "2");
+    {
+        auto txn = source_conn->transaction(TransactionMode::WRITABLE);
+        sync::ChangeLogStore changelog(source_conn->env_handle());
+        changelog.open(txn.handle());
+        append_raw_batch(changelog, txn.handle(), source_node, 1u,
+                         "documents", 0x11u);
+        txn.commit();
     }
 
+    std::shared_ptr<Connection> replica_conn = open_env(replica_path);
+    sync::SyncEngine replica(replica_conn);
+    replica.initialize_local_identity(replica_node, db_id);
+
     sync::PullRequest request;
-    request.requester = make_node(0xC7);
+    request.requester = replica_node;
     request.db_id = db_id;
     request.request_full_snapshot = true;
-    request.max_bytes = 8192u;
+    request.max_bytes = 1u;
     request.max_single_batch_bytes = 8192u;
-    const sync::PullResponse response = engine.handle_pull(request);
-    if (!response.ok || !response.is_full_snapshot || response.has_more ||
-        response.snapshot_chunk.source_tail.last_seq_for(remote_origin) != 1u) {
+
+    sync::PullResponse response = source.handle_pull(request);
+    if (!response.ok || !response.is_full_snapshot || !response.has_more) {
+        throw std::runtime_error("full snapshot source did not paginate");
+    }
+    const sync::FullSnapshotImportResult first =
+        replica.apply_full_snapshot_chunk(response.snapshot_chunk);
+    if (first.completed || first.next_chunk_index != 1u) {
+        throw std::runtime_error("first full snapshot page was not staged");
+    }
+    {
+        auto txn = replica_conn->transaction(TransactionMode::READ_ONLY);
+        MDBX_dbi dbi = 0;
+        const int rc = mdbx_dbi_open(
+            txn.handle(), "documents", static_cast<MDBX_db_flags_t>(0), &dbi);
+        if (rc != MDBX_NOTFOUND) {
+            throw std::runtime_error(
+                "full snapshot staged a destination DBI before final page");
+        }
+    }
+
+    sync::FullSnapshotImportResult result = first;
+    while (response.has_more) {
+        request.full_snapshot_id = response.snapshot_chunk.snapshot_id;
+        request.full_snapshot_continuation = response.snapshot_chunk.continuation;
+        response = source.handle_pull(request);
+        if (!response.ok || !response.is_full_snapshot) {
+            throw std::runtime_error("full snapshot continuation failed");
+        }
+        result = replica.apply_full_snapshot_chunk(response.snapshot_chunk);
+    }
+    if (!result.completed) {
+        throw std::runtime_error("final full snapshot page did not commit");
+    }
+
+    KeyValueTable<std::string, std::string> replica_documents(
+        replica_conn, "documents");
+    if (kv_or_throw(replica_conn, replica_documents, std::string("one"),
+                    "imported one") != "1" ||
+        kv_or_throw(replica_conn, replica_documents, std::string("two"),
+                    "imported two") != "2") {
+        throw std::runtime_error("full snapshot replica content is wrong");
+    }
+    if (replica.applied_cursor().last_seq_for(source_node) != 1u) {
         throw std::runtime_error(
-            "snapshot source tail omitted an applied remote origin");
+            "full snapshot did not bootstrap the source applied cursor");
+    }
+
+    source_conn->disconnect();
+    replica_conn->disconnect();
+    cleanup(source_path);
+    cleanup(replica_path);
+}
+
+void test_engine_full_snapshot_import_fails_closed_before_final_page() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_full_snapshot_import_failure.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xA4);
+    const sync::NodeId replica_node = make_node(0xB4);
+    const sync::DbId db_id = make_node(0xD4);
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
+
+    sync::FullSnapshotChunk first = make_import_chunk(
+        source_node, db_id, "snapshot-a", 0u, true);
+    append_import_clear(first);
+    const sync::FullSnapshotImportResult staged =
+        engine.apply_full_snapshot_chunk(first);
+    if (staged.completed) {
+        throw std::runtime_error("non-final snapshot page committed");
+    }
+
+    sync::FullSnapshotChunk mismatched = make_import_chunk(
+        source_node, db_id, "snapshot-b", 1u, false);
+    append_import_put(mismatched, "new", "value");
+    bool rejected = false;
+    try {
+        (void)engine.apply_full_snapshot_chunk(mismatched);
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error("mismatched snapshot continuation was accepted");
+    }
+    {
+        auto txn = conn->transaction(TransactionMode::READ_ONLY);
+        MDBX_dbi dbi = 0;
+        const int rc = mdbx_dbi_open(
+            txn.handle(), "documents", static_cast<MDBX_db_flags_t>(0), &dbi);
+        if (rc != MDBX_NOTFOUND) {
+            throw std::runtime_error(
+                "failed snapshot import mutated a destination DBI");
+        }
+    }
+
+    sync::FullSnapshotChunk restart = make_import_chunk(
+        source_node, db_id, "snapshot-c", 0u, false);
+    append_import_clear(restart);
+    append_import_put(restart, "new", "value");
+    if (!engine.apply_full_snapshot_chunk(restart).completed) {
+        throw std::runtime_error("snapshot restart after failure did not commit");
+    }
+    KeyValueTable<std::string, std::string> documents(conn, "documents");
+    if (kv_or_throw(conn, documents, std::string("new"),
+                    "restarted snapshot") != "value") {
+        throw std::runtime_error("restarted snapshot content is wrong");
     }
 
     conn->disconnect();
     cleanup(p);
 }
 
-void test_engine_exports_complete_full_snapshot_inventory() {
+void test_engine_full_snapshot_rejects_nonfresh_destination() {
     using namespace mdbxc;
-    const std::string p = "test_engine_complete_full_snapshot_inventory.mdbx";
+    const std::string p = "test_engine_full_snapshot_nonfresh.mdbx";
     cleanup(p);
 
-    const sync::NodeId source_node = make_node(0xA8);
-    const sync::DbId db_id = make_node(0xD8);
+    const sync::NodeId source_node = make_node(0xA5);
+    const sync::NodeId replica_node = make_node(0xB5);
+    const sync::DbId db_id = make_node(0xD5);
     std::shared_ptr<Connection> conn = open_env(p);
-    sync::FullSnapshotExportOptions options;
-    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
-    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
-    engine.initialize_local_identity(source_node, db_id);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
     KeyValueTable<std::string, std::string> documents(conn, "documents");
-    KeyValueTable<std::string, std::string> audit(conn, "audit");
-    documents.insert_or_assign("document", "value");
-    audit.insert_or_assign("audit", "value");
+    documents.insert_or_assign("old", "preserved");
 
-    sync::PullRequest request;
-    request.requester = make_node(0xB8);
-    request.db_id = db_id;
-    request.request_full_snapshot = true;
-    request.max_bytes = 8192u;
-    request.max_single_batch_bytes = 8192u;
-    const sync::PullResponse response = engine.handle_pull(request);
-    if (!response.ok || !response.is_full_snapshot || response.has_more ||
-        response.snapshot_chunk.replacement_scope !=
-            sync::FullSnapshotScope::CompleteUserDatabase ||
-        response.snapshot_chunk.manifest.size() != 2u ||
-        response.snapshot_chunk.manifest[0].dbi_name != "audit" ||
-        response.snapshot_chunk.manifest[1].dbi_name != "documents") {
-        throw std::runtime_error(
-            "complete full snapshot did not inventory all user DBIs");
+    sync::FullSnapshotChunk chunk = make_import_chunk(
+        source_node, db_id, "snapshot-nonfresh", 0u, false);
+    append_import_clear(chunk);
+    append_import_put(chunk, "new", "must-not-appear");
+    bool rejected = false;
+    try {
+        (void)engine.apply_full_snapshot_chunk(chunk);
+    } catch (const std::logic_error&) {
+        rejected = true;
     }
-    for (std::size_t i = 0u;
-         i < response.snapshot_chunk.manifest.size(); ++i) {
-        if (response.snapshot_chunk.manifest[i].dbi_name.find("_mdbxc_") ==
-            0u) {
+    if (!rejected ||
+        kv_or_throw(conn, documents, std::string("old"),
+                    "preserved destination") != "preserved" ||
+        kv_has(conn, documents, std::string("new"))) {
+        throw std::runtime_error(
+            "nonfresh destination was changed by full snapshot import");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_full_snapshot_import_bounds_fail_closed() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_full_snapshot_import_bounds.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xA6);
+    const sync::NodeId replica_node = make_node(0xB6);
+    const sync::DbId db_id = make_node(0xD6);
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
+    sync::FullSnapshotImportOptions limits;
+    limits.max_staged_operations = 1u;
+    limits.max_staged_bytes = 4096u;
+    engine.set_full_snapshot_import_options(limits);
+
+    sync::FullSnapshotChunk chunk = make_import_chunk(
+        source_node, db_id, "snapshot-bounds", 0u, false);
+    append_import_clear(chunk);
+    append_import_put(chunk, "new", "value");
+    bool rejected = false;
+    try {
+        (void)engine.apply_full_snapshot_chunk(chunk);
+    } catch (const std::length_error&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error("full snapshot import staging bound was ignored");
+    }
+    {
+        auto txn = conn->transaction(TransactionMode::READ_ONLY);
+        MDBX_dbi dbi = 0;
+        const int rc = mdbx_dbi_open(
+            txn.handle(), "documents", static_cast<MDBX_db_flags_t>(0), &dbi);
+        if (rc != MDBX_NOTFOUND) {
             throw std::runtime_error(
-                "complete full snapshot exported a reserved DBI");
+                "bounded full snapshot import created a destination DBI");
         }
     }
 
@@ -2429,10 +2624,14 @@ int main() {
           &test_engine_rejects_unconfigured_full_snapshot_request },
         { "test_engine_exports_stable_full_snapshot_pages",
           &test_engine_exports_stable_full_snapshot_pages },
-        { "test_engine_full_snapshot_tail_includes_applied_origins",
-          &test_engine_full_snapshot_tail_includes_applied_origins },
-        { "test_engine_exports_complete_full_snapshot_inventory",
-          &test_engine_exports_complete_full_snapshot_inventory },
+        { "test_engine_imports_full_snapshot_and_bootstraps_cursor",
+          &test_engine_imports_full_snapshot_and_bootstraps_cursor },
+        { "test_engine_full_snapshot_import_fails_closed_before_final_page",
+          &test_engine_full_snapshot_import_fails_closed_before_final_page },
+        { "test_engine_full_snapshot_rejects_nonfresh_destination",
+          &test_engine_full_snapshot_rejects_nonfresh_destination },
+        { "test_engine_full_snapshot_import_bounds_fail_closed",
+          &test_engine_full_snapshot_import_bounds_fail_closed },
         { "test_engine_changelog_page_rejects_full_snapshot_request",
           &test_engine_changelog_page_rejects_full_snapshot_request },
         { "test_engine_pull_reports_snapshot_required_after_prune",

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1740,9 +1740,7 @@ void test_engine_full_snapshot_tail_includes_applied_origins() {
     const sync::DbId db_id = make_node(0xD7);
     std::shared_ptr<Connection> conn = open_env(p);
     sync::FullSnapshotExportOptions options;
-    sync::FullSnapshotManifestEntry entry;
-    entry.dbi_name = "documents";
-    options.manifest.push_back(entry);
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
     sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
     engine.initialize_local_identity(source_node, db_id);
 
@@ -1773,18 +1771,59 @@ void test_engine_full_snapshot_tail_includes_applied_origins() {
     cleanup(p);
 }
 
+void test_engine_exports_complete_full_snapshot_inventory() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_complete_full_snapshot_inventory.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xA8);
+    const sync::DbId db_id = make_node(0xD8);
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::FullSnapshotExportOptions options;
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
+    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
+    engine.initialize_local_identity(source_node, db_id);
+    KeyValueTable<std::string, std::string> documents(conn, "documents");
+    KeyValueTable<std::string, std::string> audit(conn, "audit");
+    documents.insert_or_assign("document", "value");
+    audit.insert_or_assign("audit", "value");
+
+    sync::PullRequest request;
+    request.requester = make_node(0xB8);
+    request.db_id = db_id;
+    request.request_full_snapshot = true;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    const sync::PullResponse response = engine.handle_pull(request);
+    if (!response.ok || !response.is_full_snapshot || response.has_more ||
+        response.snapshot_chunk.replacement_scope !=
+            sync::FullSnapshotScope::CompleteUserDatabase ||
+        response.snapshot_chunk.manifest.size() != 2u ||
+        response.snapshot_chunk.manifest[0].dbi_name != "audit" ||
+        response.snapshot_chunk.manifest[1].dbi_name != "documents") {
+        throw std::runtime_error(
+            "complete full snapshot did not inventory all user DBIs");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 mdbxc::sync::FullSnapshotChunk make_import_chunk(
         const mdbxc::sync::NodeId& source_node,
         const mdbxc::sync::DbId& db_id,
         const std::string& snapshot_id,
         std::uint64_t chunk_index,
-        bool has_more) {
+        bool has_more,
+        mdbxc::sync::FullSnapshotScope scope =
+            mdbxc::sync::FullSnapshotScope::ManifestOnly) {
     mdbxc::sync::FullSnapshotChunk chunk;
     chunk.source_node_id = source_node;
     chunk.source_db_uuid = db_id;
     chunk.snapshot_id = snapshot_id;
     chunk.chunk_index = chunk_index;
     chunk.has_more = has_more;
+    chunk.replacement_scope = scope;
     chunk.continuation = has_more ? "next" : std::string();
     mdbxc::sync::FullSnapshotManifestEntry entry;
     entry.dbi_name = "documents";
@@ -1828,9 +1867,7 @@ void test_engine_imports_full_snapshot_and_bootstraps_cursor() {
     const sync::NodeId replica_node = make_node(0xB3);
     const sync::DbId db_id = make_node(0xD3);
     sync::FullSnapshotExportOptions options;
-    sync::FullSnapshotManifestEntry entry;
-    entry.dbi_name = "documents";
-    options.manifest.push_back(entry);
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
     options.max_materialized_operations = 16u;
     options.max_materialized_bytes = 4096u;
 
@@ -1841,6 +1878,9 @@ void test_engine_imports_full_snapshot_and_bootstraps_cursor() {
         source_conn, "documents");
     source_documents.insert_or_assign("one", "1");
     source_documents.insert_or_assign("two", "2");
+    KeyValueTable<std::string, std::string> source_audit(
+        source_conn, "audit");
+    source_audit.insert_or_assign("event", "snapshot");
     {
         auto txn = source_conn->transaction(TransactionMode::WRITABLE);
         sync::ChangeLogStore changelog(source_conn->env_handle());
@@ -1897,10 +1937,14 @@ void test_engine_imports_full_snapshot_and_bootstraps_cursor() {
 
     KeyValueTable<std::string, std::string> replica_documents(
         replica_conn, "documents");
+    KeyValueTable<std::string, std::string> replica_audit(
+        replica_conn, "audit");
     if (kv_or_throw(replica_conn, replica_documents, std::string("one"),
                     "imported one") != "1" ||
         kv_or_throw(replica_conn, replica_documents, std::string("two"),
-                    "imported two") != "2") {
+                    "imported two") != "2" ||
+        kv_or_throw(replica_conn, replica_audit, std::string("event"),
+                    "imported audit") != "snapshot") {
         throw std::runtime_error("full snapshot replica content is wrong");
     }
     if (replica.applied_cursor().last_seq_for(source_node) != 1u) {
@@ -1912,6 +1956,81 @@ void test_engine_imports_full_snapshot_and_bootstraps_cursor() {
     replica_conn->disconnect();
     cleanup(source_path);
     cleanup(replica_path);
+}
+
+void test_engine_manifest_only_snapshot_does_not_bootstrap_cursor() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_manifest_only_no_cursor.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xA9);
+    const sync::NodeId replica_node = make_node(0xB9);
+    const sync::DbId db_id = make_node(0xD9);
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
+
+    sync::FullSnapshotChunk chunk = make_import_chunk(
+        source_node, db_id, "manifest-only", 0u, false);
+    chunk.source_tail.last_seq_by_origin[source_node] = 2u;
+    append_import_clear(chunk);
+    append_import_put(chunk, "document", "value");
+    if (!engine.apply_full_snapshot_chunk(chunk).completed) {
+        throw std::runtime_error("ManifestOnly snapshot did not complete");
+    }
+    KeyValueTable<std::string, std::string> documents(conn, "documents");
+    if (kv_or_throw(conn, documents, std::string("document"),
+                    "ManifestOnly document") != "value" ||
+        engine.applied_cursor().last_seq_for(source_node) != 0u) {
+        throw std::runtime_error(
+            "ManifestOnly snapshot bootstrapped global applied progress");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_complete_snapshot_rejects_destination_identity_in_tail() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_complete_snapshot_reused_node.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xAA);
+    const sync::NodeId replica_node = make_node(0xBA);
+    const sync::DbId db_id = make_node(0xDA);
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
+
+    sync::FullSnapshotChunk chunk = make_import_chunk(
+        source_node, db_id, "reused-node", 0u, false,
+        sync::FullSnapshotScope::CompleteUserDatabase);
+    chunk.source_tail.last_seq_by_origin[replica_node] = 5u;
+    append_import_clear(chunk);
+    append_import_put(chunk, "document", "must-not-appear");
+    bool rejected = false;
+    try {
+        (void)engine.apply_full_snapshot_chunk(chunk);
+    } catch (const std::logic_error&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error(
+            "complete snapshot accepted destination identity from source tail");
+    }
+    {
+        auto txn = conn->transaction(TransactionMode::READ_ONLY);
+        MDBX_dbi dbi = 0;
+        const int rc = mdbx_dbi_open(
+            txn.handle(), "documents", static_cast<MDBX_db_flags_t>(0), &dbi);
+        if (rc != MDBX_NOTFOUND) {
+            throw std::runtime_error(
+                "reused-node snapshot mutated a destination DBI");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
 }
 
 void test_engine_full_snapshot_import_fails_closed_before_final_page() {
@@ -2755,8 +2874,14 @@ int main() {
           &test_engine_exports_stable_full_snapshot_pages },
         { "test_engine_full_snapshot_tail_includes_applied_origins",
           &test_engine_full_snapshot_tail_includes_applied_origins },
+        { "test_engine_exports_complete_full_snapshot_inventory",
+          &test_engine_exports_complete_full_snapshot_inventory },
         { "test_engine_imports_full_snapshot_and_bootstraps_cursor",
           &test_engine_imports_full_snapshot_and_bootstraps_cursor },
+        { "test_engine_manifest_only_snapshot_does_not_bootstrap_cursor",
+          &test_engine_manifest_only_snapshot_does_not_bootstrap_cursor },
+        { "test_engine_complete_snapshot_rejects_destination_identity_in_tail",
+          &test_engine_complete_snapshot_rejects_destination_identity_in_tail },
         { "test_engine_full_snapshot_import_fails_closed_before_final_page",
           &test_engine_full_snapshot_import_fails_closed_before_final_page },
         { "test_engine_full_snapshot_rejects_nonfresh_destination",

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1730,6 +1730,49 @@ void test_engine_exports_stable_full_snapshot_pages() {
     cleanup(p);
 }
 
+void test_engine_full_snapshot_tail_includes_applied_origins() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_full_snapshot_applied_tail.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xA7);
+    const sync::NodeId remote_origin = make_node(0xB7);
+    const sync::DbId db_id = make_node(0xD7);
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::FullSnapshotExportOptions options;
+    sync::FullSnapshotManifestEntry entry;
+    entry.dbi_name = "documents";
+    options.manifest.push_back(entry);
+    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
+    engine.initialize_local_identity(source_node, db_id);
+
+    sync::PushRequest pushed;
+    pushed.sender = remote_origin;
+    pushed.db_id = db_id;
+    pushed.batches.push_back(make_raw_batch(remote_origin, 1u,
+                                            "documents", 0x51u));
+    if (!engine.handle_push(pushed).ok) {
+        throw std::runtime_error(
+            "snapshot source did not apply remote origin batch");
+    }
+
+    sync::PullRequest request;
+    request.requester = make_node(0xC7);
+    request.db_id = db_id;
+    request.request_full_snapshot = true;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    const sync::PullResponse response = engine.handle_pull(request);
+    if (!response.ok || !response.is_full_snapshot || response.has_more ||
+        response.snapshot_chunk.source_tail.last_seq_for(remote_origin) != 1u) {
+        throw std::runtime_error(
+            "snapshot source tail omitted an applied remote origin");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 mdbxc::sync::FullSnapshotChunk make_import_chunk(
         const mdbxc::sync::NodeId& source_node,
         const mdbxc::sync::DbId& db_id,
@@ -2005,6 +2048,92 @@ void test_engine_full_snapshot_import_bounds_fail_closed() {
         if (rc != MDBX_NOTFOUND) {
             throw std::runtime_error(
                 "bounded full snapshot import created a destination DBI");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_full_snapshot_import_rejects_invalid_replacement_plan() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_full_snapshot_invalid_plan.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xA8);
+    const sync::NodeId replica_node = make_node(0xB8);
+    const sync::DbId db_id = make_node(0xD8);
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
+
+    sync::FullSnapshotChunk put_before_clear = make_import_chunk(
+        source_node, db_id, "snapshot-put-before-clear", 0u, false);
+    append_import_put(put_before_clear, "key", "value");
+    bool rejected = false;
+    try {
+        (void)engine.apply_full_snapshot_chunk(put_before_clear);
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error("snapshot accepted Put before ClearTable");
+    }
+
+    sync::FullSnapshotChunk first_clear = make_import_chunk(
+        source_node, db_id, "snapshot-duplicate-clear", 0u, true);
+    append_import_clear(first_clear);
+    (void)engine.apply_full_snapshot_chunk(first_clear);
+    sync::FullSnapshotChunk duplicate_clear = make_import_chunk(
+        source_node, db_id, "snapshot-duplicate-clear", 1u, false);
+    append_import_clear(duplicate_clear);
+    rejected = false;
+    try {
+        (void)engine.apply_full_snapshot_chunk(duplicate_clear);
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error("snapshot accepted duplicate ClearTable");
+    }
+
+    sync::FullSnapshotChunk missing_clear = make_import_chunk(
+        source_node, db_id, "snapshot-missing-clear", 0u, false);
+    sync::FullSnapshotManifestEntry secondary;
+    secondary.dbi_name = "secondary";
+    missing_clear.manifest.push_back(secondary);
+    append_import_clear(missing_clear);
+    rejected = false;
+    try {
+        (void)engine.apply_full_snapshot_chunk(missing_clear);
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error("snapshot omitted a manifest ClearTable");
+    }
+
+    sync::FullSnapshotChunk self_origin = make_import_chunk(
+        replica_node, db_id, "snapshot-self-origin", 0u, false);
+    append_import_clear(self_origin);
+    bool rejected_self_origin = false;
+    try {
+        (void)engine.apply_full_snapshot_chunk(self_origin);
+    } catch (const std::logic_error&) {
+        rejected_self_origin = true;
+    }
+    if (!rejected_self_origin) {
+        throw std::runtime_error("snapshot accepted matching source and destination node");
+    }
+
+    {
+        auto txn = conn->transaction(TransactionMode::READ_ONLY);
+        MDBX_dbi dbi = 0;
+        const int rc = mdbx_dbi_open(
+            txn.handle(), "documents", static_cast<MDBX_db_flags_t>(0), &dbi);
+        if (rc != MDBX_NOTFOUND) {
+            throw std::runtime_error(
+                "invalid snapshot replacement plan created destination DBI");
         }
     }
 
@@ -2624,6 +2753,8 @@ int main() {
           &test_engine_rejects_unconfigured_full_snapshot_request },
         { "test_engine_exports_stable_full_snapshot_pages",
           &test_engine_exports_stable_full_snapshot_pages },
+        { "test_engine_full_snapshot_tail_includes_applied_origins",
+          &test_engine_full_snapshot_tail_includes_applied_origins },
         { "test_engine_imports_full_snapshot_and_bootstraps_cursor",
           &test_engine_imports_full_snapshot_and_bootstraps_cursor },
         { "test_engine_full_snapshot_import_fails_closed_before_final_page",
@@ -2632,6 +2763,8 @@ int main() {
           &test_engine_full_snapshot_rejects_nonfresh_destination },
         { "test_engine_full_snapshot_import_bounds_fail_closed",
           &test_engine_full_snapshot_import_bounds_fail_closed },
+        { "test_engine_full_snapshot_import_rejects_invalid_replacement_plan",
+          &test_engine_full_snapshot_import_rejects_invalid_replacement_plan },
         { "test_engine_changelog_page_rejects_full_snapshot_request",
           &test_engine_changelog_page_rejects_full_snapshot_request },
         { "test_engine_pull_reports_snapshot_required_after_prune",


### PR DESCRIPTION
## Summary
- stage explicit ManifestOnly full-snapshot pages in bounded process memory
- atomically replace a fresh manifest target and bootstrap the applied cursor on the final page
- document the manual recovery boundary and cover pagination, rejection, and bounds regressions

## Validation
- C++11 MinGW: sync engine, transport codec, full snapshot protocol, and sync header targets
- C++17 MinGW: sync engine, transport codec, full snapshot protocol, and sync header targets