### PR TITLE
sync: integrate full snapshot stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ All notable changes to this project will be documented in this file.
   source-tail, replacement-scope, manifest-version, and continuation fields.
   `PullRequest`/`PullResponse` now carry explicit snapshot session state and
   chunk pages; this changes the unreleased `TransportMessageCodec` wire version
-  from 4 to 5. Source export and replacement apply remain explicitly disabled
-  until their lifecycle implementations land.
+  from 4 to 5. `SyncEngine` can materialize an explicitly configured source
+  manifest into bounded, stable pages. Replacement apply and cursor bootstrap
+  remain disabled until their lifecycle implementations land.
 - Sync: document the authoritative-baseline and multi-origin conflict
   boundary for ordered schema-v2. Baseline import and concurrent multi-writer
   resolution remain design-only and are not exposed as partial APIs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,12 @@ All notable changes to this project will be documented in this file.
   manifest into bounded, stable pages. `SyncEngine` now also stages explicit
   `ManifestOnly` pages in bounded memory and atomically imports them only into
   a fresh replica, bootstrapping `_mdbxc_applied` from the immutable source
-  tail. Worker fallback, persisted importer resume, and complete-database
-  replacement remain deferred.
+  tail. Persisted importer resume and complete-database replacement remain
+  deferred.
+- Sync: add opt-in `SyncWorker` fallback for `SnapshotRequired`. It starts a
+  new empty-cursor source session and drains the bounded fresh-replica importer
+  through its final atomic commit. Existing partial replicas and persisted
+  importer resume remain unsupported.
 - Sync: document the authoritative-baseline and multi-origin conflict
   boundary for ordered schema-v2. Baseline import and concurrent multi-writer
   resolution remain design-only and are not exposed as partial APIs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-- Sync: extend the preparatory `FullSnapshotCodec` boundary with immutable
+- Sync: add a raw-only `FullSnapshotCodec` export/import boundary with immutable
   source-tail, replacement-scope, manifest-version, and continuation fields.
   `PullRequest`/`PullResponse` now carry explicit snapshot session state and
   chunk pages; this changes the unreleased `TransportMessageCodec` wire version
@@ -13,7 +13,10 @@ All notable changes to this project will be documented in this file.
   manifest DBIs and never advances global raw-sync progress; automatic
   `CompleteUserDatabase` inventory replaces all named non-reserved user DBIs
   and atomically bootstraps `_mdbxc_applied` from the immutable source tail.
-  Persisted importer resume remains deferred.
+  Complete snapshots fail closed when a source has registered logical schemas;
+  schema markers, ordered-delivery frontiers, replay markers, and outbox state
+  require a separate logical snapshot protocol. Persisted importer resume
+  remains deferred.
 - Sync: add opt-in `SyncWorker` fallback for `SnapshotRequired`. It starts a
   new empty-cursor `CompleteUserDatabase` source session and drains the bounded
   fresh-replica importer through its final atomic commit. `ManifestOnly` remains

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ All notable changes to this project will be documented in this file.
   `PullRequest`/`PullResponse` now carry explicit snapshot session state and
   chunk pages; this changes the unreleased `TransportMessageCodec` wire version
   from 4 to 5. `SyncEngine` can materialize an explicitly configured source
-  manifest into bounded, stable pages. Replacement apply and cursor bootstrap
-  remain disabled until their lifecycle implementations land.
+  manifest into bounded, stable pages. `SyncEngine` now also stages explicit
+  `ManifestOnly` pages in bounded memory and atomically imports them only into
+  a fresh replica, bootstrapping `_mdbxc_applied` from the immutable source
+  tail. Worker fallback, persisted importer resume, and complete-database
+  replacement remain deferred.
 - Sync: document the authoritative-baseline and multi-origin conflict
   boundary for ordered schema-v2. Baseline import and concurrent multi-writer
   resolution remain design-only and are not exposed as partial APIs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,16 @@ All notable changes to this project will be documented in this file.
   source-tail, replacement-scope, manifest-version, and continuation fields.
   `PullRequest`/`PullResponse` now carry explicit snapshot session state and
   chunk pages; this changes the unreleased `TransportMessageCodec` wire version
-  from 4 to 5. `SyncEngine` can materialize an explicitly configured source
-  manifest into bounded, stable pages. `SyncEngine` now also stages explicit
-  `ManifestOnly` pages in bounded memory and atomically imports them only into
-  a fresh replica, bootstrapping `_mdbxc_applied` from the immutable source
-  tail. Persisted importer resume and complete-database replacement remain
-  deferred.
+  from 4 to 5. `SyncEngine` materializes bounded, stable source pages in two
+  explicit scopes: configured `ManifestOnly` replacement copies only its
+  manifest DBIs and never advances global raw-sync progress; automatic
+  `CompleteUserDatabase` inventory replaces all named non-reserved user DBIs
+  and atomically bootstraps `_mdbxc_applied` from the immutable source tail.
+  Persisted importer resume remains deferred.
 - Sync: add opt-in `SyncWorker` fallback for `SnapshotRequired`. It starts a
-  new empty-cursor source session and drains the bounded fresh-replica importer
-  through its final atomic commit. Existing partial replicas and persisted
+  new empty-cursor `CompleteUserDatabase` source session and drains the bounded
+  fresh-replica importer through its final atomic commit. `ManifestOnly` remains
+  a manual physical replacement mode; existing partial replicas and persisted
   importer resume remain unsupported.
 - Sync: document the authoritative-baseline and multi-origin conflict
   boundary for ordered schema-v2. Baseline import and concurrent multi-writer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ All notable changes to this project will be documented in this file.
   manifest DBIs and never advances global raw-sync progress; automatic
   `CompleteUserDatabase` inventory replaces all named non-reserved user DBIs
   and atomically bootstraps `_mdbxc_applied` from the immutable source tail.
-  Complete snapshots fail closed when a source has registered logical schemas;
-  schema markers, ordered-delivery frontiers, replay markers, and outbox state
-  require a separate logical snapshot protocol. Persisted importer resume
-  remains deferred.
+  Complete snapshots fail closed when a source has persistent logical-sync
+  state: schema markers, ordered-delivery frontiers, replay markers or pruning
+  watermarks, and durable outbox state require a separate logical snapshot
+  protocol. Persisted importer resume remains deferred.
 - Sync: add opt-in `SyncWorker` fallback for `SnapshotRequired`. It starts a
   new empty-cursor `CompleteUserDatabase` source session and drains the bounded
   fresh-replica importer through its final atomic commit. `ManifestOnly` remains

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -212,24 +212,25 @@ Operational rules:
   for future logical-key conflict resolution, but `SyncEngine` rejects it until
   timestamp/version-based apply semantics exist. `time_unix_ns` is metadata,
   not a reliable conflict authority. `Custom` is deferred to v0.2.
-- `PullRequest::request_full_snapshot=true` is reserved for the future
-  full export/import protocol. v0.1 responders reject it as
-  `PullResponse{ok=false, error=..., error_code=UnsupportedFullSnapshot}`.
-  This is a sync-level protocol rejection, not a transport retry hint. Code
+- `PullRequest::request_full_snapshot=true` starts an explicit source session
+  only when `SyncEngine` has a non-empty `FullSnapshotExportOptions::manifest`.
+  Otherwise it returns
+  `PullResponse{ok=false, error_code=SnapshotNotConfigured}`. The manual
+  receiver path accepts only bounded `ManifestOnly` chunks into a fresh
+  replica; worker-driven fallback and persisted resume remain deferred. Code
   that needs machine classification should inspect `SyncResponseErrorCode`
   instead of parsing the human-readable `error` string.
 - Pull from a cursor older than retained changelog history fails as
   `PullResponse{ok=false, error_code=SnapshotRequired}`. The response carries no
   batches because applying a later retained batch would produce a sequence gap
-  on the receiver. Until a snapshot protocol is implemented, the caller must
-  provision a fresh replica or use an out-of-band snapshot.
-- The deferred full snapshot protocol is specified in
-  `include/mdbx_containers/sync/DESIGN.md`. It must stay separate from
-  changelog replay: snapshot chunks need explicit framing, user-DBI-only apply
-  rules, a stable `snapshot_id`, an immutable manifest/tail from one source read
-  view, continuation-token validation, cursor bootstrap semantics, and
-  interruption behavior before `PullRequest::request_full_snapshot=true` can be
-  accepted.
+  on the receiver. A caller can explicitly drive the bounded fresh-replica
+  snapshot session, but sync workers do not yet turn this response into an
+  automatic fallback.
+- Full snapshot implementation notes are in
+  `include/mdbx_containers/sync/DESIGN.md`. The manual importer remains separate
+  from changelog replay: it accepts user-DBI-only chunks with an immutable
+  `snapshot_id`, manifest/tail, and continuation sequence, then commits the
+  replacement and cursor bootstrap atomically only at the final page.
 - `PushResponse::error_retryable` describes sync-level recovery. Sequence gaps
   are retryable after the receiver catches up from its persistent applied
   cursor; DBI name/flag conflicts, reserved DBI writes, and unsupported

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -217,9 +217,10 @@ Operational rules:
   Otherwise it returns
   `PullResponse{ok=false, error_code=SnapshotNotConfigured}`. The manual
   receiver path accepts only bounded `ManifestOnly` chunks into a fresh
-  replica; worker-driven fallback and persisted resume remain deferred. Code
-  that needs machine classification should inspect `SyncResponseErrorCode`
-  instead of parsing the human-readable `error` string.
+  replica. `SyncWorkerOptions::enable_full_snapshot_fallback` can explicitly
+  drive that recovery after `SnapshotRequired`; persisted resume remains
+  deferred. Code that needs machine classification should inspect
+  `SyncResponseErrorCode` instead of parsing the human-readable `error` string.
 - Pull from a cursor older than retained changelog history fails as
   `PullResponse{ok=false, error_code=SnapshotRequired}`. The response carries no
   batches because applying a later retained batch would produce a sequence gap

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -161,8 +161,10 @@ tables.
 - Extend `KeyMultiValueTable` logical capture only after every added bulk or
   reconcile operation has explicit multiset replay semantics and round-trip
   coverage. Raw capture remains disabled.
-- Implement the deferred full snapshot protocol before treating
-  `SnapshotRequired` as automatically recoverable by sync itself.
+- Integrate worker fallback, persisted importer resume, and explicit complete
+  replacement before treating `SnapshotRequired` as automatically recoverable
+  by sync itself. The current manual importer accepts only fresh-replica
+  `ManifestOnly` sessions.
 - Define explicit conflict/CRDT semantics before claiming general concurrent
   multi-writer convergence for `KeyMultiValueTable`.
 - Design baseline import and multi-origin histories for schema v2 separately;

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -164,6 +164,12 @@ tables.
 - Add persisted importer resume and explicit complete replacement before
   treating `SnapshotRequired` as universally recoverable by sync itself. The
   opt-in worker fallback accepts only fresh-replica `ManifestOnly` sessions.
+- Design scope-aware partial snapshot continuation separately from complete
+  database recovery. A partial manifest cannot bootstrap the global per-origin
+  applied cursor: this requires a stable scope identity, per-scope or per-DBI
+  applied progress, scope-filtered changelog pull and retention, and explicit
+  handling for DBI membership changes. Do not add these piecemeal to the raw
+  sync path; implement them only when a consumer needs selective replication.
 - Define explicit conflict/CRDT semantics before claiming general concurrent
   multi-writer convergence for `KeyMultiValueTable`.
 - Design baseline import and multi-origin histories for schema v2 separately;

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -161,10 +161,9 @@ tables.
 - Extend `KeyMultiValueTable` logical capture only after every added bulk or
   reconcile operation has explicit multiset replay semantics and round-trip
   coverage. Raw capture remains disabled.
-- Integrate worker fallback, persisted importer resume, and explicit complete
-  replacement before treating `SnapshotRequired` as automatically recoverable
-  by sync itself. The current manual importer accepts only fresh-replica
-  `ManifestOnly` sessions.
+- Add persisted importer resume and explicit complete replacement before
+  treating `SnapshotRequired` as universally recoverable by sync itself. The
+  opt-in worker fallback accepts only fresh-replica `ManifestOnly` sessions.
 - Define explicit conflict/CRDT semantics before claiming general concurrent
   multi-writer convergence for `KeyMultiValueTable`.
 - Design baseline import and multi-origin histories for schema v2 separately;

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -161,9 +161,10 @@ tables.
 - Extend `KeyMultiValueTable` logical capture only after every added bulk or
   reconcile operation has explicit multiset replay semantics and round-trip
   coverage. Raw capture remains disabled.
-- Add persisted importer resume and explicit complete replacement before
-  treating `SnapshotRequired` as universally recoverable by sync itself. The
-  opt-in worker fallback accepts only fresh-replica `ManifestOnly` sessions.
+- Add persisted importer resume before treating `SnapshotRequired` as
+  universally recoverable by sync itself. The opt-in worker fallback accepts
+  only fresh-replica `CompleteUserDatabase` sessions; manual `ManifestOnly`
+  imports never bootstrap global raw-sync progress.
 - Design scope-aware partial snapshot continuation separately from complete
   database recovery. A partial manifest cannot bootstrap the global per-origin
   applied cursor: this requires a stable scope identity, per-scope or per-DBI

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1033,9 +1033,10 @@ key, which is why `seq` is big-endian in the key.
 Pull detects when `request.have + 1` is older than the earliest retained
 changelog record for a known origin and returns
 `PullResponse{ok=false, error_code=SnapshotRequired}` instead of streaming a
-later non-contiguous batch. Until the reserved full snapshot protocol exists,
-callers must provision a fresh replica or use an application-defined snapshot
-outside sync v0.1.
+later non-contiguous batch. The initial full snapshot importer requires a
+fresh replica and an explicit caller-driven session; worker fallback is not
+implemented, so applications may still provision a fresh replica or use an
+application-defined snapshot outside sync v0.1.
 
 ### `_mdbxc_origins` (OriginIndexStore)
 
@@ -1436,8 +1437,8 @@ Locked contract:
   classification is available. `error_retryable` describes protocol-level
   recovery, not blind replay of the identical request: for example a
   `SequenceGap` apply conflict is retryable after the caller catches up from a
-  fresher cursor, while DBI flag conflicts and unsupported full snapshots are
-  permanent until the caller changes behavior. `SnapshotRequired` means the
+  fresher cursor, while DBI flag conflicts and an unconfigured snapshot source
+  are permanent until the caller changes behavior. `SnapshotRequired` means the
   requested changelog range was pruned and cannot be recovered through
   incremental pull. `BatchTooLarge` means a retained changelog entry exceeds
   the requester's hard per-batch limit and is permanent until the requester
@@ -1532,14 +1533,14 @@ B: applies each page as above
     -> onward sync is incremental pull-from-have
 ```
 
-The reserved `seq=0, BATCH_HAS_MORE` full export/import format is not the
-current cold-replica implementation yet. `FullSnapshotProtocol.hpp` defines and
-validates its chunk codec: every chunk carries a source identity, immutable
-per-origin replication tail, stable `snapshot_id`, chunk index, replacement scope,
-opaque next-page token, manifest version, immutable named-user-DBI manifest,
-and a nested raw batch with `seq=0`. Transport codec v5 carries the explicit
-session request and one snapshot chunk in `PullResponse`; it rejects mixed
-incremental/snapshot pages and malformed session state.
+The reserved `seq=0, BATCH_HAS_MORE` full snapshot format is separate from
+retained changelog replay. `FullSnapshotProtocol.hpp` defines and validates its
+chunk codec: every chunk carries a source identity, immutable per-origin
+replication tail, stable `snapshot_id`, chunk index, replacement scope, opaque next-page
+token, manifest version, immutable named-user-DBI manifest, and a nested raw
+batch with `seq=0`. Transport codec v5 carries the explicit session request and
+one snapshot chunk in `PullResponse`; it rejects mixed incremental/snapshot
+pages and malformed session state.
 
 `SyncEngine` can export an explicit `FullSnapshotExportOptions::manifest`: it
 materializes configured user DBIs in one read transaction, bounds active
@@ -1548,10 +1549,20 @@ manifest returns `SnapshotNotConfigured`; unknown, expired, or mismatched
 continuations or a different requester return `SnapshotSessionInvalid`; bounded
 session capacity returns retryable `SnapshotSessionBusy`.
 
-Snapshot import, applied-cursor bootstrap, and worker fallback are still not
-implemented. Consequently a snapshot export is not yet an automatic recovery
-path for `SnapshotRequired`; callers must not treat source export alone as a
-working replica-replacement workflow.
+`SyncEngine::apply_full_snapshot_chunk()` implements the first manual receiver
+path for `ManifestOnly` snapshots. It stages all pages in bounded process memory
+and validates immutable page-zero metadata on every continuation. Only the
+final page opens a write transaction: it requires zero local changelog sequence,
+an empty applied cursor, and empty manifest DBIs, then applies the staged
+`ClearTable` / `Put` plan and writes the advertised source tail to
+`_mdbxc_applied` atomically. Any interruption, malformed continuation, bound
+failure, or non-fresh target fails before a user-DBI commit. Existing
+receiver-only DBIs outside the manifest remain untouched.
+
+Worker fallback from `SnapshotRequired`, persisted importer restart state, and
+`CompleteUserDatabase` replacement are still not implemented. Consequently a
+snapshot request is not yet an automatic recovery path; a caller must drive the
+source session and the manual importer explicitly.
 If changelog pruning removed entries needed by the requester's cursor,
 `handle_pull()` returns `SnapshotRequired` with no batches. This is also a
 valid sync response, not a transport failure.
@@ -1559,15 +1570,16 @@ valid sync response, not a transport failure.
 sync-level response errors through round results, stage events, and status
 snapshots without treating them as permanent transport failures.
 
-### Deferred full snapshot protocol
+### Remaining full snapshot work
 
-The future full snapshot protocol must be explicit rather than another spelling
-of retained changelog replay. The reserved request shape is
+The full snapshot protocol is explicit rather than another spelling of retained
+changelog replay. The reserved request shape is
 `PullRequest::request_full_snapshot=true`; responders that implement it should
 return snapshot chunks only when the caller requested that mode, never as an
 implicit fallback from a normal incremental pull.
 
-Required protocol properties before enabling the flag:
+The implemented source session and fresh-replica importer preserve these
+properties. The remaining worker and resume work must preserve them too:
 
 - A full snapshot export is a named snapshot session. The first response must
   return an opaque `snapshot_id` and all later pages must present the same id;

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1535,7 +1535,7 @@ B: applies each page as above
 The reserved `seq=0, BATCH_HAS_MORE` full export/import format is not the
 current cold-replica implementation yet. `FullSnapshotProtocol.hpp` defines and
 validates its chunk codec: every chunk carries a source identity, immutable
-source changelog tail, stable `snapshot_id`, chunk index, replacement scope,
+per-origin replication tail, stable `snapshot_id`, chunk index, replacement scope,
 opaque next-page token, manifest version, immutable named-user-DBI manifest,
 and a nested raw batch with `seq=0`. Transport codec v5 carries the explicit
 session request and one snapshot chunk in `PullResponse`; it rejects mixed
@@ -1601,7 +1601,7 @@ Required protocol properties before enabling the flag:
   ambiguous resume attempts.
 - Metadata bootstrap is separate from user data import. After the snapshot data
   is committed, the receiver records applied cursors consistent with the
-  responder's advertised changelog tail so the next round can continue through
+  responder's advertised replication tail so the next round can continue through
   ordinary incremental pull.
 - Chunk pagination must use the existing pull limits: `max_bytes` as a soft page
   budget and `max_single_batch_bytes` as a hard limit for a single encoded

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1532,23 +1532,26 @@ B: applies each page as above
     -> onward sync is incremental pull-from-have
 ```
 
-The reserved `seq=0, BATCH_HAS_MORE` full export/import format remains planned
-for v0.1 and is not the current cold-replica implementation.
-`FullSnapshotProtocol.hpp` now defines and validates a preparatory chunk
-codec: every chunk carries a source identity, immutable source changelog tail,
-stable `snapshot_id`, chunk index, replacement scope, opaque next-page token,
-manifest version, immutable named-user-DBI manifest, and a nested raw batch
-with `seq=0`. Transport codec v5 carries the explicit session request and one
-snapshot chunk in `PullResponse`; it rejects mixed incremental/snapshot pages
-and malformed session state. `SyncEngine` does not accept the request yet: the
-source-export session, cursor bootstrap semantics, and atomic replacement apply
-path still need to be implemented before the flag can be enabled.
-`PullRequest::request_full_snapshot=true` is rejected explicitly until the
-transport and replacement apply path are implemented. In v0.1 this is a
-sync-level protocol rejection carried
-as `PullResponse{ok=false, error=..., error_code=UnsupportedFullSnapshot}`; it
-does not produce a transport retry hint because the server returned a valid
-sync response rather than a transport failure.
+The reserved `seq=0, BATCH_HAS_MORE` full export/import format is not the
+current cold-replica implementation yet. `FullSnapshotProtocol.hpp` defines and
+validates its chunk codec: every chunk carries a source identity, immutable
+source changelog tail, stable `snapshot_id`, chunk index, replacement scope,
+opaque next-page token, manifest version, immutable named-user-DBI manifest,
+and a nested raw batch with `seq=0`. Transport codec v5 carries the explicit
+session request and one snapshot chunk in `PullResponse`; it rejects mixed
+incremental/snapshot pages and malformed session state.
+
+`SyncEngine` can export an explicit `FullSnapshotExportOptions::manifest`: it
+materializes configured user DBIs in one read transaction, bounds active
+sessions and materialized data, and returns stable pages. An empty source
+manifest returns `SnapshotNotConfigured`; unknown, expired, or mismatched
+continuations or a different requester return `SnapshotSessionInvalid`; bounded
+session capacity returns retryable `SnapshotSessionBusy`.
+
+Snapshot import, applied-cursor bootstrap, and worker fallback are still not
+implemented. Consequently a snapshot export is not yet an automatic recovery
+path for `SnapshotRequired`; callers must not treat source export alone as a
+working replica-replacement workflow.
 If changelog pruning removed entries needed by the requester's cursor,
 `handle_pull()` returns `SnapshotRequired` with no batches. This is also a
 valid sync response, not a transport failure.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1558,10 +1558,11 @@ return `SnapshotSessionInvalid`; bounded session capacity returns retryable
 `SnapshotSessionBusy`.
 
 `CompleteUserDatabase` is currently a raw-sync-only recovery scope. Before a
-session is materialized, the source rejects a non-empty persistent schema
-registry with `SnapshotLogicalStateUnsupported`. A physical copy of logical
-adapter DBIs without `_mdbxc_sync_schema`, ordered-delivery frontiers, replay
-markers, and outbox/recovery state cannot safely continue logical delivery.
+session is materialized, the source rejects any persistent logical-sync state
+with `SnapshotLogicalStateUnsupported`: schema markers, replay markers or
+pruning watermarks, ordered-delivery frontiers, and durable outbox metadata or
+entries. A physical copy of logical adapter DBIs without this state cannot
+safely continue logical delivery.
 `ManifestOnly` is likewise only a manual physical replacement tool: it does
 not claim to repair or bootstrap logical replication. A future logical snapshot
 protocol must atomically define the logical schema, delivery, replay, and

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1542,28 +1542,36 @@ batch with `seq=0`. Transport codec v5 carries the explicit session request and
 one snapshot chunk in `PullResponse`; it rejects mixed incremental/snapshot
 pages and malformed session state.
 
-`SyncEngine` can export an explicit `FullSnapshotExportOptions::manifest`: it
-materializes configured user DBIs in one read transaction, bounds active
-sessions and materialized data, and returns stable pages. An empty source
-manifest returns `SnapshotNotConfigured`; unknown, expired, or mismatched
-continuations or a different requester return `SnapshotSessionInvalid`; bounded
-session capacity returns retryable `SnapshotSessionBusy`.
+`SyncEngine` exports two explicit snapshot scopes. `ManifestOnly` materializes
+the caller's configured user-DBI manifest in one read transaction, bounds active
+sessions and materialized data, and returns stable pages. It is a manual
+physical replacement mode: the final import replaces only manifest DBIs and
+never changes `_mdbxc_applied`. `CompleteUserDatabase` requires no caller
+manifest; the engine inventories every named non-reserved user DBI from MainDB
+under the same source read transaction. Its fresh-replica importer rejects a
+destination user DBI outside the exported inventory and, only after the complete
+replacement plan commits, atomically writes the immutable source tail to
+`_mdbxc_applied`. An empty configured `ManifestOnly` source returns
+`SnapshotNotConfigured`; a complete-source inventory with no user DBIs is
+rejected. Unknown, expired, or mismatched continuations or a different requester
+return `SnapshotSessionInvalid`; bounded session capacity returns retryable
+`SnapshotSessionBusy`.
 
-`SyncEngine::apply_full_snapshot_chunk()` implements the first manual receiver
-path for `ManifestOnly` snapshots. It stages all pages in bounded process memory
-and validates immutable page-zero metadata on every continuation. Only the
-final page opens a write transaction: it requires zero local changelog sequence,
-an empty applied cursor, and empty manifest DBIs, then applies the staged
-`ClearTable` / `Put` plan and writes the advertised source tail to
-`_mdbxc_applied` atomically. Any interruption, malformed continuation, bound
-failure, or non-fresh target fails before a user-DBI commit. Existing
-receiver-only DBIs outside the manifest remain untouched.
+`SyncEngine::apply_full_snapshot_chunk()` stages all pages in bounded process
+memory and validates immutable page-zero metadata on every continuation. Only
+the final page opens a write transaction: it requires zero local changelog
+sequence, an empty applied cursor, and empty manifest DBIs, then applies the
+staged `ClearTable` / `Put` plan. Complete replacement additionally requires a
+destination node identity absent from the source tail, so a restored database
+cannot resume local writes with an origin sequence already used by the source.
+Any interruption, malformed continuation, bound failure, or non-fresh target
+fails before a user-DBI commit.
 
-Worker fallback from `SnapshotRequired`, persisted importer restart state, and
-`CompleteUserDatabase` replacement are still not implemented. `SyncWorker`
-can opt in to the fresh-replica `ManifestOnly` fallback: on `SnapshotRequired`
-it starts a new empty-cursor snapshot session and drains every page through the
-final import commit. It does not repair an existing partial replica; a failed
+`SyncWorker` can opt in to `SnapshotRequired` recovery only with a fresh-replica
+`CompleteUserDatabase` session. It starts a new empty-cursor source session and
+drains every page through the final import commit. It never treats
+`ManifestOnly` as a raw-sync fallback, because that scope has no global cursor
+bootstrap. The worker does not repair an existing partial replica; a failed
 fresh-target preflight remains a reported sync error. Persisted importer resume
 is not implemented, so an interrupted worker discards in-memory staging and a
 later retry starts a new source session.
@@ -1582,8 +1590,9 @@ changelog replay. The reserved request shape is
 return snapshot chunks only when the caller requested that mode, never as an
 implicit fallback from a normal incremental pull.
 
-The implemented source session and fresh-replica importer preserve these
-properties. The remaining worker and resume work must preserve them too:
+The implemented source session, fresh-replica importer, and worker fallback
+preserve these properties. Persisted resume and any future selective-scope
+extension must preserve them too:
 
 - A full snapshot export is a named snapshot session. The first response must
   return an opaque `snapshot_id` and all later pages must present the same id;
@@ -1600,10 +1609,10 @@ properties. The remaining worker and resume work must preserve them too:
   manifest version/hash that later pages repeat. A receiver must reject chunks
   whose manifest identity differs from the first page.
 - Receiver-only DBIs are an explicit policy decision, not an accidental side
-  effect. The manifest must say whether the snapshot replaces the complete
-  database scope or only the listed DBIs; complete replacement may clear/drop
-  receiver-only user DBIs only when the caller opted into that scope. Otherwise
-  receiver-only DBIs are preserved or the import fails closed before data apply.
+  effect. `ManifestOnly` preserves DBIs outside its manifest and does not
+  bootstrap global cursor state. `CompleteUserDatabase` inventories all named
+  non-reserved source DBIs and fails closed if a fresh destination contains a
+  user DBI outside that manifest; it does not silently drop receiver-only DBIs.
 - Snapshot chunks must be distinguishable from ordinary changelog batches.
   The reserved shape is `ChangeBatch{seq=0, batch_flags=BATCH_HAS_MORE...}`
   with a snapshot-specific flag or versioned envelope added before release.
@@ -1615,10 +1624,10 @@ properties. The remaining worker and resume work must preserve them too:
   the receiver must clear each exported user DBI before applying that DBI's
   first snapshot entries, then apply later chunks idempotently or reject
   ambiguous resume attempts.
-- Metadata bootstrap is separate from user data import. After the snapshot data
-  is committed, the receiver records applied cursors consistent with the
-  responder's advertised replication tail so the next round can continue through
-  ordinary incremental pull.
+- Metadata bootstrap is separate from user data import. Only after a complete
+  user-database snapshot commits does the receiver record applied cursors
+  consistent with the responder's advertised replication tail. A manifest-only
+  import intentionally leaves global cursor state unchanged.
 - Chunk pagination must use the existing pull limits: `max_bytes` as a soft page
   budget and `max_single_batch_bytes` as a hard limit for a single encoded
   snapshot chunk. If one logical DBI chunk cannot fit under the hard limit, the
@@ -1636,11 +1645,14 @@ properties. The remaining worker and resume work must preserve them too:
   replica directory and fail closed on interruption.
 - `SnapshotRequired` remains the incremental-pull recovery signal. It tells the
   caller that retained changelog replay cannot satisfy the request; the caller
-  may then make a separate `request_full_snapshot=true` request once this
-  protocol exists.
+  may then make a separate `request_full_snapshot=true` request. The worker
+  uses this only for `CompleteUserDatabase` fresh-replica recovery.
 
-Until these details are implemented and covered by round-trip tests,
-`request_full_snapshot=true` remains a permanent sync-level rejection.
+Persisted importer resume and scope-aware partial snapshot continuation are
+still deferred. A partial manifest cannot share the global per-origin cursor:
+that architecture requires stable scope identity, per-scope or per-DBI applied
+progress, scope-filtered changelog pull and retention, and explicit DBI
+membership-change handling.
 
 ## Background worker lifecycle
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1557,6 +1557,16 @@ rejected. Unknown, expired, or mismatched continuations or a different requester
 return `SnapshotSessionInvalid`; bounded session capacity returns retryable
 `SnapshotSessionBusy`.
 
+`CompleteUserDatabase` is currently a raw-sync-only recovery scope. Before a
+session is materialized, the source rejects a non-empty persistent schema
+registry with `SnapshotLogicalStateUnsupported`. A physical copy of logical
+adapter DBIs without `_mdbxc_sync_schema`, ordered-delivery frontiers, replay
+markers, and outbox/recovery state cannot safely continue logical delivery.
+`ManifestOnly` is likewise only a manual physical replacement tool: it does
+not claim to repair or bootstrap logical replication. A future logical snapshot
+protocol must atomically define the logical schema, delivery, replay, and
+recovery state it transfers.
+
 `SyncEngine::apply_full_snapshot_chunk()` stages all pages in bounded process
 memory and validates immutable page-zero metadata on every continuation. Only
 the final page opens a write transaction: it requires zero local changelog

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1560,9 +1560,13 @@ failure, or non-fresh target fails before a user-DBI commit. Existing
 receiver-only DBIs outside the manifest remain untouched.
 
 Worker fallback from `SnapshotRequired`, persisted importer restart state, and
-`CompleteUserDatabase` replacement are still not implemented. Consequently a
-snapshot request is not yet an automatic recovery path; a caller must drive the
-source session and the manual importer explicitly.
+`CompleteUserDatabase` replacement are still not implemented. `SyncWorker`
+can opt in to the fresh-replica `ManifestOnly` fallback: on `SnapshotRequired`
+it starts a new empty-cursor snapshot session and drains every page through the
+final import commit. It does not repair an existing partial replica; a failed
+fresh-target preflight remains a reported sync error. Persisted importer resume
+is not implemented, so an interrupted worker discards in-memory staging and a
+later retry starts a new source session.
 If changelog pruning removed entries needed by the requester's cursor,
 `handle_pull()` returns `SnapshotRequired` with no batches. This is also a
 valid sync response, not a transport failure.

--- a/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
+++ b/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
@@ -63,7 +63,10 @@ namespace sync {
         NodeId source_node_id{};
         DbId source_db_uuid{};
         std::string snapshot_id;
-        /// \brief Immutable source changelog tail captured with this snapshot.
+        /// \brief Immutable per-origin replication tail captured with this snapshot.
+        /// \details This is the componentwise maximum of source changelog and
+        /// already-applied remote-origin progress, so a fresh receiver can
+        /// continue incremental pull from every represented origin.
         SyncCursor source_tail;
         std::uint64_t chunk_index = 0u;
         bool has_more = false;

--- a/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
+++ b/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
@@ -6,6 +6,7 @@
 /// \brief Explicit full-snapshot chunk contract and codec.
 
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <limits>
@@ -35,6 +36,21 @@ namespace sync {
     enum class FullSnapshotScope : std::uint8_t {
         ManifestOnly = 0u,
         CompleteUserDatabase = 1u
+    };
+
+    /// \brief Explicit source-side configuration for materialized snapshots.
+    /// \details The engine never scans MainDB to guess named user DBIs. A
+    /// caller declares the exportable DBIs, including empty tables, and bounds
+    /// the one-session materialization before enabling full-snapshot pull.
+    struct FullSnapshotExportOptions {
+        std::vector<FullSnapshotManifestEntry> manifest;
+        FullSnapshotScope replacement_scope = FullSnapshotScope::ManifestOnly;
+        std::uint64_t max_materialized_operations = 1000000u;
+        std::uint64_t max_materialized_bytes =
+            256ULL * 1024ULL * 1024ULL;
+        std::uint32_t max_active_sessions = 4u;
+        std::chrono::seconds session_idle_timeout =
+            std::chrono::seconds(300);
     };
 
     /// \brief One chunk of a full database export.

--- a/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
+++ b/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
@@ -30,18 +30,22 @@ namespace sync {
     };
 
     /// \brief Declares which user-DBI content a snapshot may replace.
-    /// \details \c ManifestOnly preserves receiver-only user DBIs. Complete
-    /// replacement is an explicit receiver opt-in and is not enabled by the
-    /// initial importer.
+    /// \details \c ManifestOnly replaces only manifest DBIs and never
+    /// bootstraps global raw-sync progress. \c CompleteUserDatabase replaces
+    /// every named user DBI and is the only scope that may bootstrap the
+    /// per-origin applied cursor for subsequent incremental replication.
     enum class FullSnapshotScope : std::uint8_t {
         ManifestOnly = 0u,
         CompleteUserDatabase = 1u
     };
 
     /// \brief Explicit source-side configuration for materialized snapshots.
-    /// \details The engine never scans MainDB to guess named user DBIs. A
-    /// caller declares the exportable DBIs, including empty tables, and bounds
-    /// the one-session materialization before enabling full-snapshot pull.
+    /// \details For \c ManifestOnly, c manifest explicitly declares the
+    /// exportable DBIs, including empty tables. For
+    /// \c CompleteUserDatabase, c manifest must be empty: the engine
+    /// enumerates every named non-reserved DBI in MainDB under one read
+    /// transaction. Both modes bound one-session materialization before
+    /// enabling full-snapshot pull.
     struct FullSnapshotExportOptions {
         std::vector<FullSnapshotManifestEntry> manifest;
         FullSnapshotScope replacement_scope = FullSnapshotScope::ManifestOnly;
@@ -56,9 +60,8 @@ namespace sync {
     /// \brief One chunk of a full database export.
     /// \details Snapshot chunks are not changelog batches. They carry a
     /// stable source identity, an immutable manifest, and a nested raw batch
-    /// whose sequence is always zero. A future transport may accept this
-    /// contract only after validating the complete manifest and snapshot
-    /// continuation before any user-DBI mutation.
+    /// whose sequence is always zero. The transport validates the complete
+    /// manifest and snapshot continuation before any user-DBI mutation.
     struct FullSnapshotChunk {
         NodeId source_node_id{};
         DbId source_db_uuid{};
@@ -84,9 +87,8 @@ namespace sync {
 
     /// \brief Strict codec for the explicit full-snapshot wire boundary.
     /// \details Configured sources export bounded snapshot sessions through
-    /// \c PullRequest::request_full_snapshot. The initial receiver accepts
-    /// only \c ManifestOnly pages into a fresh replica and commits the staged
-    /// replacement plan atomically at the final page.
+    /// \c PullRequest::request_full_snapshot. Receivers stage pages and
+    /// commit the validated replacement plan atomically at the final page.
     class FullSnapshotCodec {
     public:
         static const std::uint8_t* magic() {

--- a/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
+++ b/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
@@ -34,8 +34,8 @@ namespace sync {
     /// bootstraps global raw-sync progress. \c CompleteUserDatabase replaces
     /// every named user DBI and is the only scope that may bootstrap the
     /// per-origin applied cursor for subsequent incremental replication. The
-    /// current complete scope is raw-only and rejects sources with registered
-    /// logical schemas until a separate logical snapshot protocol exists.
+    /// current complete scope is raw-only and rejects sources with persistent
+    /// logical-sync state until a separate logical snapshot protocol exists.
     enum class FullSnapshotScope : std::uint8_t {
         ManifestOnly = 0u,
         CompleteUserDatabase = 1u

--- a/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
+++ b/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
@@ -57,6 +57,22 @@ namespace sync {
             std::chrono::seconds(300);
     };
 
+    /// \brief Receiver-side bounds for one staged full snapshot import.
+    /// \details The initial importer keeps pages only in process memory until
+    /// the final page. These bounds prevent a peer from accumulating an
+    /// unbounded replacement plan before the one atomic destination commit.
+    struct FullSnapshotImportOptions {
+        std::uint64_t max_staged_operations = 1000000u;
+        std::uint64_t max_staged_bytes =
+            256ULL * 1024ULL * 1024ULL;
+    };
+
+    /// \brief Progress returned after accepting one full snapshot chunk.
+    struct FullSnapshotImportResult {
+        bool completed = false;
+        std::uint64_t next_chunk_index = 0u;
+    };
+
     /// \brief One chunk of a full database export.
     /// \details Snapshot chunks are not changelog batches. They carry a
     /// stable source identity, an immutable manifest, and a nested raw batch

--- a/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
+++ b/include/mdbx_containers/sync/FullSnapshotProtocol.hpp
@@ -33,7 +33,9 @@ namespace sync {
     /// \details \c ManifestOnly replaces only manifest DBIs and never
     /// bootstraps global raw-sync progress. \c CompleteUserDatabase replaces
     /// every named user DBI and is the only scope that may bootstrap the
-    /// per-origin applied cursor for subsequent incremental replication.
+    /// per-origin applied cursor for subsequent incremental replication. The
+    /// current complete scope is raw-only and rejects sources with registered
+    /// logical schemas until a separate logical snapshot protocol exists.
     enum class FullSnapshotScope : std::uint8_t {
         ManifestOnly = 0u,
         CompleteUserDatabase = 1u

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -161,6 +161,14 @@ namespace sync {
             std::mutex mutex;
         };
 
+        class FullSnapshotLogicalStateUnsupported : public std::runtime_error {
+        public:
+            explicit FullSnapshotLogicalStateUnsupported(
+                    const std::string& message =
+                        "complete full snapshot does not support registered logical-sync state")
+                : std::runtime_error(message) {}
+        };
+
         struct FullSnapshotImportSession {
             enum class ReplacementState {
                 NotSeen,
@@ -1534,8 +1542,7 @@ namespace sync {
             materialized_bytes += add;
         }
 
-        std::string next_full_snapshot_id() {
-            std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
+        std::string next_full_snapshot_id_locked() {
             ++m_next_full_snapshot_session_id;
             return std::string("snapshot-") +
                 std::to_string(m_next_full_snapshot_session_id);
@@ -1560,11 +1567,9 @@ namespace sync {
 
         std::shared_ptr<FullSnapshotSession> materialize_full_snapshot(
                 const FullSnapshotExportOptions& options,
-                const std::string& snapshot_id,
                 const NodeId& requester) const {
             std::shared_ptr<FullSnapshotSession> session(
                 new FullSnapshotSession());
-            session->snapshot_id = snapshot_id;
             session->requester = requester;
             session->replacement_scope = options.replacement_scope;
             session->last_access = std::chrono::steady_clock::now();
@@ -1578,6 +1583,23 @@ namespace sync {
                 compare_node_id(session->source_db_uuid, NodeId()) == 0) {
                 throw std::logic_error(
                     "full snapshot source identity is not initialized");
+            }
+
+            if (options.replacement_scope ==
+                FullSnapshotScope::CompleteUserDatabase) {
+                SchemaRegistryStore schemas(m_conn->env_handle());
+                try {
+                    if (!schemas.schema_ids(txn.handle()).empty()) {
+                        throw FullSnapshotLogicalStateUnsupported();
+                    }
+                } catch (const FullSnapshotLogicalStateUnsupported&) {
+                    throw;
+                } catch (const std::exception& e) {
+                    throw FullSnapshotLogicalStateUnsupported(
+                        std::string(
+                            "complete full snapshot cannot validate logical-sync state: ") +
+                        e.what());
+                }
             }
 
             session->manifest = options.replacement_scope ==
@@ -1794,8 +1816,15 @@ namespace sync {
                     ++m_full_snapshot_creating;
                 }
                 try {
-                    session = materialize_full_snapshot(
-                        options, next_full_snapshot_id(), request.requester);
+                    session = materialize_full_snapshot(options, request.requester);
+                } catch (const FullSnapshotLogicalStateUnsupported& e) {
+                    std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
+                    --m_full_snapshot_creating;
+                    out.ok = false;
+                    out.error = e.what();
+                    out.error_code =
+                        SyncResponseErrorCode::SnapshotLogicalStateUnsupported;
+                    return out;
                 } catch (...) {
                     std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
                     --m_full_snapshot_creating;
@@ -1805,6 +1834,7 @@ namespace sync {
                     std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
                     --m_full_snapshot_creating;
                     prune_expired_full_snapshot_sessions_locked();
+                    session->snapshot_id = next_full_snapshot_id_locked();
                     m_full_snapshot_sessions[session->snapshot_id] = session;
                 }
             } else {

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -1293,7 +1293,22 @@ namespace sync {
 
         static void validate_full_snapshot_export_options(
                 const FullSnapshotExportOptions& options) {
-            if (options.manifest.empty()) {
+            switch (options.replacement_scope) {
+                case FullSnapshotScope::ManifestOnly:
+                case FullSnapshotScope::CompleteUserDatabase:
+                    break;
+                default:
+                    throw std::invalid_argument(
+                        "invalid full snapshot replacement scope");
+            }
+            if (options.replacement_scope ==
+                    FullSnapshotScope::CompleteUserDatabase &&
+                !options.manifest.empty()) {
+                throw std::invalid_argument(
+                    "complete full snapshot export enumerates its manifest");
+            }
+            if (options.replacement_scope == FullSnapshotScope::ManifestOnly &&
+                options.manifest.empty()) {
                 return;
             }
             if (options.max_materialized_operations == 0u ||
@@ -1302,14 +1317,6 @@ namespace sync {
                 options.session_idle_timeout <= std::chrono::seconds::zero()) {
                 throw std::invalid_argument(
                     "full snapshot export limits must be non-zero");
-            }
-            switch (options.replacement_scope) {
-                case FullSnapshotScope::ManifestOnly:
-                case FullSnapshotScope::CompleteUserDatabase:
-                    break;
-                default:
-                    throw std::invalid_argument(
-                        "invalid full snapshot replacement scope");
             }
             for (std::size_t i = 0u; i < options.manifest.size(); ++i) {
                 const FullSnapshotManifestEntry& entry = options.manifest[i];
@@ -1324,6 +1331,73 @@ namespace sync {
                         "full snapshot manifest must be sorted and unique");
                 }
             }
+        }
+
+        static bool full_snapshot_export_is_configured(
+                const FullSnapshotExportOptions& options) {
+            return options.replacement_scope ==
+                FullSnapshotScope::CompleteUserDatabase ||
+                !options.manifest.empty();
+        }
+
+        std::vector<FullSnapshotManifestEntry>
+        enumerate_complete_snapshot_manifest(MDBX_txn* txn) const {
+            MDBX_dbi main_dbi = 0;
+            check_mdbx(
+                mdbx_dbi_open(
+                    txn, static_cast<const char*>(MDBX_CHK_MAIN),
+                    static_cast<MDBX_db_flags_t>(0), &main_dbi),
+                "full snapshot failed to open MainDB for complete inventory");
+
+            std::vector<FullSnapshotManifestEntry> manifest;
+            MDBX_cursor* raw = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, main_dbi, &raw),
+                       "full snapshot failed to open MainDB cursor");
+            CursorGuard cursor(raw);
+            MDBX_val key;
+            MDBX_val value;
+            int rc = mdbx_cursor_get(raw, &key, &value, MDBX_FIRST);
+            while (rc == MDBX_SUCCESS) {
+                MDBX_dbi dbi = 0;
+                const int open_rc = mdbx_dbi_open2(
+                    txn, &key, MDBX_DB_ACCEDE, &dbi);
+                if (open_rc == MDBX_SUCCESS) {
+                    const char* name_data =
+                        static_cast<const char*>(key.iov_base);
+                    const std::string name(name_data, key.iov_len);
+                    if (!is_reserved_snapshot_dbi(name)) {
+                        unsigned raw_flags = 0u;
+                        check_mdbx(
+                            mdbx_dbi_flags(txn, dbi, &raw_flags),
+                            "full snapshot failed to read complete DBI flags");
+                        FullSnapshotManifestEntry entry;
+                        entry.dbi_name = name;
+                        entry.dbi_flags = persistent_dbi_flags(
+                            static_cast<std::uint32_t>(raw_flags));
+                        manifest.push_back(entry);
+                    }
+                } else if (open_rc != MDBX_INCOMPATIBLE &&
+                           open_rc != MDBX_NOTFOUND) {
+                    check_mdbx(
+                        open_rc,
+                        "full snapshot failed to inspect MainDB entry");
+                }
+                rc = mdbx_cursor_get(raw, &key, &value, MDBX_NEXT);
+            }
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc,
+                           "full snapshot failed to scan complete DBI inventory");
+            }
+            std::sort(manifest.begin(), manifest.end(),
+                [](const FullSnapshotManifestEntry& left,
+                   const FullSnapshotManifestEntry& right) {
+                    return left.dbi_name < right.dbi_name;
+                });
+            if (manifest.empty()) {
+                throw std::runtime_error(
+                    "complete full snapshot source has no user DBIs");
+            }
+            return manifest;
         }
 
         static std::uint64_t snapshot_materialized_bytes_for(
@@ -1423,7 +1497,6 @@ namespace sync {
                 new FullSnapshotSession());
             session->snapshot_id = snapshot_id;
             session->requester = requester;
-            session->manifest = options.manifest;
             session->replacement_scope = options.replacement_scope;
             session->last_access = std::chrono::steady_clock::now();
 
@@ -1438,18 +1511,26 @@ namespace sync {
                     "full snapshot source identity is not initialized");
             }
 
-            const MDBX_dbi changelog_dbi = open_changelog_ro(txn.handle());
-            session->source_tail = read_applied_cursor(
-                txn.handle(), SyncCursor());
-            if (changelog_dbi != 0) {
-                const std::vector<PullOrigin> origins =
-                    collect_known_origins(txn.handle(), changelog_dbi);
-                SyncCursor changelog_tail;
-                if (!copy_known_tail(origins, changelog_tail)) {
-                    throw std::runtime_error(
-                        "full snapshot source changelog tail is incomplete");
+            session->manifest = options.replacement_scope ==
+                    FullSnapshotScope::CompleteUserDatabase
+                ? enumerate_complete_snapshot_manifest(txn.handle())
+                : options.manifest;
+
+            if (options.replacement_scope ==
+                    FullSnapshotScope::CompleteUserDatabase) {
+                const MDBX_dbi changelog_dbi = open_changelog_ro(txn.handle());
+                session->source_tail = read_applied_cursor(
+                    txn.handle(), SyncCursor());
+                if (changelog_dbi != 0) {
+                    const std::vector<PullOrigin> origins =
+                        collect_known_origins(txn.handle(), changelog_dbi);
+                    SyncCursor changelog_tail;
+                    if (!copy_known_tail(origins, changelog_tail)) {
+                        throw std::runtime_error(
+                            "full snapshot source changelog tail is incomplete");
+                    }
+                    merge_sync_cursor_max(session->source_tail, changelog_tail);
                 }
-                merge_sync_cursor_max(session->source_tail, changelog_tail);
             }
 
             std::uint64_t materialized_bytes = 0u;
@@ -1620,7 +1701,7 @@ namespace sync {
                     std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
                     prune_expired_full_snapshot_sessions_locked();
                     options = m_full_snapshot_options;
-                    if (options.manifest.empty()) {
+                    if (!full_snapshot_export_is_configured(options)) {
                         out.ok = false;
                         out.error = "full snapshot source export is not configured";
                         out.error_code =

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -1341,7 +1341,7 @@ namespace sync {
         }
 
         std::vector<FullSnapshotManifestEntry>
-        enumerate_complete_snapshot_manifest(MDBX_txn* txn) const {
+        enumerate_user_snapshot_manifest(MDBX_txn* txn) const {
             MDBX_dbi main_dbi = 0;
             check_mdbx(
                 mdbx_dbi_open(
@@ -1393,10 +1393,6 @@ namespace sync {
                    const FullSnapshotManifestEntry& right) {
                     return left.dbi_name < right.dbi_name;
                 });
-            if (manifest.empty()) {
-                throw std::runtime_error(
-                    "complete full snapshot source has no user DBIs");
-            }
             return manifest;
         }
 
@@ -1513,8 +1509,14 @@ namespace sync {
 
             session->manifest = options.replacement_scope ==
                     FullSnapshotScope::CompleteUserDatabase
-                ? enumerate_complete_snapshot_manifest(txn.handle())
+                ? enumerate_user_snapshot_manifest(txn.handle())
                 : options.manifest;
+            if (session->replacement_scope ==
+                    FullSnapshotScope::CompleteUserDatabase &&
+                session->manifest.empty()) {
+                throw std::runtime_error(
+                    "complete full snapshot source has no user DBIs");
+            }
 
             if (options.replacement_scope ==
                     FullSnapshotScope::CompleteUserDatabase) {

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -23,10 +23,13 @@
 /// supplied transaction and are therefore valid only for its lifetime.
 
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <map>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -138,17 +141,43 @@ namespace sync {
             bool has_last_seq;
         };
 
+        struct FullSnapshotContinuation {
+            std::size_t next_operation = 0u;
+            std::uint64_t chunk_index = 0u;
+        };
+
+        struct FullSnapshotSession {
+            NodeId source_node_id{};
+            DbId source_db_uuid{};
+            NodeId requester{};
+            std::string snapshot_id;
+            SyncCursor source_tail;
+            FullSnapshotScope replacement_scope =
+                FullSnapshotScope::ManifestOnly;
+            std::vector<FullSnapshotManifestEntry> manifest;
+            std::vector<ChangeOp> operations;
+            std::map<std::string, FullSnapshotContinuation> continuations;
+            std::chrono::steady_clock::time_point last_access;
+            std::mutex mutex;
+        };
+
     public:
         /// \brief Constructs an engine bound to \p conn.
         /// \param conn Shared connection that owns the env and stores.
         /// \param policy Conflict resolution policy (default: \c Reject).
         explicit SyncEngine(std::shared_ptr<Connection> conn,
-                            ConflictPolicy policy = ConflictPolicy::Reject)
-            : m_conn(std::move(conn)), m_policy(policy) {
+                            ConflictPolicy policy = ConflictPolicy::Reject,
+                            const FullSnapshotExportOptions&
+                                full_snapshot_options =
+                                    FullSnapshotExportOptions())
+            : m_conn(std::move(conn)),
+              m_policy(policy),
+              m_full_snapshot_options(full_snapshot_options) {
             if (m_policy == ConflictPolicy::LastWriterWins) {
                 throw std::invalid_argument(
                     "ConflictPolicy::LastWriterWins is not implemented");
             }
+            validate_full_snapshot_export_options(m_full_snapshot_options);
         }
 
         /// \brief Initialises the local \c node_id and \c db_uuid.
@@ -198,6 +227,18 @@ namespace sync {
 
         /// \brief Returns the conflict resolution policy.
         ConflictPolicy policy() const noexcept { return m_policy; }
+
+        /// \brief Replaces the explicit source manifest used for full snapshots.
+        /// \details An empty manifest disables source export. Reconfiguration
+        /// invalidates all in-memory snapshot sessions, so callers must not
+        /// change it while an export is in progress.
+        void set_full_snapshot_export_options(
+                const FullSnapshotExportOptions& options) {
+            validate_full_snapshot_export_options(options);
+            std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
+            m_full_snapshot_options = options;
+            m_full_snapshot_sessions.clear();
+        }
 
         /// \brief Registers or verifies a persistent logical table schema.
         /// \details This is the normal lifecycle entry point for application
@@ -990,8 +1031,8 @@ namespace sync {
             return "unknown";
         }
 
-        /// \brief Handles a pull request: reads the local changelog
-        /// for batches newer than the requester's cursor.
+        /// \brief Handles an incremental pull or explicitly configured
+        /// full-snapshot export request.
         /// \details When \c request.have is empty, replays all retained
         /// changelog batches from seq=1 for all known origins. This is not
         /// a full database snapshot. Non-empty cursors still
@@ -1003,7 +1044,10 @@ namespace sync {
         /// \c request.max_batches or the soft page budget
         /// \c request.max_bytes rather than running out of changelog entries.
         /// A single retained batch may exceed \c max_bytes but is rejected
-        /// when it exceeds \c request.max_single_batch_bytes.
+        /// when it exceeds \c request.max_single_batch_bytes. Full snapshots
+        /// require an empty receiver cursor and an explicit source manifest;
+        /// they materialize stable, bounded source pages, while import remains
+        /// a separate lifecycle operation.
         PullResponse handle_pull(const PullRequest& request) {
             PullResponse out;
             if (!db_id_matches(request.db_id)) {
@@ -1013,11 +1057,7 @@ namespace sync {
                 return out;
             }
             if (request.request_full_snapshot) {
-                out.ok = false;
-                out.error = "PullRequest::request_full_snapshot is not implemented";
-                out.error_code =
-                    SyncResponseErrorCode::UnsupportedFullSnapshot;
-                return out;
+                return handle_full_snapshot_pull(request);
             }
 
             MDBX_txn* txn = nullptr;
@@ -1245,6 +1285,410 @@ namespace sync {
 
             MDBX_cursor* raw;
         };
+
+        static bool is_reserved_snapshot_dbi(const std::string& name) {
+            return name.size() >= 7u &&
+                name.compare(0u, 7u, "_mdbxc_") == 0;
+        }
+
+        static void validate_full_snapshot_export_options(
+                const FullSnapshotExportOptions& options) {
+            if (options.manifest.empty()) {
+                return;
+            }
+            if (options.max_materialized_operations == 0u ||
+                options.max_materialized_bytes == 0u ||
+                options.max_active_sessions == 0u ||
+                options.session_idle_timeout <= std::chrono::seconds::zero()) {
+                throw std::invalid_argument(
+                    "full snapshot export limits must be non-zero");
+            }
+            switch (options.replacement_scope) {
+                case FullSnapshotScope::ManifestOnly:
+                case FullSnapshotScope::CompleteUserDatabase:
+                    break;
+                default:
+                    throw std::invalid_argument(
+                        "invalid full snapshot replacement scope");
+            }
+            for (std::size_t i = 0u; i < options.manifest.size(); ++i) {
+                const FullSnapshotManifestEntry& entry = options.manifest[i];
+                if (entry.dbi_name.empty() ||
+                    is_reserved_snapshot_dbi(entry.dbi_name)) {
+                    throw std::invalid_argument(
+                        "full snapshot manifest contains a reserved or empty DBI");
+                }
+                if (i != 0u &&
+                    options.manifest[i - 1u].dbi_name >= entry.dbi_name) {
+                    throw std::invalid_argument(
+                        "full snapshot manifest must be sorted and unique");
+                }
+            }
+        }
+
+        static std::uint64_t snapshot_materialized_bytes_for(
+                const std::string& dbi_name,
+                const MDBX_val& key,
+                const MDBX_val& value) {
+            const std::uint64_t max =
+                (std::numeric_limits<std::uint64_t>::max)();
+            if (dbi_name.size() > max || key.iov_len > max || value.iov_len > max) {
+                throw std::length_error("full snapshot materialization size overflow");
+            }
+            const std::uint64_t name_size =
+                static_cast<std::uint64_t>(dbi_name.size());
+            const std::uint64_t key_size = static_cast<std::uint64_t>(key.iov_len);
+            const std::uint64_t value_size = static_cast<std::uint64_t>(value.iov_len);
+            const std::uint64_t operation_size =
+                static_cast<std::uint64_t>(sizeof(ChangeOp));
+            if (operation_size > max - name_size ||
+                key_size > max - name_size - operation_size ||
+                value_size > max - name_size - operation_size - key_size) {
+                throw std::length_error("full snapshot materialization size overflow");
+            }
+            return name_size + operation_size + key_size + value_size;
+        }
+
+        static void append_full_snapshot_operation(
+                FullSnapshotSession& session,
+                const FullSnapshotExportOptions& options,
+                const std::string& dbi_name,
+                std::uint32_t dbi_flags,
+                ChangeOpType op_type,
+                const MDBX_val* key,
+                const MDBX_val* value,
+                std::uint64_t& materialized_bytes) {
+            if (static_cast<std::uint64_t>(session.operations.size()) >=
+                options.max_materialized_operations) {
+                throw std::length_error(
+                    "full snapshot exceeds max_materialized_operations");
+            }
+            MDBX_val empty = { nullptr, 0u };
+            const MDBX_val& actual_key = key == nullptr ? empty : *key;
+            const MDBX_val& actual_value = value == nullptr ? empty : *value;
+            const std::uint64_t add = snapshot_materialized_bytes_for(
+                dbi_name, actual_key, actual_value);
+            if (add > options.max_materialized_bytes - materialized_bytes) {
+                throw std::length_error(
+                    "full snapshot exceeds max_materialized_bytes");
+            }
+
+            ChangeOp op;
+            op.op_type = op_type;
+            op.dbi_name = dbi_name;
+            op.dbi_flags = dbi_flags;
+            if (actual_key.iov_len != 0u) {
+                const std::uint8_t* bytes =
+                    static_cast<const std::uint8_t*>(actual_key.iov_base);
+                op.storage_key.assign(bytes, bytes + actual_key.iov_len);
+            }
+            if (actual_value.iov_len != 0u) {
+                const std::uint8_t* bytes =
+                    static_cast<const std::uint8_t*>(actual_value.iov_base);
+                op.value.assign(bytes, bytes + actual_value.iov_len);
+            }
+            session.operations.push_back(std::move(op));
+            materialized_bytes += add;
+        }
+
+        std::string next_full_snapshot_id() {
+            std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
+            ++m_next_full_snapshot_session_id;
+            return std::string("snapshot-") +
+                std::to_string(m_next_full_snapshot_session_id);
+        }
+
+        void prune_expired_full_snapshot_sessions_locked() {
+            const std::chrono::steady_clock::time_point now =
+                std::chrono::steady_clock::now();
+            std::map<std::string,
+                     std::shared_ptr<FullSnapshotSession>>::iterator it =
+                m_full_snapshot_sessions.begin();
+            while (it != m_full_snapshot_sessions.end()) {
+                const std::chrono::steady_clock::duration idle =
+                    now - it->second->last_access;
+                if (idle >= m_full_snapshot_options.session_idle_timeout) {
+                    m_full_snapshot_sessions.erase(it++);
+                } else {
+                    ++it;
+                }
+            }
+        }
+
+        std::shared_ptr<FullSnapshotSession> materialize_full_snapshot(
+                const FullSnapshotExportOptions& options,
+                const std::string& snapshot_id,
+                const NodeId& requester) const {
+            std::shared_ptr<FullSnapshotSession> session(
+                new FullSnapshotSession());
+            session->snapshot_id = snapshot_id;
+            session->requester = requester;
+            session->manifest = options.manifest;
+            session->replacement_scope = options.replacement_scope;
+            session->last_access = std::chrono::steady_clock::now();
+
+            auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
+            MetaStore meta(m_conn->env_handle());
+            meta.open(txn.handle());
+            session->source_node_id = meta.get_node_id(txn.handle());
+            session->source_db_uuid = meta.get_db_uuid(txn.handle());
+            if (compare_node_id(session->source_node_id, NodeId()) == 0 ||
+                compare_node_id(session->source_db_uuid, NodeId()) == 0) {
+                throw std::logic_error(
+                    "full snapshot source identity is not initialized");
+            }
+
+            const MDBX_dbi changelog_dbi = open_changelog_ro(txn.handle());
+            if (changelog_dbi != 0) {
+                const std::vector<PullOrigin> origins =
+                    collect_known_origins(txn.handle(), changelog_dbi);
+                copy_known_tail(origins, session->source_tail);
+            }
+
+            std::uint64_t materialized_bytes = 0u;
+            for (std::size_t i = 0u; i < session->manifest.size(); ++i) {
+                const FullSnapshotManifestEntry& entry = session->manifest[i];
+                MDBX_dbi dbi = 0;
+                const MDBX_db_flags_t open_flags =
+                    static_cast<MDBX_db_flags_t>(
+                        persistent_dbi_flags(entry.dbi_flags));
+                int rc = mdbx_dbi_open(txn.handle(), entry.dbi_name.c_str(),
+                                       open_flags, &dbi);
+                if (rc == MDBX_NOTFOUND) {
+                    throw std::runtime_error(
+                        "full snapshot manifest DBI does not exist: " +
+                        entry.dbi_name);
+                }
+                check_mdbx(rc, "full snapshot failed to open DBI '" +
+                            entry.dbi_name + "'");
+
+                unsigned actual_raw = 0u;
+                check_mdbx(mdbx_dbi_flags(txn.handle(), dbi, &actual_raw),
+                           "full snapshot failed to read DBI flags");
+                const std::uint32_t actual_flags = persistent_dbi_flags(
+                    static_cast<std::uint32_t>(actual_raw));
+                if (actual_flags != entry.dbi_flags) {
+                    throw std::runtime_error(
+                        "full snapshot manifest DBI flags mismatch: " +
+                        entry.dbi_name);
+                }
+
+                append_full_snapshot_operation(*session, options,
+                    entry.dbi_name, actual_flags, ChangeOpType::ClearTable,
+                    nullptr, nullptr, materialized_bytes);
+
+                MDBX_cursor* raw = nullptr;
+                check_mdbx(mdbx_cursor_open(txn.handle(), dbi, &raw),
+                           "full snapshot failed to open DBI cursor");
+                CursorGuard cursor(raw);
+                MDBX_val key;
+                MDBX_val value;
+                rc = mdbx_cursor_get(raw, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    append_full_snapshot_operation(*session, options,
+                        entry.dbi_name, actual_flags, ChangeOpType::Put,
+                        &key, &value, materialized_bytes);
+                    rc = mdbx_cursor_get(raw, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "full snapshot failed to scan DBI '" +
+                               entry.dbi_name + "'");
+                }
+            }
+            return session;
+        }
+
+        static std::string continuation_for(
+                FullSnapshotSession& session,
+                std::size_t next_operation,
+                std::uint64_t next_chunk_index) {
+            std::map<std::string, FullSnapshotContinuation>::const_iterator it =
+                session.continuations.begin();
+            for (; it != session.continuations.end(); ++it) {
+                if (it->second.next_operation == next_operation &&
+                    it->second.chunk_index == next_chunk_index) {
+                    return it->first;
+                }
+            }
+            const std::string token = session.snapshot_id + ":" +
+                std::to_string(next_chunk_index) + ":" +
+                std::to_string(next_operation);
+            FullSnapshotContinuation continuation;
+            continuation.next_operation = next_operation;
+            continuation.chunk_index = next_chunk_index;
+            session.continuations[token] = continuation;
+            return token;
+        }
+
+        static PullResponse make_full_snapshot_page(
+                FullSnapshotSession& session,
+                const PullRequest& request,
+                std::size_t start_operation,
+                std::uint64_t chunk_index) {
+            if (request.max_single_batch_bytes == 0u) {
+                throw std::length_error(
+                    "full snapshot max_single_batch_bytes must be non-zero");
+            }
+            const std::uint64_t hard_limit = request.max_single_batch_bytes;
+            const std::uint64_t soft_limit = request.max_bytes;
+            FullSnapshotChunk chunk;
+            chunk.source_node_id = session.source_node_id;
+            chunk.source_db_uuid = session.source_db_uuid;
+            chunk.snapshot_id = session.snapshot_id;
+            chunk.source_tail = session.source_tail;
+            chunk.chunk_index = chunk_index;
+            chunk.replacement_scope = session.replacement_scope;
+            chunk.manifest = session.manifest;
+            chunk.batch.origin_node_id = session.source_node_id;
+            chunk.batch.seq = 0u;
+            chunk.batch.version = ChangeBatchCodec::batch_version();
+
+            std::size_t next_operation = start_operation;
+            std::vector<std::uint8_t> last_encoded;
+            FullSnapshotChunk last_chunk;
+            while (next_operation < session.operations.size()) {
+                chunk.batch.ops.push_back(session.operations[next_operation]);
+                const std::size_t candidate_next = next_operation + 1u;
+                chunk.has_more = candidate_next < session.operations.size();
+                chunk.continuation = chunk.has_more
+                    ? continuation_for(session, candidate_next, chunk_index + 1u)
+                    : std::string();
+                chunk.batch.batch_flags = chunk.has_more
+                    ? static_cast<std::uint32_t>(BATCH_HAS_MORE)
+                    : static_cast<std::uint32_t>(BATCH_NONE);
+                const std::vector<std::uint8_t> encoded =
+                    FullSnapshotCodec::encode(chunk);
+                if (encoded.size() > hard_limit) {
+                    if (last_encoded.empty()) {
+                        throw std::length_error(
+                            "full snapshot operation exceeds max_single_batch_bytes");
+                    }
+                    break;
+                }
+                if (!last_encoded.empty() && soft_limit != 0u &&
+                    encoded.size() > soft_limit) {
+                    break;
+                }
+                last_chunk = chunk;
+                last_encoded = encoded;
+                next_operation = candidate_next;
+            }
+            if (last_encoded.empty()) {
+                throw std::length_error("full snapshot page contains no operations");
+            }
+
+            PullResponse out;
+            out.ok = true;
+            out.is_full_snapshot = true;
+            out.snapshot_chunk = last_chunk;
+            out.has_more = last_chunk.has_more;
+            out.remote_tail = session.source_tail;
+            out.remote_tail_known = true;
+            return out;
+        }
+
+        PullResponse handle_full_snapshot_pull(const PullRequest& request) {
+            PullResponse out;
+            if (request.full_snapshot_id.empty() !=
+                request.full_snapshot_continuation.empty()) {
+                out.ok = false;
+                out.error =
+                    "full snapshot session id and continuation must both be empty or set";
+                out.error_code = SyncResponseErrorCode::SnapshotSessionInvalid;
+                return out;
+            }
+            if (!request.have.last_seq_by_origin.empty()) {
+                out.ok = false;
+                out.error = "full snapshot requires an empty receiver cursor";
+                out.error_code = SyncResponseErrorCode::SnapshotSessionInvalid;
+                return out;
+            }
+
+            std::shared_ptr<FullSnapshotSession> session;
+            std::size_t start_operation = 0u;
+            std::uint64_t chunk_index = 0u;
+            if (request.full_snapshot_id.empty()) {
+                FullSnapshotExportOptions options;
+                {
+                    std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
+                    prune_expired_full_snapshot_sessions_locked();
+                    options = m_full_snapshot_options;
+                    if (options.manifest.empty()) {
+                        out.ok = false;
+                        out.error = "full snapshot source export is not configured";
+                        out.error_code =
+                            SyncResponseErrorCode::SnapshotNotConfigured;
+                        return out;
+                    }
+                    if (m_full_snapshot_sessions.size() +
+                        m_full_snapshot_creating >= options.max_active_sessions) {
+                        out.ok = false;
+                        out.error = "full snapshot session capacity is exhausted";
+                        out.error_code = SyncResponseErrorCode::SnapshotSessionBusy;
+                        out.error_retryable = true;
+                        return out;
+                    }
+                    ++m_full_snapshot_creating;
+                }
+                try {
+                    session = materialize_full_snapshot(
+                        options, next_full_snapshot_id(), request.requester);
+                } catch (...) {
+                    std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
+                    --m_full_snapshot_creating;
+                    throw;
+                }
+                {
+                    std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
+                    --m_full_snapshot_creating;
+                    prune_expired_full_snapshot_sessions_locked();
+                    m_full_snapshot_sessions[session->snapshot_id] = session;
+                }
+            } else {
+                std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
+                prune_expired_full_snapshot_sessions_locked();
+                std::map<std::string,
+                         std::shared_ptr<FullSnapshotSession>>::const_iterator it =
+                    m_full_snapshot_sessions.find(request.full_snapshot_id);
+                if (it == m_full_snapshot_sessions.end()) {
+                    out.ok = false;
+                    out.error = "full snapshot session is unknown or expired";
+                    out.error_code = SyncResponseErrorCode::SnapshotSessionInvalid;
+                    return out;
+                }
+                session = it->second;
+                session->last_access = std::chrono::steady_clock::now();
+            }
+
+            std::lock_guard<std::mutex> lock(session->mutex);
+            if (compare_node_id(session->requester, request.requester) != 0) {
+                out.ok = false;
+                out.error = "full snapshot requester does not own this session";
+                out.error_code = SyncResponseErrorCode::SnapshotSessionInvalid;
+                return out;
+            }
+            if (!request.full_snapshot_id.empty()) {
+                std::map<std::string, FullSnapshotContinuation>::const_iterator it =
+                    session->continuations.find(request.full_snapshot_continuation);
+                if (it == session->continuations.end()) {
+                    out.ok = false;
+                    out.error = "full snapshot continuation is invalid";
+                    out.error_code = SyncResponseErrorCode::SnapshotSessionInvalid;
+                    return out;
+                }
+                start_operation = it->second.next_operation;
+                chunk_index = it->second.chunk_index;
+            }
+            try {
+                return make_full_snapshot_page(*session, request,
+                                               start_operation, chunk_index);
+            } catch (const std::length_error& e) {
+                out.ok = false;
+                out.error = e.what();
+                out.error_code = SyncResponseErrorCode::BatchTooLarge;
+                return out;
+            }
+        }
 
         /// \brief Returns true when \p request_db_id matches the local
         /// \c db_uuid. A zero \p request_db_id is rejected: callers must
@@ -1981,6 +2425,12 @@ namespace sync {
         std::shared_ptr<Connection> m_conn;
         ConflictPolicy              m_policy;
         LogicalTableRegistry        m_logical_registry;
+        FullSnapshotExportOptions   m_full_snapshot_options;
+        mutable std::mutex          m_full_snapshot_mutex;
+        std::map<std::string, std::shared_ptr<FullSnapshotSession>>
+                                    m_full_snapshot_sessions;
+        std::uint64_t               m_next_full_snapshot_session_id = 0u;
+        std::size_t                  m_full_snapshot_creating = 0u;
     };
 
 } // namespace sync

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -1953,10 +1953,23 @@ namespace sync {
             }
         }
 
-        static void require_fresh_full_snapshot_target(
+        static bool full_snapshot_manifest_flags(
+                const std::vector<FullSnapshotManifestEntry>& manifest,
+                const std::string& name,
+                std::uint32_t& flags) {
+            for (std::size_t i = 0u; i < manifest.size(); ++i) {
+                if (manifest[i].dbi_name == name) {
+                    flags = manifest[i].dbi_flags;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        void require_fresh_full_snapshot_target(
                 MDBX_txn* txn,
                 MetaStore& meta,
-                const FullSnapshotImportSession& session) {
+                const FullSnapshotImportSession& session) const {
             if (compare_node_id(meta.get_db_uuid(txn),
                                 session.source_db_uuid) != 0) {
                 throw std::invalid_argument(
@@ -1971,6 +1984,12 @@ namespace sync {
                 throw std::logic_error(
                     "full snapshot source and destination node identities match");
             }
+            if (session.replacement_scope ==
+                    FullSnapshotScope::CompleteUserDatabase &&
+                session.source_tail.last_seq_for(local_node_id) != 0u) {
+                throw std::logic_error(
+                    "full snapshot destination node identity appears in source tail");
+            }
             if (meta.get_local_seq(txn) != 0u) {
                 throw std::logic_error(
                     "full snapshot destination has local changelog history");
@@ -1979,6 +1998,24 @@ namespace sync {
             if (!read_applied_cursor(txn, applied).last_seq_by_origin.empty()) {
                 throw std::logic_error(
                     "full snapshot destination has an applied cursor");
+            }
+
+            if (session.replacement_scope ==
+                    FullSnapshotScope::CompleteUserDatabase) {
+                const std::vector<FullSnapshotManifestEntry> destination =
+                    enumerate_user_snapshot_manifest(txn);
+                for (std::size_t i = 0u; i < destination.size(); ++i) {
+                    std::uint32_t manifest_flags = 0u;
+                    if (!full_snapshot_manifest_flags(
+                            session.manifest, destination[i].dbi_name,
+                            manifest_flags) ||
+                        manifest_flags != destination[i].dbi_flags) {
+                        throw std::logic_error(
+                            "complete full snapshot destination has a user DBI "
+                            "outside the source manifest: " +
+                            destination[i].dbi_name);
+                    }
+                }
             }
 
             for (std::size_t i = 0u; i < session.manifest.size(); ++i) {
@@ -2018,9 +2055,11 @@ namespace sync {
                 const FullSnapshotChunk& chunk,
                 Connection::SyncApplyNotification& notification,
                 bool& notification_ready) {
-            if (chunk.replacement_scope != FullSnapshotScope::ManifestOnly) {
+            if (chunk.replacement_scope != FullSnapshotScope::ManifestOnly &&
+                chunk.replacement_scope !=
+                    FullSnapshotScope::CompleteUserDatabase) {
                 throw std::invalid_argument(
-                    "full snapshot importer supports ManifestOnly replacement only");
+                    "full snapshot importer received an unsupported replacement scope");
             }
             if (!m_full_snapshot_import_session) {
                 if (chunk.chunk_index != 0u) {
@@ -2079,13 +2118,16 @@ namespace sync {
                     apply_one_op(txn.handle(), session.operations[i], dbi_cache);
                 }
 
-                AppliedStore applied(m_conn->env_handle());
-                applied.open(txn.handle());
-                for (std::map<NodeId, std::uint64_t>::const_iterator it =
-                        session.source_tail.last_seq_by_origin.begin();
-                     it != session.source_tail.last_seq_by_origin.end(); ++it) {
-                    applied.set_last_applied_seq(txn.handle(), it->first,
-                                                 it->second);
+                if (session.replacement_scope ==
+                        FullSnapshotScope::CompleteUserDatabase) {
+                    AppliedStore applied(m_conn->env_handle());
+                    applied.open(txn.handle());
+                    for (std::map<NodeId, std::uint64_t>::const_iterator it =
+                            session.source_tail.last_seq_by_origin.begin();
+                         it != session.source_tail.last_seq_by_origin.end(); ++it) {
+                        applied.set_last_applied_seq(txn.handle(), it->first,
+                                                     it->second);
+                    }
                 }
                 txn.commit();
                 result.completed = true;

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -1439,10 +1439,17 @@ namespace sync {
             }
 
             const MDBX_dbi changelog_dbi = open_changelog_ro(txn.handle());
+            session->source_tail = read_applied_cursor(
+                txn.handle(), SyncCursor());
             if (changelog_dbi != 0) {
                 const std::vector<PullOrigin> origins =
                     collect_known_origins(txn.handle(), changelog_dbi);
-                copy_known_tail(origins, session->source_tail);
+                SyncCursor changelog_tail;
+                if (!copy_known_tail(origins, changelog_tail)) {
+                    throw std::runtime_error(
+                        "full snapshot source changelog tail is incomplete");
+                }
+                merge_sync_cursor_max(session->source_tail, changelog_tail);
             }
 
             std::uint64_t materialized_bytes = 0u;
@@ -1657,7 +1664,6 @@ namespace sync {
                     return out;
                 }
                 session = it->second;
-                session->last_access = std::chrono::steady_clock::now();
             }
 
             std::lock_guard<std::mutex> lock(session->mutex);
@@ -1678,6 +1684,21 @@ namespace sync {
                 }
                 start_operation = it->second.next_operation;
                 chunk_index = it->second.chunk_index;
+            }
+            {
+                std::lock_guard<std::mutex> sessions_lock(
+                    m_full_snapshot_mutex);
+                std::map<std::string,
+                         std::shared_ptr<FullSnapshotSession>>::const_iterator it =
+                    m_full_snapshot_sessions.find(session->snapshot_id);
+                if (it == m_full_snapshot_sessions.end() ||
+                    it->second != session) {
+                    out.ok = false;
+                    out.error = "full snapshot session is unknown or expired";
+                    out.error_code = SyncResponseErrorCode::SnapshotSessionInvalid;
+                    return out;
+                }
+                session->last_access = std::chrono::steady_clock::now();
             }
             try {
                 return make_full_snapshot_page(*session, request,
@@ -2160,6 +2181,18 @@ namespace sync {
                     origins[i].last_seq;
             }
             return true;
+        }
+
+        static void merge_sync_cursor_max(SyncCursor& target,
+                                          const SyncCursor& source) {
+            for (std::map<NodeId, std::uint64_t>::const_iterator it =
+                    source.last_seq_by_origin.begin();
+                 it != source.last_seq_by_origin.end(); ++it) {
+                const std::uint64_t current = target.last_seq_for(it->first);
+                if (it->second > current) {
+                    target.last_seq_by_origin[it->first] = it->second;
+                }
+            }
         }
 
         static std::vector<PullOrigin> collect_changelog_origins(MDBX_txn* txn,

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -161,6 +161,20 @@ namespace sync {
             std::mutex mutex;
         };
 
+        struct FullSnapshotImportSession {
+            NodeId source_node_id{};
+            DbId source_db_uuid{};
+            std::string snapshot_id;
+            SyncCursor source_tail;
+            FullSnapshotScope replacement_scope =
+                FullSnapshotScope::ManifestOnly;
+            std::uint32_t manifest_version = 0u;
+            std::vector<FullSnapshotManifestEntry> manifest;
+            std::uint64_t next_chunk_index = 0u;
+            std::uint64_t staged_bytes = 0u;
+            std::vector<ChangeOp> operations;
+        };
+
     public:
         /// \brief Constructs an engine bound to \p conn.
         /// \param conn Shared connection that owns the env and stores.
@@ -238,6 +252,45 @@ namespace sync {
             std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
             m_full_snapshot_options = options;
             m_full_snapshot_sessions.clear();
+        }
+
+        /// \brief Replaces the bounds for in-memory full snapshot import staging.
+        /// \details Reconfiguration discards an incomplete import because its
+        /// pending pages were never durable and must not outlive their bounds.
+        void set_full_snapshot_import_options(
+                const FullSnapshotImportOptions& options) {
+            validate_full_snapshot_import_options(options);
+            std::lock_guard<std::mutex> lock(m_full_snapshot_import_mutex);
+            m_full_snapshot_import_options = options;
+            m_full_snapshot_import_session.reset();
+        }
+
+        /// \brief Stages or atomically applies one full snapshot chunk.
+        /// \details Only \c ManifestOnly replacement is currently accepted.
+        /// Every page is validated against immutable metadata from page zero.
+        /// No destination user DBI changes before the final page; that page
+        /// verifies a fresh manifest target, applies the complete staged plan,
+        /// and bootstraps the applied cursor in one write transaction.
+        FullSnapshotImportResult apply_full_snapshot_chunk(
+                const FullSnapshotChunk& chunk) {
+            FullSnapshotCodec::validate(chunk);
+            FullSnapshotImportResult result;
+            Connection::SyncApplyNotification notification;
+            {
+                std::lock_guard<std::mutex> lock(
+                    m_full_snapshot_import_mutex);
+                try {
+                    result = apply_full_snapshot_chunk_locked(chunk,
+                                                              notification);
+                } catch (...) {
+                    m_full_snapshot_import_session.reset();
+                    throw;
+                }
+            }
+            if (result.completed) {
+                m_conn->notify_sync_apply_observers(notification);
+            }
+            return result;
         }
 
         /// \brief Registers or verifies a persistent logical table schema.
@@ -1794,6 +1847,181 @@ namespace sync {
             }
         }
 
+        static bool full_snapshot_metadata_matches(
+                const FullSnapshotImportSession& session,
+                const FullSnapshotChunk& chunk) {
+            return compare_node_id(session.source_node_id,
+                                   chunk.source_node_id) == 0 &&
+                compare_node_id(session.source_db_uuid,
+                                chunk.source_db_uuid) == 0 &&
+                session.snapshot_id == chunk.snapshot_id &&
+                session.source_tail.last_seq_by_origin ==
+                    chunk.source_tail.last_seq_by_origin &&
+                session.replacement_scope == chunk.replacement_scope &&
+                session.manifest_version == chunk.manifest_version &&
+                full_snapshot_manifest_equal(session.manifest, chunk.manifest);
+        }
+
+        void append_full_snapshot_import_chunk(
+                FullSnapshotImportSession& session,
+                const FullSnapshotChunk& chunk) const {
+            const std::uint64_t operation_count =
+                static_cast<std::uint64_t>(session.operations.size());
+            const std::uint64_t incoming_count =
+                static_cast<std::uint64_t>(chunk.batch.ops.size());
+            if (operation_count >
+                    m_full_snapshot_import_options.max_staged_operations ||
+                incoming_count >
+                    m_full_snapshot_import_options.max_staged_operations -
+                        operation_count) {
+                throw std::length_error(
+                    "full snapshot import exceeds max_staged_operations");
+            }
+
+            std::uint64_t additional_bytes = 0u;
+            for (std::size_t i = 0u; i < chunk.batch.ops.size(); ++i) {
+                const std::uint64_t operation_bytes =
+                    full_snapshot_operation_bytes(chunk.batch.ops[i]);
+                if (operation_bytes >
+                        m_full_snapshot_import_options.max_staged_bytes -
+                            session.staged_bytes - additional_bytes) {
+                    throw std::length_error(
+                        "full snapshot import exceeds max_staged_bytes");
+                }
+                additional_bytes += operation_bytes;
+            }
+            session.operations.insert(session.operations.end(),
+                                      chunk.batch.ops.begin(),
+                                      chunk.batch.ops.end());
+            session.staged_bytes += additional_bytes;
+        }
+
+        static void require_fresh_full_snapshot_target(
+                MDBX_txn* txn,
+                MetaStore& meta,
+                const FullSnapshotImportSession& session) {
+            if (compare_node_id(meta.get_db_uuid(txn),
+                                session.source_db_uuid) != 0) {
+                throw std::invalid_argument(
+                    "full snapshot source db_uuid does not match destination");
+            }
+            if (meta.get_local_seq(txn) != 0u) {
+                throw std::logic_error(
+                    "full snapshot destination has local changelog history");
+            }
+            SyncCursor applied;
+            if (!read_applied_cursor(txn, applied).last_seq_by_origin.empty()) {
+                throw std::logic_error(
+                    "full snapshot destination has an applied cursor");
+            }
+
+            for (std::size_t i = 0u; i < session.manifest.size(); ++i) {
+                const FullSnapshotManifestEntry& entry = session.manifest[i];
+                MDBX_dbi dbi = 0;
+                int error_code = MDBX_SUCCESS;
+                if (!open_existing_user_dbi(txn, entry.dbi_name,
+                                            entry.dbi_flags, dbi,
+                                            error_code)) {
+                    throw std::runtime_error(
+                        "full snapshot destination DBI flags mismatch: " +
+                        entry.dbi_name);
+                }
+                if (dbi == 0) continue;
+
+                unsigned actual_raw = 0u;
+                check_mdbx(mdbx_dbi_flags(txn, dbi, &actual_raw),
+                           "full snapshot failed to read destination DBI flags");
+                if (persistent_dbi_flags(static_cast<std::uint32_t>(actual_raw)) !=
+                    entry.dbi_flags) {
+                    throw std::runtime_error(
+                        "full snapshot destination DBI flags mismatch: " +
+                        entry.dbi_name);
+                }
+                MDBX_stat stat;
+                check_mdbx(mdbx_dbi_stat(txn, dbi, &stat, sizeof(stat)),
+                           "full snapshot failed to inspect destination DBI");
+                if (stat.ms_entries != 0u) {
+                    throw std::logic_error(
+                        "full snapshot destination DBI is not empty: " +
+                        entry.dbi_name);
+                }
+            }
+        }
+
+        FullSnapshotImportResult apply_full_snapshot_chunk_locked(
+                const FullSnapshotChunk& chunk,
+                Connection::SyncApplyNotification& notification) {
+            if (chunk.replacement_scope != FullSnapshotScope::ManifestOnly) {
+                throw std::invalid_argument(
+                    "full snapshot importer supports ManifestOnly replacement only");
+            }
+            if (!m_full_snapshot_import_session) {
+                if (chunk.chunk_index != 0u) {
+                    throw std::invalid_argument(
+                        "full snapshot import must begin at chunk zero");
+                }
+                std::unique_ptr<FullSnapshotImportSession> session(
+                    new FullSnapshotImportSession());
+                session->source_node_id = chunk.source_node_id;
+                session->source_db_uuid = chunk.source_db_uuid;
+                session->snapshot_id = chunk.snapshot_id;
+                session->source_tail = chunk.source_tail;
+                session->replacement_scope = chunk.replacement_scope;
+                session->manifest_version = chunk.manifest_version;
+                session->manifest = chunk.manifest;
+                m_full_snapshot_import_session = std::move(session);
+            }
+
+            FullSnapshotImportSession& session =
+                *m_full_snapshot_import_session;
+            if (chunk.chunk_index != session.next_chunk_index ||
+                !full_snapshot_metadata_matches(session, chunk)) {
+                throw std::invalid_argument(
+                    "full snapshot chunk does not match the active import session");
+            }
+            append_full_snapshot_import_chunk(session, chunk);
+            ++session.next_chunk_index;
+
+            FullSnapshotImportResult result;
+            result.next_chunk_index = session.next_chunk_index;
+            if (chunk.has_more) return result;
+
+            {
+                const Connection::SyncApplyWriteGuard sync_apply_guard =
+                    m_conn->sync_apply_write_guard();
+                auto txn = m_conn->transaction(TransactionMode::WRITABLE);
+                MetaStore meta(m_conn->env_handle());
+                meta.open(txn.handle());
+                require_fresh_full_snapshot_target(txn.handle(), meta, session);
+
+                std::unordered_map<std::string, MDBX_dbi> dbi_cache;
+                for (std::size_t i = 0u; i < session.operations.size(); ++i) {
+                    apply_one_op(txn.handle(), session.operations[i], dbi_cache);
+                }
+
+                AppliedStore applied(m_conn->env_handle());
+                applied.open(txn.handle());
+                for (std::map<NodeId, std::uint64_t>::const_iterator it =
+                        session.source_tail.last_seq_by_origin.begin();
+                     it != session.source_tail.last_seq_by_origin.end(); ++it) {
+                    applied.set_last_applied_seq(txn.handle(), it->first,
+                                                 it->second);
+                }
+                txn.commit();
+
+                std::vector<std::string> affected_dbi_names;
+                for (std::size_t i = 0u; i < session.manifest.size(); ++i) {
+                    add_unique_dbi_name(affected_dbi_names,
+                                        session.manifest[i].dbi_name);
+                }
+                notification = m_conn->mark_sync_apply_committed(
+                    1u, session.operations.size(), affected_dbi_names);
+            }
+            m_full_snapshot_import_session.reset();
+            result.completed = true;
+            return result;
+        }
+
         /// \brief Returns true when \p request_db_id matches the local
         /// \c db_uuid. A zero \p request_db_id is rejected: callers must
         /// know the database identity before issuing pull/push requests.
@@ -1996,6 +2224,47 @@ namespace sync {
 
         static std::uint32_t persistent_dbi_flags(std::uint32_t dbi_flags) {
             return dbi_flags & persistent_dbi_flags_mask();
+        }
+
+        static void validate_full_snapshot_import_options(
+                const FullSnapshotImportOptions& options) {
+            if (options.max_staged_operations == 0u ||
+                options.max_staged_bytes == 0u) {
+                throw std::invalid_argument(
+                    "full snapshot import bounds must be non-zero");
+            }
+        }
+
+        static bool full_snapshot_manifest_equal(
+                const std::vector<FullSnapshotManifestEntry>& lhs,
+                const std::vector<FullSnapshotManifestEntry>& rhs) {
+            if (lhs.size() != rhs.size()) return false;
+            for (std::size_t i = 0u; i < lhs.size(); ++i) {
+                if (lhs[i].dbi_name != rhs[i].dbi_name ||
+                    lhs[i].dbi_flags != rhs[i].dbi_flags) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        static std::uint64_t full_snapshot_operation_bytes(
+                const ChangeOp& op) {
+            const std::uint64_t fixed =
+                static_cast<std::uint64_t>(sizeof(ChangeOp));
+            const std::uint64_t name =
+                static_cast<std::uint64_t>(op.dbi_name.size());
+            const std::uint64_t key =
+                static_cast<std::uint64_t>(op.storage_key.size());
+            const std::uint64_t value =
+                static_cast<std::uint64_t>(op.value.size());
+            if (name > (std::numeric_limits<std::uint64_t>::max)() - fixed ||
+                key > (std::numeric_limits<std::uint64_t>::max)() - fixed - name ||
+                value > (std::numeric_limits<std::uint64_t>::max)() - fixed - name - key) {
+                throw std::length_error(
+                    "full snapshot operation size overflow");
+            }
+            return fixed + name + key + value;
         }
 
         struct BatchDbiFlags {
@@ -2547,6 +2816,10 @@ namespace sync {
                                     m_full_snapshot_sessions;
         std::uint64_t               m_next_full_snapshot_session_id = 0u;
         std::size_t                  m_full_snapshot_creating = 0u;
+        FullSnapshotImportOptions    m_full_snapshot_import_options;
+        mutable std::mutex           m_full_snapshot_import_mutex;
+        std::unique_ptr<FullSnapshotImportSession>
+                                    m_full_snapshot_import_session;
     };
 
 } // namespace sync

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -282,11 +282,13 @@ namespace sync {
         }
 
         /// \brief Stages or atomically applies one full snapshot chunk.
-        /// \details Only \c ManifestOnly replacement is currently accepted.
-        /// Every page is validated against immutable metadata from page zero.
-        /// No destination user DBI changes before the final page; that page
-        /// verifies a fresh manifest target, applies the complete staged plan,
-        /// and bootstraps the applied cursor in one write transaction.
+        /// \details Every page is validated against immutable metadata from
+        /// page zero. No destination user DBI changes before the final page;
+        /// that page verifies a fresh manifest target and applies the complete
+        /// staged plan in one write transaction. \c ManifestOnly replaces only
+        /// its manifest DBIs and leaves global raw-sync progress unchanged.
+        /// \c CompleteUserDatabase replaces the complete named-user-DBI
+        /// inventory and bootstraps the applied cursor from its source tail.
         FullSnapshotImportResult apply_full_snapshot_chunk(
                 const FullSnapshotChunk& chunk) {
             FullSnapshotCodec::validate(chunk);

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -165,7 +165,7 @@ namespace sync {
         public:
             explicit FullSnapshotLogicalStateUnsupported(
                     const std::string& message =
-                        "complete full snapshot does not support registered logical-sync state")
+                        "complete full snapshot does not support persistent logical-sync state")
                 : std::runtime_error(message) {}
         };
 
@@ -1565,6 +1565,28 @@ namespace sync {
             }
         }
 
+        void require_raw_only_complete_snapshot_source(MDBX_txn* txn) const {
+            try {
+                SchemaRegistryStore schemas(m_conn->env_handle());
+                LogicalDeliveryStore delivery(m_conn->env_handle());
+                LogicalDeliveryOrderStore order(m_conn->env_handle());
+                LogicalOutboxStore outbox(m_conn->env_handle());
+                if (schemas.has_entries(txn) ||
+                    delivery.has_persistent_state(txn) ||
+                    order.has_entries(txn) ||
+                    outbox.has_persistent_state(txn)) {
+                    throw FullSnapshotLogicalStateUnsupported();
+                }
+            } catch (const FullSnapshotLogicalStateUnsupported&) {
+                throw;
+            } catch (const std::exception& e) {
+                throw FullSnapshotLogicalStateUnsupported(
+                    std::string(
+                        "complete full snapshot cannot validate persistent logical-sync state: ") +
+                    e.what());
+            }
+        }
+
         std::shared_ptr<FullSnapshotSession> materialize_full_snapshot(
                 const FullSnapshotExportOptions& options,
                 const NodeId& requester) const {
@@ -1587,19 +1609,7 @@ namespace sync {
 
             if (options.replacement_scope ==
                 FullSnapshotScope::CompleteUserDatabase) {
-                SchemaRegistryStore schemas(m_conn->env_handle());
-                try {
-                    if (!schemas.schema_ids(txn.handle()).empty()) {
-                        throw FullSnapshotLogicalStateUnsupported();
-                    }
-                } catch (const FullSnapshotLogicalStateUnsupported&) {
-                    throw;
-                } catch (const std::exception& e) {
-                    throw FullSnapshotLogicalStateUnsupported(
-                        std::string(
-                            "complete full snapshot cannot validate logical-sync state: ") +
-                        e.what());
-                }
+                require_raw_only_complete_snapshot_source(txn.handle());
             }
 
             session->manifest = options.replacement_scope ==

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -162,6 +162,12 @@ namespace sync {
         };
 
         struct FullSnapshotImportSession {
+            enum class ReplacementState {
+                NotSeen,
+                Cleared,
+                ReceivingPuts
+            };
+
             NodeId source_node_id{};
             DbId source_db_uuid{};
             std::string snapshot_id;
@@ -173,6 +179,7 @@ namespace sync {
             std::uint64_t next_chunk_index = 0u;
             std::uint64_t staged_bytes = 0u;
             std::vector<ChangeOp> operations;
+            std::map<std::string, ReplacementState> replacement_state;
         };
 
     public:
@@ -276,18 +283,20 @@ namespace sync {
             FullSnapshotCodec::validate(chunk);
             FullSnapshotImportResult result;
             Connection::SyncApplyNotification notification;
+            bool notification_ready = false;
             {
                 std::lock_guard<std::mutex> lock(
                     m_full_snapshot_import_mutex);
                 try {
                     result = apply_full_snapshot_chunk_locked(chunk,
-                                                              notification);
+                                                              notification,
+                                                              notification_ready);
                 } catch (...) {
                     m_full_snapshot_import_session.reset();
                     throw;
                 }
             }
-            if (result.completed) {
+            if (result.completed && notification_ready) {
                 m_conn->notify_sync_apply_observers(notification);
             }
             return result;
@@ -1865,6 +1874,38 @@ namespace sync {
         void append_full_snapshot_import_chunk(
                 FullSnapshotImportSession& session,
                 const FullSnapshotChunk& chunk) const {
+            std::map<std::string, FullSnapshotImportSession::ReplacementState>
+                replacement_state = session.replacement_state;
+            for (std::size_t i = 0u; i < chunk.batch.ops.size(); ++i) {
+                const ChangeOp& op = chunk.batch.ops[i];
+                std::map<std::string,
+                         FullSnapshotImportSession::ReplacementState>::iterator
+                    state = replacement_state.find(op.dbi_name);
+                if (state == replacement_state.end()) {
+                    throw std::invalid_argument(
+                        "full snapshot operation is outside the replacement plan");
+                }
+                if (op.op_type == ChangeOpType::ClearTable) {
+                    if (state->second !=
+                        FullSnapshotImportSession::ReplacementState::NotSeen) {
+                        throw std::invalid_argument(
+                            "full snapshot replacement DBI was cleared twice");
+                    }
+                    state->second =
+                        FullSnapshotImportSession::ReplacementState::Cleared;
+                } else if (op.op_type == ChangeOpType::Put) {
+                    if (state->second ==
+                        FullSnapshotImportSession::ReplacementState::NotSeen) {
+                        throw std::invalid_argument(
+                            "full snapshot Put precedes its replacement clear");
+                    }
+                    state->second =
+                        FullSnapshotImportSession::ReplacementState::ReceivingPuts;
+                } else {
+                    throw std::invalid_argument(
+                        "full snapshot replacement operation is unsupported");
+                }
+            }
             const std::uint64_t operation_count =
                 static_cast<std::uint64_t>(session.operations.size());
             const std::uint64_t incoming_count =
@@ -1894,6 +1935,22 @@ namespace sync {
                                       chunk.batch.ops.begin(),
                                       chunk.batch.ops.end());
             session.staged_bytes += additional_bytes;
+            session.replacement_state.swap(replacement_state);
+        }
+
+        static void require_complete_full_snapshot_replacement_plan(
+                const FullSnapshotImportSession& session) {
+            for (std::map<std::string,
+                          FullSnapshotImportSession::ReplacementState>::const_iterator
+                    it = session.replacement_state.begin();
+                 it != session.replacement_state.end(); ++it) {
+                if (it->second ==
+                    FullSnapshotImportSession::ReplacementState::NotSeen) {
+                    throw std::invalid_argument(
+                        "full snapshot replacement plan omits manifest DBI: " +
+                        it->first);
+                }
+            }
         }
 
         static void require_fresh_full_snapshot_target(
@@ -1904,6 +1961,15 @@ namespace sync {
                                 session.source_db_uuid) != 0) {
                 throw std::invalid_argument(
                     "full snapshot source db_uuid does not match destination");
+            }
+            const NodeId local_node_id = meta.get_node_id(txn);
+            if (is_zero_sync_id(local_node_id)) {
+                throw std::logic_error(
+                    "full snapshot destination node identity is not initialized");
+            }
+            if (compare_node_id(local_node_id, session.source_node_id) == 0) {
+                throw std::logic_error(
+                    "full snapshot source and destination node identities match");
             }
             if (meta.get_local_seq(txn) != 0u) {
                 throw std::logic_error(
@@ -1950,7 +2016,8 @@ namespace sync {
 
         FullSnapshotImportResult apply_full_snapshot_chunk_locked(
                 const FullSnapshotChunk& chunk,
-                Connection::SyncApplyNotification& notification) {
+                Connection::SyncApplyNotification& notification,
+                bool& notification_ready) {
             if (chunk.replacement_scope != FullSnapshotScope::ManifestOnly) {
                 throw std::invalid_argument(
                     "full snapshot importer supports ManifestOnly replacement only");
@@ -1969,6 +2036,10 @@ namespace sync {
                 session->replacement_scope = chunk.replacement_scope;
                 session->manifest_version = chunk.manifest_version;
                 session->manifest = chunk.manifest;
+                for (std::size_t i = 0u; i < session->manifest.size(); ++i) {
+                    session->replacement_state[session->manifest[i].dbi_name] =
+                        FullSnapshotImportSession::ReplacementState::NotSeen;
+                }
                 m_full_snapshot_import_session = std::move(session);
             }
 
@@ -1986,6 +2057,8 @@ namespace sync {
             result.next_chunk_index = session.next_chunk_index;
             if (chunk.has_more) return result;
 
+            require_complete_full_snapshot_replacement_plan(session);
+
             {
                 const Connection::SyncApplyWriteGuard sync_apply_guard =
                     m_conn->sync_apply_write_guard();
@@ -1993,6 +2066,13 @@ namespace sync {
                 MetaStore meta(m_conn->env_handle());
                 meta.open(txn.handle());
                 require_fresh_full_snapshot_target(txn.handle(), meta, session);
+
+                std::vector<std::string> affected_dbi_names;
+                for (std::size_t i = 0u; i < session.manifest.size(); ++i) {
+                    add_unique_dbi_name(affected_dbi_names,
+                                        session.manifest[i].dbi_name);
+                }
+                const std::size_t applied_operations = session.operations.size();
 
                 std::unordered_map<std::string, MDBX_dbi> dbi_cache;
                 for (std::size_t i = 0u; i < session.operations.size(); ++i) {
@@ -2008,17 +2088,16 @@ namespace sync {
                                                  it->second);
                 }
                 txn.commit();
-
-                std::vector<std::string> affected_dbi_names;
-                for (std::size_t i = 0u; i < session.manifest.size(); ++i) {
-                    add_unique_dbi_name(affected_dbi_names,
-                                        session.manifest[i].dbi_name);
+                result.completed = true;
+                m_full_snapshot_import_session.reset();
+                try {
+                    notification = m_conn->mark_sync_apply_committed(
+                        1u, applied_operations, affected_dbi_names);
+                    notification_ready = true;
+                } catch (...) {
+                    // Native commit is durable; observer bookkeeping is best effort.
                 }
-                notification = m_conn->mark_sync_apply_committed(
-                    1u, session.operations.size(), affected_dbi_names);
             }
-            m_full_snapshot_import_session.reset();
-            result.completed = true;
             return result;
         }
 

--- a/include/mdbx_containers/sync/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/SyncEngine.hpp
@@ -272,6 +272,15 @@ namespace sync {
             m_full_snapshot_import_session.reset();
         }
 
+        /// \brief Discards an incomplete in-memory full snapshot import.
+        /// \details No user-DBI mutation has occurred before a snapshot final
+        /// page, so this is safe after cancellation, transport failure, or a
+        /// worker restart. It never alters durable replication metadata.
+        void discard_full_snapshot_import() {
+            std::lock_guard<std::mutex> lock(m_full_snapshot_import_mutex);
+            m_full_snapshot_import_session.reset();
+        }
+
         /// \brief Stages or atomically applies one full snapshot chunk.
         /// \details Only \c ManifestOnly replacement is currently accepted.
         /// Every page is validated against immutable metadata from page zero.

--- a/include/mdbx_containers/sync/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/SyncWorker.hpp
@@ -88,10 +88,12 @@ namespace sync {
         /// \brief Requests an explicit fresh-replica snapshot after
         /// \c SnapshotRequired.
         /// \details Disabled by default. When enabled, the worker starts a
-        /// new full snapshot session with an empty cursor and drains it through
-        /// the final page in the current round. The receiver importer still
-        /// rejects non-fresh targets; this is not an in-place repair path for
-        /// a partially replicated database.
+        /// new \c CompleteUserDatabase snapshot session with an empty cursor
+        /// and drains it through the final page in the current round.
+        /// \c ManifestOnly is a manual physical replacement mode and never a
+        /// raw-sync recovery fallback. The receiver importer still rejects
+        /// non-fresh targets; this is not an in-place repair path for a
+        /// partially replicated database.
         bool enable_full_snapshot_fallback = false;
 
         /// \brief How the background worker handles permanent transport hints.
@@ -261,9 +263,9 @@ namespace sync {
     /// waiting in \c ISyncPeer::pull(), idle sleep, or backoff sleep. Pulled
     /// batches are applied through \c SyncEngine::handle_push(), which opens
     /// and commits a short local write transaction for each pulled page. With
-    /// opt-in full snapshot fallback, the worker instead stages all snapshot
-    /// pages and the engine commits their fresh-replica replacement only after
-    /// the final page.
+    /// opt-in full snapshot fallback, the worker accepts only a
+    /// \c CompleteUserDatabase session, stages all pages, and the engine
+    /// commits its fresh-replica replacement only after the final page.
     /// Stop requests cancel the active request token and call
     /// \c ISyncPeer::request_cancel() at most once for each observed in-flight
     /// peer call. Cancellation is best-effort: \c stop(), \c join(), and the
@@ -794,6 +796,17 @@ namespace sync {
                     result.ok = false;
                     result.error =
                         "full snapshot pull returned an invalid response shape";
+                    return result;
+                }
+                if (response.snapshot_chunk.replacement_scope !=
+                    FullSnapshotScope::CompleteUserDatabase) {
+                    m_engine.discard_full_snapshot_import();
+                    result.ok = false;
+                    result.error =
+                        "full snapshot fallback requires CompleteUserDatabase scope";
+                    result.sync_error_code =
+                        SyncResponseErrorCode::SnapshotSessionInvalid;
+                    result.sync_error_retryable = false;
                     return result;
                 }
                 ++result.pages_pulled;

--- a/include/mdbx_containers/sync/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/SyncWorker.hpp
@@ -85,6 +85,15 @@ namespace sync {
         /// \brief Whether one round drains all \c has_more pages immediately.
         bool drain_pages = true;
 
+        /// \brief Requests an explicit fresh-replica snapshot after
+        /// \c SnapshotRequired.
+        /// \details Disabled by default. When enabled, the worker starts a
+        /// new full snapshot session with an empty cursor and drains it through
+        /// the final page in the current round. The receiver importer still
+        /// rejects non-fresh targets; this is not an in-place repair path for
+        /// a partially replicated database.
+        bool enable_full_snapshot_fallback = false;
+
         /// \brief How the background worker handles permanent transport hints.
         /// \details The default keeps v0.1 retry hints advisory. Set to
         /// \c StopWorker when a classified permanent transport failure should
@@ -236,7 +245,7 @@ namespace sync {
         }
     };
 
-    /// \brief Drives incremental pull/apply sync in a caller-owned lifecycle.
+    /// \brief Drives pull/apply sync in a caller-owned lifecycle.
     /// \details The worker owns only its std::thread. It does not own the
     /// supplied \c SyncEngine or \c ISyncPeer; both must outlive the worker.
     /// The \c SyncWorker object itself must outlive its worker thread and must
@@ -251,7 +260,10 @@ namespace sync {
     /// The implementation never keeps a local MDBX transaction open while
     /// waiting in \c ISyncPeer::pull(), idle sleep, or backoff sleep. Pulled
     /// batches are applied through \c SyncEngine::handle_push(), which opens
-    /// and commits a short local write transaction for each pulled page.
+    /// and commits a short local write transaction for each pulled page. With
+    /// opt-in full snapshot fallback, the worker instead stages all snapshot
+    /// pages and the engine commits their fresh-replica replacement only after
+    /// the final page.
     /// Stop requests cancel the active request token and call
     /// \c ISyncPeer::request_cancel() at most once for each observed in-flight
     /// peer call. Cancellation is best-effort: \c stop(), \c join(), and the
@@ -478,6 +490,33 @@ namespace sync {
             bool        m_active;
         };
 
+        class FullSnapshotImportResetGuard {
+        public:
+            explicit FullSnapshotImportResetGuard(SyncEngine& engine)
+                : m_engine(engine), m_active(true) {
+            }
+
+            ~FullSnapshotImportResetGuard() {
+                if (!m_active) return;
+                try {
+                    m_engine.discard_full_snapshot_import();
+                } catch (...) {
+                }
+            }
+
+            void dismiss() {
+                m_active = false;
+            }
+
+            FullSnapshotImportResetGuard(const FullSnapshotImportResetGuard&) = delete;
+            FullSnapshotImportResetGuard& operator=(
+                const FullSnapshotImportResetGuard&) = delete;
+
+        private:
+            SyncEngine& m_engine;
+            bool        m_active;
+        };
+
         static void validate_options(const SyncWorkerOptions& options) {
             if (options.max_batches == 0) {
                 throw std::invalid_argument(
@@ -573,6 +612,11 @@ namespace sync {
                         notify_stage_changed(event);
                     }
                     if (!response.ok) {
+                        if (response.error_code ==
+                                SyncResponseErrorCode::SnapshotRequired &&
+                            m_options.enable_full_snapshot_fallback) {
+                            return run_full_snapshot_fallback(request, result);
+                        }
                         result.ok = false;
                         result.error = response.error.empty()
                             ? "pull failed"
@@ -690,6 +734,123 @@ namespace sync {
                 result.retry_hint = m_peer.last_retry_hint();
             }
             return result;
+        }
+
+        SyncWorkerRoundResult run_full_snapshot_fallback(
+                const PullRequest& incremental_request,
+                SyncWorkerRoundResult result) {
+            m_engine.discard_full_snapshot_import();
+            FullSnapshotImportResetGuard reset_guard(m_engine);
+            PullRequest request = incremental_request;
+            request.request_full_snapshot = true;
+            request.have = SyncCursor();
+            request.full_snapshot_id.clear();
+            request.full_snapshot_continuation.clear();
+            request.cancel_token = CancellationToken();
+
+            for (;;) {
+                if (stop_requested()) {
+                    result.has_more = true;
+                    return result;
+                }
+
+                PullResponse response;
+                {
+                    CancellationToken cancel_token;
+                    PeerCallGuard peer_call(*this, cancel_token);
+                    if (!peer_call.active()) {
+                        result.has_more = true;
+                        return result;
+                    }
+                    notify_stage_changed(make_stage_event(
+                        SyncWorkerStage::PullStarted, result));
+                    request.cancel_token = cancel_token;
+                    response = m_peer.pull(request);
+                }
+                {
+                    SyncWorkerStageEvent event = make_stage_event(
+                        SyncWorkerStage::PullFinished, result);
+                    event.has_more = response.has_more;
+                    event.ok = response.ok;
+                    event.error = response.error;
+                    event.sync_error_code = response.error_code;
+                    event.sync_error_retryable = response.error_retryable;
+                    notify_stage_changed(event);
+                }
+                if (!response.ok) {
+                    m_engine.discard_full_snapshot_import();
+                    result.ok = false;
+                    result.error = response.error.empty()
+                        ? "full snapshot pull failed"
+                        : response.error;
+                    result.retry_hint = m_peer.last_retry_hint();
+                    result.sync_error_code = response.error_code;
+                    result.sync_error_retryable = response.error_retryable;
+                    return result;
+                }
+                if (!response.is_full_snapshot || !response.batches.empty() ||
+                    response.has_more != response.snapshot_chunk.has_more) {
+                    m_engine.discard_full_snapshot_import();
+                    result.ok = false;
+                    result.error =
+                        "full snapshot pull returned an invalid response shape";
+                    return result;
+                }
+                ++result.pages_pulled;
+                if (stop_requested() || !begin_apply_stage() ||
+                    !enter_apply_gate()) {
+                    m_engine.discard_full_snapshot_import();
+                    result.has_more = response.has_more;
+                    return result;
+                }
+                {
+                    SyncWorkerStageEvent event = make_stage_event(
+                        SyncWorkerStage::ApplyStarted, result);
+                    event.has_more = response.has_more;
+                    notify_stage_changed(event);
+                }
+
+                const FullSnapshotImportResult imported =
+                    m_engine.apply_full_snapshot_chunk(response.snapshot_chunk);
+                {
+                    SyncWorkerStageEvent event = make_stage_event(
+                        SyncWorkerStage::ApplyFinished, result);
+                    event.has_more = response.has_more;
+                    event.ok = true;
+                    notify_stage_changed(event);
+                }
+                if (response.has_more && imported.completed) {
+                    m_engine.discard_full_snapshot_import();
+                    result.ok = false;
+                    result.error =
+                        "full snapshot importer completed before final page";
+                    return result;
+                }
+                if (!response.has_more && !imported.completed) {
+                    m_engine.discard_full_snapshot_import();
+                    result.ok = false;
+                    result.error =
+                        "full snapshot importer did not complete final page";
+                    return result;
+                }
+
+                result.has_more = response.has_more;
+                if (!response.has_more) {
+                    result.progress = response.remote_tail_known
+                        ? make_progress_estimate(response.remote_tail,
+                                                 m_engine.applied_cursor(),
+                                                 result.batches_applied)
+                        : SyncWorkerProgressEstimate();
+                    result.sync_error_code = SyncResponseErrorCode::None;
+                    result.sync_error_retryable = false;
+                    reset_guard.dismiss();
+                    return result;
+                }
+                request.full_snapshot_id =
+                    response.snapshot_chunk.snapshot_id;
+                request.full_snapshot_continuation =
+                    response.snapshot_chunk.continuation;
+            }
         }
 
         SyncWorkerStageEvent make_stage_event(

--- a/include/mdbx_containers/sync/TransportMessageCodec.hpp
+++ b/include/mdbx_containers/sync/TransportMessageCodec.hpp
@@ -345,6 +345,7 @@ namespace sync {
                 case SyncResponseErrorCode::SnapshotNotConfigured:
                 case SyncResponseErrorCode::SnapshotSessionInvalid:
                 case SyncResponseErrorCode::SnapshotSessionBusy:
+                case SyncResponseErrorCode::SnapshotLogicalStateUnsupported:
                     detail::append_u16_le(out,
                         static_cast<std::uint16_t>(code));
                     return;
@@ -526,6 +527,9 @@ namespace sync {
                 case static_cast<std::uint16_t>(
                         SyncResponseErrorCode::SnapshotSessionBusy):
                     return SyncResponseErrorCode::SnapshotSessionBusy;
+                case static_cast<std::uint16_t>(
+                        SyncResponseErrorCode::SnapshotLogicalStateUnsupported):
+                    return SyncResponseErrorCode::SnapshotLogicalStateUnsupported;
             }
             throw std::runtime_error("Invalid SyncResponseErrorCode");
         }

--- a/include/mdbx_containers/sync/TransportMessageCodec.hpp
+++ b/include/mdbx_containers/sync/TransportMessageCodec.hpp
@@ -342,6 +342,9 @@ namespace sync {
                 case SyncResponseErrorCode::ApplyConflict:
                 case SyncResponseErrorCode::SnapshotRequired:
                 case SyncResponseErrorCode::BatchTooLarge:
+                case SyncResponseErrorCode::SnapshotNotConfigured:
+                case SyncResponseErrorCode::SnapshotSessionInvalid:
+                case SyncResponseErrorCode::SnapshotSessionBusy:
                     detail::append_u16_le(out,
                         static_cast<std::uint16_t>(code));
                     return;
@@ -514,6 +517,15 @@ namespace sync {
                 case static_cast<std::uint16_t>(
                         SyncResponseErrorCode::BatchTooLarge):
                     return SyncResponseErrorCode::BatchTooLarge;
+                case static_cast<std::uint16_t>(
+                        SyncResponseErrorCode::SnapshotNotConfigured):
+                    return SyncResponseErrorCode::SnapshotNotConfigured;
+                case static_cast<std::uint16_t>(
+                        SyncResponseErrorCode::SnapshotSessionInvalid):
+                    return SyncResponseErrorCode::SnapshotSessionInvalid;
+                case static_cast<std::uint16_t>(
+                        SyncResponseErrorCode::SnapshotSessionBusy):
+                    return SyncResponseErrorCode::SnapshotSessionBusy;
             }
             throw std::runtime_error("Invalid SyncResponseErrorCode");
         }

--- a/include/mdbx_containers/sync/protocol.hpp
+++ b/include/mdbx_containers/sync/protocol.hpp
@@ -30,6 +30,9 @@ namespace sync {
         ApplyConflict           = 3, ///< Push apply failed on a sync conflict.
         SnapshotRequired        = 4, ///< Requested changelog history was pruned.
         BatchTooLarge           = 5, ///< A single retained batch exceeds the requested limit.
+        SnapshotNotConfigured   = 6, ///< Responder has no explicit snapshot export manifest.
+        SnapshotSessionInvalid  = 7, ///< Snapshot session is unknown, expired, or mismatched.
+        SnapshotSessionBusy     = 8, ///< Responder reached its bounded snapshot-session capacity.
     };
 
     /// \brief Returns a stable diagnostic name for a sync response error code.
@@ -48,6 +51,12 @@ namespace sync {
                 return "snapshot_required";
             case SyncResponseErrorCode::BatchTooLarge:
                 return "batch_too_large";
+            case SyncResponseErrorCode::SnapshotNotConfigured:
+                return "snapshot_not_configured";
+            case SyncResponseErrorCode::SnapshotSessionInvalid:
+                return "snapshot_session_invalid";
+            case SyncResponseErrorCode::SnapshotSessionBusy:
+                return "snapshot_session_busy";
         }
         return "unknown";
     }

--- a/include/mdbx_containers/sync/protocol.hpp
+++ b/include/mdbx_containers/sync/protocol.hpp
@@ -30,9 +30,10 @@ namespace sync {
         ApplyConflict           = 3, ///< Push apply failed on a sync conflict.
         SnapshotRequired        = 4, ///< Requested changelog history was pruned.
         BatchTooLarge           = 5, ///< A single retained batch exceeds the requested limit.
-        SnapshotNotConfigured   = 6, ///< Responder has no explicit snapshot export manifest.
+        SnapshotNotConfigured   = 6, ///< Responder has no enabled snapshot export.
         SnapshotSessionInvalid  = 7, ///< Snapshot session is unknown, expired, or mismatched.
         SnapshotSessionBusy     = 8, ///< Responder reached its bounded snapshot-session capacity.
+        SnapshotLogicalStateUnsupported = 9, ///< Snapshot needs a logical-state protocol not implemented here.
     };
 
     /// \brief Returns a stable diagnostic name for a sync response error code.
@@ -57,6 +58,8 @@ namespace sync {
                 return "snapshot_session_invalid";
             case SyncResponseErrorCode::SnapshotSessionBusy:
                 return "snapshot_session_busy";
+            case SyncResponseErrorCode::SnapshotLogicalStateUnsupported:
+                return "snapshot_logical_state_unsupported";
         }
         return "unknown";
     }

--- a/include/mdbx_containers/sync/stores/LogicalDeliveryOrderStore.hpp
+++ b/include/mdbx_containers/sync/stores/LogicalDeliveryOrderStore.hpp
@@ -6,6 +6,7 @@
 /// \brief Persistent contiguous receiver frontier for ordered delivery.
 
 #include <cstdint>
+#include <cstring>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -78,6 +79,39 @@ namespace sync {
                        "LogicalDeliveryOrderStore write failed");
         }
 
+        /// \brief Returns whether any valid ordered-delivery frontier exists.
+        /// \details The whole DBI is decoded so malformed state is not treated
+        /// as an empty receiver frontier.
+        bool has_entries(MDBX_txn* txn) const {
+            txn = checked_txn(txn,
+                              "LogicalDeliveryOrderStore::has_entries");
+            open_existing(txn);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "LogicalDeliveryOrderStore cursor open failed");
+            bool found = false;
+            try {
+                MDBX_val key;
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    (void)decode_origin(key);
+                    (void)decode_value(value);
+                    found = true;
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc,
+                               "LogicalDeliveryOrderStore cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return found;
+        }
+
     private:
         MDBX_txn* checked_txn(MDBX_txn* txn, const char* context) const {
             return checked_txn_env(txn, m_env, context);
@@ -112,6 +146,17 @@ namespace sync {
                 origin.size()
             };
             return out;
+        }
+
+        static NodeId decode_origin(const MDBX_val& key) {
+            if (key.iov_len != NodeId().size() || key.iov_base == nullptr) {
+                throw std::runtime_error(
+                    "LogicalDeliveryOrderStore key has invalid size");
+            }
+            NodeId origin;
+            std::memcpy(origin.data(), key.iov_base, origin.size());
+            validate_origin(origin);
+            return origin;
         }
 
         static MDBX_val make_val(const std::vector<std::uint8_t>& bytes) {

--- a/include/mdbx_containers/sync/stores/LogicalDeliveryStore.hpp
+++ b/include/mdbx_containers/sync/stores/LogicalDeliveryStore.hpp
@@ -109,6 +109,64 @@ namespace sync {
             return out;
         }
 
+        /// \brief Returns whether replay markers or pruning watermarks exist.
+        /// \details All present records are decoded before returning. The
+        /// optional watermark DBI is inspected without creating it.
+        bool has_persistent_state(MDBX_txn* txn) const {
+            txn = checked_txn(txn,
+                              "LogicalDeliveryStore::has_persistent_state");
+            open_const(txn);
+            bool found = false;
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "LogicalDeliveryStore marker cursor open failed");
+            try {
+                MDBX_val key;
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    (void)decode_and_validate_marker(key, value);
+                    found = true;
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc,
+                               "LogicalDeliveryStore marker cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+
+            if (!open_watermark_if_exists(txn)) {
+                return found;
+            }
+            cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_watermark_dbi, &cursor),
+                       "LogicalDeliveryStore watermark cursor open failed");
+            try {
+                MDBX_val key;
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    (void)decode_watermark_origin(key);
+                    (void)decode_watermark(value);
+                    found = true;
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc,
+                               "LogicalDeliveryStore watermark cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return found;
+        }
+
         /// \brief Lists persisted logical delivery marker identities.
         /// \param limit Maximum number of markers to return, or zero for all.
         std::vector<LogicalDeliveryMarkerInfo> list_markers(
@@ -533,6 +591,20 @@ namespace sync {
                     "LogicalDeliveryStore watermark is zero");
             }
             return sequence;
+        }
+
+        static NodeId decode_watermark_origin(const MDBX_val& key) {
+            if (key.iov_len != NodeId().size() || key.iov_base == nullptr) {
+                throw std::runtime_error(
+                    "LogicalDeliveryStore watermark key has invalid size");
+            }
+            NodeId origin;
+            std::memcpy(origin.data(), key.iov_base, origin.size());
+            if (is_zero_sync_id(origin)) {
+                throw std::runtime_error(
+                    "LogicalDeliveryStore watermark origin is zero");
+            }
+            return origin;
         }
 
         struct ValueCursor {

--- a/include/mdbx_containers/sync/stores/LogicalOutboxStore.hpp
+++ b/include/mdbx_containers/sync/stores/LogicalOutboxStore.hpp
@@ -260,6 +260,59 @@ namespace sync {
             return removed;
         }
 
+        /// \brief Returns whether any valid durable outbox state exists.
+        /// \details Metadata is state even when all entries were acknowledged:
+        /// it records an allocated logical-delivery stream. Every record is
+        /// decoded and cross-checked before this method returns.
+        bool has_persistent_state(MDBX_txn* txn,
+                                  const CodecBounds* bounds = nullptr) const {
+            txn = checked_txn(txn,
+                              "LogicalOutboxStore::has_persistent_state");
+            open_existing(txn);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "LogicalOutboxStore state cursor open failed");
+            bool found = false;
+            try {
+                MDBX_val key;
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    const DbId destination = decode_destination(key);
+                    if (is_metadata_key(key)) {
+                        (void)decode_metadata(value);
+                    } else {
+                        const std::uint64_t sequence = decode_entry_sequence(key);
+                        const Metadata metadata = read_metadata(txn, destination);
+                        const LogicalDeliveryEnvelope envelope =
+                            decode_value(value, bounds);
+                        if (is_zero_sync_id(metadata.origin_node_id) ||
+                            sequence <= metadata.acknowledged_through ||
+                            sequence >= metadata.next_sequence ||
+                            compare_node_id(envelope.destination_db_uuid,
+                                            destination) != 0 ||
+                            compare_node_id(envelope.origin_node_id,
+                                            metadata.origin_node_id) != 0 ||
+                            envelope.origin_sequence != sequence) {
+                            throw std::runtime_error(
+                                "LogicalOutboxStore entry key/value mismatch");
+                        }
+                    }
+                    found = true;
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc,
+                               "LogicalOutboxStore state cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return found;
+        }
+
     private:
         struct Metadata {
             Metadata()
@@ -350,6 +403,43 @@ namespace sync {
             return key.iov_len == prefix.size() + 8u &&
                    key.iov_base != nullptr &&
                    std::memcmp(key.iov_base, &prefix[0], prefix.size()) == 0;
+        }
+
+        static bool is_metadata_key(const MDBX_val& key) {
+            if (key.iov_len != entry_prefix_size() || key.iov_base == nullptr) {
+                return false;
+            }
+            const std::uint8_t* bytes =
+                static_cast<const std::uint8_t*>(key.iov_base);
+            return bytes[0] == key_version() &&
+                   bytes[1] == metadata_key_kind();
+        }
+
+        static DbId decode_destination(const MDBX_val& key) {
+            if (key.iov_len != entry_prefix_size() &&
+                key.iov_len != entry_key_size()) {
+                throw std::runtime_error(
+                    "LogicalOutboxStore key has invalid size");
+            }
+            if (key.iov_base == nullptr) {
+                throw std::runtime_error(
+                    "LogicalOutboxStore key is null");
+            }
+            const std::uint8_t* bytes =
+                static_cast<const std::uint8_t*>(key.iov_base);
+            if (bytes[0] != key_version() ||
+                (bytes[1] != metadata_key_kind() &&
+                 bytes[1] != entry_key_kind())) {
+                throw std::runtime_error(
+                    "LogicalOutboxStore key has invalid prefix");
+            }
+            DbId destination;
+            std::memcpy(destination.data(), bytes + 2u, destination.size());
+            if (is_zero_sync_id(destination)) {
+                throw std::runtime_error(
+                    "LogicalOutboxStore destination is zero");
+            }
+            return destination;
         }
 
         static std::uint64_t decode_entry_sequence(const MDBX_val& key) {

--- a/include/mdbx_containers/sync/stores/SchemaRegistryStore.hpp
+++ b/include/mdbx_containers/sync/stores/SchemaRegistryStore.hpp
@@ -186,6 +186,43 @@ namespace sync {
             return out;
         }
 
+        /// \brief Returns whether the registry contains any valid schema record.
+        /// \details All entries are decoded before returning so callers do not
+        /// treat malformed persistent schema metadata as an empty registry.
+        bool has_entries(MDBX_txn* txn) const {
+            txn = checked_txn(txn, "SchemaRegistryStore::has_entries");
+            open_const(txn);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "SchemaRegistryStore cursor open failed");
+            bool found = false;
+            try {
+                MDBX_val key;
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    if (key.iov_base == nullptr) {
+                        throw std::runtime_error(
+                            "SchemaRegistryStore schema id is null");
+                    }
+                    const char* data = static_cast<const char*>(key.iov_base);
+                    const std::string schema_id(data, data + key.iov_len);
+                    LogicalSchemaRecord decoded;
+                    decode_record(value, schema_id, decoded);
+                    found = true;
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "SchemaRegistryStore cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return found;
+        }
+
     private:
         MDBX_txn* checked_txn(MDBX_txn* txn, const char* context) const {
             return checked_txn_env(txn, m_env, context);

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1880,6 +1880,126 @@ void test_engine_rejects_complete_snapshot_with_logical_state() {
     cleanup(p);
 }
 
+void test_engine_rejects_complete_snapshot_with_empty_ordered_frame() {
+    using namespace mdbxc;
+    const std::string p =
+        "test_engine_complete_snapshot_empty_ordered_frame.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xAA);
+    const sync::NodeId logical_origin = make_node(0xBA);
+    const sync::DbId db_id = make_node(0xDA);
+    sync::FullSnapshotExportOptions options;
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
+    options.max_materialized_operations = 16u;
+    options.max_materialized_bytes = 4096u;
+    options.max_active_sessions = 1u;
+
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
+    engine.initialize_local_identity(source_node, db_id);
+    KeyValueTable<std::string, std::string> documents(conn, "documents");
+    documents.insert_or_assign("document", "raw-value");
+
+    sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = db_id;
+    envelope.origin_node_id = logical_origin;
+    envelope.origin_sequence = 1u;
+    envelope.frame_id = "snapshot-empty-ordered-frame";
+    const sync::LogicalDeliveryAcknowledgement acknowledgement =
+        engine.apply_ordered_logical_delivery_envelope(envelope);
+    if (!acknowledgement.ok ||
+        acknowledgement.acknowledged_through != 1u) {
+        throw std::runtime_error(
+            "failed to prepare empty ordered logical snapshot state");
+    }
+    {
+        auto txn = conn->transaction(TransactionMode::READ_ONLY);
+        sync::SchemaRegistryStore schemas(conn->env_handle());
+        if (schemas.has_entries(txn.handle())) {
+            throw std::runtime_error(
+                "empty ordered logical frame unexpectedly registered a schema");
+        }
+    }
+
+    sync::PullRequest request;
+    request.requester = make_node(0xCA);
+    request.db_id = db_id;
+    request.request_full_snapshot = true;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    const sync::PullResponse first = engine.handle_pull(request);
+    const sync::PullResponse second = engine.handle_pull(request);
+    if (first.ok || second.ok || first.is_full_snapshot ||
+        !first.snapshot_chunk.snapshot_id.empty() ||
+        !second.snapshot_chunk.snapshot_id.empty() ||
+        first.error_code !=
+            sync::SyncResponseErrorCode::SnapshotLogicalStateUnsupported ||
+        second.error_code !=
+            sync::SyncResponseErrorCode::SnapshotLogicalStateUnsupported ||
+        first.error_retryable || second.error_retryable ||
+        kv_or_throw(conn, documents, std::string("document"),
+                    "empty ordered snapshot source value") != "raw-value") {
+        throw std::runtime_error(
+            "complete snapshot accepted empty ordered logical state");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_rejects_complete_snapshot_with_logical_outbox_state() {
+    using namespace mdbxc;
+    const std::string p =
+        "test_engine_complete_snapshot_logical_outbox_state.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xAB);
+    const sync::DbId db_id = make_node(0xDB);
+    const sync::DbId destination = make_node(0xEB);
+    sync::FullSnapshotExportOptions options;
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
+    options.max_materialized_operations = 16u;
+    options.max_materialized_bytes = 4096u;
+    options.max_active_sessions = 1u;
+
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
+    engine.initialize_local_identity(source_node, db_id);
+    KeyValueTable<std::string, std::string> documents(conn, "documents");
+    documents.insert_or_assign("document", "raw-value");
+    engine.enqueue_logical_delivery(destination, sync::LogicalChangeFrame());
+    {
+        auto txn = conn->transaction(TransactionMode::READ_ONLY);
+        sync::SchemaRegistryStore schemas(conn->env_handle());
+        if (schemas.has_entries(txn.handle())) {
+            throw std::runtime_error(
+                "logical outbox unexpectedly registered a schema");
+        }
+    }
+
+    sync::PullRequest request;
+    request.requester = make_node(0xCB);
+    request.db_id = db_id;
+    request.request_full_snapshot = true;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    const sync::PullResponse response = engine.handle_pull(request);
+    if (response.ok || response.is_full_snapshot ||
+        !response.snapshot_chunk.snapshot_id.empty() ||
+        response.error_code !=
+            sync::SyncResponseErrorCode::SnapshotLogicalStateUnsupported ||
+        response.error_retryable ||
+        kv_or_throw(conn, documents, std::string("document"),
+                    "logical outbox snapshot source value") != "raw-value") {
+        throw std::runtime_error(
+            "complete snapshot accepted logical outbox state");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 mdbxc::sync::FullSnapshotChunk make_import_chunk(
         const mdbxc::sync::NodeId& source_node,
         const mdbxc::sync::DbId& db_id,
@@ -2949,6 +3069,10 @@ int main() {
           &test_engine_exports_complete_full_snapshot_inventory },
         { "test_engine_rejects_complete_snapshot_with_logical_state",
           &test_engine_rejects_complete_snapshot_with_logical_state },
+        { "test_engine_rejects_complete_snapshot_with_empty_ordered_frame",
+          &test_engine_rejects_complete_snapshot_with_empty_ordered_frame },
+        { "test_engine_rejects_complete_snapshot_with_logical_outbox_state",
+          &test_engine_rejects_complete_snapshot_with_logical_outbox_state },
         { "test_engine_imports_full_snapshot_and_bootstraps_cursor",
           &test_engine_imports_full_snapshot_and_bootstraps_cursor },
         { "test_engine_manifest_only_snapshot_does_not_bootstrap_cursor",

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1730,6 +1730,49 @@ void test_engine_exports_stable_full_snapshot_pages() {
     cleanup(p);
 }
 
+void test_engine_full_snapshot_tail_includes_applied_origins() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_full_snapshot_applied_tail.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xA7);
+    const sync::NodeId remote_origin = make_node(0xB7);
+    const sync::DbId db_id = make_node(0xD7);
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::FullSnapshotExportOptions options;
+    sync::FullSnapshotManifestEntry entry;
+    entry.dbi_name = "documents";
+    options.manifest.push_back(entry);
+    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
+    engine.initialize_local_identity(source_node, db_id);
+
+    sync::PushRequest pushed;
+    pushed.sender = remote_origin;
+    pushed.db_id = db_id;
+    pushed.batches.push_back(make_raw_batch(remote_origin, 1u,
+                                            "documents", 0x51u));
+    if (!engine.handle_push(pushed).ok) {
+        throw std::runtime_error(
+            "snapshot source did not apply remote origin batch");
+    }
+
+    sync::PullRequest request;
+    request.requester = make_node(0xC7);
+    request.db_id = db_id;
+    request.request_full_snapshot = true;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    const sync::PullResponse response = engine.handle_pull(request);
+    if (!response.ok || !response.is_full_snapshot || response.has_more ||
+        response.snapshot_chunk.source_tail.last_seq_for(remote_origin) != 1u) {
+        throw std::runtime_error(
+            "snapshot source tail omitted an applied remote origin");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 void test_engine_changelog_page_rejects_full_snapshot_request() {
     using namespace mdbxc;
     const std::string p = "test_engine_changelog_full_snapshot_request.mdbx";
@@ -2342,6 +2385,8 @@ int main() {
           &test_engine_rejects_unconfigured_full_snapshot_request },
         { "test_engine_exports_stable_full_snapshot_pages",
           &test_engine_exports_stable_full_snapshot_pages },
+        { "test_engine_full_snapshot_tail_includes_applied_origins",
+          &test_engine_full_snapshot_tail_includes_applied_origins },
         { "test_engine_changelog_page_rejects_full_snapshot_request",
           &test_engine_changelog_page_rejects_full_snapshot_request },
         { "test_engine_pull_reports_snapshot_required_after_prune",

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1730,86 +1730,281 @@ void test_engine_exports_stable_full_snapshot_pages() {
     cleanup(p);
 }
 
-void test_engine_full_snapshot_tail_includes_applied_origins() {
+mdbxc::sync::FullSnapshotChunk make_import_chunk(
+        const mdbxc::sync::NodeId& source_node,
+        const mdbxc::sync::DbId& db_id,
+        const std::string& snapshot_id,
+        std::uint64_t chunk_index,
+        bool has_more) {
+    mdbxc::sync::FullSnapshotChunk chunk;
+    chunk.source_node_id = source_node;
+    chunk.source_db_uuid = db_id;
+    chunk.snapshot_id = snapshot_id;
+    chunk.chunk_index = chunk_index;
+    chunk.has_more = has_more;
+    chunk.continuation = has_more ? "next" : std::string();
+    mdbxc::sync::FullSnapshotManifestEntry entry;
+    entry.dbi_name = "documents";
+    entry.dbi_flags = 0u;
+    chunk.manifest.push_back(entry);
+    chunk.batch.origin_node_id = source_node;
+    chunk.batch.version = mdbxc::sync::ChangeBatchCodec::batch_version();
+    chunk.batch.seq = 0u;
+    chunk.batch.batch_flags = has_more
+        ? static_cast<std::uint32_t>(mdbxc::sync::BATCH_HAS_MORE)
+        : static_cast<std::uint32_t>(mdbxc::sync::BATCH_NONE);
+    return chunk;
+}
+
+void append_import_put(mdbxc::sync::FullSnapshotChunk& chunk,
+                       const std::string& key,
+                       const std::string& value) {
+    mdbxc::sync::ChangeOp op;
+    op.op_type = mdbxc::sync::ChangeOpType::Put;
+    op.dbi_name = "documents";
+    op.storage_key.assign(key.begin(), key.end());
+    op.value.assign(value.begin(), value.end());
+    chunk.batch.ops.push_back(op);
+}
+
+void append_import_clear(mdbxc::sync::FullSnapshotChunk& chunk) {
+    mdbxc::sync::ChangeOp op;
+    op.op_type = mdbxc::sync::ChangeOpType::ClearTable;
+    op.dbi_name = "documents";
+    chunk.batch.ops.push_back(op);
+}
+
+void test_engine_imports_full_snapshot_and_bootstraps_cursor() {
     using namespace mdbxc;
-    const std::string p = "test_engine_full_snapshot_applied_tail.mdbx";
-    cleanup(p);
+    const std::string source_path = "test_engine_full_snapshot_source.mdbx";
+    const std::string replica_path = "test_engine_full_snapshot_replica.mdbx";
+    cleanup(source_path);
+    cleanup(replica_path);
 
-    const sync::NodeId source_node = make_node(0xA7);
-    const sync::NodeId remote_origin = make_node(0xB7);
-    const sync::DbId db_id = make_node(0xD7);
-    std::shared_ptr<Connection> conn = open_env(p);
+    const sync::NodeId source_node = make_node(0xA3);
+    const sync::NodeId replica_node = make_node(0xB3);
+    const sync::DbId db_id = make_node(0xD3);
     sync::FullSnapshotExportOptions options;
-    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
-    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
-    engine.initialize_local_identity(source_node, db_id);
+    sync::FullSnapshotManifestEntry entry;
+    entry.dbi_name = "documents";
+    options.manifest.push_back(entry);
+    options.max_materialized_operations = 16u;
+    options.max_materialized_bytes = 4096u;
 
-    sync::PushRequest pushed;
-    pushed.sender = remote_origin;
-    pushed.db_id = db_id;
-    pushed.batches.push_back(make_raw_batch(remote_origin, 1u,
-                                            "documents", 0x51u));
-    if (!engine.handle_push(pushed).ok) {
-        throw std::runtime_error(
-            "snapshot source did not apply remote origin batch");
+    std::shared_ptr<Connection> source_conn = open_env(source_path);
+    sync::SyncEngine source(source_conn, sync::ConflictPolicy::Reject, options);
+    source.initialize_local_identity(source_node, db_id);
+    KeyValueTable<std::string, std::string> source_documents(
+        source_conn, "documents");
+    source_documents.insert_or_assign("one", "1");
+    source_documents.insert_or_assign("two", "2");
+    {
+        auto txn = source_conn->transaction(TransactionMode::WRITABLE);
+        sync::ChangeLogStore changelog(source_conn->env_handle());
+        changelog.open(txn.handle());
+        append_raw_batch(changelog, txn.handle(), source_node, 1u,
+                         "documents", 0x11u);
+        txn.commit();
     }
 
+    std::shared_ptr<Connection> replica_conn = open_env(replica_path);
+    sync::SyncEngine replica(replica_conn);
+    replica.initialize_local_identity(replica_node, db_id);
+
     sync::PullRequest request;
-    request.requester = make_node(0xC7);
+    request.requester = replica_node;
     request.db_id = db_id;
     request.request_full_snapshot = true;
-    request.max_bytes = 8192u;
+    request.max_bytes = 1u;
     request.max_single_batch_bytes = 8192u;
-    const sync::PullResponse response = engine.handle_pull(request);
-    if (!response.ok || !response.is_full_snapshot || response.has_more ||
-        response.snapshot_chunk.source_tail.last_seq_for(remote_origin) != 1u) {
+
+    sync::PullResponse response = source.handle_pull(request);
+    if (!response.ok || !response.is_full_snapshot || !response.has_more) {
+        throw std::runtime_error("full snapshot source did not paginate");
+    }
+    const sync::FullSnapshotImportResult first =
+        replica.apply_full_snapshot_chunk(response.snapshot_chunk);
+    if (first.completed || first.next_chunk_index != 1u) {
+        throw std::runtime_error("first full snapshot page was not staged");
+    }
+    {
+        auto txn = replica_conn->transaction(TransactionMode::READ_ONLY);
+        MDBX_dbi dbi = 0;
+        const int rc = mdbx_dbi_open(
+            txn.handle(), "documents", static_cast<MDBX_db_flags_t>(0), &dbi);
+        if (rc != MDBX_NOTFOUND) {
+            throw std::runtime_error(
+                "full snapshot staged a destination DBI before final page");
+        }
+    }
+
+    sync::FullSnapshotImportResult result = first;
+    while (response.has_more) {
+        request.full_snapshot_id = response.snapshot_chunk.snapshot_id;
+        request.full_snapshot_continuation = response.snapshot_chunk.continuation;
+        response = source.handle_pull(request);
+        if (!response.ok || !response.is_full_snapshot) {
+            throw std::runtime_error("full snapshot continuation failed");
+        }
+        result = replica.apply_full_snapshot_chunk(response.snapshot_chunk);
+    }
+    if (!result.completed) {
+        throw std::runtime_error("final full snapshot page did not commit");
+    }
+
+    KeyValueTable<std::string, std::string> replica_documents(
+        replica_conn, "documents");
+    if (kv_or_throw(replica_conn, replica_documents, std::string("one"),
+                    "imported one") != "1" ||
+        kv_or_throw(replica_conn, replica_documents, std::string("two"),
+                    "imported two") != "2") {
+        throw std::runtime_error("full snapshot replica content is wrong");
+    }
+    if (replica.applied_cursor().last_seq_for(source_node) != 1u) {
         throw std::runtime_error(
-            "snapshot source tail omitted an applied remote origin");
+            "full snapshot did not bootstrap the source applied cursor");
+    }
+
+    source_conn->disconnect();
+    replica_conn->disconnect();
+    cleanup(source_path);
+    cleanup(replica_path);
+}
+
+void test_engine_full_snapshot_import_fails_closed_before_final_page() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_full_snapshot_import_failure.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xA4);
+    const sync::NodeId replica_node = make_node(0xB4);
+    const sync::DbId db_id = make_node(0xD4);
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
+
+    sync::FullSnapshotChunk first = make_import_chunk(
+        source_node, db_id, "snapshot-a", 0u, true);
+    append_import_clear(first);
+    const sync::FullSnapshotImportResult staged =
+        engine.apply_full_snapshot_chunk(first);
+    if (staged.completed) {
+        throw std::runtime_error("non-final snapshot page committed");
+    }
+
+    sync::FullSnapshotChunk mismatched = make_import_chunk(
+        source_node, db_id, "snapshot-b", 1u, false);
+    append_import_put(mismatched, "new", "value");
+    bool rejected = false;
+    try {
+        (void)engine.apply_full_snapshot_chunk(mismatched);
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error("mismatched snapshot continuation was accepted");
+    }
+    {
+        auto txn = conn->transaction(TransactionMode::READ_ONLY);
+        MDBX_dbi dbi = 0;
+        const int rc = mdbx_dbi_open(
+            txn.handle(), "documents", static_cast<MDBX_db_flags_t>(0), &dbi);
+        if (rc != MDBX_NOTFOUND) {
+            throw std::runtime_error(
+                "failed snapshot import mutated a destination DBI");
+        }
+    }
+
+    sync::FullSnapshotChunk restart = make_import_chunk(
+        source_node, db_id, "snapshot-c", 0u, false);
+    append_import_clear(restart);
+    append_import_put(restart, "new", "value");
+    if (!engine.apply_full_snapshot_chunk(restart).completed) {
+        throw std::runtime_error("snapshot restart after failure did not commit");
+    }
+    KeyValueTable<std::string, std::string> documents(conn, "documents");
+    if (kv_or_throw(conn, documents, std::string("new"),
+                    "restarted snapshot") != "value") {
+        throw std::runtime_error("restarted snapshot content is wrong");
     }
 
     conn->disconnect();
     cleanup(p);
 }
 
-void test_engine_exports_complete_full_snapshot_inventory() {
+void test_engine_full_snapshot_rejects_nonfresh_destination() {
     using namespace mdbxc;
-    const std::string p = "test_engine_complete_full_snapshot_inventory.mdbx";
+    const std::string p = "test_engine_full_snapshot_nonfresh.mdbx";
     cleanup(p);
 
-    const sync::NodeId source_node = make_node(0xA8);
-    const sync::DbId db_id = make_node(0xD8);
+    const sync::NodeId source_node = make_node(0xA5);
+    const sync::NodeId replica_node = make_node(0xB5);
+    const sync::DbId db_id = make_node(0xD5);
     std::shared_ptr<Connection> conn = open_env(p);
-    sync::FullSnapshotExportOptions options;
-    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
-    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
-    engine.initialize_local_identity(source_node, db_id);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
     KeyValueTable<std::string, std::string> documents(conn, "documents");
-    KeyValueTable<std::string, std::string> audit(conn, "audit");
-    documents.insert_or_assign("document", "value");
-    audit.insert_or_assign("audit", "value");
+    documents.insert_or_assign("old", "preserved");
 
-    sync::PullRequest request;
-    request.requester = make_node(0xB8);
-    request.db_id = db_id;
-    request.request_full_snapshot = true;
-    request.max_bytes = 8192u;
-    request.max_single_batch_bytes = 8192u;
-    const sync::PullResponse response = engine.handle_pull(request);
-    if (!response.ok || !response.is_full_snapshot || response.has_more ||
-        response.snapshot_chunk.replacement_scope !=
-            sync::FullSnapshotScope::CompleteUserDatabase ||
-        response.snapshot_chunk.manifest.size() != 2u ||
-        response.snapshot_chunk.manifest[0].dbi_name != "audit" ||
-        response.snapshot_chunk.manifest[1].dbi_name != "documents") {
-        throw std::runtime_error(
-            "complete full snapshot did not inventory all user DBIs");
+    sync::FullSnapshotChunk chunk = make_import_chunk(
+        source_node, db_id, "snapshot-nonfresh", 0u, false);
+    append_import_clear(chunk);
+    append_import_put(chunk, "new", "must-not-appear");
+    bool rejected = false;
+    try {
+        (void)engine.apply_full_snapshot_chunk(chunk);
+    } catch (const std::logic_error&) {
+        rejected = true;
     }
-    for (std::size_t i = 0u;
-         i < response.snapshot_chunk.manifest.size(); ++i) {
-        if (response.snapshot_chunk.manifest[i].dbi_name.find("_mdbxc_") ==
-            0u) {
+    if (!rejected ||
+        kv_or_throw(conn, documents, std::string("old"),
+                    "preserved destination") != "preserved" ||
+        kv_has(conn, documents, std::string("new"))) {
+        throw std::runtime_error(
+            "nonfresh destination was changed by full snapshot import");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_full_snapshot_import_bounds_fail_closed() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_full_snapshot_import_bounds.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xA6);
+    const sync::NodeId replica_node = make_node(0xB6);
+    const sync::DbId db_id = make_node(0xD6);
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
+    sync::FullSnapshotImportOptions limits;
+    limits.max_staged_operations = 1u;
+    limits.max_staged_bytes = 4096u;
+    engine.set_full_snapshot_import_options(limits);
+
+    sync::FullSnapshotChunk chunk = make_import_chunk(
+        source_node, db_id, "snapshot-bounds", 0u, false);
+    append_import_clear(chunk);
+    append_import_put(chunk, "new", "value");
+    bool rejected = false;
+    try {
+        (void)engine.apply_full_snapshot_chunk(chunk);
+    } catch (const std::length_error&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error("full snapshot import staging bound was ignored");
+    }
+    {
+        auto txn = conn->transaction(TransactionMode::READ_ONLY);
+        MDBX_dbi dbi = 0;
+        const int rc = mdbx_dbi_open(
+            txn.handle(), "documents", static_cast<MDBX_db_flags_t>(0), &dbi);
+        if (rc != MDBX_NOTFOUND) {
             throw std::runtime_error(
-                "complete full snapshot exported a reserved DBI");
+                "bounded full snapshot import created a destination DBI");
         }
     }
 
@@ -2429,10 +2624,14 @@ int main() {
           &test_engine_rejects_unconfigured_full_snapshot_request },
         { "test_engine_exports_stable_full_snapshot_pages",
           &test_engine_exports_stable_full_snapshot_pages },
-        { "test_engine_full_snapshot_tail_includes_applied_origins",
-          &test_engine_full_snapshot_tail_includes_applied_origins },
-        { "test_engine_exports_complete_full_snapshot_inventory",
-          &test_engine_exports_complete_full_snapshot_inventory },
+        { "test_engine_imports_full_snapshot_and_bootstraps_cursor",
+          &test_engine_imports_full_snapshot_and_bootstraps_cursor },
+        { "test_engine_full_snapshot_import_fails_closed_before_final_page",
+          &test_engine_full_snapshot_import_fails_closed_before_final_page },
+        { "test_engine_full_snapshot_rejects_nonfresh_destination",
+          &test_engine_full_snapshot_rejects_nonfresh_destination },
+        { "test_engine_full_snapshot_import_bounds_fail_closed",
+          &test_engine_full_snapshot_import_bounds_fail_closed },
         { "test_engine_changelog_page_rejects_full_snapshot_request",
           &test_engine_changelog_page_rejects_full_snapshot_request },
         { "test_engine_pull_reports_snapshot_required_after_prune",

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1740,9 +1740,7 @@ void test_engine_full_snapshot_tail_includes_applied_origins() {
     const sync::DbId db_id = make_node(0xD7);
     std::shared_ptr<Connection> conn = open_env(p);
     sync::FullSnapshotExportOptions options;
-    sync::FullSnapshotManifestEntry entry;
-    entry.dbi_name = "documents";
-    options.manifest.push_back(entry);
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
     sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
     engine.initialize_local_identity(source_node, db_id);
 
@@ -1773,18 +1771,59 @@ void test_engine_full_snapshot_tail_includes_applied_origins() {
     cleanup(p);
 }
 
+void test_engine_exports_complete_full_snapshot_inventory() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_complete_full_snapshot_inventory.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xA8);
+    const sync::DbId db_id = make_node(0xD8);
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::FullSnapshotExportOptions options;
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
+    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
+    engine.initialize_local_identity(source_node, db_id);
+    KeyValueTable<std::string, std::string> documents(conn, "documents");
+    KeyValueTable<std::string, std::string> audit(conn, "audit");
+    documents.insert_or_assign("document", "value");
+    audit.insert_or_assign("audit", "value");
+
+    sync::PullRequest request;
+    request.requester = make_node(0xB8);
+    request.db_id = db_id;
+    request.request_full_snapshot = true;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    const sync::PullResponse response = engine.handle_pull(request);
+    if (!response.ok || !response.is_full_snapshot || response.has_more ||
+        response.snapshot_chunk.replacement_scope !=
+            sync::FullSnapshotScope::CompleteUserDatabase ||
+        response.snapshot_chunk.manifest.size() != 2u ||
+        response.snapshot_chunk.manifest[0].dbi_name != "audit" ||
+        response.snapshot_chunk.manifest[1].dbi_name != "documents") {
+        throw std::runtime_error(
+            "complete full snapshot did not inventory all user DBIs");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 mdbxc::sync::FullSnapshotChunk make_import_chunk(
         const mdbxc::sync::NodeId& source_node,
         const mdbxc::sync::DbId& db_id,
         const std::string& snapshot_id,
         std::uint64_t chunk_index,
-        bool has_more) {
+        bool has_more,
+        mdbxc::sync::FullSnapshotScope scope =
+            mdbxc::sync::FullSnapshotScope::ManifestOnly) {
     mdbxc::sync::FullSnapshotChunk chunk;
     chunk.source_node_id = source_node;
     chunk.source_db_uuid = db_id;
     chunk.snapshot_id = snapshot_id;
     chunk.chunk_index = chunk_index;
     chunk.has_more = has_more;
+    chunk.replacement_scope = scope;
     chunk.continuation = has_more ? "next" : std::string();
     mdbxc::sync::FullSnapshotManifestEntry entry;
     entry.dbi_name = "documents";
@@ -1828,9 +1867,7 @@ void test_engine_imports_full_snapshot_and_bootstraps_cursor() {
     const sync::NodeId replica_node = make_node(0xB3);
     const sync::DbId db_id = make_node(0xD3);
     sync::FullSnapshotExportOptions options;
-    sync::FullSnapshotManifestEntry entry;
-    entry.dbi_name = "documents";
-    options.manifest.push_back(entry);
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
     options.max_materialized_operations = 16u;
     options.max_materialized_bytes = 4096u;
 
@@ -1841,6 +1878,9 @@ void test_engine_imports_full_snapshot_and_bootstraps_cursor() {
         source_conn, "documents");
     source_documents.insert_or_assign("one", "1");
     source_documents.insert_or_assign("two", "2");
+    KeyValueTable<std::string, std::string> source_audit(
+        source_conn, "audit");
+    source_audit.insert_or_assign("event", "snapshot");
     {
         auto txn = source_conn->transaction(TransactionMode::WRITABLE);
         sync::ChangeLogStore changelog(source_conn->env_handle());
@@ -1897,10 +1937,14 @@ void test_engine_imports_full_snapshot_and_bootstraps_cursor() {
 
     KeyValueTable<std::string, std::string> replica_documents(
         replica_conn, "documents");
+    KeyValueTable<std::string, std::string> replica_audit(
+        replica_conn, "audit");
     if (kv_or_throw(replica_conn, replica_documents, std::string("one"),
                     "imported one") != "1" ||
         kv_or_throw(replica_conn, replica_documents, std::string("two"),
-                    "imported two") != "2") {
+                    "imported two") != "2" ||
+        kv_or_throw(replica_conn, replica_audit, std::string("event"),
+                    "imported audit") != "snapshot") {
         throw std::runtime_error("full snapshot replica content is wrong");
     }
     if (replica.applied_cursor().last_seq_for(source_node) != 1u) {
@@ -1912,6 +1956,81 @@ void test_engine_imports_full_snapshot_and_bootstraps_cursor() {
     replica_conn->disconnect();
     cleanup(source_path);
     cleanup(replica_path);
+}
+
+void test_engine_manifest_only_snapshot_does_not_bootstrap_cursor() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_manifest_only_no_cursor.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xA9);
+    const sync::NodeId replica_node = make_node(0xB9);
+    const sync::DbId db_id = make_node(0xD9);
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
+
+    sync::FullSnapshotChunk chunk = make_import_chunk(
+        source_node, db_id, "manifest-only", 0u, false);
+    chunk.source_tail.last_seq_by_origin[source_node] = 2u;
+    append_import_clear(chunk);
+    append_import_put(chunk, "document", "value");
+    if (!engine.apply_full_snapshot_chunk(chunk).completed) {
+        throw std::runtime_error("ManifestOnly snapshot did not complete");
+    }
+    KeyValueTable<std::string, std::string> documents(conn, "documents");
+    if (kv_or_throw(conn, documents, std::string("document"),
+                    "ManifestOnly document") != "value" ||
+        engine.applied_cursor().last_seq_for(source_node) != 0u) {
+        throw std::runtime_error(
+            "ManifestOnly snapshot bootstrapped global applied progress");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_complete_snapshot_rejects_destination_identity_in_tail() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_complete_snapshot_reused_node.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xAA);
+    const sync::NodeId replica_node = make_node(0xBA);
+    const sync::DbId db_id = make_node(0xDA);
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
+
+    sync::FullSnapshotChunk chunk = make_import_chunk(
+        source_node, db_id, "reused-node", 0u, false,
+        sync::FullSnapshotScope::CompleteUserDatabase);
+    chunk.source_tail.last_seq_by_origin[replica_node] = 5u;
+    append_import_clear(chunk);
+    append_import_put(chunk, "document", "must-not-appear");
+    bool rejected = false;
+    try {
+        (void)engine.apply_full_snapshot_chunk(chunk);
+    } catch (const std::logic_error&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error(
+            "complete snapshot accepted destination identity from source tail");
+    }
+    {
+        auto txn = conn->transaction(TransactionMode::READ_ONLY);
+        MDBX_dbi dbi = 0;
+        const int rc = mdbx_dbi_open(
+            txn.handle(), "documents", static_cast<MDBX_db_flags_t>(0), &dbi);
+        if (rc != MDBX_NOTFOUND) {
+            throw std::runtime_error(
+                "reused-node snapshot mutated a destination DBI");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
 }
 
 void test_engine_full_snapshot_import_fails_closed_before_final_page() {
@@ -2755,8 +2874,14 @@ int main() {
           &test_engine_exports_stable_full_snapshot_pages },
         { "test_engine_full_snapshot_tail_includes_applied_origins",
           &test_engine_full_snapshot_tail_includes_applied_origins },
+        { "test_engine_exports_complete_full_snapshot_inventory",
+          &test_engine_exports_complete_full_snapshot_inventory },
         { "test_engine_imports_full_snapshot_and_bootstraps_cursor",
           &test_engine_imports_full_snapshot_and_bootstraps_cursor },
+        { "test_engine_manifest_only_snapshot_does_not_bootstrap_cursor",
+          &test_engine_manifest_only_snapshot_does_not_bootstrap_cursor },
+        { "test_engine_complete_snapshot_rejects_destination_identity_in_tail",
+          &test_engine_complete_snapshot_rejects_destination_identity_in_tail },
         { "test_engine_full_snapshot_import_fails_closed_before_final_page",
           &test_engine_full_snapshot_import_fails_closed_before_final_page },
         { "test_engine_full_snapshot_rejects_nonfresh_destination",

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1740,9 +1740,7 @@ void test_engine_full_snapshot_tail_includes_applied_origins() {
     const sync::DbId db_id = make_node(0xD7);
     std::shared_ptr<Connection> conn = open_env(p);
     sync::FullSnapshotExportOptions options;
-    sync::FullSnapshotManifestEntry entry;
-    entry.dbi_name = "documents";
-    options.manifest.push_back(entry);
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
     sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
     engine.initialize_local_identity(source_node, db_id);
 
@@ -1767,6 +1765,52 @@ void test_engine_full_snapshot_tail_includes_applied_origins() {
         response.snapshot_chunk.source_tail.last_seq_for(remote_origin) != 1u) {
         throw std::runtime_error(
             "snapshot source tail omitted an applied remote origin");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_exports_complete_full_snapshot_inventory() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_complete_full_snapshot_inventory.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xA8);
+    const sync::DbId db_id = make_node(0xD8);
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::FullSnapshotExportOptions options;
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
+    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
+    engine.initialize_local_identity(source_node, db_id);
+    KeyValueTable<std::string, std::string> documents(conn, "documents");
+    KeyValueTable<std::string, std::string> audit(conn, "audit");
+    documents.insert_or_assign("document", "value");
+    audit.insert_or_assign("audit", "value");
+
+    sync::PullRequest request;
+    request.requester = make_node(0xB8);
+    request.db_id = db_id;
+    request.request_full_snapshot = true;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    const sync::PullResponse response = engine.handle_pull(request);
+    if (!response.ok || !response.is_full_snapshot || response.has_more ||
+        response.snapshot_chunk.replacement_scope !=
+            sync::FullSnapshotScope::CompleteUserDatabase ||
+        response.snapshot_chunk.manifest.size() != 2u ||
+        response.snapshot_chunk.manifest[0].dbi_name != "audit" ||
+        response.snapshot_chunk.manifest[1].dbi_name != "documents") {
+        throw std::runtime_error(
+            "complete full snapshot did not inventory all user DBIs");
+    }
+    for (std::size_t i = 0u;
+         i < response.snapshot_chunk.manifest.size(); ++i) {
+        if (response.snapshot_chunk.manifest[i].dbi_name.find("_mdbxc_") ==
+            0u) {
+            throw std::runtime_error(
+                "complete full snapshot exported a reserved DBI");
+        }
     }
 
     conn->disconnect();
@@ -2387,6 +2431,8 @@ int main() {
           &test_engine_exports_stable_full_snapshot_pages },
         { "test_engine_full_snapshot_tail_includes_applied_origins",
           &test_engine_full_snapshot_tail_includes_applied_origins },
+        { "test_engine_exports_complete_full_snapshot_inventory",
+          &test_engine_exports_complete_full_snapshot_inventory },
         { "test_engine_changelog_page_rejects_full_snapshot_request",
           &test_engine_changelog_page_rejects_full_snapshot_request },
         { "test_engine_pull_reports_snapshot_required_after_prune",

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1809,6 +1809,77 @@ void test_engine_exports_complete_full_snapshot_inventory() {
     cleanup(p);
 }
 
+void test_engine_rejects_complete_snapshot_with_logical_state() {
+    using namespace mdbxc;
+    typedef sync::KeyValueLogicalStringCodec<std::string> StringCodec;
+    typedef sync::KeyValueTableLogicalAdapter<
+        std::string, std::string, StringCodec, StringCodec> LogicalAdapter;
+
+    const std::string p = "test_engine_complete_snapshot_logical_state.mdbx";
+    const std::string schema_id = "app.snapshot.logical_key_value.v1";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xA9);
+    const sync::NodeId logical_origin = make_node(0xB9);
+    const sync::DbId db_id = make_node(0xD9);
+    sync::FullSnapshotExportOptions options;
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
+    options.max_materialized_operations = 16u;
+    options.max_materialized_bytes = 4096u;
+    options.max_active_sessions = 1u;
+
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
+    engine.initialize_local_identity(source_node, db_id);
+    KeyValueTable<std::string, std::string> documents(conn, "documents");
+    LogicalAdapter adapter(documents, schema_id);
+    sync::LogicalSchemaRecord record;
+    record.dbi_name = "documents";
+    record.kind = sync::LogicalTableKind::KeyValue;
+    record.schema_version = 1u;
+    record.dbi_names.push_back("documents");
+    engine.register_logical_schema(schema_id, record);
+    engine.register_logical_adapter(adapter);
+
+    sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = db_id;
+    envelope.origin_node_id = logical_origin;
+    envelope.origin_sequence = 1u;
+    envelope.frame_id = "snapshot-logical-state";
+    envelope.frame.changes.push_back(
+        adapter.make_upsert("logical", "value"));
+    const sync::LogicalDeliveryAcknowledgement acknowledgement =
+        engine.apply_ordered_logical_delivery_envelope(envelope);
+    if (!acknowledgement.ok ||
+        kv_or_throw(conn, documents, std::string("logical"),
+                    "logical snapshot source value") != "value") {
+        throw std::runtime_error(
+            "failed to prepare logical snapshot source state");
+    }
+
+    sync::PullRequest request;
+    request.requester = make_node(0xC9);
+    request.db_id = db_id;
+    request.request_full_snapshot = true;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    const sync::PullResponse first = engine.handle_pull(request);
+    const sync::PullResponse second = engine.handle_pull(request);
+    if (first.ok || second.ok || first.is_full_snapshot ||
+        !first.snapshot_chunk.snapshot_id.empty() ||
+        first.error_code !=
+            sync::SyncResponseErrorCode::SnapshotLogicalStateUnsupported ||
+        second.error_code !=
+            sync::SyncResponseErrorCode::SnapshotLogicalStateUnsupported ||
+        first.error_retryable || second.error_retryable) {
+        throw std::runtime_error(
+            "complete snapshot accepted registered logical state");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 mdbxc::sync::FullSnapshotChunk make_import_chunk(
         const mdbxc::sync::NodeId& source_node,
         const mdbxc::sync::DbId& db_id,
@@ -2876,6 +2947,8 @@ int main() {
           &test_engine_full_snapshot_tail_includes_applied_origins },
         { "test_engine_exports_complete_full_snapshot_inventory",
           &test_engine_exports_complete_full_snapshot_inventory },
+        { "test_engine_rejects_complete_snapshot_with_logical_state",
+          &test_engine_rejects_complete_snapshot_with_logical_state },
         { "test_engine_imports_full_snapshot_and_bootstraps_cursor",
           &test_engine_imports_full_snapshot_and_bootstraps_cursor },
         { "test_engine_manifest_only_snapshot_does_not_bootstrap_cursor",

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1587,7 +1587,7 @@ void test_engine_handle_pull_wrong_db_id() {
     cleanup(p);
 }
 
-void test_engine_rejects_full_snapshot_request() {
+void test_engine_rejects_unconfigured_full_snapshot_request() {
     using namespace mdbxc;
     const std::string p = "test_engine_full_snapshot_request.mdbx";
     cleanup(p);
@@ -1608,12 +1608,122 @@ void test_engine_rejects_full_snapshot_request() {
     if (!resp.batches.empty()) {
         throw std::runtime_error("full snapshot rejection returned batches");
     }
-    if (resp.error.find("request_full_snapshot") == std::string::npos) {
+    if (resp.error.find("not configured") == std::string::npos) {
         throw std::runtime_error("full snapshot rejection error is not explicit");
     }
-    if (resp.error_code != sync::SyncResponseErrorCode::UnsupportedFullSnapshot ||
+    if (resp.error_code != sync::SyncResponseErrorCode::SnapshotNotConfigured ||
         resp.error_retryable) {
         throw std::runtime_error("full snapshot rejection code incorrect");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_exports_stable_full_snapshot_pages() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_full_snapshot_export.mdbx";
+    cleanup(p);
+
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::FullSnapshotExportOptions options;
+    sync::FullSnapshotManifestEntry entry;
+    entry.dbi_name = "documents";
+    entry.dbi_flags = 0u;
+    options.manifest.push_back(entry);
+    options.max_materialized_operations = 16u;
+    options.max_materialized_bytes = 4096u;
+    options.max_active_sessions = 1u;
+    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
+    const sync::NodeId source_node = make_node(0xA2);
+    const sync::NodeId db_id = make_node(0xD2);
+    engine.initialize_local_identity(source_node, db_id);
+
+    KeyValueTable<std::string, std::string> documents(conn, "documents");
+    documents.insert_or_assign("one", "1");
+    documents.insert_or_assign("two", "2");
+    documents.insert_or_assign("three", "3");
+
+    sync::PullRequest request;
+    request.requester = make_node(0xB2);
+    request.db_id = db_id;
+    request.request_full_snapshot = true;
+    request.max_bytes = 1u;
+    request.max_single_batch_bytes = 8192u;
+
+    sync::PullResponse response = engine.handle_pull(request);
+    if (!response.ok || !response.is_full_snapshot ||
+        !response.batches.empty() || !response.has_more) {
+        throw std::runtime_error("first full snapshot page is invalid");
+    }
+    if (response.snapshot_chunk.chunk_index != 0u ||
+        response.snapshot_chunk.snapshot_id.empty() ||
+        response.snapshot_chunk.continuation.empty() ||
+        response.snapshot_chunk.manifest.size() != 1u ||
+        response.snapshot_chunk.manifest[0].dbi_name != "documents") {
+        throw std::runtime_error("first full snapshot session metadata is invalid");
+    }
+
+    const sync::PullResponse busy = engine.handle_pull(request);
+    if (busy.ok ||
+        busy.error_code != sync::SyncResponseErrorCode::SnapshotSessionBusy ||
+        !busy.error_retryable) {
+        throw std::runtime_error("full snapshot session capacity is not bounded");
+    }
+
+    sync::PullRequest foreign_request = request;
+    foreign_request.requester = make_node(0xC2);
+    foreign_request.full_snapshot_id = response.snapshot_chunk.snapshot_id;
+    foreign_request.full_snapshot_continuation =
+        response.snapshot_chunk.continuation;
+    const sync::PullResponse foreign = engine.handle_pull(foreign_request);
+    if (foreign.ok ||
+        foreign.error_code != sync::SyncResponseErrorCode::SnapshotSessionInvalid) {
+        throw std::runtime_error("full snapshot session accepted a foreign requester");
+    }
+
+    documents.insert_or_assign("late", "not-in-snapshot");
+
+    std::size_t clear_count = 0u;
+    std::size_t put_count = 0u;
+    for (;;) {
+        const std::vector<sync::ChangeOp>& ops = response.snapshot_chunk.batch.ops;
+        for (std::size_t i = 0u; i < ops.size(); ++i) {
+            if (ops[i].op_type == sync::ChangeOpType::ClearTable) {
+                ++clear_count;
+            } else if (ops[i].op_type == sync::ChangeOpType::Put) {
+                ++put_count;
+                const std::string key(ops[i].storage_key.begin(),
+                                      ops[i].storage_key.end());
+                if (key == "late") {
+                    throw std::runtime_error(
+                        "full snapshot included a post-session source write");
+                }
+            } else {
+                throw std::runtime_error("full snapshot contains a non-physical op");
+            }
+        }
+        if (!response.has_more) {
+            break;
+        }
+        request.full_snapshot_id = response.snapshot_chunk.snapshot_id;
+        request.full_snapshot_continuation =
+            response.snapshot_chunk.continuation;
+        response = engine.handle_pull(request);
+        if (!response.ok || !response.is_full_snapshot ||
+            response.snapshot_chunk.snapshot_id != request.full_snapshot_id) {
+            throw std::runtime_error("full snapshot continuation was rejected");
+        }
+    }
+    if (clear_count != 1u || put_count != 3u) {
+        throw std::runtime_error("full snapshot materialization has wrong content");
+    }
+
+    request.full_snapshot_continuation = "foreign-token";
+    const sync::PullResponse invalid = engine.handle_pull(request);
+    if (invalid.ok ||
+        invalid.error_code != sync::SyncResponseErrorCode::SnapshotSessionInvalid) {
+        throw std::runtime_error("invalid full snapshot continuation was accepted");
     }
 
     conn->disconnect();
@@ -2228,8 +2338,10 @@ int main() {
           &test_sync_apply_observer_reports_clear_and_delete_dbi_names },
         { "test_engine_push_multi_batch_gap_cursor",&test_engine_push_multi_batch_gap_reports_persistent_cursor },
         { "test_engine_handle_pull_wrong_db_id",&test_engine_handle_pull_wrong_db_id },
-        { "test_engine_rejects_full_snapshot_request",
-          &test_engine_rejects_full_snapshot_request },
+        { "test_engine_rejects_unconfigured_full_snapshot_request",
+          &test_engine_rejects_unconfigured_full_snapshot_request },
+        { "test_engine_exports_stable_full_snapshot_pages",
+          &test_engine_exports_stable_full_snapshot_pages },
         { "test_engine_changelog_page_rejects_full_snapshot_request",
           &test_engine_changelog_page_rejects_full_snapshot_request },
         { "test_engine_pull_reports_snapshot_required_after_prune",

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -1730,6 +1730,49 @@ void test_engine_exports_stable_full_snapshot_pages() {
     cleanup(p);
 }
 
+void test_engine_full_snapshot_tail_includes_applied_origins() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_full_snapshot_applied_tail.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xA7);
+    const sync::NodeId remote_origin = make_node(0xB7);
+    const sync::DbId db_id = make_node(0xD7);
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::FullSnapshotExportOptions options;
+    sync::FullSnapshotManifestEntry entry;
+    entry.dbi_name = "documents";
+    options.manifest.push_back(entry);
+    sync::SyncEngine engine(conn, sync::ConflictPolicy::Reject, options);
+    engine.initialize_local_identity(source_node, db_id);
+
+    sync::PushRequest pushed;
+    pushed.sender = remote_origin;
+    pushed.db_id = db_id;
+    pushed.batches.push_back(make_raw_batch(remote_origin, 1u,
+                                            "documents", 0x51u));
+    if (!engine.handle_push(pushed).ok) {
+        throw std::runtime_error(
+            "snapshot source did not apply remote origin batch");
+    }
+
+    sync::PullRequest request;
+    request.requester = make_node(0xC7);
+    request.db_id = db_id;
+    request.request_full_snapshot = true;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    const sync::PullResponse response = engine.handle_pull(request);
+    if (!response.ok || !response.is_full_snapshot || response.has_more ||
+        response.snapshot_chunk.source_tail.last_seq_for(remote_origin) != 1u) {
+        throw std::runtime_error(
+            "snapshot source tail omitted an applied remote origin");
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
 mdbxc::sync::FullSnapshotChunk make_import_chunk(
         const mdbxc::sync::NodeId& source_node,
         const mdbxc::sync::DbId& db_id,
@@ -2005,6 +2048,92 @@ void test_engine_full_snapshot_import_bounds_fail_closed() {
         if (rc != MDBX_NOTFOUND) {
             throw std::runtime_error(
                 "bounded full snapshot import created a destination DBI");
+        }
+    }
+
+    conn->disconnect();
+    cleanup(p);
+}
+
+void test_engine_full_snapshot_import_rejects_invalid_replacement_plan() {
+    using namespace mdbxc;
+    const std::string p = "test_engine_full_snapshot_invalid_plan.mdbx";
+    cleanup(p);
+
+    const sync::NodeId source_node = make_node(0xA8);
+    const sync::NodeId replica_node = make_node(0xB8);
+    const sync::DbId db_id = make_node(0xD8);
+    std::shared_ptr<Connection> conn = open_env(p);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(replica_node, db_id);
+
+    sync::FullSnapshotChunk put_before_clear = make_import_chunk(
+        source_node, db_id, "snapshot-put-before-clear", 0u, false);
+    append_import_put(put_before_clear, "key", "value");
+    bool rejected = false;
+    try {
+        (void)engine.apply_full_snapshot_chunk(put_before_clear);
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error("snapshot accepted Put before ClearTable");
+    }
+
+    sync::FullSnapshotChunk first_clear = make_import_chunk(
+        source_node, db_id, "snapshot-duplicate-clear", 0u, true);
+    append_import_clear(first_clear);
+    (void)engine.apply_full_snapshot_chunk(first_clear);
+    sync::FullSnapshotChunk duplicate_clear = make_import_chunk(
+        source_node, db_id, "snapshot-duplicate-clear", 1u, false);
+    append_import_clear(duplicate_clear);
+    rejected = false;
+    try {
+        (void)engine.apply_full_snapshot_chunk(duplicate_clear);
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error("snapshot accepted duplicate ClearTable");
+    }
+
+    sync::FullSnapshotChunk missing_clear = make_import_chunk(
+        source_node, db_id, "snapshot-missing-clear", 0u, false);
+    sync::FullSnapshotManifestEntry secondary;
+    secondary.dbi_name = "secondary";
+    missing_clear.manifest.push_back(secondary);
+    append_import_clear(missing_clear);
+    rejected = false;
+    try {
+        (void)engine.apply_full_snapshot_chunk(missing_clear);
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    if (!rejected) {
+        throw std::runtime_error("snapshot omitted a manifest ClearTable");
+    }
+
+    sync::FullSnapshotChunk self_origin = make_import_chunk(
+        replica_node, db_id, "snapshot-self-origin", 0u, false);
+    append_import_clear(self_origin);
+    bool rejected_self_origin = false;
+    try {
+        (void)engine.apply_full_snapshot_chunk(self_origin);
+    } catch (const std::logic_error&) {
+        rejected_self_origin = true;
+    }
+    if (!rejected_self_origin) {
+        throw std::runtime_error("snapshot accepted matching source and destination node");
+    }
+
+    {
+        auto txn = conn->transaction(TransactionMode::READ_ONLY);
+        MDBX_dbi dbi = 0;
+        const int rc = mdbx_dbi_open(
+            txn.handle(), "documents", static_cast<MDBX_db_flags_t>(0), &dbi);
+        if (rc != MDBX_NOTFOUND) {
+            throw std::runtime_error(
+                "invalid snapshot replacement plan created destination DBI");
         }
     }
 
@@ -2624,6 +2753,8 @@ int main() {
           &test_engine_rejects_unconfigured_full_snapshot_request },
         { "test_engine_exports_stable_full_snapshot_pages",
           &test_engine_exports_stable_full_snapshot_pages },
+        { "test_engine_full_snapshot_tail_includes_applied_origins",
+          &test_engine_full_snapshot_tail_includes_applied_origins },
         { "test_engine_imports_full_snapshot_and_bootstraps_cursor",
           &test_engine_imports_full_snapshot_and_bootstraps_cursor },
         { "test_engine_full_snapshot_import_fails_closed_before_final_page",
@@ -2632,6 +2763,8 @@ int main() {
           &test_engine_full_snapshot_rejects_nonfresh_destination },
         { "test_engine_full_snapshot_import_bounds_fail_closed",
           &test_engine_full_snapshot_import_bounds_fail_closed },
+        { "test_engine_full_snapshot_import_rejects_invalid_replacement_plan",
+          &test_engine_full_snapshot_import_rejects_invalid_replacement_plan },
         { "test_engine_changelog_page_rejects_full_snapshot_request",
           &test_engine_changelog_page_rejects_full_snapshot_request },
         { "test_engine_pull_reports_snapshot_required_after_prune",

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -2593,11 +2593,93 @@ void test_sync_node_session_rolls_back_hooks_when_worker_start_fails() {
     cleanup(replica_path);
 }
 
+void test_worker_recovers_fresh_replica_with_full_snapshot() {
+    using namespace mdbxc;
+    const std::string source_path = "test_worker_snapshot_source.mdbx";
+    const std::string replica_path = "test_worker_snapshot_replica.mdbx";
+    cleanup(source_path);
+    cleanup(replica_path);
+
+    const sync::NodeId source_node = make_node(0xA9);
+    const sync::NodeId replica_node = make_node(0xB9);
+    const sync::DbId db_id = make_node(0xD9);
+    sync::FullSnapshotExportOptions snapshot_options;
+    sync::FullSnapshotManifestEntry entry;
+    entry.dbi_name = "documents";
+    snapshot_options.manifest.push_back(entry);
+    snapshot_options.max_materialized_operations = 16u;
+    snapshot_options.max_materialized_bytes = 4096u;
+
+    std::shared_ptr<Connection> source_conn = open_env(source_path);
+    sync::SyncEngine source_engine(
+        source_conn, sync::ConflictPolicy::Reject, snapshot_options);
+    source_engine.initialize_local_identity(source_node, db_id);
+    KeyValueTable<std::string, std::string> source_documents(
+        source_conn, "documents");
+    source_documents.insert_or_assign("one", "1");
+    source_documents.insert_or_assign("two", "2");
+    {
+        auto txn = source_conn->transaction(TransactionMode::WRITABLE);
+        sync::ChangeLogStore changelog(source_conn->env_handle());
+        changelog.open(txn.handle());
+        const std::vector<std::uint8_t> encoded =
+            sync::ChangeBatchCodec::encode(
+                make_raw_batch(source_node, 3u, "documents", 0x21u));
+        changelog.append(txn.handle(), source_node, 3u, encoded);
+        txn.commit();
+    }
+
+    std::shared_ptr<Connection> replica_conn = open_env(replica_path);
+    sync::SyncEngine replica_engine(replica_conn);
+    replica_engine.initialize_local_identity(replica_node, db_id);
+    sync::DirectSyncPeer peer(&source_engine);
+    {
+        sync::SyncWorker disabled_worker(replica_engine, peer);
+        const sync::SyncWorkerRoundResult disabled =
+            disabled_worker.run_once();
+        if (disabled.ok ||
+            disabled.sync_error_code != sync::SyncResponseErrorCode::SnapshotRequired) {
+            throw std::runtime_error(
+                "worker enabled full snapshot fallback without opt-in");
+        }
+    }
+    sync::SyncWorkerOptions options;
+    options.enable_full_snapshot_fallback = true;
+    options.max_bytes = 1u;
+    options.max_single_batch_bytes = 8192u;
+    sync::SyncWorker worker(replica_engine, peer, options);
+
+    const sync::SyncWorkerRoundResult result = worker.run_once();
+    if (!result.ok || result.pages_pulled < 2u ||
+        result.batches_applied != 0u || result.has_more ||
+        result.sync_error_code != sync::SyncResponseErrorCode::None) {
+        throw std::runtime_error(
+            "worker did not complete fresh-replica full snapshot fallback");
+    }
+    KeyValueTable<std::string, std::string> replica_documents(
+        replica_conn, "documents");
+    if (kv_or_throw(replica_conn, replica_documents, std::string("one"),
+                    "snapshot one") != "1" ||
+        kv_or_throw(replica_conn, replica_documents, std::string("two"),
+                    "snapshot two") != "2" ||
+        replica_engine.applied_cursor().last_seq_for(source_node) != 3u) {
+        throw std::runtime_error(
+            "worker full snapshot fallback did not bootstrap replica state");
+    }
+
+    source_conn->disconnect();
+    replica_conn->disconnect();
+    cleanup(source_path);
+    cleanup(replica_path);
+}
+
 } // namespace
 
 int main() {
     struct Case { const char* name; void (*fn)(); };
     const Case cases[] = {
+        { "test_worker_recovers_fresh_replica_with_full_snapshot",
+          &test_worker_recovers_fresh_replica_with_full_snapshot },
         { "test_worker_run_once_drains_paginated_pull",
           &test_worker_run_once_drains_paginated_pull },
         { "test_worker_start_stop_idle", &test_worker_start_stop_idle },

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -2844,6 +2844,68 @@ void test_worker_rejects_manifest_only_snapshot_fallback() {
     cleanup(replica_path);
 }
 
+void test_worker_rejects_logical_complete_snapshot_fallback() {
+    using namespace mdbxc;
+    const std::string source_path = "test_worker_logical_snapshot_source.mdbx";
+    const std::string replica_path = "test_worker_logical_snapshot_replica.mdbx";
+    cleanup(source_path);
+    cleanup(replica_path);
+
+    const sync::NodeId source_node = make_node(0xAC);
+    const sync::NodeId replica_node = make_node(0xBC);
+    const sync::DbId db_id = make_node(0xDC);
+    sync::FullSnapshotExportOptions snapshot_options;
+    snapshot_options.replacement_scope =
+        sync::FullSnapshotScope::CompleteUserDatabase;
+    snapshot_options.max_materialized_operations = 16u;
+    snapshot_options.max_materialized_bytes = 4096u;
+
+    std::shared_ptr<Connection> source_conn = open_env(source_path);
+    sync::SyncEngine source(
+        source_conn, sync::ConflictPolicy::Reject, snapshot_options);
+    source.initialize_local_identity(source_node, db_id);
+    sync::LogicalSchemaRecord record;
+    record.dbi_name = "documents";
+    record.kind = sync::LogicalTableKind::KeyValue;
+    record.schema_version = 1u;
+    record.dbi_names.push_back("documents");
+    source.register_logical_schema("app.worker_snapshot.logical.v1", record);
+    {
+        auto txn = source_conn->transaction(TransactionMode::WRITABLE);
+        sync::ChangeLogStore changelog(source_conn->env_handle());
+        changelog.open(txn.handle());
+        const std::vector<std::uint8_t> encoded =
+            sync::ChangeBatchCodec::encode(
+                make_raw_batch(source_node, 3u, "documents", 0x51u));
+        changelog.append(txn.handle(), source_node, 3u, encoded);
+        txn.commit();
+    }
+
+    std::shared_ptr<Connection> replica_conn = open_env(replica_path);
+    sync::SyncEngine replica(replica_conn);
+    replica.initialize_local_identity(replica_node, db_id);
+    sync::DirectSyncPeer peer(&source);
+    sync::SyncWorkerOptions options;
+    options.enable_full_snapshot_fallback = true;
+    options.max_bytes = 8192u;
+    options.max_single_batch_bytes = 8192u;
+    sync::SyncWorker worker(replica, peer, options);
+    const sync::SyncWorkerRoundResult result = worker.run_once();
+    if (result.ok ||
+        result.sync_error_code !=
+            sync::SyncResponseErrorCode::SnapshotLogicalStateUnsupported ||
+        result.sync_error_retryable ||
+        replica.applied_cursor().last_seq_for(source_node) != 0u) {
+        throw std::runtime_error(
+            "worker accepted a logical complete snapshot fallback");
+    }
+
+    source_conn->disconnect();
+    replica_conn->disconnect();
+    cleanup(source_path);
+    cleanup(replica_path);
+}
+
 } // namespace
 
 int main() {
@@ -2855,6 +2917,8 @@ int main() {
           &test_worker_snapshot_recovery_preserves_remote_origin_cursor },
         { "test_worker_rejects_manifest_only_snapshot_fallback",
           &test_worker_rejects_manifest_only_snapshot_fallback },
+        { "test_worker_rejects_logical_complete_snapshot_fallback",
+          &test_worker_rejects_logical_complete_snapshot_fallback },
         { "test_worker_run_once_drains_paginated_pull",
           &test_worker_run_once_drains_paginated_pull },
         { "test_worker_start_stop_idle", &test_worker_start_stop_idle },

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -2673,6 +2673,112 @@ void test_worker_recovers_fresh_replica_with_full_snapshot() {
     cleanup(replica_path);
 }
 
+void test_worker_snapshot_recovery_preserves_remote_origin_cursor() {
+    using namespace mdbxc;
+    const std::string snapshot_source_path =
+        "test_worker_snapshot_remote_source.mdbx";
+    const std::string remote_origin_path =
+        "test_worker_snapshot_remote_origin.mdbx";
+    const std::string replica_path =
+        "test_worker_snapshot_remote_replica.mdbx";
+    cleanup(snapshot_source_path);
+    cleanup(remote_origin_path);
+    cleanup(replica_path);
+
+    const sync::NodeId snapshot_source_node = make_node(0xAA);
+    const sync::NodeId remote_origin_node = make_node(0xBA);
+    const sync::NodeId replica_node = make_node(0xCA);
+    const sync::DbId db_id = make_node(0xDA);
+    sync::FullSnapshotExportOptions snapshot_options;
+    sync::FullSnapshotManifestEntry entry;
+    entry.dbi_name = "documents";
+    snapshot_options.manifest.push_back(entry);
+    snapshot_options.max_materialized_operations = 16u;
+    snapshot_options.max_materialized_bytes = 4096u;
+
+    std::shared_ptr<Connection> snapshot_source_conn =
+        open_env(snapshot_source_path);
+    sync::SyncEngine snapshot_source(
+        snapshot_source_conn, sync::ConflictPolicy::Reject, snapshot_options);
+    snapshot_source.initialize_local_identity(snapshot_source_node, db_id);
+    sync::PushRequest applied_remote;
+    applied_remote.sender = remote_origin_node;
+    applied_remote.db_id = db_id;
+    applied_remote.batches.push_back(
+        make_raw_batch(remote_origin_node, 1u, "documents", 0x41u));
+    if (!snapshot_source.handle_push(applied_remote).ok) {
+        throw std::runtime_error(
+            "snapshot source did not apply remote origin sequence one");
+    }
+    {
+        auto txn = snapshot_source_conn->transaction(TransactionMode::WRITABLE);
+        sync::ChangeLogStore changelog(snapshot_source_conn->env_handle());
+        changelog.open(txn.handle());
+        const std::vector<std::uint8_t> encoded =
+            sync::ChangeBatchCodec::encode(
+                make_raw_batch(snapshot_source_node, 3u, "documents", 0x31u));
+        changelog.append(txn.handle(), snapshot_source_node, 3u, encoded);
+        txn.commit();
+    }
+
+    std::shared_ptr<Connection> remote_origin_conn = open_env(remote_origin_path);
+    sync::SyncEngine remote_origin(remote_origin_conn);
+    remote_origin.initialize_local_identity(remote_origin_node, db_id);
+    {
+        auto txn = remote_origin_conn->transaction(TransactionMode::WRITABLE);
+        sync::ChangeLogStore changelog(remote_origin_conn->env_handle());
+        changelog.open(txn.handle());
+        const std::vector<std::uint8_t> first =
+            sync::ChangeBatchCodec::encode(
+                make_raw_batch(remote_origin_node, 1u, "documents", 0x41u));
+        const std::vector<std::uint8_t> second =
+            sync::ChangeBatchCodec::encode(
+                make_raw_batch(remote_origin_node, 2u, "documents", 0x42u));
+        changelog.append(txn.handle(), remote_origin_node, 1u, first);
+        changelog.append(txn.handle(), remote_origin_node, 2u, second);
+        txn.commit();
+    }
+
+    std::shared_ptr<Connection> replica_conn = open_env(replica_path);
+    sync::SyncEngine replica(replica_conn);
+    replica.initialize_local_identity(replica_node, db_id);
+    sync::DirectSyncPeer snapshot_peer(&snapshot_source);
+    sync::SyncWorkerOptions snapshot_worker_options;
+    snapshot_worker_options.enable_full_snapshot_fallback = true;
+    snapshot_worker_options.max_bytes = 1u;
+    snapshot_worker_options.max_single_batch_bytes = 8192u;
+    sync::SyncWorker snapshot_worker(
+        replica, snapshot_peer, snapshot_worker_options);
+    const sync::SyncWorkerRoundResult snapshot_result =
+        snapshot_worker.run_once();
+    if (!snapshot_result.ok ||
+        replica.applied_cursor().last_seq_for(remote_origin_node) != 1u) {
+        throw std::runtime_error(
+            "snapshot recovery did not preserve remote origin progress");
+    }
+
+    sync::DirectSyncPeer remote_origin_peer(&remote_origin);
+    sync::SyncWorkerOptions incremental_options;
+    incremental_options.max_bytes = 8192u;
+    incremental_options.max_single_batch_bytes = 8192u;
+    sync::SyncWorker incremental_worker(
+        replica, remote_origin_peer, incremental_options);
+    const sync::SyncWorkerRoundResult incremental_result =
+        incremental_worker.run_once();
+    if (!incremental_result.ok || incremental_result.batches_applied != 1u ||
+        replica.applied_cursor().last_seq_for(remote_origin_node) != 2u) {
+        throw std::runtime_error(
+            "incremental remote origin delivery failed after snapshot recovery");
+    }
+
+    snapshot_source_conn->disconnect();
+    remote_origin_conn->disconnect();
+    replica_conn->disconnect();
+    cleanup(snapshot_source_path);
+    cleanup(remote_origin_path);
+    cleanup(replica_path);
+}
+
 } // namespace
 
 int main() {
@@ -2680,6 +2786,8 @@ int main() {
     const Case cases[] = {
         { "test_worker_recovers_fresh_replica_with_full_snapshot",
           &test_worker_recovers_fresh_replica_with_full_snapshot },
+        { "test_worker_snapshot_recovery_preserves_remote_origin_cursor",
+          &test_worker_snapshot_recovery_preserves_remote_origin_cursor },
         { "test_worker_run_once_drains_paginated_pull",
           &test_worker_run_once_drains_paginated_pull },
         { "test_worker_start_stop_idle", &test_worker_start_stop_idle },

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -2864,12 +2864,29 @@ void test_worker_rejects_logical_complete_snapshot_fallback() {
     sync::SyncEngine source(
         source_conn, sync::ConflictPolicy::Reject, snapshot_options);
     source.initialize_local_identity(source_node, db_id);
-    sync::LogicalSchemaRecord record;
-    record.dbi_name = "documents";
-    record.kind = sync::LogicalTableKind::KeyValue;
-    record.schema_version = 1u;
-    record.dbi_names.push_back("documents");
-    source.register_logical_schema("app.worker_snapshot.logical.v1", record);
+    KeyValueTable<std::string, std::string> documents(
+        source_conn, "documents");
+    documents.insert_or_assign("document", "raw-value");
+    sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = db_id;
+    envelope.origin_node_id = make_node(0xCD);
+    envelope.origin_sequence = 1u;
+    envelope.frame_id = "worker-empty-ordered-frame";
+    const sync::LogicalDeliveryAcknowledgement acknowledgement =
+        source.apply_ordered_logical_delivery_envelope(envelope);
+    if (!acknowledgement.ok ||
+        acknowledgement.acknowledged_through != 1u) {
+        throw std::runtime_error(
+            "failed to prepare worker empty ordered logical state");
+    }
+    {
+        auto txn = source_conn->transaction(TransactionMode::READ_ONLY);
+        sync::SchemaRegistryStore schemas(source_conn->env_handle());
+        if (schemas.has_entries(txn.handle())) {
+            throw std::runtime_error(
+                "worker empty ordered frame unexpectedly registered a schema");
+        }
+    }
     {
         auto txn = source_conn->transaction(TransactionMode::WRITABLE);
         sync::ChangeLogStore changelog(source_conn->env_handle());

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -2604,9 +2604,8 @@ void test_worker_recovers_fresh_replica_with_full_snapshot() {
     const sync::NodeId replica_node = make_node(0xB9);
     const sync::DbId db_id = make_node(0xD9);
     sync::FullSnapshotExportOptions snapshot_options;
-    sync::FullSnapshotManifestEntry entry;
-    entry.dbi_name = "documents";
-    snapshot_options.manifest.push_back(entry);
+    snapshot_options.replacement_scope =
+        sync::FullSnapshotScope::CompleteUserDatabase;
     snapshot_options.max_materialized_operations = 16u;
     snapshot_options.max_materialized_bytes = 4096u;
 
@@ -2690,9 +2689,8 @@ void test_worker_snapshot_recovery_preserves_remote_origin_cursor() {
     const sync::NodeId replica_node = make_node(0xCA);
     const sync::DbId db_id = make_node(0xDA);
     sync::FullSnapshotExportOptions snapshot_options;
-    sync::FullSnapshotManifestEntry entry;
-    entry.dbi_name = "documents";
-    snapshot_options.manifest.push_back(entry);
+    snapshot_options.replacement_scope =
+        sync::FullSnapshotScope::CompleteUserDatabase;
     snapshot_options.max_materialized_operations = 16u;
     snapshot_options.max_materialized_bytes = 4096u;
 
@@ -2779,6 +2777,73 @@ void test_worker_snapshot_recovery_preserves_remote_origin_cursor() {
     cleanup(replica_path);
 }
 
+void test_worker_rejects_manifest_only_snapshot_fallback() {
+    using namespace mdbxc;
+    const std::string source_path = "test_worker_manifest_only_source.mdbx";
+    const std::string replica_path = "test_worker_manifest_only_replica.mdbx";
+    cleanup(source_path);
+    cleanup(replica_path);
+
+    const sync::NodeId source_node = make_node(0xAB);
+    const sync::NodeId replica_node = make_node(0xBB);
+    const sync::DbId db_id = make_node(0xDB);
+    sync::FullSnapshotExportOptions snapshot_options;
+    sync::FullSnapshotManifestEntry entry;
+    entry.dbi_name = "documents";
+    snapshot_options.manifest.push_back(entry);
+    snapshot_options.max_materialized_operations = 16u;
+    snapshot_options.max_materialized_bytes = 4096u;
+
+    std::shared_ptr<Connection> source_conn = open_env(source_path);
+    sync::SyncEngine source(
+        source_conn, sync::ConflictPolicy::Reject, snapshot_options);
+    source.initialize_local_identity(source_node, db_id);
+    KeyValueTable<std::string, std::string> documents(source_conn, "documents");
+    documents.insert_or_assign("document", "value");
+    {
+        auto txn = source_conn->transaction(TransactionMode::WRITABLE);
+        sync::ChangeLogStore changelog(source_conn->env_handle());
+        changelog.open(txn.handle());
+        const std::vector<std::uint8_t> encoded =
+            sync::ChangeBatchCodec::encode(
+                make_raw_batch(source_node, 3u, "documents", 0x51u));
+        changelog.append(txn.handle(), source_node, 3u, encoded);
+        txn.commit();
+    }
+
+    std::shared_ptr<Connection> replica_conn = open_env(replica_path);
+    sync::SyncEngine replica(replica_conn);
+    replica.initialize_local_identity(replica_node, db_id);
+    sync::DirectSyncPeer peer(&source);
+    sync::SyncWorkerOptions options;
+    options.enable_full_snapshot_fallback = true;
+    options.max_bytes = 8192u;
+    options.max_single_batch_bytes = 8192u;
+    sync::SyncWorker worker(replica, peer, options);
+    const sync::SyncWorkerRoundResult result = worker.run_once();
+    if (result.ok ||
+        result.sync_error_code != sync::SyncResponseErrorCode::SnapshotSessionInvalid ||
+        replica.applied_cursor().last_seq_for(source_node) != 0u) {
+        throw std::runtime_error(
+            "worker accepted ManifestOnly snapshot fallback");
+    }
+    {
+        auto txn = replica_conn->transaction(TransactionMode::READ_ONLY);
+        MDBX_dbi dbi = 0;
+        const int rc = mdbx_dbi_open(
+            txn.handle(), "documents", static_cast<MDBX_db_flags_t>(0), &dbi);
+        if (rc != MDBX_NOTFOUND) {
+            throw std::runtime_error(
+                "ManifestOnly worker fallback changed destination DBI");
+        }
+    }
+
+    source_conn->disconnect();
+    replica_conn->disconnect();
+    cleanup(source_path);
+    cleanup(replica_path);
+}
+
 } // namespace
 
 int main() {
@@ -2788,6 +2853,8 @@ int main() {
           &test_worker_recovers_fresh_replica_with_full_snapshot },
         { "test_worker_snapshot_recovery_preserves_remote_origin_cursor",
           &test_worker_snapshot_recovery_preserves_remote_origin_cursor },
+        { "test_worker_rejects_manifest_only_snapshot_fallback",
+          &test_worker_rejects_manifest_only_snapshot_fallback },
         { "test_worker_run_once_drains_paginated_pull",
           &test_worker_run_once_drains_paginated_pull },
         { "test_worker_start_stop_idle", &test_worker_start_stop_idle },

--- a/tests/test_transport_codec.cpp
+++ b/tests/test_transport_codec.cpp
@@ -417,6 +417,25 @@ void test_response_error_code_rejections() {
     });
 }
 
+void test_logical_snapshot_error_roundtrip() {
+    using namespace mdbxc::sync;
+    PullResponse response;
+    response.ok = false;
+    response.error = "logical snapshot state is unsupported";
+    response.error_code =
+        SyncResponseErrorCode::SnapshotLogicalStateUnsupported;
+
+    const std::vector<std::uint8_t> bytes =
+        TransportMessageCodec::encode_pull_response(response);
+    const PullResponse decoded =
+        TransportMessageCodec::decode_pull_response(bytes);
+    require_true(decoded.error_code ==
+                     SyncResponseErrorCode::SnapshotLogicalStateUnsupported,
+                 "logical snapshot error code mismatch");
+    require_true(!decoded.error_retryable,
+                 "logical snapshot error unexpectedly retryable");
+}
+
 void test_golden_header_shape() {
     using namespace mdbxc::sync;
     const std::vector<std::uint8_t> bytes =
@@ -448,6 +467,7 @@ int main() {
     test_message_header_rejections();
     test_bounds_rejections();
     test_response_error_code_rejections();
+    test_logical_snapshot_error_roundtrip();
     test_golden_header_shape();
     return 0;
 }


### PR DESCRIPTION
Integrate the already reviewed full snapshot stack after sequential stacked merges.\n\nIncluded reviewed PRs: #284, #285, and #286, on top of #283 already merged into main.\n\nThe final cumulative head is 278e76553defad3ce997b3cc12e69eecd74ded0f. No new functional scope is introduced by this integration PR.