### PR TITLE
test(ci): validate library-side MinGW TLS fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "external/libmdbx"]
 	path = external/libmdbx
-	url = https://github.com/erthink/libmdbx.git
+	url = https://github.com/LimiNode/libmdbx.git
 [submodule ".github/doxygen-awesome-css"]
 	path = .github/doxygen-awesome-css
 	url = https://github.com/jothepro/doxygen-awesome-css.git

--- a/cmake/deps/mdbx.cmake
+++ b/cmake/deps/mdbx.cmake
@@ -208,6 +208,11 @@ function(_mdbx_try_submodule out_ok)
 
         # Upstream usually exposes mdbx-static (or mdbx)
         if(TARGET mdbx-static)
+            if(MINGW AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+                # Keep the PE TLS directory required by libmdbx's callback.
+                target_link_options(mdbx-static INTERFACE
+                    "-Wl,--undefined=_tls_used")
+            endif()
             _mdbx_make_aliases("" "mdbx-static")
             if(NOT TARGET mdbx::mdbx)
                 # canonical shared alias points to static in bundled builds
@@ -245,6 +250,11 @@ function(_mdbx_try_fetchcontent out_ok)
     FetchContent_MakeAvailable(libmdbx)
 
     if(TARGET mdbx-static)
+        if(MINGW AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+            # Keep the PE TLS directory required by libmdbx's callback.
+            target_link_options(mdbx-static INTERFACE
+                "-Wl,--undefined=_tls_used")
+        endif()
         _mdbx_make_aliases("" "mdbx-static")
         if(NOT TARGET mdbx::mdbx)
             add_library(mdbx::mdbx ALIAS mdbx-static)

--- a/cmake/deps/mdbx.cmake
+++ b/cmake/deps/mdbx.cmake
@@ -208,11 +208,6 @@ function(_mdbx_try_submodule out_ok)
 
         # Upstream usually exposes mdbx-static (or mdbx)
         if(TARGET mdbx-static)
-            if(MINGW AND CMAKE_SIZEOF_VOID_P EQUAL 8)
-                # Keep the PE TLS directory required by libmdbx's callback.
-                target_link_options(mdbx-static INTERFACE
-                    "-Wl,--undefined=_tls_used")
-            endif()
             _mdbx_make_aliases("" "mdbx-static")
             if(NOT TARGET mdbx::mdbx)
                 # canonical shared alias points to static in bundled builds
@@ -250,11 +245,6 @@ function(_mdbx_try_fetchcontent out_ok)
     FetchContent_MakeAvailable(libmdbx)
 
     if(TARGET mdbx-static)
-        if(MINGW AND CMAKE_SIZEOF_VOID_P EQUAL 8)
-            # Keep the PE TLS directory required by libmdbx's callback.
-            target_link_options(mdbx-static INTERFACE
-                "-Wl,--undefined=_tls_used")
-        endif()
         _mdbx_make_aliases("" "mdbx-static")
         if(NOT TARGET mdbx::mdbx)
             add_library(mdbx::mdbx ALIAS mdbx-static)


### PR DESCRIPTION
## Purpose
Disposable A/B validation of the library-side libmdbx TLS fix without the mdbx-containers consumer workaround.

## Change
- use the exact v0.13.12 backport LimiNode/libmdbx@021de41 as the bundled submodule
- remove -Wl,--undefined=_tls_used from mdbx-containers

## Why this is isolated
MDBXC_DEPS_MODE=BUNDLED resolves external/libmdbx before FetchContent, so the submodule URL and gitlink are changed only in this validation branch. PR #293 remains unchanged as the production workaround candidate.

## Acceptance criterion
The full 19-job mdbx-containers matrix must pass on the existing MSYS2 MinGW image, including Windows C++11/C++17 and both transport fallback jobs, without a consumer-side linker option.

## Local validation
MinGW GCC 15.2.0 with C++11 and C++17: mdbx_test and upstream c_api passed. Generated link commands did not contain _tls_used.

Do not merge this PR; it is evidence for the upstream fix.