### PR TITLE
fix(build): retain MDBX TLS directory on MinGW

### DIFF
--- a/cmake/deps/mdbx.cmake
+++ b/cmake/deps/mdbx.cmake
@@ -208,6 +208,11 @@ function(_mdbx_try_submodule out_ok)
 
         # Upstream usually exposes mdbx-static (or mdbx)
         if(TARGET mdbx-static)
+            if(MINGW AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+                # Keep the PE TLS directory required by libmdbx's callback.
+                target_link_options(mdbx-static INTERFACE
+                    "-Wl,--undefined=_tls_used")
+            endif()
             _mdbx_make_aliases("" "mdbx-static")
             if(NOT TARGET mdbx::mdbx)
                 # canonical shared alias points to static in bundled builds
@@ -245,6 +250,11 @@ function(_mdbx_try_fetchcontent out_ok)
     FetchContent_MakeAvailable(libmdbx)
 
     if(TARGET mdbx-static)
+        if(MINGW AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+            # Keep the PE TLS directory required by libmdbx's callback.
+            target_link_options(mdbx-static INTERFACE
+                "-Wl,--undefined=_tls_used")
+        endif()
         _mdbx_make_aliases("" "mdbx-static")
         if(NOT TARGET mdbx::mdbx)
             add_library(mdbx::mdbx ALIAS mdbx-static)


### PR DESCRIPTION
## Summary
- force-link MinGW's _tls_used symbol for bundled static libmdbx
- apply the flag only to 64-bit MinGW bundled paths (submodule and FetchContent)

## Root cause
Recent mingw-w64 CRT versions no longer emit a PE TLS directory for executables without an explicit TLS dependency. libmdbx's static-build callback lives in .CRT, but Windows invokes that callback only through the PE TLS directory. Linking _tls_used pulls in MinGW's TLS directory support so mdbx_module_handler() initializes the MDBX runtime.

## Validation
- MinGW GCC 15.2.0, C++11: mdbx_test and upstream c_api passed
- MinGW GCC 15.2.0, C++17: mdbx_test and upstream c_api passed
- verified generated MinGW link commands contain -Wl,--undefined=_tls_used`n
## Scope
This is a CI/build experiment for the Windows MinGW failure tracked in #291. It does not add a waiver, change MSVC support, or affect system MDBX targets.