### PR TITLE
feat(sync): recover fresh replicas from snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,12 @@ All notable changes to this project will be documented in this file.
   manifest into bounded, stable pages. `SyncEngine` now also stages explicit
   `ManifestOnly` pages in bounded memory and atomically imports them only into
   a fresh replica, bootstrapping `_mdbxc_applied` from the immutable source
-  tail. Worker fallback, persisted importer resume, and complete-database
-  replacement remain deferred.
+  tail. Persisted importer resume and complete-database replacement remain
+  deferred.
+- Sync: add opt-in `SyncWorker` fallback for `SnapshotRequired`. It starts a
+  new empty-cursor source session and drains the bounded fresh-replica importer
+  through its final atomic commit. Existing partial replicas and persisted
+  importer resume remain unsupported.
 - Sync: document the authoritative-baseline and multi-origin conflict
   boundary for ordered schema-v2. Baseline import and concurrent multi-writer
   resolution remain design-only and are not exposed as partial APIs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-- Sync: extend the preparatory `FullSnapshotCodec` boundary with immutable
+- Sync: add a raw-only `FullSnapshotCodec` export/import boundary with immutable
   source-tail, replacement-scope, manifest-version, and continuation fields.
   `PullRequest`/`PullResponse` now carry explicit snapshot session state and
   chunk pages; this changes the unreleased `TransportMessageCodec` wire version
@@ -13,7 +13,10 @@ All notable changes to this project will be documented in this file.
   manifest DBIs and never advances global raw-sync progress; automatic
   `CompleteUserDatabase` inventory replaces all named non-reserved user DBIs
   and atomically bootstraps `_mdbxc_applied` from the immutable source tail.
-  Persisted importer resume remains deferred.
+  Complete snapshots fail closed when a source has registered logical schemas;
+  schema markers, ordered-delivery frontiers, replay markers, and outbox state
+  require a separate logical snapshot protocol. Persisted importer resume
+  remains deferred.
 - Sync: add opt-in `SyncWorker` fallback for `SnapshotRequired`. It starts a
   new empty-cursor `CompleteUserDatabase` source session and drains the bounded
   fresh-replica importer through its final atomic commit. `ManifestOnly` remains

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,16 @@ All notable changes to this project will be documented in this file.
   source-tail, replacement-scope, manifest-version, and continuation fields.
   `PullRequest`/`PullResponse` now carry explicit snapshot session state and
   chunk pages; this changes the unreleased `TransportMessageCodec` wire version
-  from 4 to 5. `SyncEngine` can materialize an explicitly configured source
-  manifest into bounded, stable pages. `SyncEngine` now also stages explicit
-  `ManifestOnly` pages in bounded memory and atomically imports them only into
-  a fresh replica, bootstrapping `_mdbxc_applied` from the immutable source
-  tail. Persisted importer resume and complete-database replacement remain
-  deferred.
+  from 4 to 5. `SyncEngine` materializes bounded, stable source pages in two
+  explicit scopes: configured `ManifestOnly` replacement copies only its
+  manifest DBIs and never advances global raw-sync progress; automatic
+  `CompleteUserDatabase` inventory replaces all named non-reserved user DBIs
+  and atomically bootstraps `_mdbxc_applied` from the immutable source tail.
+  Persisted importer resume remains deferred.
 - Sync: add opt-in `SyncWorker` fallback for `SnapshotRequired`. It starts a
-  new empty-cursor source session and drains the bounded fresh-replica importer
-  through its final atomic commit. Existing partial replicas and persisted
+  new empty-cursor `CompleteUserDatabase` source session and drains the bounded
+  fresh-replica importer through its final atomic commit. `ManifestOnly` remains
+  a manual physical replacement mode; existing partial replicas and persisted
   importer resume remain unsupported.
 - Sync: document the authoritative-baseline and multi-origin conflict
   boundary for ordered schema-v2. Baseline import and concurrent multi-writer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ All notable changes to this project will be documented in this file.
   manifest DBIs and never advances global raw-sync progress; automatic
   `CompleteUserDatabase` inventory replaces all named non-reserved user DBIs
   and atomically bootstraps `_mdbxc_applied` from the immutable source tail.
-  Complete snapshots fail closed when a source has registered logical schemas;
-  schema markers, ordered-delivery frontiers, replay markers, and outbox state
-  require a separate logical snapshot protocol. Persisted importer resume
-  remains deferred.
+  Complete snapshots fail closed when a source has persistent logical-sync
+  state: schema markers, ordered-delivery frontiers, replay markers or pruning
+  watermarks, and durable outbox state require a separate logical snapshot
+  protocol. Persisted importer resume remains deferred.
 - Sync: add opt-in `SyncWorker` fallback for `SnapshotRequired`. It starts a
   new empty-cursor `CompleteUserDatabase` source session and drains the bounded
   fresh-replica importer through its final atomic commit. `ManifestOnly` remains

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -217,9 +217,10 @@ Operational rules:
   Otherwise it returns
   `PullResponse{ok=false, error_code=SnapshotNotConfigured}`. The manual
   receiver path accepts only bounded `ManifestOnly` chunks into a fresh
-  replica; worker-driven fallback and persisted resume remain deferred. Code
-  that needs machine classification should inspect `SyncResponseErrorCode`
-  instead of parsing the human-readable `error` string.
+  replica. `SyncWorkerOptions::enable_full_snapshot_fallback` can explicitly
+  drive that recovery after `SnapshotRequired`; persisted resume remains
+  deferred. Code that needs machine classification should inspect
+  `SyncResponseErrorCode` instead of parsing the human-readable `error` string.
 - Pull from a cursor older than retained changelog history fails as
   `PullResponse{ok=false, error_code=SnapshotRequired}`. The response carries no
   batches because applying a later retained batch would produce a sequence gap

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -164,6 +164,12 @@ tables.
 - Add persisted importer resume and explicit complete replacement before
   treating `SnapshotRequired` as universally recoverable by sync itself. The
   opt-in worker fallback accepts only fresh-replica `ManifestOnly` sessions.
+- Design scope-aware partial snapshot continuation separately from complete
+  database recovery. A partial manifest cannot bootstrap the global per-origin
+  applied cursor: this requires a stable scope identity, per-scope or per-DBI
+  applied progress, scope-filtered changelog pull and retention, and explicit
+  handling for DBI membership changes. Do not add these piecemeal to the raw
+  sync path; implement them only when a consumer needs selective replication.
 - Define explicit conflict/CRDT semantics before claiming general concurrent
   multi-writer convergence for `KeyMultiValueTable`.
 - Design baseline import and multi-origin histories for schema v2 separately;

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -161,10 +161,9 @@ tables.
 - Extend `KeyMultiValueTable` logical capture only after every added bulk or
   reconcile operation has explicit multiset replay semantics and round-trip
   coverage. Raw capture remains disabled.
-- Integrate worker fallback, persisted importer resume, and explicit complete
-  replacement before treating `SnapshotRequired` as automatically recoverable
-  by sync itself. The current manual importer accepts only fresh-replica
-  `ManifestOnly` sessions.
+- Add persisted importer resume and explicit complete replacement before
+  treating `SnapshotRequired` as universally recoverable by sync itself. The
+  opt-in worker fallback accepts only fresh-replica `ManifestOnly` sessions.
 - Define explicit conflict/CRDT semantics before claiming general concurrent
   multi-writer convergence for `KeyMultiValueTable`.
 - Design baseline import and multi-origin histories for schema v2 separately;

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -161,9 +161,10 @@ tables.
 - Extend `KeyMultiValueTable` logical capture only after every added bulk or
   reconcile operation has explicit multiset replay semantics and round-trip
   coverage. Raw capture remains disabled.
-- Add persisted importer resume and explicit complete replacement before
-  treating `SnapshotRequired` as universally recoverable by sync itself. The
-  opt-in worker fallback accepts only fresh-replica `ManifestOnly` sessions.
+- Add persisted importer resume before treating `SnapshotRequired` as
+  universally recoverable by sync itself. The opt-in worker fallback accepts
+  only fresh-replica `CompleteUserDatabase` sessions; manual `ManifestOnly`
+  imports never bootstrap global raw-sync progress.
 - Design scope-aware partial snapshot continuation separately from complete
   database recovery. A partial manifest cannot bootstrap the global per-origin
   applied cursor: this requires a stable scope identity, per-scope or per-DBI

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1558,10 +1558,11 @@ return `SnapshotSessionInvalid`; bounded session capacity returns retryable
 `SnapshotSessionBusy`.
 
 `CompleteUserDatabase` is currently a raw-sync-only recovery scope. Before a
-session is materialized, the source rejects a non-empty persistent schema
-registry with `SnapshotLogicalStateUnsupported`. A physical copy of logical
-adapter DBIs without `_mdbxc_sync_schema`, ordered-delivery frontiers, replay
-markers, and outbox/recovery state cannot safely continue logical delivery.
+session is materialized, the source rejects any persistent logical-sync state
+with `SnapshotLogicalStateUnsupported`: schema markers, replay markers or
+pruning watermarks, ordered-delivery frontiers, and durable outbox metadata or
+entries. A physical copy of logical adapter DBIs without this state cannot
+safely continue logical delivery.
 `ManifestOnly` is likewise only a manual physical replacement tool: it does
 not claim to repair or bootstrap logical replication. A future logical snapshot
 protocol must atomically define the logical schema, delivery, replay, and

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1542,28 +1542,36 @@ batch with `seq=0`. Transport codec v5 carries the explicit session request and
 one snapshot chunk in `PullResponse`; it rejects mixed incremental/snapshot
 pages and malformed session state.
 
-`SyncEngine` can export an explicit `FullSnapshotExportOptions::manifest`: it
-materializes configured user DBIs in one read transaction, bounds active
-sessions and materialized data, and returns stable pages. An empty source
-manifest returns `SnapshotNotConfigured`; unknown, expired, or mismatched
-continuations or a different requester return `SnapshotSessionInvalid`; bounded
-session capacity returns retryable `SnapshotSessionBusy`.
+`SyncEngine` exports two explicit snapshot scopes. `ManifestOnly` materializes
+the caller's configured user-DBI manifest in one read transaction, bounds active
+sessions and materialized data, and returns stable pages. It is a manual
+physical replacement mode: the final import replaces only manifest DBIs and
+never changes `_mdbxc_applied`. `CompleteUserDatabase` requires no caller
+manifest; the engine inventories every named non-reserved user DBI from MainDB
+under the same source read transaction. Its fresh-replica importer rejects a
+destination user DBI outside the exported inventory and, only after the complete
+replacement plan commits, atomically writes the immutable source tail to
+`_mdbxc_applied`. An empty configured `ManifestOnly` source returns
+`SnapshotNotConfigured`; a complete-source inventory with no user DBIs is
+rejected. Unknown, expired, or mismatched continuations or a different requester
+return `SnapshotSessionInvalid`; bounded session capacity returns retryable
+`SnapshotSessionBusy`.
 
-`SyncEngine::apply_full_snapshot_chunk()` implements the first manual receiver
-path for `ManifestOnly` snapshots. It stages all pages in bounded process memory
-and validates immutable page-zero metadata on every continuation. Only the
-final page opens a write transaction: it requires zero local changelog sequence,
-an empty applied cursor, and empty manifest DBIs, then applies the staged
-`ClearTable` / `Put` plan and writes the advertised source tail to
-`_mdbxc_applied` atomically. Any interruption, malformed continuation, bound
-failure, or non-fresh target fails before a user-DBI commit. Existing
-receiver-only DBIs outside the manifest remain untouched.
+`SyncEngine::apply_full_snapshot_chunk()` stages all pages in bounded process
+memory and validates immutable page-zero metadata on every continuation. Only
+the final page opens a write transaction: it requires zero local changelog
+sequence, an empty applied cursor, and empty manifest DBIs, then applies the
+staged `ClearTable` / `Put` plan. Complete replacement additionally requires a
+destination node identity absent from the source tail, so a restored database
+cannot resume local writes with an origin sequence already used by the source.
+Any interruption, malformed continuation, bound failure, or non-fresh target
+fails before a user-DBI commit.
 
-Worker fallback from `SnapshotRequired`, persisted importer restart state, and
-`CompleteUserDatabase` replacement are still not implemented. `SyncWorker`
-can opt in to the fresh-replica `ManifestOnly` fallback: on `SnapshotRequired`
-it starts a new empty-cursor snapshot session and drains every page through the
-final import commit. It does not repair an existing partial replica; a failed
+`SyncWorker` can opt in to `SnapshotRequired` recovery only with a fresh-replica
+`CompleteUserDatabase` session. It starts a new empty-cursor source session and
+drains every page through the final import commit. It never treats
+`ManifestOnly` as a raw-sync fallback, because that scope has no global cursor
+bootstrap. The worker does not repair an existing partial replica; a failed
 fresh-target preflight remains a reported sync error. Persisted importer resume
 is not implemented, so an interrupted worker discards in-memory staging and a
 later retry starts a new source session.
@@ -1582,8 +1590,9 @@ changelog replay. The reserved request shape is
 return snapshot chunks only when the caller requested that mode, never as an
 implicit fallback from a normal incremental pull.
 
-The implemented source session and fresh-replica importer preserve these
-properties. The remaining worker and resume work must preserve them too:
+The implemented source session, fresh-replica importer, and worker fallback
+preserve these properties. Persisted resume and any future selective-scope
+extension must preserve them too:
 
 - A full snapshot export is a named snapshot session. The first response must
   return an opaque `snapshot_id` and all later pages must present the same id;
@@ -1600,10 +1609,10 @@ properties. The remaining worker and resume work must preserve them too:
   manifest version/hash that later pages repeat. A receiver must reject chunks
   whose manifest identity differs from the first page.
 - Receiver-only DBIs are an explicit policy decision, not an accidental side
-  effect. The manifest must say whether the snapshot replaces the complete
-  database scope or only the listed DBIs; complete replacement may clear/drop
-  receiver-only user DBIs only when the caller opted into that scope. Otherwise
-  receiver-only DBIs are preserved or the import fails closed before data apply.
+  effect. `ManifestOnly` preserves DBIs outside its manifest and does not
+  bootstrap global cursor state. `CompleteUserDatabase` inventories all named
+  non-reserved source DBIs and fails closed if a fresh destination contains a
+  user DBI outside that manifest; it does not silently drop receiver-only DBIs.
 - Snapshot chunks must be distinguishable from ordinary changelog batches.
   The reserved shape is `ChangeBatch{seq=0, batch_flags=BATCH_HAS_MORE...}`
   with a snapshot-specific flag or versioned envelope added before release.
@@ -1615,10 +1624,10 @@ properties. The remaining worker and resume work must preserve them too:
   the receiver must clear each exported user DBI before applying that DBI's
   first snapshot entries, then apply later chunks idempotently or reject
   ambiguous resume attempts.
-- Metadata bootstrap is separate from user data import. After the snapshot data
-  is committed, the receiver records applied cursors consistent with the
-  responder's advertised replication tail so the next round can continue through
-  ordinary incremental pull.
+- Metadata bootstrap is separate from user data import. Only after a complete
+  user-database snapshot commits does the receiver record applied cursors
+  consistent with the responder's advertised replication tail. A manifest-only
+  import intentionally leaves global cursor state unchanged.
 - Chunk pagination must use the existing pull limits: `max_bytes` as a soft page
   budget and `max_single_batch_bytes` as a hard limit for a single encoded
   snapshot chunk. If one logical DBI chunk cannot fit under the hard limit, the
@@ -1636,11 +1645,14 @@ properties. The remaining worker and resume work must preserve them too:
   replica directory and fail closed on interruption.
 - `SnapshotRequired` remains the incremental-pull recovery signal. It tells the
   caller that retained changelog replay cannot satisfy the request; the caller
-  may then make a separate `request_full_snapshot=true` request once this
-  protocol exists.
+  may then make a separate `request_full_snapshot=true` request. The worker
+  uses this only for `CompleteUserDatabase` fresh-replica recovery.
 
-Until these details are implemented and covered by round-trip tests,
-`request_full_snapshot=true` remains a permanent sync-level rejection.
+Persisted importer resume and scope-aware partial snapshot continuation are
+still deferred. A partial manifest cannot share the global per-origin cursor:
+that architecture requires stable scope identity, per-scope or per-DBI applied
+progress, scope-filtered changelog pull and retention, and explicit DBI
+membership-change handling.
 
 ## Background worker lifecycle
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1557,6 +1557,16 @@ rejected. Unknown, expired, or mismatched continuations or a different requester
 return `SnapshotSessionInvalid`; bounded session capacity returns retryable
 `SnapshotSessionBusy`.
 
+`CompleteUserDatabase` is currently a raw-sync-only recovery scope. Before a
+session is materialized, the source rejects a non-empty persistent schema
+registry with `SnapshotLogicalStateUnsupported`. A physical copy of logical
+adapter DBIs without `_mdbxc_sync_schema`, ordered-delivery frontiers, replay
+markers, and outbox/recovery state cannot safely continue logical delivery.
+`ManifestOnly` is likewise only a manual physical replacement tool: it does
+not claim to repair or bootstrap logical replication. A future logical snapshot
+protocol must atomically define the logical schema, delivery, replay, and
+recovery state it transfers.
+
 `SyncEngine::apply_full_snapshot_chunk()` stages all pages in bounded process
 memory and validates immutable page-zero metadata on every continuation. Only
 the final page opens a write transaction: it requires zero local changelog

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1560,9 +1560,13 @@ failure, or non-fresh target fails before a user-DBI commit. Existing
 receiver-only DBIs outside the manifest remain untouched.
 
 Worker fallback from `SnapshotRequired`, persisted importer restart state, and
-`CompleteUserDatabase` replacement are still not implemented. Consequently a
-snapshot request is not yet an automatic recovery path; a caller must drive the
-source session and the manual importer explicitly.
+`CompleteUserDatabase` replacement are still not implemented. `SyncWorker`
+can opt in to the fresh-replica `ManifestOnly` fallback: on `SnapshotRequired`
+it starts a new empty-cursor snapshot session and drains every page through the
+final import commit. It does not repair an existing partial replica; a failed
+fresh-target preflight remains a reported sync error. Persisted importer resume
+is not implemented, so an interrupted worker discards in-memory staging and a
+later retry starts a new source session.
 If changelog pruning removed entries needed by the requester's cursor,
 `handle_pull()` returns `SnapshotRequired` with no batches. This is also a
 valid sync response, not a transport failure.

--- a/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
+++ b/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
@@ -34,8 +34,8 @@ namespace sync {
     /// bootstraps global raw-sync progress. \c CompleteUserDatabase replaces
     /// every named user DBI and is the only scope that may bootstrap the
     /// per-origin applied cursor for subsequent incremental replication. The
-    /// current complete scope is raw-only and rejects sources with registered
-    /// logical schemas until a separate logical snapshot protocol exists.
+    /// current complete scope is raw-only and rejects sources with persistent
+    /// logical-sync state until a separate logical snapshot protocol exists.
     enum class FullSnapshotScope : std::uint8_t {
         ManifestOnly = 0u,
         CompleteUserDatabase = 1u

--- a/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
+++ b/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
@@ -33,7 +33,9 @@ namespace sync {
     /// \details \c ManifestOnly replaces only manifest DBIs and never
     /// bootstraps global raw-sync progress. \c CompleteUserDatabase replaces
     /// every named user DBI and is the only scope that may bootstrap the
-    /// per-origin applied cursor for subsequent incremental replication.
+    /// per-origin applied cursor for subsequent incremental replication. The
+    /// current complete scope is raw-only and rejects sources with registered
+    /// logical schemas until a separate logical snapshot protocol exists.
     enum class FullSnapshotScope : std::uint8_t {
         ManifestOnly = 0u,
         CompleteUserDatabase = 1u

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -161,6 +161,14 @@ namespace sync {
             std::mutex mutex;
         };
 
+        class FullSnapshotLogicalStateUnsupported : public std::runtime_error {
+        public:
+            explicit FullSnapshotLogicalStateUnsupported(
+                    const std::string& message =
+                        "complete full snapshot does not support registered logical-sync state")
+                : std::runtime_error(message) {}
+        };
+
         struct FullSnapshotImportSession {
             enum class ReplacementState {
                 NotSeen,
@@ -1534,8 +1542,7 @@ namespace sync {
             materialized_bytes += add;
         }
 
-        std::string next_full_snapshot_id() {
-            std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
+        std::string next_full_snapshot_id_locked() {
             ++m_next_full_snapshot_session_id;
             return std::string("snapshot-") +
                 std::to_string(m_next_full_snapshot_session_id);
@@ -1560,11 +1567,9 @@ namespace sync {
 
         std::shared_ptr<FullSnapshotSession> materialize_full_snapshot(
                 const FullSnapshotExportOptions& options,
-                const std::string& snapshot_id,
                 const NodeId& requester) const {
             std::shared_ptr<FullSnapshotSession> session(
                 new FullSnapshotSession());
-            session->snapshot_id = snapshot_id;
             session->requester = requester;
             session->replacement_scope = options.replacement_scope;
             session->last_access = std::chrono::steady_clock::now();
@@ -1578,6 +1583,23 @@ namespace sync {
                 compare_node_id(session->source_db_uuid, NodeId()) == 0) {
                 throw std::logic_error(
                     "full snapshot source identity is not initialized");
+            }
+
+            if (options.replacement_scope ==
+                FullSnapshotScope::CompleteUserDatabase) {
+                SchemaRegistryStore schemas(m_conn->env_handle());
+                try {
+                    if (!schemas.schema_ids(txn.handle()).empty()) {
+                        throw FullSnapshotLogicalStateUnsupported();
+                    }
+                } catch (const FullSnapshotLogicalStateUnsupported&) {
+                    throw;
+                } catch (const std::exception& e) {
+                    throw FullSnapshotLogicalStateUnsupported(
+                        std::string(
+                            "complete full snapshot cannot validate logical-sync state: ") +
+                        e.what());
+                }
             }
 
             session->manifest = options.replacement_scope ==
@@ -1794,8 +1816,15 @@ namespace sync {
                     ++m_full_snapshot_creating;
                 }
                 try {
-                    session = materialize_full_snapshot(
-                        options, next_full_snapshot_id(), request.requester);
+                    session = materialize_full_snapshot(options, request.requester);
+                } catch (const FullSnapshotLogicalStateUnsupported& e) {
+                    std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
+                    --m_full_snapshot_creating;
+                    out.ok = false;
+                    out.error = e.what();
+                    out.error_code =
+                        SyncResponseErrorCode::SnapshotLogicalStateUnsupported;
+                    return out;
                 } catch (...) {
                     std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
                     --m_full_snapshot_creating;
@@ -1805,6 +1834,7 @@ namespace sync {
                     std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
                     --m_full_snapshot_creating;
                     prune_expired_full_snapshot_sessions_locked();
+                    session->snapshot_id = next_full_snapshot_id_locked();
                     m_full_snapshot_sessions[session->snapshot_id] = session;
                 }
             } else {

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -282,11 +282,13 @@ namespace sync {
         }
 
         /// \brief Stages or atomically applies one full snapshot chunk.
-        /// \details Only \c ManifestOnly replacement is currently accepted.
-        /// Every page is validated against immutable metadata from page zero.
-        /// No destination user DBI changes before the final page; that page
-        /// verifies a fresh manifest target, applies the complete staged plan,
-        /// and bootstraps the applied cursor in one write transaction.
+        /// \details Every page is validated against immutable metadata from
+        /// page zero. No destination user DBI changes before the final page;
+        /// that page verifies a fresh manifest target and applies the complete
+        /// staged plan in one write transaction. \c ManifestOnly replaces only
+        /// its manifest DBIs and leaves global raw-sync progress unchanged.
+        /// \c CompleteUserDatabase replaces the complete named-user-DBI
+        /// inventory and bootstraps the applied cursor from its source tail.
         FullSnapshotImportResult apply_full_snapshot_chunk(
                 const FullSnapshotChunk& chunk) {
             FullSnapshotCodec::validate(chunk);

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -165,7 +165,7 @@ namespace sync {
         public:
             explicit FullSnapshotLogicalStateUnsupported(
                     const std::string& message =
-                        "complete full snapshot does not support registered logical-sync state")
+                        "complete full snapshot does not support persistent logical-sync state")
                 : std::runtime_error(message) {}
         };
 
@@ -1565,6 +1565,28 @@ namespace sync {
             }
         }
 
+        void require_raw_only_complete_snapshot_source(MDBX_txn* txn) const {
+            try {
+                SchemaRegistryStore schemas(m_conn->env_handle());
+                LogicalDeliveryStore delivery(m_conn->env_handle());
+                LogicalDeliveryOrderStore order(m_conn->env_handle());
+                LogicalOutboxStore outbox(m_conn->env_handle());
+                if (schemas.has_entries(txn) ||
+                    delivery.has_persistent_state(txn) ||
+                    order.has_entries(txn) ||
+                    outbox.has_persistent_state(txn)) {
+                    throw FullSnapshotLogicalStateUnsupported();
+                }
+            } catch (const FullSnapshotLogicalStateUnsupported&) {
+                throw;
+            } catch (const std::exception& e) {
+                throw FullSnapshotLogicalStateUnsupported(
+                    std::string(
+                        "complete full snapshot cannot validate persistent logical-sync state: ") +
+                    e.what());
+            }
+        }
+
         std::shared_ptr<FullSnapshotSession> materialize_full_snapshot(
                 const FullSnapshotExportOptions& options,
                 const NodeId& requester) const {
@@ -1587,19 +1609,7 @@ namespace sync {
 
             if (options.replacement_scope ==
                 FullSnapshotScope::CompleteUserDatabase) {
-                SchemaRegistryStore schemas(m_conn->env_handle());
-                try {
-                    if (!schemas.schema_ids(txn.handle()).empty()) {
-                        throw FullSnapshotLogicalStateUnsupported();
-                    }
-                } catch (const FullSnapshotLogicalStateUnsupported&) {
-                    throw;
-                } catch (const std::exception& e) {
-                    throw FullSnapshotLogicalStateUnsupported(
-                        std::string(
-                            "complete full snapshot cannot validate logical-sync state: ") +
-                        e.what());
-                }
+                require_raw_only_complete_snapshot_source(txn.handle());
             }
 
             session->manifest = options.replacement_scope ==

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -272,6 +272,15 @@ namespace sync {
             m_full_snapshot_import_session.reset();
         }
 
+        /// \brief Discards an incomplete in-memory full snapshot import.
+        /// \details No user-DBI mutation has occurred before a snapshot final
+        /// page, so this is safe after cancellation, transport failure, or a
+        /// worker restart. It never alters durable replication metadata.
+        void discard_full_snapshot_import() {
+            std::lock_guard<std::mutex> lock(m_full_snapshot_import_mutex);
+            m_full_snapshot_import_session.reset();
+        }
+
         /// \brief Stages or atomically applies one full snapshot chunk.
         /// \details Only \c ManifestOnly replacement is currently accepted.
         /// Every page is validated against immutable metadata from page zero.

--- a/include/mdbx_containers/sync/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/SyncWorker.hpp
@@ -88,10 +88,12 @@ namespace sync {
         /// \brief Requests an explicit fresh-replica snapshot after
         /// \c SnapshotRequired.
         /// \details Disabled by default. When enabled, the worker starts a
-        /// new full snapshot session with an empty cursor and drains it through
-        /// the final page in the current round. The receiver importer still
-        /// rejects non-fresh targets; this is not an in-place repair path for
-        /// a partially replicated database.
+        /// new \c CompleteUserDatabase snapshot session with an empty cursor
+        /// and drains it through the final page in the current round.
+        /// \c ManifestOnly is a manual physical replacement mode and never a
+        /// raw-sync recovery fallback. The receiver importer still rejects
+        /// non-fresh targets; this is not an in-place repair path for a
+        /// partially replicated database.
         bool enable_full_snapshot_fallback = false;
 
         /// \brief How the background worker handles permanent transport hints.
@@ -261,9 +263,9 @@ namespace sync {
     /// waiting in \c ISyncPeer::pull(), idle sleep, or backoff sleep. Pulled
     /// batches are applied through \c SyncEngine::handle_push(), which opens
     /// and commits a short local write transaction for each pulled page. With
-    /// opt-in full snapshot fallback, the worker instead stages all snapshot
-    /// pages and the engine commits their fresh-replica replacement only after
-    /// the final page.
+    /// opt-in full snapshot fallback, the worker accepts only a
+    /// \c CompleteUserDatabase session, stages all pages, and the engine
+    /// commits its fresh-replica replacement only after the final page.
     /// Stop requests cancel the active request token and call
     /// \c ISyncPeer::request_cancel() at most once for each observed in-flight
     /// peer call. Cancellation is best-effort: \c stop(), \c join(), and the
@@ -794,6 +796,17 @@ namespace sync {
                     result.ok = false;
                     result.error =
                         "full snapshot pull returned an invalid response shape";
+                    return result;
+                }
+                if (response.snapshot_chunk.replacement_scope !=
+                    FullSnapshotScope::CompleteUserDatabase) {
+                    m_engine.discard_full_snapshot_import();
+                    result.ok = false;
+                    result.error =
+                        "full snapshot fallback requires CompleteUserDatabase scope";
+                    result.sync_error_code =
+                        SyncResponseErrorCode::SnapshotSessionInvalid;
+                    result.sync_error_retryable = false;
                     return result;
                 }
                 ++result.pages_pulled;

--- a/include/mdbx_containers/sync/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/SyncWorker.hpp
@@ -85,6 +85,15 @@ namespace sync {
         /// \brief Whether one round drains all \c has_more pages immediately.
         bool drain_pages = true;
 
+        /// \brief Requests an explicit fresh-replica snapshot after
+        /// \c SnapshotRequired.
+        /// \details Disabled by default. When enabled, the worker starts a
+        /// new full snapshot session with an empty cursor and drains it through
+        /// the final page in the current round. The receiver importer still
+        /// rejects non-fresh targets; this is not an in-place repair path for
+        /// a partially replicated database.
+        bool enable_full_snapshot_fallback = false;
+
         /// \brief How the background worker handles permanent transport hints.
         /// \details The default keeps v0.1 retry hints advisory. Set to
         /// \c StopWorker when a classified permanent transport failure should
@@ -236,7 +245,7 @@ namespace sync {
         }
     };
 
-    /// \brief Drives incremental pull/apply sync in a caller-owned lifecycle.
+    /// \brief Drives pull/apply sync in a caller-owned lifecycle.
     /// \details The worker owns only its std::thread. It does not own the
     /// supplied \c SyncEngine or \c ISyncPeer; both must outlive the worker.
     /// The \c SyncWorker object itself must outlive its worker thread and must
@@ -251,7 +260,10 @@ namespace sync {
     /// The implementation never keeps a local MDBX transaction open while
     /// waiting in \c ISyncPeer::pull(), idle sleep, or backoff sleep. Pulled
     /// batches are applied through \c SyncEngine::handle_push(), which opens
-    /// and commits a short local write transaction for each pulled page.
+    /// and commits a short local write transaction for each pulled page. With
+    /// opt-in full snapshot fallback, the worker instead stages all snapshot
+    /// pages and the engine commits their fresh-replica replacement only after
+    /// the final page.
     /// Stop requests cancel the active request token and call
     /// \c ISyncPeer::request_cancel() at most once for each observed in-flight
     /// peer call. Cancellation is best-effort: \c stop(), \c join(), and the
@@ -478,6 +490,33 @@ namespace sync {
             bool        m_active;
         };
 
+        class FullSnapshotImportResetGuard {
+        public:
+            explicit FullSnapshotImportResetGuard(SyncEngine& engine)
+                : m_engine(engine), m_active(true) {
+            }
+
+            ~FullSnapshotImportResetGuard() {
+                if (!m_active) return;
+                try {
+                    m_engine.discard_full_snapshot_import();
+                } catch (...) {
+                }
+            }
+
+            void dismiss() {
+                m_active = false;
+            }
+
+            FullSnapshotImportResetGuard(const FullSnapshotImportResetGuard&) = delete;
+            FullSnapshotImportResetGuard& operator=(
+                const FullSnapshotImportResetGuard&) = delete;
+
+        private:
+            SyncEngine& m_engine;
+            bool        m_active;
+        };
+
         static void validate_options(const SyncWorkerOptions& options) {
             if (options.max_batches == 0) {
                 throw std::invalid_argument(
@@ -573,6 +612,11 @@ namespace sync {
                         notify_stage_changed(event);
                     }
                     if (!response.ok) {
+                        if (response.error_code ==
+                                SyncResponseErrorCode::SnapshotRequired &&
+                            m_options.enable_full_snapshot_fallback) {
+                            return run_full_snapshot_fallback(request, result);
+                        }
                         result.ok = false;
                         result.error = response.error.empty()
                             ? "pull failed"
@@ -690,6 +734,123 @@ namespace sync {
                 result.retry_hint = m_peer.last_retry_hint();
             }
             return result;
+        }
+
+        SyncWorkerRoundResult run_full_snapshot_fallback(
+                const PullRequest& incremental_request,
+                SyncWorkerRoundResult result) {
+            m_engine.discard_full_snapshot_import();
+            FullSnapshotImportResetGuard reset_guard(m_engine);
+            PullRequest request = incremental_request;
+            request.request_full_snapshot = true;
+            request.have = SyncCursor();
+            request.full_snapshot_id.clear();
+            request.full_snapshot_continuation.clear();
+            request.cancel_token = CancellationToken();
+
+            for (;;) {
+                if (stop_requested()) {
+                    result.has_more = true;
+                    return result;
+                }
+
+                PullResponse response;
+                {
+                    CancellationToken cancel_token;
+                    PeerCallGuard peer_call(*this, cancel_token);
+                    if (!peer_call.active()) {
+                        result.has_more = true;
+                        return result;
+                    }
+                    notify_stage_changed(make_stage_event(
+                        SyncWorkerStage::PullStarted, result));
+                    request.cancel_token = cancel_token;
+                    response = m_peer.pull(request);
+                }
+                {
+                    SyncWorkerStageEvent event = make_stage_event(
+                        SyncWorkerStage::PullFinished, result);
+                    event.has_more = response.has_more;
+                    event.ok = response.ok;
+                    event.error = response.error;
+                    event.sync_error_code = response.error_code;
+                    event.sync_error_retryable = response.error_retryable;
+                    notify_stage_changed(event);
+                }
+                if (!response.ok) {
+                    m_engine.discard_full_snapshot_import();
+                    result.ok = false;
+                    result.error = response.error.empty()
+                        ? "full snapshot pull failed"
+                        : response.error;
+                    result.retry_hint = m_peer.last_retry_hint();
+                    result.sync_error_code = response.error_code;
+                    result.sync_error_retryable = response.error_retryable;
+                    return result;
+                }
+                if (!response.is_full_snapshot || !response.batches.empty() ||
+                    response.has_more != response.snapshot_chunk.has_more) {
+                    m_engine.discard_full_snapshot_import();
+                    result.ok = false;
+                    result.error =
+                        "full snapshot pull returned an invalid response shape";
+                    return result;
+                }
+                ++result.pages_pulled;
+                if (stop_requested() || !begin_apply_stage() ||
+                    !enter_apply_gate()) {
+                    m_engine.discard_full_snapshot_import();
+                    result.has_more = response.has_more;
+                    return result;
+                }
+                {
+                    SyncWorkerStageEvent event = make_stage_event(
+                        SyncWorkerStage::ApplyStarted, result);
+                    event.has_more = response.has_more;
+                    notify_stage_changed(event);
+                }
+
+                const FullSnapshotImportResult imported =
+                    m_engine.apply_full_snapshot_chunk(response.snapshot_chunk);
+                {
+                    SyncWorkerStageEvent event = make_stage_event(
+                        SyncWorkerStage::ApplyFinished, result);
+                    event.has_more = response.has_more;
+                    event.ok = true;
+                    notify_stage_changed(event);
+                }
+                if (response.has_more && imported.completed) {
+                    m_engine.discard_full_snapshot_import();
+                    result.ok = false;
+                    result.error =
+                        "full snapshot importer completed before final page";
+                    return result;
+                }
+                if (!response.has_more && !imported.completed) {
+                    m_engine.discard_full_snapshot_import();
+                    result.ok = false;
+                    result.error =
+                        "full snapshot importer did not complete final page";
+                    return result;
+                }
+
+                result.has_more = response.has_more;
+                if (!response.has_more) {
+                    result.progress = response.remote_tail_known
+                        ? make_progress_estimate(response.remote_tail,
+                                                 m_engine.applied_cursor(),
+                                                 result.batches_applied)
+                        : SyncWorkerProgressEstimate();
+                    result.sync_error_code = SyncResponseErrorCode::None;
+                    result.sync_error_retryable = false;
+                    reset_guard.dismiss();
+                    return result;
+                }
+                request.full_snapshot_id =
+                    response.snapshot_chunk.snapshot_id;
+                request.full_snapshot_continuation =
+                    response.snapshot_chunk.continuation;
+            }
         }
 
         SyncWorkerStageEvent make_stage_event(

--- a/include/mdbx_containers/sync/TransportMessageCodec.hpp
+++ b/include/mdbx_containers/sync/TransportMessageCodec.hpp
@@ -345,6 +345,7 @@ namespace sync {
                 case SyncResponseErrorCode::SnapshotNotConfigured:
                 case SyncResponseErrorCode::SnapshotSessionInvalid:
                 case SyncResponseErrorCode::SnapshotSessionBusy:
+                case SyncResponseErrorCode::SnapshotLogicalStateUnsupported:
                     detail::append_u16_le(out,
                         static_cast<std::uint16_t>(code));
                     return;
@@ -526,6 +527,9 @@ namespace sync {
                 case static_cast<std::uint16_t>(
                         SyncResponseErrorCode::SnapshotSessionBusy):
                     return SyncResponseErrorCode::SnapshotSessionBusy;
+                case static_cast<std::uint16_t>(
+                        SyncResponseErrorCode::SnapshotLogicalStateUnsupported):
+                    return SyncResponseErrorCode::SnapshotLogicalStateUnsupported;
             }
             throw std::runtime_error("Invalid SyncResponseErrorCode");
         }

--- a/include/mdbx_containers/sync/protocol.hpp
+++ b/include/mdbx_containers/sync/protocol.hpp
@@ -30,9 +30,10 @@ namespace sync {
         ApplyConflict           = 3, ///< Push apply failed on a sync conflict.
         SnapshotRequired        = 4, ///< Requested changelog history was pruned.
         BatchTooLarge           = 5, ///< A single retained batch exceeds the requested limit.
-        SnapshotNotConfigured   = 6, ///< Responder has no explicit snapshot export manifest.
+        SnapshotNotConfigured   = 6, ///< Responder has no enabled snapshot export.
         SnapshotSessionInvalid  = 7, ///< Snapshot session is unknown, expired, or mismatched.
         SnapshotSessionBusy     = 8, ///< Responder reached its bounded snapshot-session capacity.
+        SnapshotLogicalStateUnsupported = 9, ///< Snapshot needs a logical-state protocol not implemented here.
     };
 
     /// \brief Returns a stable diagnostic name for a sync response error code.
@@ -57,6 +58,8 @@ namespace sync {
                 return "snapshot_session_invalid";
             case SyncResponseErrorCode::SnapshotSessionBusy:
                 return "snapshot_session_busy";
+            case SyncResponseErrorCode::SnapshotLogicalStateUnsupported:
+                return "snapshot_logical_state_unsupported";
         }
         return "unknown";
     }

--- a/include/mdbx_containers/sync/stores/LogicalDeliveryOrderStore.hpp
+++ b/include/mdbx_containers/sync/stores/LogicalDeliveryOrderStore.hpp
@@ -6,6 +6,7 @@
 /// \brief Persistent contiguous receiver frontier for ordered delivery.
 
 #include <cstdint>
+#include <cstring>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -78,6 +79,39 @@ namespace sync {
                        "LogicalDeliveryOrderStore write failed");
         }
 
+        /// \brief Returns whether any valid ordered-delivery frontier exists.
+        /// \details The whole DBI is decoded so malformed state is not treated
+        /// as an empty receiver frontier.
+        bool has_entries(MDBX_txn* txn) const {
+            txn = checked_txn(txn,
+                              "LogicalDeliveryOrderStore::has_entries");
+            open_existing(txn);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "LogicalDeliveryOrderStore cursor open failed");
+            bool found = false;
+            try {
+                MDBX_val key;
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    (void)decode_origin(key);
+                    (void)decode_value(value);
+                    found = true;
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc,
+                               "LogicalDeliveryOrderStore cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return found;
+        }
+
     private:
         MDBX_txn* checked_txn(MDBX_txn* txn, const char* context) const {
             return checked_txn_env(txn, m_env, context);
@@ -112,6 +146,17 @@ namespace sync {
                 origin.size()
             };
             return out;
+        }
+
+        static NodeId decode_origin(const MDBX_val& key) {
+            if (key.iov_len != NodeId().size() || key.iov_base == nullptr) {
+                throw std::runtime_error(
+                    "LogicalDeliveryOrderStore key has invalid size");
+            }
+            NodeId origin;
+            std::memcpy(origin.data(), key.iov_base, origin.size());
+            validate_origin(origin);
+            return origin;
         }
 
         static MDBX_val make_val(const std::vector<std::uint8_t>& bytes) {

--- a/include/mdbx_containers/sync/stores/LogicalDeliveryStore.hpp
+++ b/include/mdbx_containers/sync/stores/LogicalDeliveryStore.hpp
@@ -109,6 +109,64 @@ namespace sync {
             return out;
         }
 
+        /// \brief Returns whether replay markers or pruning watermarks exist.
+        /// \details All present records are decoded before returning. The
+        /// optional watermark DBI is inspected without creating it.
+        bool has_persistent_state(MDBX_txn* txn) const {
+            txn = checked_txn(txn,
+                              "LogicalDeliveryStore::has_persistent_state");
+            open_const(txn);
+            bool found = false;
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "LogicalDeliveryStore marker cursor open failed");
+            try {
+                MDBX_val key;
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    (void)decode_and_validate_marker(key, value);
+                    found = true;
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc,
+                               "LogicalDeliveryStore marker cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+
+            if (!open_watermark_if_exists(txn)) {
+                return found;
+            }
+            cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_watermark_dbi, &cursor),
+                       "LogicalDeliveryStore watermark cursor open failed");
+            try {
+                MDBX_val key;
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    (void)decode_watermark_origin(key);
+                    (void)decode_watermark(value);
+                    found = true;
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc,
+                               "LogicalDeliveryStore watermark cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return found;
+        }
+
         /// \brief Lists persisted logical delivery marker identities.
         /// \param limit Maximum number of markers to return, or zero for all.
         std::vector<LogicalDeliveryMarkerInfo> list_markers(
@@ -533,6 +591,20 @@ namespace sync {
                     "LogicalDeliveryStore watermark is zero");
             }
             return sequence;
+        }
+
+        static NodeId decode_watermark_origin(const MDBX_val& key) {
+            if (key.iov_len != NodeId().size() || key.iov_base == nullptr) {
+                throw std::runtime_error(
+                    "LogicalDeliveryStore watermark key has invalid size");
+            }
+            NodeId origin;
+            std::memcpy(origin.data(), key.iov_base, origin.size());
+            if (is_zero_sync_id(origin)) {
+                throw std::runtime_error(
+                    "LogicalDeliveryStore watermark origin is zero");
+            }
+            return origin;
         }
 
         struct ValueCursor {

--- a/include/mdbx_containers/sync/stores/LogicalOutboxStore.hpp
+++ b/include/mdbx_containers/sync/stores/LogicalOutboxStore.hpp
@@ -260,6 +260,59 @@ namespace sync {
             return removed;
         }
 
+        /// \brief Returns whether any valid durable outbox state exists.
+        /// \details Metadata is state even when all entries were acknowledged:
+        /// it records an allocated logical-delivery stream. Every record is
+        /// decoded and cross-checked before this method returns.
+        bool has_persistent_state(MDBX_txn* txn,
+                                  const CodecBounds* bounds = nullptr) const {
+            txn = checked_txn(txn,
+                              "LogicalOutboxStore::has_persistent_state");
+            open_existing(txn);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "LogicalOutboxStore state cursor open failed");
+            bool found = false;
+            try {
+                MDBX_val key;
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    const DbId destination = decode_destination(key);
+                    if (is_metadata_key(key)) {
+                        (void)decode_metadata(value);
+                    } else {
+                        const std::uint64_t sequence = decode_entry_sequence(key);
+                        const Metadata metadata = read_metadata(txn, destination);
+                        const LogicalDeliveryEnvelope envelope =
+                            decode_value(value, bounds);
+                        if (is_zero_sync_id(metadata.origin_node_id) ||
+                            sequence <= metadata.acknowledged_through ||
+                            sequence >= metadata.next_sequence ||
+                            compare_node_id(envelope.destination_db_uuid,
+                                            destination) != 0 ||
+                            compare_node_id(envelope.origin_node_id,
+                                            metadata.origin_node_id) != 0 ||
+                            envelope.origin_sequence != sequence) {
+                            throw std::runtime_error(
+                                "LogicalOutboxStore entry key/value mismatch");
+                        }
+                    }
+                    found = true;
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc,
+                               "LogicalOutboxStore state cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return found;
+        }
+
     private:
         struct Metadata {
             Metadata()
@@ -350,6 +403,43 @@ namespace sync {
             return key.iov_len == prefix.size() + 8u &&
                    key.iov_base != nullptr &&
                    std::memcmp(key.iov_base, &prefix[0], prefix.size()) == 0;
+        }
+
+        static bool is_metadata_key(const MDBX_val& key) {
+            if (key.iov_len != entry_prefix_size() || key.iov_base == nullptr) {
+                return false;
+            }
+            const std::uint8_t* bytes =
+                static_cast<const std::uint8_t*>(key.iov_base);
+            return bytes[0] == key_version() &&
+                   bytes[1] == metadata_key_kind();
+        }
+
+        static DbId decode_destination(const MDBX_val& key) {
+            if (key.iov_len != entry_prefix_size() &&
+                key.iov_len != entry_key_size()) {
+                throw std::runtime_error(
+                    "LogicalOutboxStore key has invalid size");
+            }
+            if (key.iov_base == nullptr) {
+                throw std::runtime_error(
+                    "LogicalOutboxStore key is null");
+            }
+            const std::uint8_t* bytes =
+                static_cast<const std::uint8_t*>(key.iov_base);
+            if (bytes[0] != key_version() ||
+                (bytes[1] != metadata_key_kind() &&
+                 bytes[1] != entry_key_kind())) {
+                throw std::runtime_error(
+                    "LogicalOutboxStore key has invalid prefix");
+            }
+            DbId destination;
+            std::memcpy(destination.data(), bytes + 2u, destination.size());
+            if (is_zero_sync_id(destination)) {
+                throw std::runtime_error(
+                    "LogicalOutboxStore destination is zero");
+            }
+            return destination;
         }
 
         static std::uint64_t decode_entry_sequence(const MDBX_val& key) {

--- a/include/mdbx_containers/sync/stores/SchemaRegistryStore.hpp
+++ b/include/mdbx_containers/sync/stores/SchemaRegistryStore.hpp
@@ -186,6 +186,43 @@ namespace sync {
             return out;
         }
 
+        /// \brief Returns whether the registry contains any valid schema record.
+        /// \details All entries are decoded before returning so callers do not
+        /// treat malformed persistent schema metadata as an empty registry.
+        bool has_entries(MDBX_txn* txn) const {
+            txn = checked_txn(txn, "SchemaRegistryStore::has_entries");
+            open_const(txn);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "SchemaRegistryStore cursor open failed");
+            bool found = false;
+            try {
+                MDBX_val key;
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    if (key.iov_base == nullptr) {
+                        throw std::runtime_error(
+                            "SchemaRegistryStore schema id is null");
+                    }
+                    const char* data = static_cast<const char*>(key.iov_base);
+                    const std::string schema_id(data, data + key.iov_len);
+                    LogicalSchemaRecord decoded;
+                    decode_record(value, schema_id, decoded);
+                    found = true;
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "SchemaRegistryStore cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return found;
+        }
+
     private:
         MDBX_txn* checked_txn(MDBX_txn* txn, const char* context) const {
             return checked_txn_env(txn, m_env, context);

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1880,6 +1880,126 @@ void test_engine_rejects_complete_snapshot_with_logical_state() {
     cleanup(p);
 }
 
+void test_engine_rejects_complete_snapshot_with_empty_ordered_frame() {
+    using namespace mdbxc;
+    const std::string p =
+        "test_engine_complete_snapshot_empty_ordered_frame.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xAA);
+    const sync::NodeId logical_origin = make_node(0xBA);
+    const sync::DbId db_id = make_node(0xDA);
+    sync::FullSnapshotExportOptions options;
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
+    options.max_materialized_operations = 16u;
+    options.max_materialized_bytes = 4096u;
+    options.max_active_sessions = 1u;
+
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
+    engine.initialize_local_identity(source_node, db_id);
+    KeyValueTable<std::string, std::string> documents(conn, "documents");
+    documents.insert_or_assign("document", "raw-value");
+
+    sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = db_id;
+    envelope.origin_node_id = logical_origin;
+    envelope.origin_sequence = 1u;
+    envelope.frame_id = "snapshot-empty-ordered-frame";
+    const sync::LogicalDeliveryAcknowledgement acknowledgement =
+        engine.apply_ordered_logical_delivery_envelope(envelope);
+    if (!acknowledgement.ok ||
+        acknowledgement.acknowledged_through != 1u) {
+        throw std::runtime_error(
+            "failed to prepare empty ordered logical snapshot state");
+    }
+    {
+        auto txn = conn->transaction(TransactionMode::READ_ONLY);
+        sync::SchemaRegistryStore schemas(conn->env_handle());
+        if (schemas.has_entries(txn.handle())) {
+            throw std::runtime_error(
+                "empty ordered logical frame unexpectedly registered a schema");
+        }
+    }
+
+    sync::PullRequest request;
+    request.requester = make_node(0xCA);
+    request.db_id = db_id;
+    request.request_full_snapshot = true;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    const sync::PullResponse first = engine.handle_pull(request);
+    const sync::PullResponse second = engine.handle_pull(request);
+    if (first.ok || second.ok || first.is_full_snapshot ||
+        !first.snapshot_chunk.snapshot_id.empty() ||
+        !second.snapshot_chunk.snapshot_id.empty() ||
+        first.error_code !=
+            sync::SyncResponseErrorCode::SnapshotLogicalStateUnsupported ||
+        second.error_code !=
+            sync::SyncResponseErrorCode::SnapshotLogicalStateUnsupported ||
+        first.error_retryable || second.error_retryable ||
+        kv_or_throw(conn, documents, std::string("document"),
+                    "empty ordered snapshot source value") != "raw-value") {
+        throw std::runtime_error(
+            "complete snapshot accepted empty ordered logical state");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_rejects_complete_snapshot_with_logical_outbox_state() {
+    using namespace mdbxc;
+    const std::string p =
+        "test_engine_complete_snapshot_logical_outbox_state.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xAB);
+    const sync::DbId db_id = make_node(0xDB);
+    const sync::DbId destination = make_node(0xEB);
+    sync::FullSnapshotExportOptions options;
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
+    options.max_materialized_operations = 16u;
+    options.max_materialized_bytes = 4096u;
+    options.max_active_sessions = 1u;
+
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
+    engine.initialize_local_identity(source_node, db_id);
+    KeyValueTable<std::string, std::string> documents(conn, "documents");
+    documents.insert_or_assign("document", "raw-value");
+    engine.enqueue_logical_delivery(destination, sync::LogicalChangeFrame());
+    {
+        auto txn = conn->transaction(TransactionMode::READ_ONLY);
+        sync::SchemaRegistryStore schemas(conn->env_handle());
+        if (schemas.has_entries(txn.handle())) {
+            throw std::runtime_error(
+                "logical outbox unexpectedly registered a schema");
+        }
+    }
+
+    sync::PullRequest request;
+    request.requester = make_node(0xCB);
+    request.db_id = db_id;
+    request.request_full_snapshot = true;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    const sync::PullResponse response = engine.handle_pull(request);
+    if (response.ok || response.is_full_snapshot ||
+        !response.snapshot_chunk.snapshot_id.empty() ||
+        response.error_code !=
+            sync::SyncResponseErrorCode::SnapshotLogicalStateUnsupported ||
+        response.error_retryable ||
+        kv_or_throw(conn, documents, std::string("document"),
+                    "logical outbox snapshot source value") != "raw-value") {
+        throw std::runtime_error(
+            "complete snapshot accepted logical outbox state");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 mdbxc::sync::FullSnapshotChunk make_import_chunk(
         const mdbxc::sync::NodeId& source_node,
         const mdbxc::sync::DbId& db_id,
@@ -2949,6 +3069,10 @@ int main() {
           &test_engine_exports_complete_full_snapshot_inventory },
         { "test_engine_rejects_complete_snapshot_with_logical_state",
           &test_engine_rejects_complete_snapshot_with_logical_state },
+        { "test_engine_rejects_complete_snapshot_with_empty_ordered_frame",
+          &test_engine_rejects_complete_snapshot_with_empty_ordered_frame },
+        { "test_engine_rejects_complete_snapshot_with_logical_outbox_state",
+          &test_engine_rejects_complete_snapshot_with_logical_outbox_state },
         { "test_engine_imports_full_snapshot_and_bootstraps_cursor",
           &test_engine_imports_full_snapshot_and_bootstraps_cursor },
         { "test_engine_manifest_only_snapshot_does_not_bootstrap_cursor",

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1809,6 +1809,77 @@ void test_engine_exports_complete_full_snapshot_inventory() {
     cleanup(p);
 }
 
+void test_engine_rejects_complete_snapshot_with_logical_state() {
+    using namespace mdbxc;
+    typedef sync::KeyValueLogicalStringCodec<std::string> StringCodec;
+    typedef sync::KeyValueTableLogicalAdapter<
+        std::string, std::string, StringCodec, StringCodec> LogicalAdapter;
+
+    const std::string p = "test_engine_complete_snapshot_logical_state.mdbx";
+    const std::string schema_id = "app.snapshot.logical_key_value.v1";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xA9);
+    const sync::NodeId logical_origin = make_node(0xB9);
+    const sync::DbId db_id = make_node(0xD9);
+    sync::FullSnapshotExportOptions options;
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
+    options.max_materialized_operations = 16u;
+    options.max_materialized_bytes = 4096u;
+    options.max_active_sessions = 1u;
+
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
+    engine.initialize_local_identity(source_node, db_id);
+    KeyValueTable<std::string, std::string> documents(conn, "documents");
+    LogicalAdapter adapter(documents, schema_id);
+    sync::LogicalSchemaRecord record;
+    record.dbi_name = "documents";
+    record.kind = sync::LogicalTableKind::KeyValue;
+    record.schema_version = 1u;
+    record.dbi_names.push_back("documents");
+    engine.register_logical_schema(schema_id, record);
+    engine.register_logical_adapter(adapter);
+
+    sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = db_id;
+    envelope.origin_node_id = logical_origin;
+    envelope.origin_sequence = 1u;
+    envelope.frame_id = "snapshot-logical-state";
+    envelope.frame.changes.push_back(
+        adapter.make_upsert("logical", "value"));
+    const sync::LogicalDeliveryAcknowledgement acknowledgement =
+        engine.apply_ordered_logical_delivery_envelope(envelope);
+    if (!acknowledgement.ok ||
+        kv_or_throw(conn, documents, std::string("logical"),
+                    "logical snapshot source value") != "value") {
+        throw std::runtime_error(
+            "failed to prepare logical snapshot source state");
+    }
+
+    sync::PullRequest request;
+    request.requester = make_node(0xC9);
+    request.db_id = db_id;
+    request.request_full_snapshot = true;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    const sync::PullResponse first = engine.handle_pull(request);
+    const sync::PullResponse second = engine.handle_pull(request);
+    if (first.ok || second.ok || first.is_full_snapshot ||
+        !first.snapshot_chunk.snapshot_id.empty() ||
+        first.error_code !=
+            sync::SyncResponseErrorCode::SnapshotLogicalStateUnsupported ||
+        second.error_code !=
+            sync::SyncResponseErrorCode::SnapshotLogicalStateUnsupported ||
+        first.error_retryable || second.error_retryable) {
+        throw std::runtime_error(
+            "complete snapshot accepted registered logical state");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 mdbxc::sync::FullSnapshotChunk make_import_chunk(
         const mdbxc::sync::NodeId& source_node,
         const mdbxc::sync::DbId& db_id,
@@ -2876,6 +2947,8 @@ int main() {
           &test_engine_full_snapshot_tail_includes_applied_origins },
         { "test_engine_exports_complete_full_snapshot_inventory",
           &test_engine_exports_complete_full_snapshot_inventory },
+        { "test_engine_rejects_complete_snapshot_with_logical_state",
+          &test_engine_rejects_complete_snapshot_with_logical_state },
         { "test_engine_imports_full_snapshot_and_bootstraps_cursor",
           &test_engine_imports_full_snapshot_and_bootstraps_cursor },
         { "test_engine_manifest_only_snapshot_does_not_bootstrap_cursor",

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -2593,11 +2593,93 @@ void test_sync_node_session_rolls_back_hooks_when_worker_start_fails() {
     cleanup(replica_path);
 }
 
+void test_worker_recovers_fresh_replica_with_full_snapshot() {
+    using namespace mdbxc;
+    const std::string source_path = "test_worker_snapshot_source.mdbx";
+    const std::string replica_path = "test_worker_snapshot_replica.mdbx";
+    cleanup(source_path);
+    cleanup(replica_path);
+
+    const sync::NodeId source_node = make_node(0xA9);
+    const sync::NodeId replica_node = make_node(0xB9);
+    const sync::DbId db_id = make_node(0xD9);
+    sync::FullSnapshotExportOptions snapshot_options;
+    sync::FullSnapshotManifestEntry entry;
+    entry.dbi_name = "documents";
+    snapshot_options.manifest.push_back(entry);
+    snapshot_options.max_materialized_operations = 16u;
+    snapshot_options.max_materialized_bytes = 4096u;
+
+    std::shared_ptr<Connection> source_conn = open_env(source_path);
+    sync::SyncEngine source_engine(
+        source_conn, sync::ConflictPolicy::Reject, snapshot_options);
+    source_engine.initialize_local_identity(source_node, db_id);
+    KeyValueTable<std::string, std::string> source_documents(
+        source_conn, "documents");
+    source_documents.insert_or_assign("one", "1");
+    source_documents.insert_or_assign("two", "2");
+    {
+        auto txn = source_conn->transaction(TransactionMode::WRITABLE);
+        sync::ChangeLogStore changelog(source_conn->env_handle());
+        changelog.open(txn.handle());
+        const std::vector<std::uint8_t> encoded =
+            sync::ChangeBatchCodec::encode(
+                make_raw_batch(source_node, 3u, "documents", 0x21u));
+        changelog.append(txn.handle(), source_node, 3u, encoded);
+        txn.commit();
+    }
+
+    std::shared_ptr<Connection> replica_conn = open_env(replica_path);
+    sync::SyncEngine replica_engine(replica_conn);
+    replica_engine.initialize_local_identity(replica_node, db_id);
+    sync::DirectSyncPeer peer(&source_engine);
+    {
+        sync::SyncWorker disabled_worker(replica_engine, peer);
+        const sync::SyncWorkerRoundResult disabled =
+            disabled_worker.run_once();
+        if (disabled.ok ||
+            disabled.sync_error_code != sync::SyncResponseErrorCode::SnapshotRequired) {
+            throw std::runtime_error(
+                "worker enabled full snapshot fallback without opt-in");
+        }
+    }
+    sync::SyncWorkerOptions options;
+    options.enable_full_snapshot_fallback = true;
+    options.max_bytes = 1u;
+    options.max_single_batch_bytes = 8192u;
+    sync::SyncWorker worker(replica_engine, peer, options);
+
+    const sync::SyncWorkerRoundResult result = worker.run_once();
+    if (!result.ok || result.pages_pulled < 2u ||
+        result.batches_applied != 0u || result.has_more ||
+        result.sync_error_code != sync::SyncResponseErrorCode::None) {
+        throw std::runtime_error(
+            "worker did not complete fresh-replica full snapshot fallback");
+    }
+    KeyValueTable<std::string, std::string> replica_documents(
+        replica_conn, "documents");
+    if (kv_or_throw(replica_conn, replica_documents, std::string("one"),
+                    "snapshot one") != "1" ||
+        kv_or_throw(replica_conn, replica_documents, std::string("two"),
+                    "snapshot two") != "2" ||
+        replica_engine.applied_cursor().last_seq_for(source_node) != 3u) {
+        throw std::runtime_error(
+            "worker full snapshot fallback did not bootstrap replica state");
+    }
+
+    source_conn->disconnect();
+    replica_conn->disconnect();
+    cleanup(source_path);
+    cleanup(replica_path);
+}
+
 } // namespace
 
 int main() {
     struct Case { const char* name; void (*fn)(); };
     const Case cases[] = {
+        { "test_worker_recovers_fresh_replica_with_full_snapshot",
+          &test_worker_recovers_fresh_replica_with_full_snapshot },
         { "test_worker_run_once_drains_paginated_pull",
           &test_worker_run_once_drains_paginated_pull },
         { "test_worker_start_stop_idle", &test_worker_start_stop_idle },

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -2844,6 +2844,68 @@ void test_worker_rejects_manifest_only_snapshot_fallback() {
     cleanup(replica_path);
 }
 
+void test_worker_rejects_logical_complete_snapshot_fallback() {
+    using namespace mdbxc;
+    const std::string source_path = "test_worker_logical_snapshot_source.mdbx";
+    const std::string replica_path = "test_worker_logical_snapshot_replica.mdbx";
+    cleanup(source_path);
+    cleanup(replica_path);
+
+    const sync::NodeId source_node = make_node(0xAC);
+    const sync::NodeId replica_node = make_node(0xBC);
+    const sync::DbId db_id = make_node(0xDC);
+    sync::FullSnapshotExportOptions snapshot_options;
+    snapshot_options.replacement_scope =
+        sync::FullSnapshotScope::CompleteUserDatabase;
+    snapshot_options.max_materialized_operations = 16u;
+    snapshot_options.max_materialized_bytes = 4096u;
+
+    std::shared_ptr<Connection> source_conn = open_env(source_path);
+    sync::SyncEngine source(
+        source_conn, sync::ConflictPolicy::Reject, snapshot_options);
+    source.initialize_local_identity(source_node, db_id);
+    sync::LogicalSchemaRecord record;
+    record.dbi_name = "documents";
+    record.kind = sync::LogicalTableKind::KeyValue;
+    record.schema_version = 1u;
+    record.dbi_names.push_back("documents");
+    source.register_logical_schema("app.worker_snapshot.logical.v1", record);
+    {
+        auto txn = source_conn->transaction(TransactionMode::WRITABLE);
+        sync::ChangeLogStore changelog(source_conn->env_handle());
+        changelog.open(txn.handle());
+        const std::vector<std::uint8_t> encoded =
+            sync::ChangeBatchCodec::encode(
+                make_raw_batch(source_node, 3u, "documents", 0x51u));
+        changelog.append(txn.handle(), source_node, 3u, encoded);
+        txn.commit();
+    }
+
+    std::shared_ptr<Connection> replica_conn = open_env(replica_path);
+    sync::SyncEngine replica(replica_conn);
+    replica.initialize_local_identity(replica_node, db_id);
+    sync::DirectSyncPeer peer(&source);
+    sync::SyncWorkerOptions options;
+    options.enable_full_snapshot_fallback = true;
+    options.max_bytes = 8192u;
+    options.max_single_batch_bytes = 8192u;
+    sync::SyncWorker worker(replica, peer, options);
+    const sync::SyncWorkerRoundResult result = worker.run_once();
+    if (result.ok ||
+        result.sync_error_code !=
+            sync::SyncResponseErrorCode::SnapshotLogicalStateUnsupported ||
+        result.sync_error_retryable ||
+        replica.applied_cursor().last_seq_for(source_node) != 0u) {
+        throw std::runtime_error(
+            "worker accepted a logical complete snapshot fallback");
+    }
+
+    source_conn->disconnect();
+    replica_conn->disconnect();
+    cleanup(source_path);
+    cleanup(replica_path);
+}
+
 } // namespace
 
 int main() {
@@ -2855,6 +2917,8 @@ int main() {
           &test_worker_snapshot_recovery_preserves_remote_origin_cursor },
         { "test_worker_rejects_manifest_only_snapshot_fallback",
           &test_worker_rejects_manifest_only_snapshot_fallback },
+        { "test_worker_rejects_logical_complete_snapshot_fallback",
+          &test_worker_rejects_logical_complete_snapshot_fallback },
         { "test_worker_run_once_drains_paginated_pull",
           &test_worker_run_once_drains_paginated_pull },
         { "test_worker_start_stop_idle", &test_worker_start_stop_idle },

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -2673,6 +2673,112 @@ void test_worker_recovers_fresh_replica_with_full_snapshot() {
     cleanup(replica_path);
 }
 
+void test_worker_snapshot_recovery_preserves_remote_origin_cursor() {
+    using namespace mdbxc;
+    const std::string snapshot_source_path =
+        "test_worker_snapshot_remote_source.mdbx";
+    const std::string remote_origin_path =
+        "test_worker_snapshot_remote_origin.mdbx";
+    const std::string replica_path =
+        "test_worker_snapshot_remote_replica.mdbx";
+    cleanup(snapshot_source_path);
+    cleanup(remote_origin_path);
+    cleanup(replica_path);
+
+    const sync::NodeId snapshot_source_node = make_node(0xAA);
+    const sync::NodeId remote_origin_node = make_node(0xBA);
+    const sync::NodeId replica_node = make_node(0xCA);
+    const sync::DbId db_id = make_node(0xDA);
+    sync::FullSnapshotExportOptions snapshot_options;
+    sync::FullSnapshotManifestEntry entry;
+    entry.dbi_name = "documents";
+    snapshot_options.manifest.push_back(entry);
+    snapshot_options.max_materialized_operations = 16u;
+    snapshot_options.max_materialized_bytes = 4096u;
+
+    std::shared_ptr<Connection> snapshot_source_conn =
+        open_env(snapshot_source_path);
+    sync::SyncEngine snapshot_source(
+        snapshot_source_conn, sync::ConflictPolicy::Reject, snapshot_options);
+    snapshot_source.initialize_local_identity(snapshot_source_node, db_id);
+    sync::PushRequest applied_remote;
+    applied_remote.sender = remote_origin_node;
+    applied_remote.db_id = db_id;
+    applied_remote.batches.push_back(
+        make_raw_batch(remote_origin_node, 1u, "documents", 0x41u));
+    if (!snapshot_source.handle_push(applied_remote).ok) {
+        throw std::runtime_error(
+            "snapshot source did not apply remote origin sequence one");
+    }
+    {
+        auto txn = snapshot_source_conn->transaction(TransactionMode::WRITABLE);
+        sync::ChangeLogStore changelog(snapshot_source_conn->env_handle());
+        changelog.open(txn.handle());
+        const std::vector<std::uint8_t> encoded =
+            sync::ChangeBatchCodec::encode(
+                make_raw_batch(snapshot_source_node, 3u, "documents", 0x31u));
+        changelog.append(txn.handle(), snapshot_source_node, 3u, encoded);
+        txn.commit();
+    }
+
+    std::shared_ptr<Connection> remote_origin_conn = open_env(remote_origin_path);
+    sync::SyncEngine remote_origin(remote_origin_conn);
+    remote_origin.initialize_local_identity(remote_origin_node, db_id);
+    {
+        auto txn = remote_origin_conn->transaction(TransactionMode::WRITABLE);
+        sync::ChangeLogStore changelog(remote_origin_conn->env_handle());
+        changelog.open(txn.handle());
+        const std::vector<std::uint8_t> first =
+            sync::ChangeBatchCodec::encode(
+                make_raw_batch(remote_origin_node, 1u, "documents", 0x41u));
+        const std::vector<std::uint8_t> second =
+            sync::ChangeBatchCodec::encode(
+                make_raw_batch(remote_origin_node, 2u, "documents", 0x42u));
+        changelog.append(txn.handle(), remote_origin_node, 1u, first);
+        changelog.append(txn.handle(), remote_origin_node, 2u, second);
+        txn.commit();
+    }
+
+    std::shared_ptr<Connection> replica_conn = open_env(replica_path);
+    sync::SyncEngine replica(replica_conn);
+    replica.initialize_local_identity(replica_node, db_id);
+    sync::DirectSyncPeer snapshot_peer(&snapshot_source);
+    sync::SyncWorkerOptions snapshot_worker_options;
+    snapshot_worker_options.enable_full_snapshot_fallback = true;
+    snapshot_worker_options.max_bytes = 1u;
+    snapshot_worker_options.max_single_batch_bytes = 8192u;
+    sync::SyncWorker snapshot_worker(
+        replica, snapshot_peer, snapshot_worker_options);
+    const sync::SyncWorkerRoundResult snapshot_result =
+        snapshot_worker.run_once();
+    if (!snapshot_result.ok ||
+        replica.applied_cursor().last_seq_for(remote_origin_node) != 1u) {
+        throw std::runtime_error(
+            "snapshot recovery did not preserve remote origin progress");
+    }
+
+    sync::DirectSyncPeer remote_origin_peer(&remote_origin);
+    sync::SyncWorkerOptions incremental_options;
+    incremental_options.max_bytes = 8192u;
+    incremental_options.max_single_batch_bytes = 8192u;
+    sync::SyncWorker incremental_worker(
+        replica, remote_origin_peer, incremental_options);
+    const sync::SyncWorkerRoundResult incremental_result =
+        incremental_worker.run_once();
+    if (!incremental_result.ok || incremental_result.batches_applied != 1u ||
+        replica.applied_cursor().last_seq_for(remote_origin_node) != 2u) {
+        throw std::runtime_error(
+            "incremental remote origin delivery failed after snapshot recovery");
+    }
+
+    snapshot_source_conn->disconnect();
+    remote_origin_conn->disconnect();
+    replica_conn->disconnect();
+    cleanup(snapshot_source_path);
+    cleanup(remote_origin_path);
+    cleanup(replica_path);
+}
+
 } // namespace
 
 int main() {
@@ -2680,6 +2786,8 @@ int main() {
     const Case cases[] = {
         { "test_worker_recovers_fresh_replica_with_full_snapshot",
           &test_worker_recovers_fresh_replica_with_full_snapshot },
+        { "test_worker_snapshot_recovery_preserves_remote_origin_cursor",
+          &test_worker_snapshot_recovery_preserves_remote_origin_cursor },
         { "test_worker_run_once_drains_paginated_pull",
           &test_worker_run_once_drains_paginated_pull },
         { "test_worker_start_stop_idle", &test_worker_start_stop_idle },

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -2864,12 +2864,29 @@ void test_worker_rejects_logical_complete_snapshot_fallback() {
     sync::SyncEngine source(
         source_conn, sync::ConflictPolicy::Reject, snapshot_options);
     source.initialize_local_identity(source_node, db_id);
-    sync::LogicalSchemaRecord record;
-    record.dbi_name = "documents";
-    record.kind = sync::LogicalTableKind::KeyValue;
-    record.schema_version = 1u;
-    record.dbi_names.push_back("documents");
-    source.register_logical_schema("app.worker_snapshot.logical.v1", record);
+    KeyValueTable<std::string, std::string> documents(
+        source_conn, "documents");
+    documents.insert_or_assign("document", "raw-value");
+    sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = db_id;
+    envelope.origin_node_id = make_node(0xCD);
+    envelope.origin_sequence = 1u;
+    envelope.frame_id = "worker-empty-ordered-frame";
+    const sync::LogicalDeliveryAcknowledgement acknowledgement =
+        source.apply_ordered_logical_delivery_envelope(envelope);
+    if (!acknowledgement.ok ||
+        acknowledgement.acknowledged_through != 1u) {
+        throw std::runtime_error(
+            "failed to prepare worker empty ordered logical state");
+    }
+    {
+        auto txn = source_conn->transaction(TransactionMode::READ_ONLY);
+        sync::SchemaRegistryStore schemas(source_conn->env_handle());
+        if (schemas.has_entries(txn.handle())) {
+            throw std::runtime_error(
+                "worker empty ordered frame unexpectedly registered a schema");
+        }
+    }
     {
         auto txn = source_conn->transaction(TransactionMode::WRITABLE);
         sync::ChangeLogStore changelog(source_conn->env_handle());

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -2604,9 +2604,8 @@ void test_worker_recovers_fresh_replica_with_full_snapshot() {
     const sync::NodeId replica_node = make_node(0xB9);
     const sync::DbId db_id = make_node(0xD9);
     sync::FullSnapshotExportOptions snapshot_options;
-    sync::FullSnapshotManifestEntry entry;
-    entry.dbi_name = "documents";
-    snapshot_options.manifest.push_back(entry);
+    snapshot_options.replacement_scope =
+        sync::FullSnapshotScope::CompleteUserDatabase;
     snapshot_options.max_materialized_operations = 16u;
     snapshot_options.max_materialized_bytes = 4096u;
 
@@ -2690,9 +2689,8 @@ void test_worker_snapshot_recovery_preserves_remote_origin_cursor() {
     const sync::NodeId replica_node = make_node(0xCA);
     const sync::DbId db_id = make_node(0xDA);
     sync::FullSnapshotExportOptions snapshot_options;
-    sync::FullSnapshotManifestEntry entry;
-    entry.dbi_name = "documents";
-    snapshot_options.manifest.push_back(entry);
+    snapshot_options.replacement_scope =
+        sync::FullSnapshotScope::CompleteUserDatabase;
     snapshot_options.max_materialized_operations = 16u;
     snapshot_options.max_materialized_bytes = 4096u;
 
@@ -2779,6 +2777,73 @@ void test_worker_snapshot_recovery_preserves_remote_origin_cursor() {
     cleanup(replica_path);
 }
 
+void test_worker_rejects_manifest_only_snapshot_fallback() {
+    using namespace mdbxc;
+    const std::string source_path = "test_worker_manifest_only_source.mdbx";
+    const std::string replica_path = "test_worker_manifest_only_replica.mdbx";
+    cleanup(source_path);
+    cleanup(replica_path);
+
+    const sync::NodeId source_node = make_node(0xAB);
+    const sync::NodeId replica_node = make_node(0xBB);
+    const sync::DbId db_id = make_node(0xDB);
+    sync::FullSnapshotExportOptions snapshot_options;
+    sync::FullSnapshotManifestEntry entry;
+    entry.dbi_name = "documents";
+    snapshot_options.manifest.push_back(entry);
+    snapshot_options.max_materialized_operations = 16u;
+    snapshot_options.max_materialized_bytes = 4096u;
+
+    std::shared_ptr<Connection> source_conn = open_env(source_path);
+    sync::SyncEngine source(
+        source_conn, sync::ConflictPolicy::Reject, snapshot_options);
+    source.initialize_local_identity(source_node, db_id);
+    KeyValueTable<std::string, std::string> documents(source_conn, "documents");
+    documents.insert_or_assign("document", "value");
+    {
+        auto txn = source_conn->transaction(TransactionMode::WRITABLE);
+        sync::ChangeLogStore changelog(source_conn->env_handle());
+        changelog.open(txn.handle());
+        const std::vector<std::uint8_t> encoded =
+            sync::ChangeBatchCodec::encode(
+                make_raw_batch(source_node, 3u, "documents", 0x51u));
+        changelog.append(txn.handle(), source_node, 3u, encoded);
+        txn.commit();
+    }
+
+    std::shared_ptr<Connection> replica_conn = open_env(replica_path);
+    sync::SyncEngine replica(replica_conn);
+    replica.initialize_local_identity(replica_node, db_id);
+    sync::DirectSyncPeer peer(&source);
+    sync::SyncWorkerOptions options;
+    options.enable_full_snapshot_fallback = true;
+    options.max_bytes = 8192u;
+    options.max_single_batch_bytes = 8192u;
+    sync::SyncWorker worker(replica, peer, options);
+    const sync::SyncWorkerRoundResult result = worker.run_once();
+    if (result.ok ||
+        result.sync_error_code != sync::SyncResponseErrorCode::SnapshotSessionInvalid ||
+        replica.applied_cursor().last_seq_for(source_node) != 0u) {
+        throw std::runtime_error(
+            "worker accepted ManifestOnly snapshot fallback");
+    }
+    {
+        auto txn = replica_conn->transaction(TransactionMode::READ_ONLY);
+        MDBX_dbi dbi = 0;
+        const int rc = mdbx_dbi_open(
+            txn.handle(), "documents", static_cast<MDBX_db_flags_t>(0), &dbi);
+        if (rc != MDBX_NOTFOUND) {
+            throw std::runtime_error(
+                "ManifestOnly worker fallback changed destination DBI");
+        }
+    }
+
+    source_conn->disconnect();
+    replica_conn->disconnect();
+    cleanup(source_path);
+    cleanup(replica_path);
+}
+
 } // namespace
 
 int main() {
@@ -2788,6 +2853,8 @@ int main() {
           &test_worker_recovers_fresh_replica_with_full_snapshot },
         { "test_worker_snapshot_recovery_preserves_remote_origin_cursor",
           &test_worker_snapshot_recovery_preserves_remote_origin_cursor },
+        { "test_worker_rejects_manifest_only_snapshot_fallback",
+          &test_worker_rejects_manifest_only_snapshot_fallback },
         { "test_worker_run_once_drains_paginated_pull",
           &test_worker_run_once_drains_paginated_pull },
         { "test_worker_start_stop_idle", &test_worker_start_stop_idle },

--- a/tests/test_transport_codec.cpp
+++ b/tests/test_transport_codec.cpp
@@ -417,6 +417,25 @@ void test_response_error_code_rejections() {
     });
 }
 
+void test_logical_snapshot_error_roundtrip() {
+    using namespace mdbxc::sync;
+    PullResponse response;
+    response.ok = false;
+    response.error = "logical snapshot state is unsupported";
+    response.error_code =
+        SyncResponseErrorCode::SnapshotLogicalStateUnsupported;
+
+    const std::vector<std::uint8_t> bytes =
+        TransportMessageCodec::encode_pull_response(response);
+    const PullResponse decoded =
+        TransportMessageCodec::decode_pull_response(bytes);
+    require_true(decoded.error_code ==
+                     SyncResponseErrorCode::SnapshotLogicalStateUnsupported,
+                 "logical snapshot error code mismatch");
+    require_true(!decoded.error_retryable,
+                 "logical snapshot error unexpectedly retryable");
+}
+
 void test_golden_header_shape() {
     using namespace mdbxc::sync;
     const std::vector<std::uint8_t> bytes =
@@ -448,6 +467,7 @@ int main() {
     test_message_header_rejections();
     test_bounds_rejections();
     test_response_error_code_rejections();
+    test_logical_snapshot_error_roundtrip();
     test_golden_header_shape();
     return 0;
 }


### PR DESCRIPTION
## Summary
- add opt-in SyncWorker fallback for SnapshotRequired
- drain ManifestOnly snapshot pages through one final fresh-replica import commit
- discard incomplete memory-only staging after cancellation or failure

## Validation
- C++11 MinGW: sync worker, sync engine, transport codec, full snapshot protocol, and sync umbrella headers
- C++17 MinGW: same affected targets