### PR TITLE
[codex] Deliver logical outbox through sync peers

### DIFF
--- a/docs/sync-RU.md
+++ b/docs/sync-RU.md
@@ -18,13 +18,15 @@ English version: [sync.md](sync.md).
 | --- | --- | --- |
 | Реплицировать обычные записи таблиц между копиями БД | Raw-репликация | `ThreadLocalChangeAccumulator`, `SyncCaptureScope`, `SyncWorker`, `ISyncPeer` |
 | Реплицировать таблицу через явную типизированную схему приложения | Logical frames | Logical adapter таблицы, `LogicalChangeFrameCodec`, `SyncEngine::apply_logical_frame_bytes()` |
-| Сохранить одну авторитетную упорядоченную историю и безопасно повторять её доставку | Ordered logical delivery | Logical adapter `KeyOrderedMultiValueTable`, durable outbox, `SyncEngine::apply_ordered_logical_delivery_envelope()` |
+| Сохранить одну авторитетную упорядоченную историю и безопасно повторять её доставку | Ordered logical delivery | Durable outbox, logical-capable `ISyncPeer`, `SyncWorkerOptions::enable_logical_delivery` |
 | Восстановить свежую raw-реплику после удаления нужной истории из changelog | Full snapshot recovery | `SyncWorkerOptions::enable_full_snapshot_fallback`, `CompleteUserDatabase` |
 
 Эти режимы намеренно разделены. Обычный pull/push transport protocol несёт
-только raw DBI operations. Logical frames и ordered delivery доставляются
-приложением; они не преобразуются молча в raw операции и не попадают в обычный
-`ChangeBatch`.
+только raw DBI operations. Ordered logical delivery использует отдельный
+capability-negotiated protocol и явно включается в `SyncWorker`; он не
+преобразуется молча в raw операции и не попадает в обычный `ChangeBatch`.
+Direct logical frames остаются application-delivered, когда routing, порядок и
+retry policy принадлежат самому приложению.
 
 ## Основные понятия
 
@@ -50,7 +52,7 @@ flowchart LR
     Capture --> RawLog[_mdbxc_changelog]
     Capture --> Outbox[Ordered logical outbox]
     RawLog --> Peer[ISyncPeer или transport binding]
-    Outbox --> LogicalTransport[Протокол доставки приложения]
+    Outbox --> LogicalTransport[Logical-capable peer]
     Peer --> EngineB[SyncEngine на B]
     LogicalTransport --> EngineB
     EngineB --> UserDb[Пользовательские DBI]
@@ -58,9 +60,10 @@ flowchart LR
 ```
 
 Две стрелки в `EngineB` означают разные admission paths. Raw-страница идёт
-через `handle_push()`. Logical frame использует явный logical apply method; у
-ordered envelope дополнительно проверяются destination, порядок origin, replay
-state и persistent schema marker.
+через `handle_push()`. Direct logical frame использует явный logical apply
+method. Ordered envelope проходит через logical peer protocol; дополнительно
+проверяются destination, порядок origin, replay state и persistent schema
+marker.
 
 ## Raw-репликация
 
@@ -122,6 +125,24 @@ last-writer-wins policy для конкурентных изменений пр�
 `DirectSyncPeer` - in-process peer для вводных примеров. Framework-neutral
 HTTP- и WebSocket-seams используют `TransportMessageCodec`; опциональные
 Simple-Web и Kurlyk bindings дают concrete transport, не меняя core messages.
+
+### Упорядоченная логическая доставка
+
+`ISyncPeer` также имеет optional logical-delivery capability. Его реализуют
+`DirectSyncPeer`, `HttpSyncPeer` и `WebSocketSyncPeer`. HTTP использует
+отдельные logical hello и delivery routes; WebSocket определяет logical
+protocol по собственному magic. Ни `TransportMessageCodec`, ни raw pull/push
+wire layout при этом не меняются.
+
+Установите `SyncWorkerOptions::enable_logical_delivery = true`, чтобы worker
+после полного raw pull round отправлял durable outbox local engine. В качестве
+logical destination используется текущий replication `DbId`; worker
+согласует ordered delivery и cumulative acknowledgements и удаляет только
+acknowledged outbox prefix. `max_logical_deliveries` при необходимости
+ограничивает один round; ноль означает отправить весь pending prefix. Raw-only
+peer допускается, пока outbox пуст, но при pending delivery round завершается
+ошибкой без удаления queued frames. Retryable acknowledgement failure также
+сохраняет unacknowledged suffix для следующего round.
 
 Transport authentication, TLS, remote-address policy, rate limiting, request
 id и HTTP/WebSocket status mapping остаются на стороне adapter. Они намеренно

--- a/docs/sync-logical-RU.md
+++ b/docs/sync-logical-RU.md
@@ -94,6 +94,24 @@ origin отклоняется до table mutation. Sender outbox позволя�
 повторить доставку после process или transport failure, не теряя local ordered
 history, закоммиченную вместе с envelope.
 
+Каждая упорядоченная отправка адресуется ровно одному узлу-получателю. Wire
+`DeliveryRequest` связывает этот receiver id с envelope, а получатель проверяет
+его до replay, frontier и работы adapter'а; acknowledgement повторяет
+фактический receiver id. HTTP и WebSocket принимают для упорядоченной доставки
+только такой receiver-bound request. Устаревшее envelope-only сообщение
+`Delivery` не является сетевым маршрутом упорядоченной доставки.
+
+В v0.1 один capture/session commit атомарно публикует envelope для одного
+получателя. Atomic fan-out на несколько получателей и peer registry отложены.
+Outbox entries всегда укладываются в library-default codec bounds, поэтому
+поздний worker декодирует их без caller-specific bounds.
+
+`origin_sequence` идентифицирует одно logical event для его origin и database;
+он не выделяется заново для другого receiver. Pending delivery и
+acknowledgement state остаются receiver-specific. Перед переносом v0.1 route
+на новую replica восстановите её из текущего receiver, чтобы она импортировала
+origin frontier. Иначе первая новая доставка будет отклонена как sequence gap.
+
 Для `DirectSyncPeer`, `HttpSyncPeer` и `WebSocketSyncPeer` этот dispatcher может
 предоставить optional logical-delivery pass worker'а. Он запускается только при
 `SyncWorkerOptions::enable_logical_delivery = true`, только после полного raw

--- a/docs/sync-logical-RU.md
+++ b/docs/sync-logical-RU.md
@@ -19,8 +19,10 @@ raw `PullRequest` / `PushRequest` wire path.
 4. Выполняйте записи source через typed capture session adapter'а. Успешный
    session commit публикует logical changes только после успешной local table
    mutation.
-5. Доставляйте `LogicalChangeFrame` через application protocol либо ordered
-   delivery envelope, когда он нужен adapter'у.
+5. Доставляйте `LogicalChangeFrame` через application protocol либо коммитьте
+   ordered envelope в durable outbox через `commit_to_outbox()`.
+   `SyncWorkerOptions::enable_logical_delivery` отправляет второй вариант через
+   logical-capable peer после полного raw pull round.
 6. Применяйте изменения на destination соответствующим методом `SyncEngine`.
    Marker validation и adapter preflight происходят до mutation adapter'а;
    ошибки откатывают engine-owned transaction.
@@ -29,13 +31,13 @@ raw `PullRequest` / `PushRequest` wire path.
 sequenceDiagram
     participant S as Source adapter session
     participant Schema as _mdbxc_sync_schema
-    participant Wire as Доставка приложения
+    participant Wire as Application delivery или logical peer
     participant E as Receiver SyncEngine
     participant A as Receiver adapter
 
     S->>Schema: проверка registered schema
     S->>S: mutation local table и сбор typed changes
-    S-->>Wire: LogicalChangeFrame или delivery envelope
+    S-->>Wire: LogicalChangeFrame или durable delivery envelope
     Wire->>E: явный apply call
     E->>Schema: проверка persistent marker
     E->>A: preflight каждого change
@@ -74,7 +76,7 @@ origin.
 sequenceDiagram
     participant O as Authoritative origin
     participant Outbox as Durable ordered outbox
-    participant D as Application dispatcher
+    participant D as SyncWorker или application dispatcher
     participant R as Replica SyncEngine
     participant State as Replay marker и frontier
 
@@ -92,6 +94,17 @@ origin отклоняется до table mutation. Sender outbox позволя�
 повторить доставку после process или transport failure, не теряя local ordered
 history, закоммиченную вместе с envelope.
 
+Для `DirectSyncPeer`, `HttpSyncPeer` и `WebSocketSyncPeer` этот dispatcher может
+предоставить optional logical-delivery pass worker'а. Он запускается только при
+`SyncWorkerOptions::enable_logical_delivery = true`, только после полного raw
+pull round и только для текущего `DbId` worker'а. Peer сначала согласует ordered
+delivery и cumulative acknowledgement. Каждый acknowledged prefix durably
+удаляется из sender outbox; unsupported peer, sequence gap или retryable
+acknowledgement failure сохраняют unacknowledged suffix в очереди.
+`max_logical_deliveries` ограничивает round при необходимости, а ноль отправляет
+весь pending prefix. Этот protocol остаётся отдельным от raw `PullRequest` /
+`PushRequest`.
+
 Смена authoritative origin - application-coordinated cutover. Приложение
 должно остановить старый capture, доставить старый outbox, сохранить replay
 state на свой retry horizon, мигрировать marker на всех участниках и только
@@ -102,10 +115,10 @@ state на свой retry horizon, мигрировать marker на всех �
 
 | Adapter | Реализованный typed contract | Граница |
 | --- | --- | --- |
-| `KeyValueTableLogicalAdapter` | Явный typed capture и apply. | Application владеет frame delivery. |
-| `KeyTableLogicalAdapter` | Явный typed capture и apply. | Application владеет frame delivery. |
-| `VectorStoreLogicalAdapter` | Schema v1 add, erase и clear по DBI ids, embeddings, text и metadata. Explicit IDs проверяются до mutation. | Один authoritative либо externally serialized writer на коллекцию. |
-| `KeyMultiValueTableLogicalAdapter` | v1: insert, version-neutral batch `append()`, key erase, all-matching-value erase, clear. v2 добавляет exact-one erase и `reconcile()`. v3 добавляет bounded typed `erase_range()`, разложенный в точные key erasures. | Unordered multiset semantics; один writer либо causally serialized destructive updates. |
+| `KeyValueTableLogicalAdapter` | Явный typed capture и apply; `commit_to_outbox()` атомарно публикует ordered envelope. | Direct frames остаются manual; ordered outbox delivery требует capable peer. |
+| `KeyTableLogicalAdapter` | Явный typed capture и apply; `commit_to_outbox()` атомарно публикует ordered envelope. | Direct frames остаются manual; ordered outbox delivery требует capable peer. |
+| `VectorStoreLogicalAdapter` | Schema v1 add, erase и clear по DBI ids, embeddings, text и metadata. Explicit IDs проверяются до mutation; `commit_to_outbox()` атомарен. | Один authoritative либо externally serialized writer на коллекцию. |
+| `KeyMultiValueTableLogicalAdapter` | v1: insert, version-neutral batch `append()`, key erase, all-matching-value erase, clear. v2 добавляет exact-one erase и `reconcile()`. v3 добавляет bounded typed `erase_range()`, разложенный в точные key erasures. `commit_to_outbox()` атомарен. | Unordered multiset semantics; один writer либо causally serialized destructive updates. |
 | `KeyOrderedMultiValueTableLogicalAdapter` | v1 append-only ordered delivery. | Один authoritative origin. |
 | `KeyOrderedMultiValueTableDestructiveLogicalAdapter` | v2 exact append/erase по persistent element ID, bounded selector erasure, clear и single-origin `replace_with()`. | Один authoritative origin; baseline import, multi-origin history и tombstone compaction отложены. |
 

--- a/docs/sync-logical.md
+++ b/docs/sync-logical.md
@@ -94,6 +94,24 @@ mismatched origin is rejected before table mutation. The sender outbox lets an
 application retry delivery after process or transport failure without losing
 the local ordered history that was committed with the envelope.
 
+Each ordered dispatch targets exactly one receiver node. The wire
+`DeliveryRequest` binds that receiver id to the envelope, and the receiver
+checks it before replay, frontier, or adapter work; its acknowledgement repeats
+the actual receiver id. HTTP and WebSocket accept only this receiver-bound
+request for ordered delivery. The legacy envelope-only `Delivery` message is
+not an ordered network-delivery route.
+
+In v0.1, one capture/session commit atomically publishes an envelope for one
+receiver. Atomic fan-out to several receivers and a peer registry are deferred.
+Outbox entries always fit the library-default codec bounds, so a later worker
+can decode them without inheriting caller-specific bounds.
+
+`origin_sequence` identifies one logical event for its origin and database; it
+is not reallocated for another receiver. Pending delivery and acknowledgement
+state remain receiver-specific. Before moving the v0.1 receiver route, recover
+the new replica from the current receiver so it imports the origin frontier.
+Otherwise its first new delivery is rejected as a sequence gap.
+
 For `DirectSyncPeer`, `HttpSyncPeer`, and `WebSocketSyncPeer`, the optional
 worker logical-delivery pass supplies this dispatcher. It runs only when
 `SyncWorkerOptions::enable_logical_delivery` is true, only after raw pull pages

--- a/docs/sync-logical.md
+++ b/docs/sync-logical.md
@@ -19,8 +19,10 @@ Read [Sync Replication](sync.md) first. Russian version:
 4. Perform source writes through the adapter's typed capture session. A
    successful session commit publishes logical changes only after the local
    table mutation succeeds.
-5. Deliver either a `LogicalChangeFrame` through an application protocol or an
-   ordered delivery envelope when the adapter requires it.
+5. Deliver a `LogicalChangeFrame` through an application protocol, or commit an
+   ordered envelope to the durable outbox with `commit_to_outbox()`.
+   `SyncWorkerOptions::enable_logical_delivery` dispatches the latter through a
+   logical-capable peer after raw pull pages are drained.
 6. Apply on the destination through the matching `SyncEngine` method. Marker
    validation and adapter preflight happen before adapter mutation; failures
    roll back the engine-owned transaction.
@@ -29,13 +31,13 @@ Read [Sync Replication](sync.md) first. Russian version:
 sequenceDiagram
     participant S as Source adapter session
     participant Schema as _mdbxc_sync_schema
-    participant Wire as Application delivery
+    participant Wire as Application delivery or logical peer
     participant E as Receiver SyncEngine
     participant A as Receiver adapter
 
     S->>Schema: verify registered schema
     S->>S: mutate local table and collect typed changes
-    S-->>Wire: LogicalChangeFrame or delivery envelope
+    S-->>Wire: LogicalChangeFrame or durable delivery envelope
     Wire->>E: explicit apply call
     E->>Schema: verify persistent marker
     E->>A: preflight every change
@@ -74,7 +76,7 @@ rejected. The schema marker names one non-zero authoritative origin.
 sequenceDiagram
     participant O as Authoritative origin
     participant Outbox as Durable ordered outbox
-    participant D as Application dispatcher
+    participant D as SyncWorker or application dispatcher
     participant R as Replica SyncEngine
     participant State as Replay marker and frontier
 
@@ -92,6 +94,16 @@ mismatched origin is rejected before table mutation. The sender outbox lets an
 application retry delivery after process or transport failure without losing
 the local ordered history that was committed with the envelope.
 
+For `DirectSyncPeer`, `HttpSyncPeer`, and `WebSocketSyncPeer`, the optional
+worker logical-delivery pass supplies this dispatcher. It runs only when
+`SyncWorkerOptions::enable_logical_delivery` is true, only after raw pull pages
+are drained, and only for the worker's current `DbId`. The peer first negotiates
+ordered delivery and cumulative acknowledgement. Each acknowledged prefix is
+removed durably from the sender outbox; an unsupported peer, sequence gap, or
+retryable acknowledgement failure leaves the unacknowledged suffix queued.
+`max_logical_deliveries` can bound a round, while zero drains the pending
+prefix. This remains a separate protocol from raw `PullRequest` / `PushRequest`.
+
 Changing the authoritative origin is an application-coordinated cutover. The
 application must quiesce old capture, drain the old outbox, retain replay state
 through its retry horizon, migrate the marker on every participant, and only
@@ -102,10 +114,10 @@ two origins concurrently valid for one ordered dataset.
 
 | Adapter | Implemented typed contract | Boundary |
 | --- | --- | --- |
-| `KeyValueTableLogicalAdapter` | Explicit typed capture and apply. | Application owns frame delivery. |
-| `KeyTableLogicalAdapter` | Explicit typed capture and apply. | Application owns frame delivery. |
-| `VectorStoreLogicalAdapter` | Schema v1 add, erase, and clear across ids, embeddings, text, and metadata DBIs. Explicit IDs are validated before mutation. | One authoritative or externally serialized writer per collection. |
-| `KeyMultiValueTableLogicalAdapter` | v1: insert, version-neutral batch `append()`, key erase, all-matching-value erase, clear. v2 adds exact-one erase and `reconcile()`. v3 adds bounded typed `erase_range()` expanded into exact key erasures. | Unordered multiset semantics; one writer or causally serialized destructive updates. |
+| `KeyValueTableLogicalAdapter` | Explicit typed capture and apply; `commit_to_outbox()` atomically publishes its ordered envelope. | Direct frames remain manual; ordered outbox delivery needs a capable peer. |
+| `KeyTableLogicalAdapter` | Explicit typed capture and apply; `commit_to_outbox()` atomically publishes its ordered envelope. | Direct frames remain manual; ordered outbox delivery needs a capable peer. |
+| `VectorStoreLogicalAdapter` | Schema v1 add, erase, and clear across ids, embeddings, text, and metadata DBIs. Explicit IDs are validated before mutation; `commit_to_outbox()` is atomic. | One authoritative or externally serialized writer per collection. |
+| `KeyMultiValueTableLogicalAdapter` | v1: insert, version-neutral batch `append()`, key erase, all-matching-value erase, clear. v2 adds exact-one erase and `reconcile()`. v3 adds bounded typed `erase_range()` expanded into exact key erasures. `commit_to_outbox()` is atomic. | Unordered multiset semantics; one writer or causally serialized destructive updates. |
 | `KeyOrderedMultiValueTableLogicalAdapter` | v1 append-only ordered delivery. | One authoritative origin. |
 | `KeyOrderedMultiValueTableDestructiveLogicalAdapter` | v2 exact append/erase by persistent element ID, bounded selector erasure, clear, and single-origin `replace_with()`. | One authoritative origin; baseline import, multi-origin history, and tombstone compaction are deferred. |
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -17,13 +17,15 @@ Russian version: [sync-RU.md](sync-RU.md).
 | --- | --- | --- |
 | Replicate ordinary table writes between database copies | Raw replication | `ThreadLocalChangeAccumulator`, `SyncCaptureScope`, `SyncWorker`, `ISyncPeer` |
 | Replicate a table through an explicit typed application schema | Logical frames | A table logical adapter, `LogicalChangeFrameCodec`, `SyncEngine::apply_logical_frame_bytes()` |
-| Preserve one authoritative ordered history and retry its delivery safely | Ordered logical delivery | `KeyOrderedMultiValueTable` logical adapter, durable outbox, `SyncEngine::apply_ordered_logical_delivery_envelope()` |
+| Preserve one authoritative ordered history and retry its delivery safely | Ordered logical delivery | Durable outbox, logical-capable `ISyncPeer`, `SyncWorkerOptions::enable_logical_delivery` |
 | Rebuild a fresh raw replica after changelog retention removed needed history | Full snapshot recovery | `SyncWorkerOptions::enable_full_snapshot_fallback`, `CompleteUserDatabase` |
 
 These modes are deliberately separate. The normal pull/push transport protocol
-carries raw DBI operations only. Logical frames and ordered delivery are
-application-delivered protocols; they are not silently converted to raw
-operations or inserted into a normal `ChangeBatch`.
+carries raw DBI operations only. Ordered logical delivery uses a separate
+capability-negotiated protocol and is enabled explicitly on `SyncWorker`; it is
+not silently converted to raw operations or inserted into a normal
+`ChangeBatch`. Direct logical frames remain application-delivered when the
+application owns routing, ordering, and retries itself.
 
 ## Concepts
 
@@ -46,7 +48,7 @@ flowchart LR
     Capture --> RawLog[_mdbxc_changelog]
     Capture --> Outbox[Ordered logical outbox]
     RawLog --> Peer[ISyncPeer or transport binding]
-    Outbox --> LogicalTransport[Application delivery protocol]
+    Outbox --> LogicalTransport[Logical-capable peer]
     Peer --> EngineB[SyncEngine on B]
     LogicalTransport --> EngineB
     EngineB --> UserDb[User DBIs]
@@ -54,9 +56,10 @@ flowchart LR
 ```
 
 The two arrows into `EngineB` represent different admission paths. A raw page
-uses `handle_push()`. A logical frame uses an explicit logical apply method;
-an ordered envelope additionally checks destination, origin order, replay
-state, and its persistent schema marker.
+uses `handle_push()`. A direct logical frame uses an explicit logical apply
+method. An ordered envelope travels through the logical peer protocol and
+additionally checks destination, origin order, replay state, and its persistent
+schema marker.
 
 ## Raw Replication
 
@@ -118,6 +121,24 @@ writes to the same logical data.
 Framework-neutral HTTP and WebSocket seams use `TransportMessageCodec`; the
 optional Simple-Web and Kurlyk bindings supply concrete transports without
 changing core messages.
+
+### Ordered Logical Delivery
+
+`ISyncPeer` also exposes an optional logical-delivery capability. `DirectSyncPeer`,
+`HttpSyncPeer`, and `WebSocketSyncPeer` implement it. HTTP uses dedicated
+logical hello and delivery routes; WebSocket distinguishes the logical protocol
+by its own magic. Neither transport changes `TransportMessageCodec` or the raw
+pull/push wire layout.
+
+Set `SyncWorkerOptions::enable_logical_delivery = true` to dispatch the local
+engine's durable outbox after a round has drained raw pull pages. The worker
+uses the current replication `DbId` as the logical destination, negotiates
+ordered delivery and cumulative acknowledgements, and removes only the
+acknowledged outbox prefix. `max_logical_deliveries` optionally bounds one
+round; zero drains the pending prefix. A raw-only peer is accepted while the
+outbox is empty, but produces a failed round without deleting queued frames
+when delivery is pending. Retryable acknowledgement failures likewise retain
+the unacknowledged suffix for the next round.
 
 Transport authentication, TLS, remote-address policy, rate limiting, request
 ids, and HTTP/WebSocket status mapping are adapter-local. They are intentionally

--- a/guides/sync-table-coverage.md
+++ b/guides/sync-table-coverage.md
@@ -3,14 +3,15 @@
 This document is the source-of-truth matrix for sync v0.1 table coverage. It
 describes which public table wrappers emit `ChangeOp` records when a
 `ThreadLocalChangeAccumulator` is attached to the writing `Connection`, and
-which wrappers intentionally stay outside sync until their wire format and
-round-trip semantics are defined.
+which wrappers intentionally stay outside raw capture until their wire format
+and round-trip semantics are defined.
 
 The Sync v0.1 transport path replicates raw physical DBI operations. It does
 not deserialize table values during transport, and remote apply replays the
 captured physical `storage_key` / `value` bytes through
-`SyncEngine::handle_push()`. Explicit logical adapters are caller-delivered
-apply paths and are documented separately below.
+`SyncEngine::handle_push()`. Explicit logical adapters have their own ordered
+delivery protocol and durable outbox; `SyncWorkerOptions::enable_logical_delivery`
+can dispatch that outbox through a logical-capable peer after a raw round drains.
 
 ## Matrix
 
@@ -20,7 +21,7 @@ apply paths and are documented separately below.
 | `KeyTable<K>` | Supported | `Put`, `Delete`, `ClearTable`; insert, erase, range erase, and clear paths are implemented. | Raw key bytes are replayed with empty values. | `test_sync_capture`, `test_sync_engine`, `test_sync_replication` |
 | `ValueTable<V>` | Supported | `Put`, `Delete`, `ClearTable`; set, insert, update, erase, and clear paths are implemented. | The singleton physical key and serialized value bytes are replayed. | `test_sync_capture`, `test_sync_replication` |
 | `SequenceTable<V>` | Supported | `Put`, `Delete`, `ClearTable`; append, `insert_or_assign`, erase, and clear paths are implemented. | Stable `uint64_t` sequence keys and value bytes are replayed. | `test_sync_capture`, `test_sync_replication` |
-| `VectorStore` | Raw plus limited logical adapter | Raw capture flows through its internal `SequenceTable` and `KeyValueTable` members. The schema-v1 `VectorStoreLogicalAdapter` explicitly captures and applies add, erase, and clear across ids, embeddings, text, and metadata with explicit record ids. Erase retains the ids marker as allocation high-water; clear resets all four DBIs. | Raw apply replays physical member-table operations; logical apply validates the adapter marker, record state, and embedding dimension before mutation. Both paths require one authoritative or externally serialized writer per collection. The logical adapter is opt-in and caller-delivered, not a generic multi-DBI primitive or distributed conflict resolver. | `test_sync_capture`, `test_sync_replication`, `test_vector_store_logical_adapter` |
+| `VectorStore` | Raw plus limited logical adapter | Raw capture flows through its internal `SequenceTable` and `KeyValueTable` members. The schema-v1 `VectorStoreLogicalAdapter` explicitly captures and applies add, erase, and clear across ids, embeddings, text, and metadata with explicit record ids. Erase retains the ids marker as allocation high-water; clear resets all four DBIs. | Raw apply replays physical member-table operations; logical apply validates the adapter marker, record state, and embedding dimension before mutation. `commit_to_outbox()` can publish the logical frame atomically and the worker can deliver it through a capable peer. Both paths require one authoritative or externally serialized writer per collection. The logical adapter is opt-in, not a generic multi-DBI primitive or distributed conflict resolver. | `test_sync_capture`, `test_sync_replication`, `test_vector_store_logical_adapter` |
 | `AnyValueTable<K>` | Deferred | No `ChangeOp` in v0.1. | Not applied by sync as a typed heterogeneous table. | `test_sync_capture` negative coverage |
 | `KeyMultiValueTable<K, V>` | Limited logical adapter | No raw `ChangeOp` in v0.1. | Schema v1 explicitly captures unordered insert, key erase, all-matching-value erase, and clear. Schema v2 additionally captures exact-one erase and typed `reconcile()`. Schema v3 adds bounded typed range erasure, expanded before mutation into canonical `EraseKey` changes; raw calls and general multi-writer destructive convergence remain deferred. | `test_key_value_logical_adapter`, `test_sync_capture` negative coverage |
 | `KeyOrderedMultiValueTable<K, V>` | Limited ordered logical adapters | No raw `ChangeOp` in v0.1. Schema v1 captures append-only changes; schema v2 captures `AppendElement` and exact `EraseElement` by persistent id. | Both schemas require one authoritative ordered origin and fail closed for direct logical frames or unordered delivery. Schema v2 persists element identity and tombstones, and its typed capture atomically commits local mutations plus an ordered outbox envelope. Bounded `erase_at`, key/value erase, and clear resolve selectors to exact ids before mutation; `replace_with()` is also implemented for single-origin schema-v2 capture. The default resolver performs full reverse validation, while an opt-in transaction-bound proof uses a non-reusable session token, bounds its complete materialized ID set, and can reuse that validated set for trusted selector calls with a separate budget. Baseline import, multi-origin histories, and tombstone pruning/compaction remain separately deferred. | `test_key_value_logical_adapter`, `test_key_ordered_multi_value_destructive_state`, `test_key_ordered_multi_value_destructive_adapter` |
@@ -54,8 +55,10 @@ has three separate pieces that must not be treated as support by themselves:
 
 `KeyValueTableLogicalAdapter`, `KeyTableLogicalAdapter`, and
 `VectorStoreLogicalAdapter` are explicit logical apply helpers with opt-in
-typed capture sessions. They are not connected to the transport pull/push
-path; callers own logical frame delivery.
+typed capture sessions. Their `commit_to_outbox()` paths atomically publish a
+logical envelope; a worker with `enable_logical_delivery` sends that envelope
+through the separate capability-gated logical peer protocol. Direct logical
+frames remain caller-delivered and are not placed in raw pull/push messages.
 
 Until a wrapper has a codec extension, a registered adapter, capture tests, and
 round-trip tests, it must remain in the deferred rows below and must not emit
@@ -73,7 +76,7 @@ ids, embeddings, text, and metadata. The opt-in schema-v1
 and clear, with explicit ids and a four-DBI preflight. Both paths support a
 leader/follower topology or an application that serializes writers externally.
 Neither provides a distributed id allocator or cross-node conflict resolution;
-the logical adapter is an application-owned recipe rather than a generic
+the logical adapter is an application-owned schema rather than a generic
 multi-DBI primitive.
 
 For a collection with an existing logical schema marker, reopen through

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -17,8 +17,9 @@ rules, see [Sync table coverage matrix](sync-table-coverage.md).
   `VectorStoreLogicalAdapter` additionally captures and applies add, erase, and
   clear with explicit record ids across the ids, embeddings, text, and metadata
   DBIs. Both modes require one authoritative or externally serialized writer
-  per collection; the logical adapter is not a multi-writer contract and is
-  not connected to the transport pull/push path.
+  per collection; the logical adapter is not a multi-writer contract. Its
+  durable outbox uses the separate capability-gated logical peer protocol, not
+  raw pull/push messages.
 - Standalone writes become standalone sync batches; an explicit transaction
   spanning multiple supported tables becomes one local atomic batch.
 - Reads, scans, vector search, and other non-mutating APIs are not captured.
@@ -110,14 +111,16 @@ delivery. The logical core uses the following contracts:
   after any mutation. The transport `handle_push()` path still applies raw DBI
   operations only.
 - `KeyValueTableLogicalAdapter` and `KeyTableLogicalAdapter` are explicit
-  apply helpers with opt-in typed capture sessions. Neither is connected to
-  the transport pull/push path yet; callers own logical frame delivery.
+  apply helpers with opt-in typed capture sessions. Their `commit_to_outbox()`
+  paths can be dispatched by a worker with `enable_logical_delivery`; direct
+  logical frames remain caller-delivered and never enter raw pull/push messages.
 - `VectorStoreLogicalAdapter` is an explicit schema-v1 apply helper with an
   opt-in typed capture session. It carries explicit record ids and applies
   add, erase, and clear atomically across the four collection DBIs. Erase
   retains the ids marker as allocation high-water, while clear resets every
   DBI; incoming adds validate their embedding dimension before mutation.
-  Callers own logical frame delivery and must serialize conflicting writers.
+  `commit_to_outbox()` can publish its logical frame atomically, and writers
+  must still serialize conflicting updates.
 - `KeyMultiValueTableLogicalAdapter` follows the same explicit logical-frame
   path. Schema v1 provides unordered insert, version-neutral batch `append()`,
   key erase, all-matching-value erase, and clear; schema v2 adds exact-one
@@ -147,9 +150,10 @@ delivery. The logical core uses the following contracts:
   watermark. The watermark DBI is created lazily on the first pruning call, so
   deployments that use pruning must reserve one additional named-DBI slot in
   `Config::max_dbs`; older layouts without it remain readable with a zero
-  watermark. Callers must advance it only from an external delivery/acknowledge
-  protocol that rules out later unseen frames at or below the boundary; the
-  engine does not supply ordering, buffering, or acknowledgements itself.
+  watermark. Callers must advance it only after an external retention policy
+  rules out later unseen frames at or below the boundary. The engine supplies
+  ordered delivery and cumulative acknowledgement, but intentionally does not
+  supply gap buffering or a universal replay-retention horizon.
 
 Until a causal context or another conflict model is implemented, future logical
 table support should document either one authoritative writer for the affected
@@ -165,8 +169,10 @@ tables.
 - Extend logical-frame capability negotiation only when a new adapter requires
   a compatibility distinction beyond the existing schema marker and adapter
   registry fail-closed checks.
-- Integrate `LogicalTableRegistry` with `SyncEngine::handle_push()` only after
-  logical changes can be parsed separately from raw DBI operations.
+- Design logical-aware recovery separately from raw complete snapshots. Raw
+  `CompleteUserDatabase` snapshots intentionally reject persistent logical
+  state; a future baseline protocol must preserve schema, outbox, replay, and
+  order-frontier invariants together.
 - Extend `KeyMultiValueTable` logical capture only after every added bulk or
   reconcile operation has explicit multiset replay semantics and round-trip
   coverage. Raw capture remains disabled.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1207,13 +1207,16 @@ or decide whether it is safe to advance one.
 `LogicalOutboxStore` is the sender-side durable foundation for ordered delivery.
 `SyncEngine::enqueue_logical_delivery()` persists an envelope
 in `_mdbxc_logical_outbox` and allocates a monotonic `origin_sequence` per
-destination database, not globally across unrelated destinations. Its MDBX entry
-keys contain the destination and a big-endian sequence suffix, so
-`pending_logical_deliveries()` reads the stream in numeric order. The generated
-frame id is stable for that stored sequence, and allocating a frame, updating the
-next sequence, acknowledging a prefix, and deleting acknowledged entries are all
-transactional. A rollback therefore neither consumes a sequence nor leaves a
-queue entry behind. `_mdbxc_logical_outbox` is created during the normal
+destination database and receiver node pair, not globally across unrelated
+destinations or replicas of one replication set. Its MDBX entry keys contain the
+destination, receiver node id, and a big-endian sequence suffix, so
+`pending_logical_deliveries()` reads one receiver stream in numeric order. The
+generated frame id is stable for that stored sequence, and allocating a frame,
+updating the next sequence, acknowledging a prefix, and deleting acknowledged
+entries are all transactional. A receiver hello must match the selected receiver
+node id before its queue can be dispatched; an acknowledgement can therefore
+advance only that receiver's durable frontier. A rollback neither consumes a
+sequence nor leaves a queue entry behind. `_mdbxc_logical_outbox` is created during the normal
 committed sync-system initialization lifecycle, so deployments need one
 additional named-DBI slot in `Config::max_dbs` compared with a layout that did
 not use the outbox.
@@ -1235,8 +1238,8 @@ each acknowledged outbox prefix before continuing. The older
 `apply_logical_delivery_envelope()` API remains intentionally unordered and is
 not implicitly redirected through this outbox.
 
-`LogicalDeliveryProtocol.hpp` reserves a separate versioned wire boundary for
-that future exchange. Its `Hello` message carries optional capability bits; an
+`LogicalDeliveryProtocol.hpp` defines the separate versioned wire boundary for
+that exchange. Its `Hello` message carries optional capability bits; an
 unknown bit is preserved but does not become negotiated unless both peers expose
 a known capability. `Delivery` wraps a strict `LogicalDeliveryEnvelope`, and
 `Acknowledgement` carries a destination-scoped cumulative lower bound with
@@ -1248,9 +1251,9 @@ against its own durable outbox known tail, then atomically removes the verified
 contiguous local prefix. This supports a sender restart after the receiver
 committed an earlier delivery but before the sender persisted cleanup. Existing
 peers that implement only the envelope-only delivery virtual method remain on
-the conservative contract. No existing HTTP, WebSocket, or raw pull/push
-endpoint advertises or accepts this protocol yet, so current transports remain
-backward-compatible raw-sync-only.
+the conservative contract. Direct, HTTP, and WebSocket peers expose dedicated
+logical routes; the raw pull/push protocol remains unchanged and raw-only peers
+remain source-compatible.
 
 `SyncEngine::apply_ordered_logical_delivery_envelope()` is the receiver-side
 implementation of `OrderedDelivery`. `_mdbxc_logical_delivery_order` stores the
@@ -1271,8 +1274,8 @@ one transaction.
 
 `ILogicalDeliveryPeer` and `DirectLogicalDeliveryPeer` provide the capability-
 gated dispatch boundary. `SyncEngine::deliver_pending_logical_deliveries()`
-checks destination identity and negotiated `OrderedDelivery` before sending its
-outbox prefix. A negotiated cumulative success is bounded by the sender's
+checks destination database, expected receiver node identity, and negotiated
+`OrderedDelivery` before sending its outbox prefix. A negotiated cumulative success is bounded by the sender's
 durable known tail, so it can safely clean a prefix that was delivered before a
 sender restart; entries already removed by that acknowledgement are skipped from
 the in-memory pending snapshot. A retryable negative acknowledgement can still
@@ -1761,9 +1764,9 @@ or equivalent mechanism when polling alone cannot unblock the operation.
 
 `SyncWorkerOptions::enable_logical_delivery` is false by default. When enabled,
 the worker attempts logical dispatch only after its normal raw pull loop has
-drained the current round (`has_more == false`). It first checks whether the
-outbox has an envelope for the worker's replication `DbId`; an empty outbox does
-not require logical peer support. A non-empty outbox requires
+drained the current round (`has_more == false`). It obtains the remote hello,
+then checks the outbox for that replication `DbId` and receiver node pair; an
+empty receiver queue does not require dispatch. A non-empty outbox requires
 `ISyncPeer::supports_logical_delivery()`. The worker dispatches at most one
 envelope in each peer call, reports `LogicalDeliveryStarted` and
 `LogicalDeliveryFinished` stages, and stores delivered and acknowledged counts

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1779,10 +1779,12 @@ or equivalent mechanism when polling alone cannot unblock the operation.
 
 `SyncWorkerOptions::enable_logical_delivery` is false by default. When enabled,
 the worker attempts logical dispatch only after its normal raw pull loop has
-drained the current round (`has_more == false`). It obtains the remote hello,
-then checks the outbox for that replication `DbId` and receiver node pair; an
-empty receiver queue does not require dispatch. A non-empty outbox requires
-`ISyncPeer::supports_logical_delivery()`. The worker dispatches at most one
+drained the current round (`has_more == false`). It first checks whether the
+replication `DbId` has any pending logical entry. An empty logical outbox does
+not require capability negotiation, so a raw-only peer still completes the
+round. Pending logical state requires `ISyncPeer::supports_logical_delivery()`;
+the worker then obtains the remote hello and checks its receiver route. The
+worker dispatches at most one
 envelope in each peer call, reports `LogicalDeliveryStarted` and
 `LogicalDeliveryFinished` stages, and stores delivered and acknowledged counts
 in its round result. `max_logical_deliveries == 0` drains the pending prefix;

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1207,19 +1207,27 @@ or decide whether it is safe to advance one.
 `LogicalOutboxStore` is the sender-side durable foundation for ordered delivery.
 `SyncEngine::enqueue_logical_delivery()` persists an envelope
 in `_mdbxc_logical_outbox` and allocates a monotonic `origin_sequence` per
-destination database and receiver node pair, not globally across unrelated
-destinations or replicas of one replication set. Its MDBX entry keys contain the
-destination, receiver node id, and a big-endian sequence suffix, so
-`pending_logical_deliveries()` reads one receiver stream in numeric order. The
-generated frame id is stable for that stored sequence, and allocating a frame,
-updating the next sequence, acknowledging a prefix, and deleting acknowledged
-entries are all transactional. A receiver hello must match the selected receiver
-node id before its queue can be dispatched; an acknowledgement can therefore
-advance only that receiver's durable frontier. A rollback neither consumes a
-sequence nor leaves a queue entry behind. `_mdbxc_logical_outbox` is created during the normal
+destination database and origin, independent of the selected receiver. This is
+the stable logical-event identity carried by replay markers and ordered
+frontiers. Receiver routes retain only their own pending entries,
+`acknowledged_through`, and known tail. Its MDBX entry keys contain the
+destination, receiver node id, and a big-endian event-sequence suffix, so
+`pending_logical_deliveries()` reads one receiver route in numeric order. The
+generated frame id is stable for the origin event sequence, and allocating a
+frame, updating the global allocator, acknowledging a route prefix, and
+deleting acknowledged route entries are all transactional. A receiver hello
+must match the selected receiver node id before its queue can be dispatched; an
+acknowledgement can therefore advance only that receiver's durable frontier. A
+rollback neither consumes a sequence nor leaves a queue entry behind.
+`_mdbxc_logical_outbox` is created during the normal
 committed sync-system initialization lifecycle, so deployments need one
 additional named-DBI slot in `Config::max_dbs` compared with a layout that did
 not use the outbox.
+
+Persisted outbox entries always satisfy the library-default `CodecBounds`, so a
+later worker can decode them without carrying a caller-specific bounds object.
+A non-default bound passed to enqueue is an additional validation constraint; it
+cannot widen the durable outbox format.
 
 `LogicalDeliveryProtocolCodec` defines a separate logical wire protocol with its
 own magic and version. It carries `Hello`, stateless `HelloRequest`, legacy
@@ -1227,7 +1235,12 @@ envelope-only `Delivery`, capability-bearing `DeliveryRequest`, and cumulative
 `Acknowledgement` messages. It does not change `TransportMessageCodec` or the
 raw `ChangeBatchCodec` version. HTTP maps the request messages to dedicated
 logical routes, while WebSocket chooses the protocol by its magic before raw
-transport decoding.
+transport decoding. `DeliveryRequest` carries the selected receiver node id;
+the acknowledgement repeats the actual receiver node id. The receiver verifies
+that binding before ordered replay, frontier, or adapter work. HTTP and
+WebSocket reject the legacy envelope-only `Delivery` message for ordered
+delivery, so a routed request cannot be applied by another node with the same
+database id.
 
 `ISyncPeer` is also an `ILogicalDeliveryPeer`. Its default logical methods keep
 raw-only peers source-compatible: they report no support and never acknowledge a
@@ -1250,10 +1263,10 @@ persisted contiguous frontier for a duplicate. The sender validates that value
 against its own durable outbox known tail, then atomically removes the verified
 contiguous local prefix. This supports a sender restart after the receiver
 committed an earlier delivery but before the sender persisted cleanup. Existing
-peers that implement only the envelope-only delivery virtual method remain on
-the conservative contract. Direct, HTTP, and WebSocket peers expose dedicated
-logical routes; the raw pull/push protocol remains unchanged and raw-only peers
-remain source-compatible.
+peers that implement only the envelope-only delivery virtual method cannot
+receive ordered `DeliveryRequest` messages. Direct, HTTP, and WebSocket peers
+expose receiver-bound logical routes; the raw pull/push protocol remains
+unchanged and raw-only peers remain source-compatible.
 
 `SyncEngine::apply_ordered_logical_delivery_envelope()` is the receiver-side
 implementation of `OrderedDelivery`. `_mdbxc_logical_delivery_order` stores the
@@ -1275,7 +1288,9 @@ one transaction.
 `ILogicalDeliveryPeer` and `DirectLogicalDeliveryPeer` provide the capability-
 gated dispatch boundary. `SyncEngine::deliver_pending_logical_deliveries()`
 checks destination database, expected receiver node identity, and negotiated
-`OrderedDelivery` before sending its outbox prefix. A negotiated cumulative success is bounded by the sender's
+`OrderedDelivery` before sending its outbox prefix. The receiver independently
+checks the receiver id carried by the request before it advances ordered state.
+A negotiated cumulative success is bounded by the sender's
 durable known tail, so it can safely clean a prefix that was delivered before a
 sender restart; entries already removed by that acknowledgement are skipped from
 the in-memory pending snapshot. A retryable negative acknowledgement can still

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1204,8 +1204,8 @@ the numeric `origin_sequence`: it does not decide whether an envelope is an
 exact duplicate delivery identity, persist a watermark, buffer missing frames,
 or decide whether it is safe to advance one.
 
-`LogicalOutboxStore` is the sender-side durable foundation for a future ordered
-delivery protocol. `SyncEngine::enqueue_logical_delivery()` persists an envelope
+`LogicalOutboxStore` is the sender-side durable foundation for ordered delivery.
+`SyncEngine::enqueue_logical_delivery()` persists an envelope
 in `_mdbxc_logical_outbox` and allocates a monotonic `origin_sequence` per
 destination database, not globally across unrelated destinations. Its MDBX entry
 keys contain the destination and a big-endian sequence suffix, so
@@ -1218,11 +1218,22 @@ committed sync-system initialization lifecycle, so deployments need one
 additional named-DBI slot in `Config::max_dbs` compared with a layout that did
 not use the outbox.
 
-`acknowledge_logical_deliveries()` currently exposes only a local cumulative
-frontier and deletes its acknowledged outbox prefix. It does not establish a
-wire acknowledgement, receiver-side ordering, capability negotiation, or retry
-scheduling. The older `apply_logical_delivery_envelope()` API remains intentionally
-unordered and is not implicitly redirected through this outbox.
+`LogicalDeliveryProtocolCodec` defines a separate logical wire protocol with its
+own magic and version. It carries `Hello`, stateless `HelloRequest`, legacy
+envelope-only `Delivery`, capability-bearing `DeliveryRequest`, and cumulative
+`Acknowledgement` messages. It does not change `TransportMessageCodec` or the
+raw `ChangeBatchCodec` version. HTTP maps the request messages to dedicated
+logical routes, while WebSocket chooses the protocol by its magic before raw
+transport decoding.
+
+`ISyncPeer` is also an `ILogicalDeliveryPeer`. Its default logical methods keep
+raw-only peers source-compatible: they report no support and never acknowledge a
+logical envelope. `DirectSyncPeer`, `HttpSyncPeer`, and `WebSocketSyncPeer`
+implement hello plus capability-bearing delivery. `SyncEngine::deliver_pending_logical_deliveries()` negotiates ordered delivery and cumulative acknowledgement,
+validates every acknowledgement against the durable sender tail, and commits
+each acknowledged outbox prefix before continuing. The older
+`apply_logical_delivery_envelope()` API remains intentionally unordered and is
+not implicitly redirected through this outbox.
 
 `LogicalDeliveryProtocol.hpp` reserves a separate versioned wire boundary for
 that future exchange. Its `Hello` message carries optional capability bits; an
@@ -1328,9 +1339,9 @@ helpers. They translate typed table operations into adapter-owned logical
 payloads and apply them through
 `SyncEngine::apply_logical_changes()` or
 `LogicalTableRegistry::preflight_then_apply()` inside a caller-owned write
-transaction. These helpers prove the adapter contract and payload shape for
-simple tables, but they are not yet connected to the automatic pull/push wire
-pipeline.
+transaction. Their `commit_to_outbox()` paths atomically commit local table
+mutations and a durable ordered envelope. The envelope uses the separate logical
+peer protocol rather than the automatic raw pull/push wire pipeline.
 `KeyValueTableLogicalAdapter` supports upsert/delete/clear,
 `KeyTableLogicalAdapter` supports insert/delete/clear, and
 `VectorStoreLogicalAdapter` supports add/erase/clear over its four owned DBIs.
@@ -1704,15 +1715,16 @@ Stopped -> Starting -> Idle -> Pulling -> Applying -> Idle
 
 Worker invariants:
 
-- no local MDBX transaction is held while waiting in `ISyncPeer::pull()`;
+- no local MDBX transaction is held while waiting in a peer pull or logical
+  delivery call;
 - no local MDBX transaction is held during idle or backoff sleeps;
 - pulled pages are applied through `SyncEngine::handle_push()`, so each page
   uses one short local write transaction;
-- stop requests cancel the active `PullRequest::cancel_token` and call
+- stop requests cancel the active raw request token and call
   `ISyncPeer::request_cancel()` at most once for each observed in-flight
-  peer pull call, and a page returned after stop was requested is not applied;
-- a stop request recorded before peer-call activation prevents the next pull
-  call from starting;
+  peer call. A page returned after stop was requested is not applied, and a
+  stop request recorded between logical envelopes prevents the next logical
+  delivery from starting;
 - `stop()`, `join()`, and destruction may wait for an in-flight peer call to
   return when the concrete transport does not support cancellation;
 - `SyncWorkerGuard` may own a single background run session for an existing
@@ -1725,8 +1737,9 @@ Worker invariants:
   while `request_stop`, `state`, `last_error`, `last_observer_error`, and
   `wait_until_state` are thread-safe;
 - optional `ISyncWorkerObserver` callbacks report coarse sync stages
-  (`round`, `pull`, `apply`, `backoff`), page application, round completion,
-  and backoff entry synchronously on the thread that runs the sync round;
+  (`round`, `pull`, `apply`, `logical delivery`, `backoff`), page application,
+  round completion, and backoff entry synchronously on the thread that runs the
+  sync round;
   observer implementations must outlive the worker, return quickly, and avoid
   caller-serialized lifecycle calls from worker-thread callbacks;
 - worker stage and round events include a best-effort progress estimate derived
@@ -1745,6 +1758,18 @@ peers remain separate adapters over `ISyncPeer`. Transport adapters that can
 interrupt blocking I/O should poll the request `cancel_token` where possible
 and implement `request_cancel()` by using their own timeout, socket shutdown,
 or equivalent mechanism when polling alone cannot unblock the operation.
+
+`SyncWorkerOptions::enable_logical_delivery` is false by default. When enabled,
+the worker attempts logical dispatch only after its normal raw pull loop has
+drained the current round (`has_more == false`). It first checks whether the
+outbox has an envelope for the worker's replication `DbId`; an empty outbox does
+not require logical peer support. A non-empty outbox requires
+`ISyncPeer::supports_logical_delivery()`. The worker dispatches at most one
+envelope in each peer call, reports `LogicalDeliveryStarted` and
+`LogicalDeliveryFinished` stages, and stores delivered and acknowledged counts
+in its round result. `max_logical_deliveries == 0` drains the pending prefix;
+any positive value bounds one round. Unsupported peers and failed
+acknowledgements leave the unacknowledged outbox suffix durable for retry.
 
 Cancellation intentionally stays minimal in the core API: operation-scoped
 tokens plus the existing best-effort peer hook. Do not add callback

--- a/include/mdbx_containers/sync/engine/DirectLogicalDeliveryPeer.hpp
+++ b/include/mdbx_containers/sync/engine/DirectLogicalDeliveryPeer.hpp
@@ -55,8 +55,8 @@ namespace sync {
                 const CodecBounds* bounds = nullptr,
                 const CancellationToken* cancel_token = nullptr) override {
             (void)cancel_token;
-            return m_remote.apply_ordered_logical_delivery_envelope(
-                request.envelope, &request.sender_capabilities, bounds);
+            return m_remote.apply_ordered_logical_delivery_request(
+                request, bounds);
         }
 
     private:

--- a/include/mdbx_containers/sync/engine/DirectLogicalDeliveryPeer.hpp
+++ b/include/mdbx_containers/sync/engine/DirectLogicalDeliveryPeer.hpp
@@ -16,12 +16,28 @@ namespace sync {
             : m_remote(remote) {}
 
         LogicalDeliveryHello logical_delivery_hello() override {
+            return logical_delivery_hello_with_cancel(nullptr);
+        }
+
+        LogicalDeliveryHello logical_delivery_hello_with_cancel(
+                const CancellationToken* cancel_token = nullptr) override {
+            (void)cancel_token;
             return m_remote.logical_delivery_hello();
         }
 
         LogicalDeliveryAcknowledgement deliver_ordered_logical_delivery(
                 const LogicalDeliveryEnvelope& envelope,
                 const CodecBounds* bounds = nullptr) override {
+            return deliver_ordered_logical_delivery_with_cancel(
+                envelope, bounds, nullptr);
+        }
+
+        LogicalDeliveryAcknowledgement
+        deliver_ordered_logical_delivery_with_cancel(
+                const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds = nullptr,
+                const CancellationToken* cancel_token = nullptr) override {
+            (void)cancel_token;
             return m_remote.apply_ordered_logical_delivery_envelope(
                 envelope, bounds);
         }
@@ -29,6 +45,16 @@ namespace sync {
         LogicalDeliveryAcknowledgement deliver_ordered_logical_request(
                 const LogicalDeliveryRequest& request,
                 const CodecBounds* bounds = nullptr) override {
+            return deliver_ordered_logical_request_with_cancel(
+                request, bounds, nullptr);
+        }
+
+        LogicalDeliveryAcknowledgement
+        deliver_ordered_logical_request_with_cancel(
+                const LogicalDeliveryRequest& request,
+                const CodecBounds* bounds = nullptr,
+                const CancellationToken* cancel_token = nullptr) override {
+            (void)cancel_token;
             return m_remote.apply_ordered_logical_delivery_envelope(
                 request.envelope, &request.sender_capabilities, bounds);
         }

--- a/include/mdbx_containers/sync/engine/DirectSyncPeer.hpp
+++ b/include/mdbx_containers/sync/engine/DirectSyncPeer.hpp
@@ -80,8 +80,8 @@ namespace sync {
                 const CancellationToken* cancel_token = nullptr) override {
             (void)cancel_token;
             assert(m_remote != nullptr);
-            return m_remote->apply_ordered_logical_delivery_envelope(
-                request.envelope, &request.sender_capabilities, bounds);
+            return m_remote->apply_ordered_logical_delivery_request(
+                request, bounds);
         }
 
     private:

--- a/include/mdbx_containers/sync/engine/DirectSyncPeer.hpp
+++ b/include/mdbx_containers/sync/engine/DirectSyncPeer.hpp
@@ -33,6 +33,57 @@ namespace sync {
             return m_remote->handle_push(request);
         }
 
+        bool supports_logical_delivery() const override {
+            return true;
+        }
+
+        LogicalDeliveryHello logical_delivery_hello() override {
+            return logical_delivery_hello_with_cancel(nullptr);
+        }
+
+        LogicalDeliveryHello logical_delivery_hello_with_cancel(
+                const CancellationToken* cancel_token = nullptr) override {
+            (void)cancel_token;
+            assert(m_remote != nullptr);
+            return m_remote->logical_delivery_hello();
+        }
+
+        LogicalDeliveryAcknowledgement deliver_ordered_logical_delivery(
+                const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds = nullptr) override {
+            return deliver_ordered_logical_delivery_with_cancel(
+                envelope, bounds, nullptr);
+        }
+
+        LogicalDeliveryAcknowledgement
+        deliver_ordered_logical_delivery_with_cancel(
+                const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds = nullptr,
+                const CancellationToken* cancel_token = nullptr) override {
+            (void)cancel_token;
+            assert(m_remote != nullptr);
+            return m_remote->apply_ordered_logical_delivery_envelope(
+                envelope, bounds);
+        }
+
+        LogicalDeliveryAcknowledgement deliver_ordered_logical_request(
+                const LogicalDeliveryRequest& request,
+                const CodecBounds* bounds = nullptr) override {
+            return deliver_ordered_logical_request_with_cancel(
+                request, bounds, nullptr);
+        }
+
+        LogicalDeliveryAcknowledgement
+        deliver_ordered_logical_request_with_cancel(
+                const LogicalDeliveryRequest& request,
+                const CodecBounds* bounds = nullptr,
+                const CancellationToken* cancel_token = nullptr) override {
+            (void)cancel_token;
+            assert(m_remote != nullptr);
+            return m_remote->apply_ordered_logical_delivery_envelope(
+                request.envelope, &request.sender_capabilities, bounds);
+        }
+
     private:
         SyncEngine* m_remote;
     };

--- a/include/mdbx_containers/sync/engine/ISyncPeer.hpp
+++ b/include/mdbx_containers/sync/engine/ISyncPeer.hpp
@@ -6,6 +6,7 @@
 /// \brief Abstract peer used by \c SyncWorker and \c SyncEngine clients.
 
 #include <cstdint>
+#include <stdexcept>
 
 namespace mdbxc {
 namespace sync {
@@ -34,7 +35,7 @@ namespace sync {
     /// must allow \c request_cancel() to be called concurrently with
     /// \c pull() / \c push() and tolerate calls that race with operation
     /// startup or completion.
-    class ISyncPeer {
+    class ISyncPeer : public ILogicalDeliveryPeer {
     public:
         virtual ~ISyncPeer() {}
 
@@ -59,6 +60,32 @@ namespace sync {
         /// \return Retry hint for the last observed transport failure.
         virtual SyncTransportRetryHint last_retry_hint() const {
             return SyncTransportRetryHint();
+        }
+
+        /// \brief Returns whether this peer can exchange ordered logical frames.
+        /// \details Raw-only peers preserve the v0.1 contract by returning
+        /// \c false. Callers must opt in before treating logical outbox state
+        /// as a transport responsibility.
+        virtual bool supports_logical_delivery() const {
+            return false;
+        }
+
+        LogicalDeliveryHello logical_delivery_hello() override {
+            throw std::logic_error(
+                "Sync peer does not support logical delivery");
+        }
+
+        LogicalDeliveryAcknowledgement deliver_ordered_logical_delivery(
+                const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds = nullptr) override {
+            (void)bounds;
+            LogicalDeliveryAcknowledgement acknowledgement;
+            acknowledgement.destination_db_uuid = envelope.destination_db_uuid;
+            acknowledgement.origin_node_id = envelope.origin_node_id;
+            acknowledgement.ok = false;
+            acknowledgement.error =
+                "Sync peer does not support logical delivery";
+            return acknowledgement;
         }
     };
 

--- a/include/mdbx_containers/sync/engine/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/engine/SyncEngine.hpp
@@ -920,10 +920,17 @@ namespace sync {
                 ILogicalDeliveryPeer& peer,
                 const DbId& destination,
                 std::size_t limit = 0u,
-                const CodecBounds* bounds = nullptr) {
+                const CodecBounds* bounds = nullptr,
+                const CancellationToken* cancel_token = nullptr) {
             try {
+                if (cancel_token != nullptr &&
+                    cancel_token->is_cancellation_requested()) {
+                    return LogicalDeliveryDispatchResult::failure(
+                        "Logical delivery dispatch cancelled", true);
+                }
                 const LogicalDeliveryHello local = logical_delivery_hello();
-                const LogicalDeliveryHello remote = peer.logical_delivery_hello();
+                const LogicalDeliveryHello remote =
+                    peer.logical_delivery_hello_with_cancel(cancel_token);
                 if (compare_node_id(remote.db_uuid, destination) != 0) {
                     return LogicalDeliveryDispatchResult::failure(
                         "Logical delivery peer destination db_uuid mismatch");
@@ -947,6 +954,11 @@ namespace sync {
                 const std::uint64_t known_tail =
                     logical_delivery_known_tail(destination);
                 for (std::size_t i = 0; i < pending.size(); ++i) {
+                    if (cancel_token != nullptr &&
+                        cancel_token->is_cancellation_requested()) {
+                        return LogicalDeliveryDispatchResult::failure(
+                            "Logical delivery dispatch cancelled", true);
+                    }
                     if (pending[i].origin_sequence <=
                         out.acknowledged_through) {
                         continue;
@@ -955,7 +967,8 @@ namespace sync {
                     request.envelope = pending[i];
                     request.sender_capabilities = local.capabilities;
                     const LogicalDeliveryAcknowledgement acknowledgement =
-                        peer.deliver_ordered_logical_request(request, bounds);
+                        peer.deliver_ordered_logical_request_with_cancel(
+                            request, bounds, cancel_token);
                     try {
                         validate_logical_delivery_acknowledgement_for_sender(
                             acknowledgement, pending[i], known_tail,

--- a/include/mdbx_containers/sync/engine/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/engine/SyncEngine.hpp
@@ -611,7 +611,8 @@ namespace sync {
         LogicalDeliveryAcknowledgement apply_ordered_logical_delivery_envelope(
                 const LogicalDeliveryEnvelope& envelope,
                 const LogicalDeliveryCapabilities* sender_capabilities,
-                const CodecBounds* bounds = nullptr) {
+                const CodecBounds* bounds = nullptr,
+                const NodeId* receiver = nullptr) {
             LogicalDeliveryAcknowledgement acknowledgement;
             acknowledgement.destination_db_uuid = envelope.destination_db_uuid;
             acknowledgement.origin_node_id = envelope.origin_node_id;
@@ -647,11 +648,21 @@ namespace sync {
                 const DbId local_db_uuid = meta.get_db_uuid(txn.handle());
                 const NodeId local_node_id = meta.get_node_id(txn.handle());
                 acknowledgement.destination_db_uuid = local_db_uuid;
+                acknowledgement.receiver_node_id = local_node_id;
                 if (compare_node_id(local_db_uuid,
                                     envelope.destination_db_uuid) != 0) {
                     set_logical_delivery_acknowledgement_failure(
                         acknowledgement,
                         "Logical ordered delivery destination db_uuid mismatch",
+                        false, bounds);
+                    txn.rollback();
+                    return acknowledgement;
+                }
+                if (receiver != nullptr &&
+                    compare_node_id(local_node_id, *receiver) != 0) {
+                    set_logical_delivery_acknowledgement_failure(
+                        acknowledgement,
+                        "Logical ordered delivery receiver node_id mismatch",
                         false, bounds);
                     txn.rollback();
                     return acknowledgement;
@@ -777,6 +788,15 @@ namespace sync {
             return acknowledgement;
         }
 
+        /// \brief Applies a receiver-bound ordered delivery request.
+        LogicalDeliveryAcknowledgement apply_ordered_logical_delivery_request(
+                const LogicalDeliveryRequest& request,
+                const CodecBounds* bounds = nullptr) {
+            return apply_ordered_logical_delivery_envelope(
+                request.envelope, &request.sender_capabilities, bounds,
+                &request.receiver_node_id);
+        }
+
         /// \brief Decodes and applies a logical delivery envelope.
         LogicalApplyResult apply_logical_delivery_envelope_bytes(
                 const std::vector<std::uint8_t>& encoded,
@@ -831,8 +851,8 @@ namespace sync {
         }
 
         /// \brief Persists a locally-originated ordered logical delivery.
-        /// \details Sequences are allocated independently for each destination
-        /// database and receiver node pair.
+        /// \details Sequences are allocated per destination database and
+        /// origin; receiver routes retain their own pending state.
         /// This only enqueues the envelope; transport dispatch and receiver
         /// acknowledgements are separate protocol layers.
         LogicalDeliveryEnvelope enqueue_logical_delivery(
@@ -980,6 +1000,7 @@ namespace sync {
                         continue;
                     }
                     LogicalDeliveryRequest request;
+                    request.receiver_node_id = receiver;
                     request.envelope = pending[i];
                     request.sender_capabilities = local.capabilities;
                     const LogicalDeliveryAcknowledgement acknowledgement =
@@ -987,7 +1008,7 @@ namespace sync {
                             request, bounds, cancel_token);
                     try {
                         validate_logical_delivery_acknowledgement_for_sender(
-                            acknowledgement, pending[i], known_tail,
+                            acknowledgement, pending[i], receiver, known_tail,
                             cumulative_acknowledgement_negotiated, bounds);
                     } catch (const std::exception& e) {
                         return LogicalDeliveryDispatchResult::failure(

--- a/include/mdbx_containers/sync/engine/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/engine/SyncEngine.hpp
@@ -904,6 +904,18 @@ namespace sync {
                                        limit, bounds);
         }
 
+        /// \brief Returns whether any receiver route has pending delivery.
+        /// \details A raw-only worker uses this before it can obtain a
+        /// receiver-specific logical hello.
+        bool has_pending_logical_deliveries(
+                const DbId& destination,
+                const CodecBounds* bounds = nullptr) const {
+            auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
+            LogicalOutboxStore outbox(m_conn->env_handle());
+            return outbox.has_pending_for_destination(txn.handle(), destination,
+                                                      bounds);
+        }
+
         /// \brief Persists a cumulative acknowledgement and removes its prefix.
         std::size_t acknowledge_logical_deliveries(
                 const DbId& destination,

--- a/include/mdbx_containers/sync/engine/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/engine/SyncEngine.hpp
@@ -831,16 +831,18 @@ namespace sync {
         }
 
         /// \brief Persists a locally-originated ordered logical delivery.
-        /// \details Sequences are allocated independently for each destination.
+        /// \details Sequences are allocated independently for each destination
+        /// database and receiver node pair.
         /// This only enqueues the envelope; transport dispatch and receiver
         /// acknowledgements are separate protocol layers.
         LogicalDeliveryEnvelope enqueue_logical_delivery(
                 const DbId& destination,
+                const NodeId& receiver,
                 const LogicalChangeFrame& frame,
                 const CodecBounds* bounds = nullptr) {
             auto txn = m_conn->transaction(TransactionMode::WRITABLE);
             const LogicalDeliveryEnvelope envelope = enqueue_logical_delivery(
-                txn.handle(), destination, frame, bounds);
+                txn.handle(), destination, receiver, frame, bounds);
             txn.commit();
             return envelope;
         }
@@ -852,6 +854,7 @@ namespace sync {
         LogicalDeliveryEnvelope enqueue_logical_delivery(
                 MDBX_txn* txn,
                 const DbId& destination,
+                const NodeId& receiver,
                 const LogicalChangeFrame& frame,
                 const CodecBounds* bounds = nullptr) override {
             txn = checked_external_txn(
@@ -865,48 +868,55 @@ namespace sync {
                 throw std::logic_error(
                     "SyncEngine local node identity is not initialised");
             }
-            return outbox.enqueue(txn, destination, origin, frame, bounds);
+            return outbox.enqueue(txn, destination, receiver, origin, frame,
+                                  bounds);
         }
 
-        /// \brief Lists locally queued ordered deliveries for one destination.
+        /// \brief Lists locally queued ordered deliveries for one receiver.
         std::vector<LogicalDeliveryEnvelope> pending_logical_deliveries(
                 const DbId& destination,
+                const NodeId& receiver,
                 std::size_t limit = 0u,
                 const CodecBounds* bounds = nullptr) const {
             auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
             LogicalOutboxStore outbox(m_conn->env_handle());
-            return outbox.list_pending(txn.handle(), destination, limit, bounds);
+            return outbox.list_pending(txn.handle(), destination, receiver,
+                                       limit, bounds);
         }
 
         /// \brief Persists a cumulative acknowledgement and removes its prefix.
         std::size_t acknowledge_logical_deliveries(
                 const DbId& destination,
+                const NodeId& receiver,
                 std::uint64_t acknowledged_through) {
             auto txn = m_conn->transaction(TransactionMode::WRITABLE);
             initialize_system_stores(txn.handle());
             LogicalOutboxStore outbox(m_conn->env_handle());
             const std::size_t removed = outbox.acknowledge_through(
-                txn.handle(), destination, acknowledged_through);
+                txn.handle(), destination, receiver, acknowledged_through);
             txn.commit();
             return removed;
         }
 
         /// \brief Returns the persisted cumulative acknowledgement frontier.
         std::uint64_t logical_delivery_acknowledged_through(
-                const DbId& destination) const {
+                const DbId& destination,
+                const NodeId& receiver) const {
             auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
             LogicalOutboxStore outbox(m_conn->env_handle());
-            return outbox.acknowledged_through(txn.handle(), destination);
+            return outbox.acknowledged_through(txn.handle(), destination,
+                                               receiver);
         }
 
         /// \brief Returns the highest locally persisted delivery sequence.
         /// \details This durable value bounds any cumulative acknowledgement
         /// accepted from a peer, including after a sender restart.
         std::uint64_t logical_delivery_known_tail(
-                const DbId& destination) const {
+                const DbId& destination,
+                const NodeId& receiver) const {
             auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
             LogicalOutboxStore outbox(m_conn->env_handle());
-            return outbox.known_tail(txn.handle(), destination);
+            return outbox.known_tail(txn.handle(), destination, receiver);
         }
 
         /// \brief Delivers a pending ordered outbox prefix to one capable peer.
@@ -919,6 +929,7 @@ namespace sync {
         LogicalDeliveryDispatchResult deliver_pending_logical_deliveries(
                 ILogicalDeliveryPeer& peer,
                 const DbId& destination,
+                const NodeId& receiver,
                 std::size_t limit = 0u,
                 const CodecBounds* bounds = nullptr,
                 const CancellationToken* cancel_token = nullptr) {
@@ -935,6 +946,10 @@ namespace sync {
                     return LogicalDeliveryDispatchResult::failure(
                         "Logical delivery peer destination db_uuid mismatch");
                 }
+                if (compare_node_id(remote.node_id, receiver) != 0) {
+                    return LogicalDeliveryDispatchResult::failure(
+                        "Logical delivery peer receiver node_id mismatch");
+                }
                 if (!logical_delivery_capability_negotiated(
                         local.capabilities, remote.capabilities,
                         LogicalDeliveryCapability::OrderedDelivery)) {
@@ -948,11 +963,12 @@ namespace sync {
 
                 LogicalDeliveryDispatchResult out;
                 const std::vector<LogicalDeliveryEnvelope> pending =
-                    pending_logical_deliveries(destination, limit, bounds);
+                    pending_logical_deliveries(destination, receiver, limit,
+                                               bounds);
                 out.acknowledged_through =
-                    logical_delivery_acknowledged_through(destination);
+                    logical_delivery_acknowledged_through(destination, receiver);
                 const std::uint64_t known_tail =
-                    logical_delivery_known_tail(destination);
+                    logical_delivery_known_tail(destination, receiver);
                 for (std::size_t i = 0; i < pending.size(); ++i) {
                     if (cancel_token != nullptr &&
                         cancel_token->is_cancellation_requested()) {
@@ -981,6 +997,7 @@ namespace sync {
                         out.acknowledged_through) {
                         acknowledge_logical_deliveries(
                             destination,
+                            receiver,
                             acknowledgement.acknowledged_through);
                         out.acknowledged_through =
                             acknowledgement.acknowledged_through;

--- a/include/mdbx_containers/sync/engine/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/engine/SyncWorker.hpp
@@ -772,6 +772,9 @@ namespace sync {
                 }
 
                 if (!m_peer.supports_logical_delivery()) {
+                    if (!m_engine.has_pending_logical_deliveries(destination)) {
+                        return;
+                    }
                     result.ok = false;
                     result.error =
                         "Sync peer does not support configured logical delivery";

--- a/include/mdbx_containers/sync/engine/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/engine/SyncWorker.hpp
@@ -27,7 +27,7 @@ namespace sync {
         Stopped,  ///< No worker thread is running.
         Starting, ///< Worker thread has been created but has not entered the loop.
         Idle,     ///< Worker is sleeping between sync rounds.
-        Pulling,  ///< Worker is waiting for \c ISyncPeer::pull().
+        Pulling,  ///< Worker is waiting for a remote peer call.
         Applying, ///< Worker is applying a pulled page locally.
         Backoff,  ///< Last round failed; worker is waiting before retry.
         Stopping, ///< Stop has been requested; current operation is draining.
@@ -41,6 +41,8 @@ namespace sync {
         PullFinished,   ///< A pull page request returned.
         ApplyStarted,   ///< A non-empty pulled page is about to be applied.
         ApplyFinished,  ///< A non-empty pulled page finished applying.
+        LogicalDeliveryStarted,  ///< A queued logical delivery is about to be sent.
+        LogicalDeliveryFinished, ///< A queued logical delivery returned an acknowledgement.
         RoundCompleted, ///< The round finished with a final result.
         BackoffStarted, ///< Background worker entered retry backoff.
     };
@@ -91,6 +93,20 @@ namespace sync {
         /// partially replicated database.
         bool enable_full_snapshot_fallback = false;
 
+        /// \brief Sends this engine's queued logical deliveries after raw sync.
+        /// \details Disabled by default, preserving the raw-only worker contract.
+        /// When enabled, the worker sends only the outbox prefix addressed to
+        /// this worker's remote database and only after it has drained raw pull
+        /// pages for the round. The peer must explicitly support logical
+        /// delivery whenever that prefix is non-empty.
+        bool enable_logical_delivery = false;
+
+        /// \brief Maximum logical envelopes delivered in one round.
+        /// \details Zero drains the pending prefix. Deliveries are dispatched
+        /// one at a time so a stop request can prevent the next envelope from
+        /// starting after the current peer call returns.
+        std::size_t max_logical_deliveries = 0u;
+
         /// \brief How the background worker handles permanent transport hints.
         /// \details The default keeps v0.1 retry hints advisory. Set to
         /// \c StopWorker when a classified permanent transport failure should
@@ -126,6 +142,8 @@ namespace sync {
         bool        ok = true; ///< Whether the round completed without error.
         std::size_t pages_pulled = 0; ///< Number of successful pull pages.
         std::size_t batches_applied = 0; ///< Number of batches applied locally.
+        std::size_t logical_deliveries_delivered = 0; ///< Logical envelopes ACKed this round.
+        std::uint64_t logical_acknowledged_through = 0; ///< Latest logical ACK frontier.
         bool        has_more = false; ///< Whether the peer reported more pages.
         SyncWorkerProgressEstimate progress; ///< Last known progress.
         std::string error; ///< Failure detail when \c ok is false.
@@ -147,6 +165,8 @@ namespace sync {
         std::size_t pages_pulled = 0; ///< Pages pulled so far in the round.
         std::size_t batches_in_page = 0; ///< Batches in the current page.
         std::size_t batches_applied = 0; ///< Batches applied so far.
+        std::size_t logical_deliveries_delivered = 0; ///< Logical envelopes ACKed so far.
+        std::uint64_t logical_acknowledged_through = 0; ///< Latest logical ACK frontier.
         bool        has_more = false; ///< Latest peer pagination flag.
         bool        ok = true; ///< Whether the current stage succeeded.
         SyncWorkerProgressEstimate progress; ///< Last known progress.
@@ -255,7 +275,7 @@ namespace sync {
     /// thread that executes the sync round.
     ///
     /// The implementation never keeps a local MDBX transaction open while
-    /// waiting in \c ISyncPeer::pull(), idle sleep, or backoff sleep. Pulled
+        /// waiting in a remote peer call, idle sleep, or backoff sleep. Pulled
     /// batches are applied through \c SyncEngine::handle_push(), which opens
     /// and commits a short local write transaction for each pulled page. With
     /// opt-in full snapshot fallback, the worker accepts only a
@@ -286,7 +306,7 @@ namespace sync {
         }
 
         /// \brief Requests stop and waits for the background worker to finish.
-        /// \details May block until an in-flight \c ISyncPeer::pull() returns.
+        /// \details May block until an in-flight remote peer call returns.
         /// The worker object must not be destroyed from its own worker thread.
         ~SyncWorker() {
             request_stop();
@@ -333,7 +353,7 @@ namespace sync {
         }
 
         /// \brief Requests background worker shutdown.
-        /// \details Cancels the active \c PullRequest token and calls
+        /// \details Cancels the active raw request token and calls
         /// \c ISyncPeer::request_cancel() outside the worker mutex at most
         /// once for each observed in-flight peer call.
         /// Cancellation is best-effort; the worker exits before applying a
@@ -721,6 +741,11 @@ namespace sync {
                     }
                     result.has_more = has_more;
                 } while (has_more && m_options.drain_pages);
+
+                if (!has_more && m_options.enable_logical_delivery &&
+                    !stop_requested()) {
+                    deliver_pending_logical_deliveries(result);
+                }
             } catch (const std::exception& e) {
                 result.ok = false;
                 result.error = e.what();
@@ -731,6 +756,71 @@ namespace sync {
                 result.retry_hint = m_peer.last_retry_hint();
             }
             return result;
+        }
+
+        void deliver_pending_logical_deliveries(
+                SyncWorkerRoundResult& result) {
+            const DbId destination = m_engine.db_uuid();
+            std::size_t remaining = m_options.max_logical_deliveries;
+            for (;;) {
+                if (stop_requested()) {
+                    return;
+                }
+                if (m_options.max_logical_deliveries != 0u &&
+                    remaining == 0u) {
+                    return;
+                }
+
+                const std::vector<LogicalDeliveryEnvelope> pending =
+                    m_engine.pending_logical_deliveries(destination, 1u);
+                if (pending.empty()) {
+                    return;
+                }
+                if (!m_peer.supports_logical_delivery()) {
+                    result.ok = false;
+                    result.error =
+                        "Sync peer does not support configured logical delivery";
+                    return;
+                }
+
+                LogicalDeliveryDispatchResult dispatch;
+                {
+                    CancellationToken cancel_token;
+                    PeerCallGuard peer_call(*this, cancel_token);
+                    if (!peer_call.active()) {
+                        return;
+                    }
+                    notify_stage_changed(make_stage_event(
+                        SyncWorkerStage::LogicalDeliveryStarted, result));
+                    dispatch = m_engine.deliver_pending_logical_deliveries(
+                        m_peer, destination, 1u, nullptr, &cancel_token);
+                }
+                result.logical_deliveries_delivered += dispatch.delivered;
+                result.logical_acknowledged_through =
+                    dispatch.acknowledged_through;
+                {
+                    SyncWorkerStageEvent event = make_stage_event(
+                        SyncWorkerStage::LogicalDeliveryFinished, result);
+                    event.ok = dispatch.ok;
+                    event.error = dispatch.error;
+                    event.sync_error_retryable = dispatch.retryable;
+                    notify_stage_changed(event);
+                }
+                if (!dispatch.ok) {
+                    result.ok = false;
+                    result.error = dispatch.error.empty()
+                        ? "logical delivery failed"
+                        : dispatch.error;
+                    result.sync_error_retryable = dispatch.retryable;
+                    return;
+                }
+                if (dispatch.delivered == 0u) {
+                    return;
+                }
+                if (remaining != 0u) {
+                    --remaining;
+                }
+            }
         }
 
         SyncWorkerRoundResult run_full_snapshot_fallback(
@@ -868,7 +958,11 @@ namespace sync {
             event.stage = stage;
             event.state = state();
             event.pages_pulled = result.pages_pulled;
-                event.batches_applied = result.batches_applied;
+            event.batches_applied = result.batches_applied;
+            event.logical_deliveries_delivered =
+                result.logical_deliveries_delivered;
+            event.logical_acknowledged_through =
+                result.logical_acknowledged_through;
             event.has_more = result.has_more;
             event.ok = result.ok;
             event.progress = result.progress;

--- a/include/mdbx_containers/sync/engine/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/engine/SyncWorker.hpp
@@ -98,7 +98,7 @@ namespace sync {
         /// When enabled, the worker sends only the outbox prefix addressed to
         /// this worker's remote database and only after it has drained raw pull
         /// pages for the round. The peer must explicitly support logical
-        /// delivery whenever that prefix is non-empty.
+        /// delivery whenever the destination has pending logical entries.
         bool enable_logical_delivery = false;
 
         /// \brief Maximum logical envelopes delivered in one round.

--- a/include/mdbx_containers/sync/engine/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/engine/SyncWorker.hpp
@@ -771,15 +771,27 @@ namespace sync {
                     return;
                 }
 
-                const std::vector<LogicalDeliveryEnvelope> pending =
-                    m_engine.pending_logical_deliveries(destination, 1u);
-                if (pending.empty()) {
-                    return;
-                }
                 if (!m_peer.supports_logical_delivery()) {
                     result.ok = false;
                     result.error =
                         "Sync peer does not support configured logical delivery";
+                    return;
+                }
+
+                LogicalDeliveryHello remote_hello;
+                {
+                    CancellationToken cancel_token;
+                    PeerCallGuard peer_call(*this, cancel_token);
+                    if (!peer_call.active()) {
+                        return;
+                    }
+                    remote_hello =
+                        m_peer.logical_delivery_hello_with_cancel(&cancel_token);
+                }
+                const std::vector<LogicalDeliveryEnvelope> pending =
+                    m_engine.pending_logical_deliveries(
+                        destination, remote_hello.node_id, 1u);
+                if (pending.empty()) {
                     return;
                 }
 
@@ -793,7 +805,8 @@ namespace sync {
                     notify_stage_changed(make_stage_event(
                         SyncWorkerStage::LogicalDeliveryStarted, result));
                     dispatch = m_engine.deliver_pending_logical_deliveries(
-                        m_peer, destination, 1u, nullptr, &cancel_token);
+                        m_peer, destination, remote_hello.node_id, 1u,
+                        nullptr, &cancel_token);
                 }
                 result.logical_deliveries_delivered += dispatch.delivered;
                 result.logical_acknowledged_through =

--- a/include/mdbx_containers/sync/logical/ILogicalDeliveryOutbox.hpp
+++ b/include/mdbx_containers/sync/logical/ILogicalDeliveryOutbox.hpp
@@ -23,6 +23,7 @@ namespace sync {
         virtual LogicalDeliveryEnvelope enqueue_logical_delivery(
                 MDBX_txn* txn,
                 const DbId& destination,
+                const NodeId& receiver,
                 const LogicalChangeFrame& frame,
                 const CodecBounds* bounds = nullptr) = 0;
     };

--- a/include/mdbx_containers/sync/logical/ILogicalDeliveryPeer.hpp
+++ b/include/mdbx_containers/sync/logical/ILogicalDeliveryPeer.hpp
@@ -47,14 +47,22 @@ namespace sync {
             return deliver_ordered_logical_delivery(envelope, bounds);
         }
 
-        /// \brief Delivers one request with sender feature context.
-        /// \details The default preserves existing peers that implemented the
-        /// earlier envelope-only virtual method. Such peers remain on the
-        /// conservative acknowledgement path until they override this method.
+        /// \brief Delivers one receiver-bound request with sender context.
+        /// \details An envelope-only peer cannot prove that it received the
+        /// selected receiver route, so it must not be used for ordered delivery.
         virtual LogicalDeliveryAcknowledgement deliver_ordered_logical_request(
                 const LogicalDeliveryRequest& request,
                 const CodecBounds* bounds = nullptr) {
-            return deliver_ordered_logical_delivery(request.envelope, bounds);
+            (void)bounds;
+            LogicalDeliveryAcknowledgement acknowledgement;
+            acknowledgement.destination_db_uuid =
+                request.envelope.destination_db_uuid;
+            acknowledgement.receiver_node_id = request.receiver_node_id;
+            acknowledgement.origin_node_id = request.envelope.origin_node_id;
+            acknowledgement.ok = false;
+            acknowledgement.error =
+                "Logical delivery peer does not implement receiver-bound requests";
+            return acknowledgement;
         }
 
         /// \brief Delivers a request with optional cancellation.

--- a/include/mdbx_containers/sync/logical/ILogicalDeliveryPeer.hpp
+++ b/include/mdbx_containers/sync/logical/ILogicalDeliveryPeer.hpp
@@ -13,6 +13,8 @@
 namespace mdbxc {
 namespace sync {
 
+    class CancellationToken;
+
     /// \brief Optional transport boundary for ordered logical delivery.
     class ILogicalDeliveryPeer {
     public:
@@ -24,6 +26,27 @@ namespace sync {
                 const LogicalDeliveryEnvelope& envelope,
                 const CodecBounds* bounds = nullptr) = 0;
 
+        /// \brief Retrieves peer capabilities with optional cancellation.
+        /// \details The default preserves existing logical peers that do not
+        /// own an interruptible transport call.
+        virtual LogicalDeliveryHello logical_delivery_hello_with_cancel(
+                const CancellationToken* cancel_token = nullptr) {
+            (void)cancel_token;
+            return logical_delivery_hello();
+        }
+
+        /// \brief Delivers an envelope with optional cancellation.
+        /// \details The default preserves the original envelope-only peer
+        /// contract for existing source implementations.
+        virtual LogicalDeliveryAcknowledgement
+        deliver_ordered_logical_delivery_with_cancel(
+                const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds = nullptr,
+                const CancellationToken* cancel_token = nullptr) {
+            (void)cancel_token;
+            return deliver_ordered_logical_delivery(envelope, bounds);
+        }
+
         /// \brief Delivers one request with sender feature context.
         /// \details The default preserves existing peers that implemented the
         /// earlier envelope-only virtual method. Such peers remain on the
@@ -32,6 +55,16 @@ namespace sync {
                 const LogicalDeliveryRequest& request,
                 const CodecBounds* bounds = nullptr) {
             return deliver_ordered_logical_delivery(request.envelope, bounds);
+        }
+
+        /// \brief Delivers a request with optional cancellation.
+        virtual LogicalDeliveryAcknowledgement
+        deliver_ordered_logical_request_with_cancel(
+                const LogicalDeliveryRequest& request,
+                const CodecBounds* bounds = nullptr,
+                const CancellationToken* cancel_token = nullptr) {
+            (void)cancel_token;
+            return deliver_ordered_logical_request(request, bounds);
         }
     };
 

--- a/include/mdbx_containers/sync/logical/LogicalDeliveryProtocol.hpp
+++ b/include/mdbx_containers/sync/logical/LogicalDeliveryProtocol.hpp
@@ -200,7 +200,9 @@ namespace sync {
         enum class MessageType : std::uint8_t {
             Hello = 1u,
             Delivery = 2u,
-            Acknowledgement = 3u
+            Acknowledgement = 3u,
+            HelloRequest = 4u,
+            DeliveryRequest = 5u
         };
 
         static const std::uint8_t* magic() {
@@ -238,6 +240,24 @@ namespace sync {
             return out;
         }
 
+        /// \brief Encodes a stateless request for the remote hello.
+        static std::vector<std::uint8_t> encode_hello_request(
+                const CodecBounds* bounds = nullptr) {
+            std::vector<std::uint8_t> out =
+                make_header(MessageType::HelloRequest);
+            validate_size(out, bounds);
+            return out;
+        }
+
+        /// \brief Strictly decodes a stateless remote-hello request.
+        static void decode_hello_request(
+                const std::vector<std::uint8_t>& encoded,
+                const CodecBounds* bounds = nullptr) {
+            Cursor cur = make_cursor(encoded, bounds);
+            check_header(cur, MessageType::HelloRequest);
+            check_consumed(cur);
+        }
+
         static std::vector<std::uint8_t> encode_delivery(
                 const LogicalDeliveryEnvelope& envelope,
                 const CodecBounds* bounds = nullptr) {
@@ -266,6 +286,42 @@ namespace sync {
             }
             const LogicalDeliveryEnvelope out =
                 LogicalDeliveryEnvelopeCodec::decode(nested, bounds);
+            check_consumed(cur);
+            return out;
+        }
+
+        /// \brief Encodes an ordered delivery with sender capabilities.
+        static std::vector<std::uint8_t> encode_delivery_request(
+                const LogicalDeliveryRequest& request,
+                const CodecBounds* bounds = nullptr) {
+            const std::vector<std::uint8_t> nested =
+                LogicalDeliveryEnvelopeCodec::encode(request.envelope, bounds);
+            std::vector<std::uint8_t> out =
+                make_header(MessageType::DeliveryRequest);
+            detail::append_u64_le(out, request.sender_capabilities.flags);
+            append_u32_size(out, nested.size(),
+                            "logical delivery envelope exceeds u32");
+            append_bytes(out, nested.empty() ? nullptr : &nested[0],
+                         nested.size(), bounds);
+            validate_size(out, bounds);
+            return out;
+        }
+
+        /// \brief Strictly decodes an ordered delivery with sender capabilities.
+        static LogicalDeliveryRequest decode_delivery_request(
+                const std::vector<std::uint8_t>& encoded,
+                const CodecBounds* bounds = nullptr) {
+            Cursor cur = make_cursor(encoded, bounds);
+            check_header(cur, MessageType::DeliveryRequest);
+            LogicalDeliveryRequest out;
+            out.sender_capabilities.flags = read_u64_le(cur);
+            const std::uint32_t size = read_u32_le(cur);
+            const std::uint8_t* data = read_bytes(cur, size);
+            std::vector<std::uint8_t> nested(size);
+            if (size != 0u) {
+                std::memcpy(&nested[0], data, size);
+            }
+            out.envelope = LogicalDeliveryEnvelopeCodec::decode(nested, bounds);
             check_consumed(cur);
             return out;
         }
@@ -511,6 +567,10 @@ namespace sync {
                     return MessageType::Delivery;
                 case static_cast<std::uint8_t>(MessageType::Acknowledgement):
                     return MessageType::Acknowledgement;
+                case static_cast<std::uint8_t>(MessageType::HelloRequest):
+                    return MessageType::HelloRequest;
+                case static_cast<std::uint8_t>(MessageType::DeliveryRequest):
+                    return MessageType::DeliveryRequest;
                 default:
                     throw std::runtime_error(
                         "Unexpected logical delivery protocol message type");

--- a/include/mdbx_containers/sync/logical/LogicalDeliveryProtocol.hpp
+++ b/include/mdbx_containers/sync/logical/LogicalDeliveryProtocol.hpp
@@ -43,10 +43,10 @@ namespace sync {
     };
 
     /// \brief One ordered delivery attempt with sender feature context.
-    /// \details The envelope remains the stable persisted object. Capability
-    /// context describes only this peer exchange and lets a receiver retain
-    /// conservative acknowledgements for older senders.
+    /// \details The receiver identity binds this exchange to one sender-side
+    /// ordered outbox route. The envelope remains the stable persisted object.
     struct LogicalDeliveryRequest {
+        NodeId receiver_node_id{};
         LogicalDeliveryEnvelope envelope;
         LogicalDeliveryCapabilities sender_capabilities;
     };
@@ -59,6 +59,7 @@ namespace sync {
     /// known tail during validation.
     struct LogicalDeliveryAcknowledgement {
         DbId destination_db_uuid{};
+        NodeId receiver_node_id{};
         NodeId origin_node_id{};
         std::uint64_t acknowledged_through = 0u;
         bool ok = true;
@@ -71,6 +72,7 @@ namespace sync {
             const LogicalDeliveryAcknowledgement& acknowledgement,
             const CodecBounds* bounds = nullptr) {
         if (is_zero_sync_id(acknowledgement.destination_db_uuid) ||
+            is_zero_sync_id(acknowledgement.receiver_node_id) ||
             is_zero_sync_id(acknowledgement.origin_node_id)) {
             throw std::runtime_error(
                 "Logical delivery acknowledgement identity is incomplete");
@@ -88,16 +90,29 @@ namespace sync {
         }
     }
 
+    /// \brief Validates the receiver-bound ordered delivery request.
+    inline void validate_logical_delivery_request(
+            const LogicalDeliveryRequest& request,
+            const CodecBounds* bounds = nullptr) {
+        if (is_zero_sync_id(request.receiver_node_id)) {
+            throw std::runtime_error(
+                "Logical delivery request receiver identity is incomplete");
+        }
+        validate_logical_delivery_envelope(request.envelope, bounds);
+    }
+
     /// \brief Validates an acknowledgement against the delivery it answers.
     /// \details A successful response acknowledges exactly the delivered
     /// sequence. A failed response may acknowledge only an earlier prefix.
     inline void validate_logical_delivery_acknowledgement_for_delivery(
             const LogicalDeliveryAcknowledgement& acknowledgement,
             const LogicalDeliveryEnvelope& delivery,
+            const NodeId& receiver,
             const CodecBounds* bounds = nullptr) {
         validate_logical_delivery_acknowledgement(acknowledgement, bounds);
         if (compare_node_id(acknowledgement.destination_db_uuid,
                             delivery.destination_db_uuid) != 0 ||
+            compare_node_id(acknowledgement.receiver_node_id, receiver) != 0 ||
             compare_node_id(acknowledgement.origin_node_id,
                             delivery.origin_node_id) != 0) {
             throw std::runtime_error(
@@ -129,12 +144,14 @@ namespace sync {
     inline void validate_logical_delivery_acknowledgement_for_sender(
             const LogicalDeliveryAcknowledgement& acknowledgement,
             const LogicalDeliveryEnvelope& delivery,
+            const NodeId& receiver,
             std::uint64_t known_tail,
             bool cumulative_acknowledgement_negotiated,
             const CodecBounds* bounds = nullptr) {
         validate_logical_delivery_acknowledgement(acknowledgement, bounds);
         if (compare_node_id(acknowledgement.destination_db_uuid,
                             delivery.destination_db_uuid) != 0 ||
+            compare_node_id(acknowledgement.receiver_node_id, receiver) != 0 ||
             compare_node_id(acknowledgement.origin_node_id,
                             delivery.origin_node_id) != 0) {
             throw std::runtime_error(
@@ -212,7 +229,7 @@ namespace sync {
         }
 
         static std::size_t magic_size() { return 8u; }
-        static std::uint16_t codec_version() { return 1u; }
+        static std::uint16_t codec_version() { return 2u; }
 
         static std::vector<std::uint8_t> encode_hello(
                 const LogicalDeliveryHello& hello,
@@ -294,10 +311,12 @@ namespace sync {
         static std::vector<std::uint8_t> encode_delivery_request(
                 const LogicalDeliveryRequest& request,
                 const CodecBounds* bounds = nullptr) {
+            validate_logical_delivery_request(request, bounds);
             const std::vector<std::uint8_t> nested =
                 LogicalDeliveryEnvelopeCodec::encode(request.envelope, bounds);
             std::vector<std::uint8_t> out =
                 make_header(MessageType::DeliveryRequest);
+            append_id(out, request.receiver_node_id, bounds);
             detail::append_u64_le(out, request.sender_capabilities.flags);
             append_u32_size(out, nested.size(),
                             "logical delivery envelope exceeds u32");
@@ -314,6 +333,7 @@ namespace sync {
             Cursor cur = make_cursor(encoded, bounds);
             check_header(cur, MessageType::DeliveryRequest);
             LogicalDeliveryRequest out;
+            read_id(cur, out.receiver_node_id);
             out.sender_capabilities.flags = read_u64_le(cur);
             const std::uint32_t size = read_u32_le(cur);
             const std::uint8_t* data = read_bytes(cur, size);
@@ -322,6 +342,7 @@ namespace sync {
                 std::memcpy(&nested[0], data, size);
             }
             out.envelope = LogicalDeliveryEnvelopeCodec::decode(nested, bounds);
+            validate_logical_delivery_request(out, bounds);
             check_consumed(cur);
             return out;
         }
@@ -333,6 +354,7 @@ namespace sync {
             std::vector<std::uint8_t> out =
                 make_header(MessageType::Acknowledgement);
             append_id(out, acknowledgement.destination_db_uuid, bounds);
+            append_id(out, acknowledgement.receiver_node_id, bounds);
             append_id(out, acknowledgement.origin_node_id, bounds);
             detail::append_u64_le(out, acknowledgement.acknowledged_through);
             append_bool(out, acknowledgement.ok);
@@ -349,6 +371,7 @@ namespace sync {
             check_header(cur, MessageType::Acknowledgement);
             LogicalDeliveryAcknowledgement out;
             read_id(cur, out.destination_db_uuid);
+            read_id(cur, out.receiver_node_id);
             read_id(cur, out.origin_node_id);
             out.acknowledged_through = read_u64_le(cur);
             out.ok = read_bool(cur);

--- a/include/mdbx_containers/sync/logical/LogicalDeliveryProtocol.hpp
+++ b/include/mdbx_containers/sync/logical/LogicalDeliveryProtocol.hpp
@@ -385,8 +385,9 @@ namespace sync {
 
         static Cursor make_cursor(const std::vector<std::uint8_t>& encoded,
                                   const CodecBounds* bounds) {
-            if (bounds != nullptr &&
-                encoded.size() > bounds->max_transport_message_bytes) {
+            const CodecBounds& effective = logical_delivery_effective_bounds(
+                bounds);
+            if (encoded.size() > effective.max_transport_message_bytes) {
                 throw std::length_error(
                     "logical delivery protocol exceeds max_transport_message_bytes");
             }
@@ -408,8 +409,9 @@ namespace sync {
 
         static void validate_size(const std::vector<std::uint8_t>& out,
                                   const CodecBounds* bounds) {
-            if (bounds != nullptr &&
-                out.size() > bounds->max_transport_message_bytes) {
+            const CodecBounds& effective = logical_delivery_effective_bounds(
+                bounds);
+            if (out.size() > effective.max_transport_message_bytes) {
                 throw std::length_error(
                     "logical delivery protocol exceeds max_transport_message_bytes");
             }
@@ -426,8 +428,9 @@ namespace sync {
                 size > (std::numeric_limits<std::size_t>::max)() - out.size()) {
                 throw std::length_error("logical delivery protocol size overflow");
             }
-            if (bounds != nullptr &&
-                out.size() + size > bounds->max_transport_message_bytes) {
+            const CodecBounds& effective = logical_delivery_effective_bounds(
+                bounds);
+            if (out.size() + size > effective.max_transport_message_bytes) {
                 throw std::length_error(
                     "logical delivery protocol exceeds max_transport_message_bytes");
             }

--- a/include/mdbx_containers/sync/logical/adapters/KeyMultiValueTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/logical/adapters/KeyMultiValueTableLogicalAdapter.hpp
@@ -432,9 +432,11 @@ namespace sync {
             LogicalDeliveryEnvelope commit_to_outbox(
                     ILogicalDeliveryOutbox& outbox,
                     const DbId& destination,
+                    const NodeId& receiver,
                     const CodecBounds* bounds = nullptr) {
                 ensure_active();
-                return commit_pending_to_outbox(outbox, destination, bounds);
+                return commit_pending_to_outbox(outbox, destination, receiver,
+                                                bounds);
             }
 
             void rollback() noexcept {

--- a/include/mdbx_containers/sync/logical/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/logical/adapters/KeyOrderedMultiValueTableDestructiveLogicalAdapter.hpp
@@ -575,6 +575,7 @@ namespace sync {
             LogicalDeliveryEnvelope commit_to_outbox(
                     ILogicalDeliveryOutbox& outbox,
                     const DbId& destination,
+                    const NodeId& receiver,
                     const CodecBounds* bounds = nullptr) {
                 ensure_active();
                 try {
@@ -582,7 +583,7 @@ namespace sync {
                     frame.changes = m_pending;
                     const LogicalDeliveryEnvelope envelope =
                         outbox.enqueue_logical_delivery(
-                            m_txn.handle(), destination, frame, bounds);
+                            m_txn.handle(), destination, receiver, frame, bounds);
                     if (compare_node_id(envelope.origin_node_id, m_origin) != 0) {
                         throw std::runtime_error(
                             "Ordered destructive outbox origin does not match capture origin");

--- a/include/mdbx_containers/sync/logical/adapters/KeyOrderedMultiValueTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/logical/adapters/KeyOrderedMultiValueTableLogicalAdapter.hpp
@@ -174,9 +174,11 @@ namespace sync {
             LogicalDeliveryEnvelope commit_to_outbox(
                     ILogicalDeliveryOutbox& outbox,
                     const DbId& destination,
+                    const NodeId& receiver,
                     const CodecBounds* bounds = nullptr) {
                 ensure_active();
-                return commit_pending_to_outbox(outbox, destination, bounds);
+                return commit_pending_to_outbox(outbox, destination, receiver,
+                                                bounds);
             }
 
             void rollback() noexcept {

--- a/include/mdbx_containers/sync/logical/adapters/KeyTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/logical/adapters/KeyTableLogicalAdapter.hpp
@@ -212,9 +212,11 @@ namespace sync {
             LogicalDeliveryEnvelope commit_to_outbox(
                     ILogicalDeliveryOutbox& outbox,
                     const DbId& destination,
+                    const NodeId& receiver,
                     const CodecBounds* bounds = nullptr) {
                 ensure_active();
-                return commit_pending_to_outbox(outbox, destination, bounds);
+                return commit_pending_to_outbox(outbox, destination, receiver,
+                                                bounds);
             }
 
             void rollback() noexcept {

--- a/include/mdbx_containers/sync/logical/adapters/KeyValueTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/logical/adapters/KeyValueTableLogicalAdapter.hpp
@@ -494,9 +494,11 @@ namespace detail {
             LogicalDeliveryEnvelope commit_to_outbox(
                     ILogicalDeliveryOutbox& outbox,
                     const DbId& destination,
+                    const NodeId& receiver,
                     const CodecBounds* bounds = nullptr) {
                 ensure_active();
-                return commit_pending_to_outbox(outbox, destination, bounds);
+                return commit_pending_to_outbox(outbox, destination, receiver,
+                                                bounds);
             }
 
             void rollback() noexcept {

--- a/include/mdbx_containers/sync/logical/adapters/VectorStoreLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/logical/adapters/VectorStoreLogicalAdapter.hpp
@@ -347,6 +347,7 @@ namespace sync {
             LogicalDeliveryEnvelope commit_to_outbox(
                     ILogicalDeliveryOutbox& outbox,
                     const DbId& destination,
+                    const NodeId& receiver,
                     const CodecBounds* bounds = nullptr) {
                 ensure_active();
                 LogicalChangeFrame frame;
@@ -354,7 +355,7 @@ namespace sync {
                 try {
                     const LogicalDeliveryEnvelope envelope =
                         outbox.enqueue_logical_delivery(
-                            m_txn.handle(), destination, frame, bounds);
+                            m_txn.handle(), destination, receiver, frame, bounds);
                     m_txn.commit();
                     m_pending.clear();
                     m_active = false;

--- a/include/mdbx_containers/sync/logical/adapters/detail/captured_logical_transaction.hpp
+++ b/include/mdbx_containers/sync/logical/adapters/detail/captured_logical_transaction.hpp
@@ -39,6 +39,7 @@ namespace detail {
         LogicalDeliveryEnvelope commit_pending_to_outbox(
                 ILogicalDeliveryOutbox& outbox,
                 const DbId& destination,
+                const NodeId& receiver,
                 const CodecBounds* bounds = nullptr) {
             ensure_active("Logical capture session is not active");
             LogicalChangeFrame frame;
@@ -46,7 +47,7 @@ namespace detail {
             try {
                 const LogicalDeliveryEnvelope envelope =
                     outbox.enqueue_logical_delivery(
-                        m_txn.handle(), destination, frame, bounds);
+                        m_txn.handle(), destination, receiver, frame, bounds);
                 m_txn.commit();
                 m_pending.clear();
                 m_active = false;

--- a/include/mdbx_containers/sync/logical/stores/LogicalOutboxStore.hpp
+++ b/include/mdbx_containers/sync/logical/stores/LogicalOutboxStore.hpp
@@ -18,12 +18,13 @@
 namespace mdbxc {
 namespace sync {
 
-    /// \brief Persists ordered logical delivery envelopes per receiver.
-    /// \details Each destination database and receiver node pair has an
-    /// independent monotonic sequence. Entry
-    /// keys use a big-endian sequence suffix so MDBX cursor scans return the
-    /// pending stream in delivery order. This store owns sender-side queueing;
-    /// it does not send frames or interpret receiver acknowledgements.
+    /// \brief Persists ordered logical events and receiver-local delivery state.
+    /// \details Event sequence allocation is global for one destination
+    /// database and origin. Receiver routes retain only their acknowledgement
+    /// and known-tail state. Entry keys use a big-endian sequence suffix so
+    /// MDBX cursor scans return the pending route in delivery order. This store
+    /// owns sender-side queueing; it does not send frames or interpret receiver
+    /// acknowledgements.
     class LogicalOutboxStore {
     public:
         explicit LogicalOutboxStore(
@@ -46,9 +47,10 @@ namespace sync {
             return m_dbi;
         }
 
-        /// \brief Appends one envelope to one receiver's ordered stream.
-        /// \details The generated frame id is stable for the persisted
-        /// sequence. A rollback also rolls back the sequence allocation.
+        /// \brief Appends one globally ordered event to one receiver route.
+        /// \details The generated frame id is stable for the origin event
+        /// sequence. A rollback also rolls back sequence allocation and route
+        /// state.
         LogicalDeliveryEnvelope enqueue(
                 MDBX_txn* txn,
                 const DbId& destination,
@@ -60,56 +62,75 @@ namespace sync {
             validate_identity(destination, receiver, origin);
             open_for_write(txn);
 
-            Metadata metadata = read_metadata(txn, destination, receiver);
-            if (is_zero_sync_id(metadata.origin_node_id)) {
-                metadata.origin_node_id = origin;
-            } else if (compare_node_id(metadata.origin_node_id, origin) != 0) {
-                throw std::invalid_argument(
-                    "LogicalOutboxStore receiver already belongs to a different origin");
-            }
-            if (metadata.next_sequence ==
+            OriginMetadata origin_metadata = read_origin_metadata(
+                txn, destination, origin);
+            if (origin_metadata.next_sequence ==
                 (std::numeric_limits<std::uint64_t>::max)()) {
                 throw std::overflow_error(
                     "LogicalOutboxStore sequence exhausted");
             }
 
+            RouteMetadata route_metadata = read_route_metadata(
+                txn, destination, receiver);
+            if (is_zero_sync_id(route_metadata.origin_node_id)) {
+                route_metadata.origin_node_id = origin;
+                route_metadata.acknowledged_through =
+                    origin_metadata.next_sequence - 1u;
+                route_metadata.known_tail =
+                    origin_metadata.next_sequence - 1u;
+            } else if (compare_node_id(route_metadata.origin_node_id, origin) != 0) {
+                throw std::invalid_argument(
+                    "LogicalOutboxStore receiver already belongs to a different origin");
+            }
+
             LogicalDeliveryEnvelope envelope;
             envelope.destination_db_uuid = destination;
             envelope.origin_node_id = origin;
-            envelope.origin_sequence = metadata.next_sequence;
-            envelope.frame_id = make_frame_id(metadata.next_sequence);
+            envelope.origin_sequence = origin_metadata.next_sequence;
+            envelope.frame_id = make_frame_id(origin_metadata.next_sequence);
             envelope.frame = frame;
+            if (bounds != nullptr) {
+                (void)LogicalDeliveryEnvelopeCodec::encode(envelope, bounds);
+            }
+            // Pending entries can be decoded by a later worker invocation
+            // without carrying a caller-specific bounds object.
             const std::vector<std::uint8_t> encoded =
-                LogicalDeliveryEnvelopeCodec::encode(envelope, bounds);
+                LogicalDeliveryEnvelopeCodec::encode(envelope);
             const std::vector<std::uint8_t> key =
-                make_entry_key(destination, receiver, metadata.next_sequence);
+                make_entry_key(destination, receiver,
+                               origin_metadata.next_sequence);
             MDBX_val raw_key = make_val(key);
             MDBX_val raw_value = make_val(encoded);
             check_mdbx(mdbx_put(txn, m_dbi, &raw_key, &raw_value,
                                 MDBX_NOOVERWRITE),
                        "LogicalOutboxStore enqueue failed");
 
-            ++metadata.next_sequence;
-            write_metadata(txn, destination, receiver, metadata);
+            ++origin_metadata.next_sequence;
+            route_metadata.known_tail = envelope.origin_sequence;
+            write_origin_metadata(txn, destination, origin, origin_metadata);
+            write_route_metadata(txn, destination, receiver, route_metadata);
             return envelope;
         }
 
-        /// \brief Returns envelopes still pending for one \p receiver.
-        /// \param limit Maximum number of envelopes, or zero for all pending.
-        std::vector<LogicalDeliveryEnvelope> list_pending(
+        /// \brief Visits envelopes still pending for one \p receiver.
+        /// \details The visitor runs while the MDBX cursor is open and may
+        /// throw to stop enumeration without retaining later envelopes.
+        template <typename Visitor>
+        void for_each_pending(
                 MDBX_txn* txn,
                 const DbId& destination,
                 const NodeId& receiver,
-                std::size_t limit = 0,
-                const CodecBounds* bounds = nullptr) const {
-            txn = checked_txn(txn, "LogicalOutboxStore::list_pending");
+                Visitor visitor,
+                const CodecBounds* bounds = nullptr,
+                std::size_t limit = 0u) const {
+            txn = checked_txn(txn, "LogicalOutboxStore::for_each_pending");
             validate_route(destination, receiver);
             open_existing(txn);
-            const Metadata metadata = read_metadata(txn, destination, receiver);
-            std::vector<LogicalDeliveryEnvelope> out;
-            if (metadata.acknowledged_through + 1u >=
-                metadata.next_sequence) {
-                return out;
+            const RouteMetadata metadata = read_route_metadata(
+                txn, destination, receiver);
+            if (is_zero_sync_id(metadata.origin_node_id) ||
+                metadata.acknowledged_through >= metadata.known_tail) {
+                return;
             }
 
             const std::vector<std::uint8_t> prefix =
@@ -120,13 +141,14 @@ namespace sync {
             MDBX_cursor* cursor = nullptr;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
                        "LogicalOutboxStore pending cursor open failed");
+            std::size_t visited = 0u;
             try {
                 MDBX_val key = make_val(first_key);
                 MDBX_val value;
                 int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_SET_RANGE);
                 while (rc == MDBX_SUCCESS && has_entry_prefix(key, prefix)) {
                     const std::uint64_t sequence = decode_entry_sequence(key);
-                    if (sequence >= metadata.next_sequence) {
+                    if (sequence > metadata.known_tail) {
                         break;
                     }
                     LogicalDeliveryEnvelope envelope = decode_value(value, bounds);
@@ -138,8 +160,9 @@ namespace sync {
                         throw std::runtime_error(
                             "LogicalOutboxStore entry key/value mismatch");
                     }
-                    out.push_back(envelope);
-                    if (limit != 0u && out.size() >= limit) {
+                    visitor(envelope);
+                    ++visited;
+                    if (limit != 0u && visited >= limit) {
                         break;
                     }
                     rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
@@ -153,6 +176,21 @@ namespace sync {
                 throw;
             }
             mdbx_cursor_close(cursor);
+        }
+
+        /// \brief Returns envelopes still pending for one \p receiver.
+        /// \param limit Maximum number of envelopes, or zero for all pending.
+        std::vector<LogicalDeliveryEnvelope> list_pending(
+                MDBX_txn* txn,
+                const DbId& destination,
+                const NodeId& receiver,
+                std::size_t limit = 0,
+                const CodecBounds* bounds = nullptr) const {
+            std::vector<LogicalDeliveryEnvelope> out;
+            for_each_pending(txn, destination, receiver,
+                [&out](const LogicalDeliveryEnvelope& envelope) {
+                    out.push_back(envelope);
+                }, bounds, limit);
             return out;
         }
 
@@ -165,7 +203,8 @@ namespace sync {
                               "LogicalOutboxStore::acknowledged_through");
             validate_route(destination, receiver);
             open_existing(txn);
-            return read_metadata(txn, destination, receiver).acknowledged_through;
+            return read_route_metadata(txn, destination, receiver).
+                acknowledged_through;
         }
 
         /// \brief Returns the highest sequence durably allocated locally.
@@ -178,8 +217,68 @@ namespace sync {
             txn = checked_txn(txn, "LogicalOutboxStore::known_tail");
             validate_route(destination, receiver);
             open_existing(txn);
-            const Metadata metadata = read_metadata(txn, destination, receiver);
-            return metadata.next_sequence - 1u;
+            return read_route_metadata(txn, destination, receiver).known_tail;
+        }
+
+        /// \brief Returns whether any receiver route has pending work.
+        /// \details This is used before a raw-only peer can provide a logical
+        /// hello and therefore cannot identify one receiver route.
+        bool has_pending_for_destination(
+                MDBX_txn* txn,
+                const DbId& destination,
+                const CodecBounds* bounds = nullptr) const {
+            txn = checked_txn(txn,
+                              "LogicalOutboxStore::has_pending_for_destination");
+            if (is_zero_sync_id(destination)) {
+                throw std::invalid_argument(
+                    "LogicalOutboxStore destination is zero");
+            }
+            open_existing(txn);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "LogicalOutboxStore pending-state cursor open failed");
+            try {
+                MDBX_val key;
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    if (!is_origin_metadata_key(key) &&
+                        !is_route_metadata_key(key)) {
+                        const Route route = decode_route(key);
+                        if (compare_node_id(route.destination, destination) == 0) {
+                            const std::uint64_t sequence =
+                                decode_entry_sequence(key);
+                            const RouteMetadata metadata = read_route_metadata(
+                                txn, route.destination, route.receiver);
+                            const LogicalDeliveryEnvelope envelope =
+                                decode_value(value, bounds);
+                            if (is_zero_sync_id(metadata.origin_node_id) ||
+                                sequence <= metadata.acknowledged_through ||
+                                sequence > metadata.known_tail ||
+                                compare_node_id(envelope.destination_db_uuid,
+                                                route.destination) != 0 ||
+                                compare_node_id(envelope.origin_node_id,
+                                                metadata.origin_node_id) != 0 ||
+                                envelope.origin_sequence != sequence) {
+                                throw std::runtime_error(
+                                    "LogicalOutboxStore entry key/value mismatch");
+                            }
+                            mdbx_cursor_close(cursor);
+                            return true;
+                        }
+                    }
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc,
+                               "LogicalOutboxStore pending-state cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return false;
         }
 
         /// \brief Advances one destination's cumulative acknowledgement.
@@ -192,7 +291,12 @@ namespace sync {
                               "LogicalOutboxStore::acknowledge_through");
             validate_route(destination, receiver);
             open_for_write(txn);
-            Metadata metadata = read_metadata(txn, destination, receiver);
+            RouteMetadata metadata = read_route_metadata(txn, destination,
+                                                         receiver);
+            if (is_zero_sync_id(metadata.origin_node_id)) {
+                throw std::invalid_argument(
+                    "LogicalOutboxStore acknowledgement route is unknown");
+            }
             if (sequence < metadata.acknowledged_through) {
                 throw std::invalid_argument(
                     "LogicalOutboxStore acknowledgement moved backwards");
@@ -200,9 +304,32 @@ namespace sync {
             if (sequence == metadata.acknowledged_through) {
                 return 0u;
             }
-            if (sequence >= metadata.next_sequence) {
+            if (sequence > metadata.known_tail) {
                 throw std::invalid_argument(
                     "LogicalOutboxStore acknowledgement exceeds enqueued sequence");
+            }
+
+            const std::vector<std::uint8_t> acknowledged_key =
+                make_entry_key(destination, receiver, sequence);
+            MDBX_val raw_acknowledged_key = make_val(acknowledged_key);
+            MDBX_val raw_acknowledged_value;
+            const int acknowledged_rc = mdbx_get(
+                txn, m_dbi, &raw_acknowledged_key, &raw_acknowledged_value);
+            if (acknowledged_rc == MDBX_NOTFOUND) {
+                throw std::runtime_error(
+                    "LogicalOutboxStore acknowledgement target is missing");
+            }
+            check_mdbx(acknowledged_rc,
+                       "LogicalOutboxStore acknowledgement target read failed");
+            const LogicalDeliveryEnvelope acknowledged = decode_value(
+                raw_acknowledged_value, nullptr);
+            if (compare_node_id(acknowledged.destination_db_uuid,
+                                destination) != 0 ||
+                compare_node_id(acknowledged.origin_node_id,
+                                metadata.origin_node_id) != 0 ||
+                acknowledged.origin_sequence != sequence) {
+                throw std::runtime_error(
+                    "LogicalOutboxStore acknowledgement target is invalid");
             }
 
             const std::vector<std::uint8_t> prefix =
@@ -210,10 +337,6 @@ namespace sync {
             std::vector<std::uint8_t> first_key = prefix;
             detail::append_u64_be(first_key,
                                   metadata.acknowledged_through + 1u);
-            validate_acknowledgement_prefix(
-                txn, prefix, first_key, metadata.acknowledged_through + 1u,
-                sequence);
-
             MDBX_cursor* cursor = nullptr;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
                        "LogicalOutboxStore acknowledgement cursor open failed");
@@ -227,6 +350,11 @@ namespace sync {
                     if (current > sequence) {
                         break;
                     }
+                    if (current <= metadata.acknowledged_through ||
+                        current > metadata.known_tail) {
+                        throw std::runtime_error(
+                            "LogicalOutboxStore acknowledgement entry is invalid");
+                    }
                     check_mdbx(mdbx_cursor_del(cursor, MDBX_CURRENT),
                                "LogicalOutboxStore acknowledgement delete failed");
                     ++removed;
@@ -236,18 +364,13 @@ namespace sync {
                     check_mdbx(rc,
                                "LogicalOutboxStore acknowledgement cursor read failed");
                 }
-                if (removed != static_cast<std::size_t>(
-                        sequence - metadata.acknowledged_through)) {
-                    throw std::runtime_error(
-                        "LogicalOutboxStore acknowledgement delete count is invalid");
-                }
             } catch (...) {
                 mdbx_cursor_close(cursor);
                 throw;
             }
             mdbx_cursor_close(cursor);
             metadata.acknowledged_through = sequence;
-            write_metadata(txn, destination, receiver, metadata);
+            write_route_metadata(txn, destination, receiver, metadata);
             return removed;
         }
 
@@ -269,18 +392,25 @@ namespace sync {
                 MDBX_val value;
                 int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
                 while (rc == MDBX_SUCCESS) {
-                    const Route route = decode_route(key);
-                    if (is_metadata_key(key)) {
-                        (void)decode_metadata(value);
+                    if (is_origin_metadata_key(key)) {
+                        (void)decode_origin_metadata(value);
                     } else {
+                        const Route route = decode_route(key);
+                        if (is_route_metadata_key(key)) {
+                            (void)decode_metadata(value);
+                            found = true;
+                            rc = mdbx_cursor_get(cursor, &key, &value,
+                                                 MDBX_NEXT);
+                            continue;
+                        }
                         const std::uint64_t sequence = decode_entry_sequence(key);
-                        const Metadata metadata = read_metadata(
+                        const RouteMetadata metadata = read_route_metadata(
                             txn, route.destination, route.receiver);
                         const LogicalDeliveryEnvelope envelope =
                             decode_value(value, bounds);
                         if (is_zero_sync_id(metadata.origin_node_id) ||
                             sequence <= metadata.acknowledged_through ||
-                            sequence >= metadata.next_sequence ||
+                            sequence > metadata.known_tail ||
                             compare_node_id(envelope.destination_db_uuid,
                                             route.destination) != 0 ||
                             compare_node_id(envelope.origin_node_id,
@@ -306,14 +436,21 @@ namespace sync {
         }
 
     private:
-        struct Metadata {
-            Metadata()
-                : next_sequence(1u),
-                  acknowledged_through(0u),
-                  origin_node_id() {}
+        struct OriginMetadata {
+            OriginMetadata()
+                : next_sequence(1u) {}
 
             std::uint64_t next_sequence;
+        };
+
+        struct RouteMetadata {
+            RouteMetadata()
+                : acknowledged_through(0u),
+                  known_tail(0u),
+                  origin_node_id() {}
+
             std::uint64_t acknowledged_through;
+            std::uint64_t known_tail;
             NodeId origin_node_id;
         };
 
@@ -368,13 +505,25 @@ namespace sync {
             return std::string("mdbxc-ordered-") + std::to_string(sequence);
         }
 
-        static std::vector<std::uint8_t> make_metadata_key(
+        static std::vector<std::uint8_t> make_origin_metadata_key(
+                const DbId& destination,
+                const NodeId& origin) {
+            std::vector<std::uint8_t> out;
+            out.reserve(2u + destination.size() + origin.size());
+            out.push_back(key_version());
+            out.push_back(origin_metadata_key_kind());
+            out.insert(out.end(), destination.begin(), destination.end());
+            out.insert(out.end(), origin.begin(), origin.end());
+            return out;
+        }
+
+        static std::vector<std::uint8_t> make_route_metadata_key(
                 const DbId& destination,
                 const NodeId& receiver) {
             std::vector<std::uint8_t> out;
             out.reserve(2u + destination.size() + receiver.size());
             out.push_back(key_version());
-            out.push_back(metadata_key_kind());
+            out.push_back(route_metadata_key_kind());
             out.insert(out.end(), destination.begin(), destination.end());
             out.insert(out.end(), receiver.begin(), receiver.end());
             return out;
@@ -418,14 +567,24 @@ namespace sync {
                    std::memcmp(key.iov_base, &prefix[0], prefix.size()) == 0;
         }
 
-        static bool is_metadata_key(const MDBX_val& key) {
+        static bool is_origin_metadata_key(const MDBX_val& key) {
             if (key.iov_len != entry_prefix_size() || key.iov_base == nullptr) {
                 return false;
             }
             const std::uint8_t* bytes =
                 static_cast<const std::uint8_t*>(key.iov_base);
             return bytes[0] == key_version() &&
-                   bytes[1] == metadata_key_kind();
+                   bytes[1] == origin_metadata_key_kind();
+        }
+
+        static bool is_route_metadata_key(const MDBX_val& key) {
+            if (key.iov_len != entry_prefix_size() || key.iov_base == nullptr) {
+                return false;
+            }
+            const std::uint8_t* bytes =
+                static_cast<const std::uint8_t*>(key.iov_base);
+            return bytes[0] == key_version() &&
+                   bytes[1] == route_metadata_key_kind();
         }
 
         static Route decode_route(const MDBX_val& key) {
@@ -441,7 +600,7 @@ namespace sync {
             const std::uint8_t* bytes =
                 static_cast<const std::uint8_t*>(key.iov_base);
             if (bytes[0] != key_version() ||
-                (bytes[1] != metadata_key_kind() &&
+                (bytes[1] != route_metadata_key_kind() &&
                  bytes[1] != entry_key_kind())) {
                 throw std::runtime_error(
                     "LogicalOutboxStore key has invalid prefix");
@@ -474,112 +633,137 @@ namespace sync {
             return detail::read_u64_be(bytes + entry_prefix_size());
         }
 
-        void validate_acknowledgement_prefix(
-                MDBX_txn* txn,
-                const std::vector<std::uint8_t>& prefix,
-                const std::vector<std::uint8_t>& first_key,
-                std::uint64_t first_sequence,
-                std::uint64_t last_sequence) const {
-            MDBX_cursor* cursor = nullptr;
-            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
-                       "LogicalOutboxStore acknowledgement validation cursor open failed");
-            try {
-                std::uint64_t expected = first_sequence;
-                MDBX_val key = make_val(first_key);
-                MDBX_val value;
-                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_SET_RANGE);
-                while (expected <= last_sequence) {
-                    if (rc != MDBX_SUCCESS || !has_entry_prefix(key, prefix) ||
-                        decode_entry_sequence(key) != expected) {
-                        throw std::runtime_error(
-                            "LogicalOutboxStore acknowledgement prefix is not contiguous");
-                    }
-                    if (expected == last_sequence) {
-                        break;
-                    }
-                    ++expected;
-                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
-                }
-                if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
-                    check_mdbx(rc,
-                               "LogicalOutboxStore acknowledgement validation cursor read failed");
-                }
-            } catch (...) {
-                mdbx_cursor_close(cursor);
-                throw;
+        OriginMetadata read_origin_metadata(MDBX_txn* txn,
+                                            const DbId& destination,
+                                            const NodeId& origin) const {
+            const std::vector<std::uint8_t> key = make_origin_metadata_key(
+                destination, origin);
+            MDBX_val raw_key = make_val(key);
+            MDBX_val raw_value;
+            const int rc = mdbx_get(txn, m_dbi, &raw_key, &raw_value);
+            if (rc == MDBX_NOTFOUND) {
+                return OriginMetadata();
             }
-            mdbx_cursor_close(cursor);
+            check_mdbx(rc, "LogicalOutboxStore origin metadata read failed");
+            return decode_origin_metadata(raw_value);
         }
 
-        Metadata read_metadata(MDBX_txn* txn,
-                               const DbId& destination,
-                               const NodeId& receiver) const {
-            const std::vector<std::uint8_t> key = make_metadata_key(
+        RouteMetadata read_route_metadata(MDBX_txn* txn,
+                                          const DbId& destination,
+                                          const NodeId& receiver) const {
+            const std::vector<std::uint8_t> key = make_route_metadata_key(
                 destination, receiver);
             MDBX_val raw_key = make_val(key);
             MDBX_val raw_value;
             const int rc = mdbx_get(txn, m_dbi, &raw_key, &raw_value);
             if (rc == MDBX_NOTFOUND) {
-                return Metadata();
+                return RouteMetadata();
             }
-            check_mdbx(rc, "LogicalOutboxStore metadata read failed");
+            check_mdbx(rc, "LogicalOutboxStore route metadata read failed");
             return decode_metadata(raw_value);
         }
 
-        void write_metadata(MDBX_txn* txn,
-                            const DbId& destination,
-                            const NodeId& receiver,
-                            const Metadata& metadata) const {
-            const std::vector<std::uint8_t> key = make_metadata_key(
+        void write_origin_metadata(MDBX_txn* txn,
+                                   const DbId& destination,
+                                   const NodeId& origin,
+                                   const OriginMetadata& metadata) const {
+            const std::vector<std::uint8_t> key = make_origin_metadata_key(
+                destination, origin);
+            const std::vector<std::uint8_t> value =
+                encode_origin_metadata(metadata);
+            MDBX_val raw_key = make_val(key);
+            MDBX_val raw_value = make_val(value);
+            check_mdbx(mdbx_put(txn, m_dbi, &raw_key, &raw_value,
+                                MDBX_UPSERT),
+                       "LogicalOutboxStore origin metadata write failed");
+        }
+
+        void write_route_metadata(MDBX_txn* txn,
+                                  const DbId& destination,
+                                  const NodeId& receiver,
+                                  const RouteMetadata& metadata) const {
+            const std::vector<std::uint8_t> key = make_route_metadata_key(
                 destination, receiver);
             const std::vector<std::uint8_t> value = encode_metadata(metadata);
             MDBX_val raw_key = make_val(key);
             MDBX_val raw_value = make_val(value);
             check_mdbx(mdbx_put(txn, m_dbi, &raw_key, &raw_value,
                                 MDBX_UPSERT),
-                       "LogicalOutboxStore metadata write failed");
+                       "LogicalOutboxStore route metadata write failed");
+        }
+
+        static std::vector<std::uint8_t> encode_origin_metadata(
+                const OriginMetadata& metadata) {
+            if (metadata.next_sequence == 0u) {
+                throw std::logic_error(
+                    "LogicalOutboxStore origin metadata is invalid");
+            }
+            std::vector<std::uint8_t> out;
+            out.reserve(2u + 8u);
+            detail::append_u16_le(out, origin_metadata_value_version());
+            detail::append_u64_le(out, metadata.next_sequence);
+            return out;
+        }
+
+        static OriginMetadata decode_origin_metadata(const MDBX_val& value) {
+            if (value.iov_len != origin_metadata_value_size() ||
+                value.iov_base == nullptr) {
+                throw std::runtime_error(
+                    "LogicalOutboxStore origin metadata has invalid size");
+            }
+            const std::uint8_t* bytes =
+                static_cast<const std::uint8_t*>(value.iov_base);
+            if (detail::read_u16_le(bytes) != origin_metadata_value_version()) {
+                throw std::runtime_error(
+                    "Unsupported LogicalOutboxStore origin metadata version");
+            }
+            OriginMetadata out;
+            out.next_sequence = detail::read_u64_le(bytes + 2u);
+            if (out.next_sequence == 0u) {
+                throw std::runtime_error(
+                    "LogicalOutboxStore origin metadata is invalid");
+            }
+            return out;
         }
 
         static std::vector<std::uint8_t> encode_metadata(
-                const Metadata& metadata) {
-            if (metadata.next_sequence == 0u ||
-                metadata.acknowledged_through >= metadata.next_sequence ||
+                const RouteMetadata& metadata) {
+            if (metadata.known_tail < metadata.acknowledged_through ||
                 is_zero_sync_id(metadata.origin_node_id)) {
                 throw std::logic_error(
-                    "LogicalOutboxStore metadata is invalid");
+                    "LogicalOutboxStore route metadata is invalid");
             }
             std::vector<std::uint8_t> out;
             out.reserve(2u + 8u + 8u + metadata.origin_node_id.size());
-            detail::append_u16_le(out, metadata_value_version());
-            detail::append_u64_le(out, metadata.next_sequence);
+            detail::append_u16_le(out, route_metadata_value_version());
             detail::append_u64_le(out, metadata.acknowledged_through);
+            detail::append_u64_le(out, metadata.known_tail);
             out.insert(out.end(), metadata.origin_node_id.begin(),
                        metadata.origin_node_id.end());
             return out;
         }
 
-        static Metadata decode_metadata(const MDBX_val& value) {
-            if (value.iov_len != metadata_value_size() ||
+        static RouteMetadata decode_metadata(const MDBX_val& value) {
+            if (value.iov_len != route_metadata_value_size() ||
                 value.iov_base == nullptr) {
                 throw std::runtime_error(
-                    "LogicalOutboxStore metadata has invalid size");
+                    "LogicalOutboxStore route metadata has invalid size");
             }
             const std::uint8_t* bytes =
                 static_cast<const std::uint8_t*>(value.iov_base);
-            if (detail::read_u16_le(bytes) != metadata_value_version()) {
+            if (detail::read_u16_le(bytes) != route_metadata_value_version()) {
                 throw std::runtime_error(
-                    "Unsupported LogicalOutboxStore metadata version");
+                    "Unsupported LogicalOutboxStore route metadata version");
             }
-            Metadata out;
-            out.next_sequence = detail::read_u64_le(bytes + 2u);
-            out.acknowledged_through = detail::read_u64_le(bytes + 10u);
+            RouteMetadata out;
+            out.acknowledged_through = detail::read_u64_le(bytes + 2u);
+            out.known_tail = detail::read_u64_le(bytes + 10u);
             std::memcpy(out.origin_node_id.data(), bytes + 18u,
                         out.origin_node_id.size());
-            if (out.next_sequence == 0u ||
-                out.acknowledged_through >= out.next_sequence ||
+            if (out.known_tail < out.acknowledged_through ||
                 is_zero_sync_id(out.origin_node_id)) {
                 throw std::runtime_error(
-                    "LogicalOutboxStore metadata is invalid");
+                    "LogicalOutboxStore route metadata is invalid");
             }
             return out;
         }
@@ -598,15 +782,18 @@ namespace sync {
             return LogicalDeliveryEnvelopeCodec::decode(encoded, bounds);
         }
 
-        static std::uint8_t key_version() { return 2u; }
-        static std::uint8_t metadata_key_kind() { return 0u; }
-        static std::uint8_t entry_key_kind() { return 1u; }
-        static std::uint16_t metadata_value_version() { return 2u; }
+        static std::uint8_t key_version() { return 3u; }
+        static std::uint8_t origin_metadata_key_kind() { return 0u; }
+        static std::uint8_t route_metadata_key_kind() { return 1u; }
+        static std::uint8_t entry_key_kind() { return 2u; }
+        static std::uint16_t origin_metadata_value_version() { return 1u; }
+        static std::uint16_t route_metadata_value_version() { return 1u; }
         static std::size_t entry_prefix_size() {
             return 2u + DbId().size() + NodeId().size();
         }
         static std::size_t entry_key_size() { return entry_prefix_size() + 8u; }
-        static std::size_t metadata_value_size() {
+        static std::size_t origin_metadata_value_size() { return 2u + 8u; }
+        static std::size_t route_metadata_value_size() {
             return 2u + 8u + 8u + NodeId().size();
         }
 

--- a/include/mdbx_containers/sync/logical/stores/LogicalOutboxStore.hpp
+++ b/include/mdbx_containers/sync/logical/stores/LogicalOutboxStore.hpp
@@ -18,8 +18,9 @@
 namespace mdbxc {
 namespace sync {
 
-    /// \brief Persists ordered logical delivery envelopes per destination.
-    /// \details Each destination has an independent monotonic sequence. Entry
+    /// \brief Persists ordered logical delivery envelopes per receiver.
+    /// \details Each destination database and receiver node pair has an
+    /// independent monotonic sequence. Entry
     /// keys use a big-endian sequence suffix so MDBX cursor scans return the
     /// pending stream in delivery order. This store owns sender-side queueing;
     /// it does not send frames or interpret receiver acknowledgements.
@@ -45,25 +46,26 @@ namespace sync {
             return m_dbi;
         }
 
-        /// \brief Appends one envelope to \p destination's ordered stream.
+        /// \brief Appends one envelope to one receiver's ordered stream.
         /// \details The generated frame id is stable for the persisted
         /// sequence. A rollback also rolls back the sequence allocation.
         LogicalDeliveryEnvelope enqueue(
                 MDBX_txn* txn,
                 const DbId& destination,
+                const NodeId& receiver,
                 const NodeId& origin,
                 const LogicalChangeFrame& frame,
                 const CodecBounds* bounds = nullptr) {
             txn = checked_txn(txn, "LogicalOutboxStore::enqueue");
-            validate_identity(destination, origin);
+            validate_identity(destination, receiver, origin);
             open_for_write(txn);
 
-            Metadata metadata = read_metadata(txn, destination);
+            Metadata metadata = read_metadata(txn, destination, receiver);
             if (is_zero_sync_id(metadata.origin_node_id)) {
                 metadata.origin_node_id = origin;
             } else if (compare_node_id(metadata.origin_node_id, origin) != 0) {
                 throw std::invalid_argument(
-                    "LogicalOutboxStore destination already belongs to a different origin");
+                    "LogicalOutboxStore receiver already belongs to a different origin");
             }
             if (metadata.next_sequence ==
                 (std::numeric_limits<std::uint64_t>::max)()) {
@@ -80,7 +82,7 @@ namespace sync {
             const std::vector<std::uint8_t> encoded =
                 LogicalDeliveryEnvelopeCodec::encode(envelope, bounds);
             const std::vector<std::uint8_t> key =
-                make_entry_key(destination, metadata.next_sequence);
+                make_entry_key(destination, receiver, metadata.next_sequence);
             MDBX_val raw_key = make_val(key);
             MDBX_val raw_value = make_val(encoded);
             check_mdbx(mdbx_put(txn, m_dbi, &raw_key, &raw_value,
@@ -88,24 +90,22 @@ namespace sync {
                        "LogicalOutboxStore enqueue failed");
 
             ++metadata.next_sequence;
-            write_metadata(txn, destination, metadata);
+            write_metadata(txn, destination, receiver, metadata);
             return envelope;
         }
 
-        /// \brief Returns envelopes still pending for \p destination.
+        /// \brief Returns envelopes still pending for one \p receiver.
         /// \param limit Maximum number of envelopes, or zero for all pending.
         std::vector<LogicalDeliveryEnvelope> list_pending(
                 MDBX_txn* txn,
                 const DbId& destination,
+                const NodeId& receiver,
                 std::size_t limit = 0,
                 const CodecBounds* bounds = nullptr) const {
             txn = checked_txn(txn, "LogicalOutboxStore::list_pending");
-            if (is_zero_sync_id(destination)) {
-                throw std::invalid_argument(
-                    "LogicalOutboxStore destination is zero");
-            }
+            validate_route(destination, receiver);
             open_existing(txn);
-            const Metadata metadata = read_metadata(txn, destination);
+            const Metadata metadata = read_metadata(txn, destination, receiver);
             std::vector<LogicalDeliveryEnvelope> out;
             if (metadata.acknowledged_through + 1u >=
                 metadata.next_sequence) {
@@ -113,7 +113,7 @@ namespace sync {
             }
 
             const std::vector<std::uint8_t> prefix =
-                make_entry_prefix(destination);
+                make_entry_prefix(destination, receiver);
             std::vector<std::uint8_t> first_key = prefix;
             detail::append_u64_be(first_key,
                                   metadata.acknowledged_through + 1u);
@@ -159,15 +159,13 @@ namespace sync {
         /// \brief Returns the persisted cumulative acknowledgement frontier.
         std::uint64_t acknowledged_through(
                 MDBX_txn* txn,
-                const DbId& destination) const {
+                const DbId& destination,
+                const NodeId& receiver) const {
             txn = checked_txn(txn,
                               "LogicalOutboxStore::acknowledged_through");
-            if (is_zero_sync_id(destination)) {
-                throw std::invalid_argument(
-                    "LogicalOutboxStore destination is zero");
-            }
+            validate_route(destination, receiver);
             open_existing(txn);
-            return read_metadata(txn, destination).acknowledged_through;
+            return read_metadata(txn, destination, receiver).acknowledged_through;
         }
 
         /// \brief Returns the highest sequence durably allocated locally.
@@ -175,14 +173,12 @@ namespace sync {
         /// acknowledgement must never advance beyond it, including after the
         /// sender restarts and redelivers an earlier pending entry.
         std::uint64_t known_tail(MDBX_txn* txn,
-                                 const DbId& destination) const {
+                                 const DbId& destination,
+                                 const NodeId& receiver) const {
             txn = checked_txn(txn, "LogicalOutboxStore::known_tail");
-            if (is_zero_sync_id(destination)) {
-                throw std::invalid_argument(
-                    "LogicalOutboxStore destination is zero");
-            }
+            validate_route(destination, receiver);
             open_existing(txn);
-            const Metadata metadata = read_metadata(txn, destination);
+            const Metadata metadata = read_metadata(txn, destination, receiver);
             return metadata.next_sequence - 1u;
         }
 
@@ -190,15 +186,13 @@ namespace sync {
         /// \return Number of deleted pending entries.
         std::size_t acknowledge_through(MDBX_txn* txn,
                                         const DbId& destination,
+                                        const NodeId& receiver,
                                         std::uint64_t sequence) {
             txn = checked_txn(txn,
                               "LogicalOutboxStore::acknowledge_through");
-            if (is_zero_sync_id(destination)) {
-                throw std::invalid_argument(
-                    "LogicalOutboxStore destination is zero");
-            }
+            validate_route(destination, receiver);
             open_for_write(txn);
-            Metadata metadata = read_metadata(txn, destination);
+            Metadata metadata = read_metadata(txn, destination, receiver);
             if (sequence < metadata.acknowledged_through) {
                 throw std::invalid_argument(
                     "LogicalOutboxStore acknowledgement moved backwards");
@@ -212,7 +206,7 @@ namespace sync {
             }
 
             const std::vector<std::uint8_t> prefix =
-                make_entry_prefix(destination);
+                make_entry_prefix(destination, receiver);
             std::vector<std::uint8_t> first_key = prefix;
             detail::append_u64_be(first_key,
                                   metadata.acknowledged_through + 1u);
@@ -253,7 +247,7 @@ namespace sync {
             }
             mdbx_cursor_close(cursor);
             metadata.acknowledged_through = sequence;
-            write_metadata(txn, destination, metadata);
+            write_metadata(txn, destination, receiver, metadata);
             return removed;
         }
 
@@ -275,19 +269,20 @@ namespace sync {
                 MDBX_val value;
                 int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
                 while (rc == MDBX_SUCCESS) {
-                    const DbId destination = decode_destination(key);
+                    const Route route = decode_route(key);
                     if (is_metadata_key(key)) {
                         (void)decode_metadata(value);
                     } else {
                         const std::uint64_t sequence = decode_entry_sequence(key);
-                        const Metadata metadata = read_metadata(txn, destination);
+                        const Metadata metadata = read_metadata(
+                            txn, route.destination, route.receiver);
                         const LogicalDeliveryEnvelope envelope =
                             decode_value(value, bounds);
                         if (is_zero_sync_id(metadata.origin_node_id) ||
                             sequence <= metadata.acknowledged_through ||
                             sequence >= metadata.next_sequence ||
                             compare_node_id(envelope.destination_db_uuid,
-                                            destination) != 0 ||
+                                            route.destination) != 0 ||
                             compare_node_id(envelope.origin_node_id,
                                             metadata.origin_node_id) != 0 ||
                             envelope.origin_sequence != sequence) {
@@ -342,12 +337,27 @@ namespace sync {
             check_mdbx(rc, "Failed to open LogicalOutboxStore DBI");
         }
 
-        static void validate_identity(const DbId& destination,
-                                      const NodeId& origin) {
+        struct Route {
+            DbId destination;
+            NodeId receiver;
+        };
+
+        static void validate_route(const DbId& destination,
+                                   const NodeId& receiver) {
             if (is_zero_sync_id(destination)) {
                 throw std::invalid_argument(
                     "LogicalOutboxStore destination is zero");
             }
+            if (is_zero_sync_id(receiver)) {
+                throw std::invalid_argument(
+                    "LogicalOutboxStore receiver is zero");
+            }
+        }
+
+        static void validate_identity(const DbId& destination,
+                                      const NodeId& receiver,
+                                      const NodeId& origin) {
+            validate_route(destination, receiver);
             if (is_zero_sync_id(origin)) {
                 throw std::invalid_argument(
                     "LogicalOutboxStore origin is zero");
@@ -359,29 +369,35 @@ namespace sync {
         }
 
         static std::vector<std::uint8_t> make_metadata_key(
-                const DbId& destination) {
+                const DbId& destination,
+                const NodeId& receiver) {
             std::vector<std::uint8_t> out;
-            out.reserve(2u + destination.size());
+            out.reserve(2u + destination.size() + receiver.size());
             out.push_back(key_version());
             out.push_back(metadata_key_kind());
             out.insert(out.end(), destination.begin(), destination.end());
+            out.insert(out.end(), receiver.begin(), receiver.end());
             return out;
         }
 
         static std::vector<std::uint8_t> make_entry_prefix(
-                const DbId& destination) {
+                const DbId& destination,
+                const NodeId& receiver) {
             std::vector<std::uint8_t> out;
-            out.reserve(2u + destination.size());
+            out.reserve(2u + destination.size() + receiver.size());
             out.push_back(key_version());
             out.push_back(entry_key_kind());
             out.insert(out.end(), destination.begin(), destination.end());
+            out.insert(out.end(), receiver.begin(), receiver.end());
             return out;
         }
 
         static std::vector<std::uint8_t> make_entry_key(
                 const DbId& destination,
+                const NodeId& receiver,
                 std::uint64_t sequence) {
-            std::vector<std::uint8_t> out = make_entry_prefix(destination);
+            std::vector<std::uint8_t> out = make_entry_prefix(destination,
+                                                                receiver);
             detail::append_u64_be(out, sequence);
             return out;
         }
@@ -412,7 +428,7 @@ namespace sync {
                    bytes[1] == metadata_key_kind();
         }
 
-        static DbId decode_destination(const MDBX_val& key) {
+        static Route decode_route(const MDBX_val& key) {
             if (key.iov_len != entry_prefix_size() &&
                 key.iov_len != entry_key_size()) {
                 throw std::runtime_error(
@@ -430,13 +446,17 @@ namespace sync {
                 throw std::runtime_error(
                     "LogicalOutboxStore key has invalid prefix");
             }
-            DbId destination;
-            std::memcpy(destination.data(), bytes + 2u, destination.size());
-            if (is_zero_sync_id(destination)) {
-                throw std::runtime_error(
-                    "LogicalOutboxStore destination is zero");
+            Route route;
+            std::memcpy(route.destination.data(), bytes + 2u,
+                        route.destination.size());
+            std::memcpy(route.receiver.data(),
+                        bytes + 2u + route.destination.size(),
+                        route.receiver.size());
+            if (is_zero_sync_id(route.destination) ||
+                is_zero_sync_id(route.receiver)) {
+                throw std::runtime_error("LogicalOutboxStore route is incomplete");
             }
-            return destination;
+            return route;
         }
 
         static std::uint64_t decode_entry_sequence(const MDBX_val& key) {
@@ -492,8 +512,10 @@ namespace sync {
         }
 
         Metadata read_metadata(MDBX_txn* txn,
-                               const DbId& destination) const {
-            const std::vector<std::uint8_t> key = make_metadata_key(destination);
+                               const DbId& destination,
+                               const NodeId& receiver) const {
+            const std::vector<std::uint8_t> key = make_metadata_key(
+                destination, receiver);
             MDBX_val raw_key = make_val(key);
             MDBX_val raw_value;
             const int rc = mdbx_get(txn, m_dbi, &raw_key, &raw_value);
@@ -506,8 +528,10 @@ namespace sync {
 
         void write_metadata(MDBX_txn* txn,
                             const DbId& destination,
+                            const NodeId& receiver,
                             const Metadata& metadata) const {
-            const std::vector<std::uint8_t> key = make_metadata_key(destination);
+            const std::vector<std::uint8_t> key = make_metadata_key(
+                destination, receiver);
             const std::vector<std::uint8_t> value = encode_metadata(metadata);
             MDBX_val raw_key = make_val(key);
             MDBX_val raw_value = make_val(value);
@@ -574,11 +598,13 @@ namespace sync {
             return LogicalDeliveryEnvelopeCodec::decode(encoded, bounds);
         }
 
-        static std::uint8_t key_version() { return 1u; }
+        static std::uint8_t key_version() { return 2u; }
         static std::uint8_t metadata_key_kind() { return 0u; }
         static std::uint8_t entry_key_kind() { return 1u; }
         static std::uint16_t metadata_value_version() { return 2u; }
-        static std::size_t entry_prefix_size() { return 2u + DbId().size(); }
+        static std::size_t entry_prefix_size() {
+            return 2u + DbId().size() + NodeId().size();
+        }
         static std::size_t entry_key_size() { return entry_prefix_size() + 8u; }
         static std::size_t metadata_value_size() {
             return 2u + 8u + 8u + NodeId().size();

--- a/include/mdbx_containers/sync/transport/HttpTransport.hpp
+++ b/include/mdbx_containers/sync/transport/HttpTransport.hpp
@@ -267,6 +267,14 @@ namespace sync {
         static const char* push_target() {
             return "/mdbxc/sync/v1/push";
         }
+
+        static const char* logical_hello_target() {
+            return "/mdbxc/sync/v1/logical/hello";
+        }
+
+        static const char* logical_delivery_target() {
+            return "/mdbxc/sync/v1/logical/delivery";
+        }
     };
 
     /// \brief Server-side dispatcher from HTTP-shaped requests to SyncEngine.
@@ -290,6 +298,12 @@ namespace sync {
                 response = handle_pull(request.body);
             } else if (request.target == HttpSyncRoutes::push_target()) {
                 response = handle_push(request.body);
+            } else if (request.target ==
+                       HttpSyncRoutes::logical_hello_target()) {
+                response = handle_logical_hello(request.body);
+            } else if (request.target ==
+                       HttpSyncRoutes::logical_delivery_target()) {
+                response = handle_logical_delivery(request.body);
             } else {
                 response = make_error(404, "unknown sync route");
             }
@@ -340,6 +354,57 @@ namespace sync {
                         response, &m_bounds));
             } catch (const std::exception& e) {
                 return make_error(500, e.what());
+            }
+        }
+
+        HttpSyncResponse handle_logical_hello(
+                const std::vector<std::uint8_t>& body) const {
+            try {
+                LogicalDeliveryProtocolCodec::decode_hello_request(
+                    body, &m_bounds);
+                return make_binary(
+                    LogicalDeliveryProtocolCodec::encode_hello(
+                        m_engine.logical_delivery_hello(), &m_bounds));
+            } catch (const std::length_error& e) {
+                return make_error(413, e.what());
+            } catch (const std::exception& e) {
+                return make_error(400, e.what());
+            }
+        }
+
+        HttpSyncResponse handle_logical_delivery(
+                const std::vector<std::uint8_t>& body) const {
+            try {
+                const LogicalDeliveryProtocolCodec::MessageType type =
+                    LogicalDeliveryProtocolCodec::peek_message_type(
+                        body, &m_bounds);
+                LogicalDeliveryAcknowledgement acknowledgement;
+                if (type == LogicalDeliveryProtocolCodec::MessageType::Delivery) {
+                    acknowledgement =
+                        m_engine.apply_ordered_logical_delivery_envelope(
+                            LogicalDeliveryProtocolCodec::decode_delivery(
+                                body, &m_bounds),
+                            &m_bounds);
+                } else if (type ==
+                           LogicalDeliveryProtocolCodec::MessageType::DeliveryRequest) {
+                    const LogicalDeliveryRequest request =
+                        LogicalDeliveryProtocolCodec::decode_delivery_request(
+                            body, &m_bounds);
+                    acknowledgement =
+                        m_engine.apply_ordered_logical_delivery_envelope(
+                            request.envelope, &request.sender_capabilities,
+                            &m_bounds);
+                } else {
+                    return make_error(
+                        400, "unexpected logical delivery message type");
+                }
+                return make_binary(
+                    LogicalDeliveryProtocolCodec::encode_acknowledgement(
+                        acknowledgement, &m_bounds));
+            } catch (const std::length_error& e) {
+                return make_error(413, e.what());
+            } catch (const std::exception& e) {
+                return make_error(400, e.what());
             }
         }
 
@@ -403,6 +468,66 @@ namespace sync {
                 response.body, &m_bounds);
         }
 
+        bool supports_logical_delivery() const override {
+            return true;
+        }
+
+        LogicalDeliveryHello logical_delivery_hello() override {
+            return logical_delivery_hello_with_cancel(nullptr);
+        }
+
+        LogicalDeliveryHello logical_delivery_hello_with_cancel(
+                const CancellationToken* cancel_token = nullptr) override {
+            clear_last_retry_hint();
+            const CancellationToken token = cancel_token != nullptr
+                ? *cancel_token
+                : CancellationToken();
+            const HttpSyncResponse response = m_client.post(
+                HttpSyncRoutes::logical_hello_target(),
+                HttpSyncRoutes::content_type(),
+                LogicalDeliveryProtocolCodec::encode_hello_request(&m_bounds),
+                token);
+            require_ok_response(response, "logical hello");
+            return LogicalDeliveryProtocolCodec::decode_hello(
+                response.body, &m_bounds);
+        }
+
+        LogicalDeliveryAcknowledgement deliver_ordered_logical_delivery(
+                const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds = nullptr) override {
+            return deliver_ordered_logical_delivery_with_cancel(
+                envelope, bounds, nullptr);
+        }
+
+        LogicalDeliveryAcknowledgement
+        deliver_ordered_logical_delivery_with_cancel(
+                const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds = nullptr,
+                const CancellationToken* cancel_token = nullptr) override {
+            return deliver_logical_message(
+                LogicalDeliveryProtocolCodec::encode_delivery(envelope,
+                                                              effective_logical_bounds(bounds)),
+                cancel_token);
+        }
+
+        LogicalDeliveryAcknowledgement deliver_ordered_logical_request(
+                const LogicalDeliveryRequest& request,
+                const CodecBounds* bounds = nullptr) override {
+            return deliver_ordered_logical_request_with_cancel(
+                request, bounds, nullptr);
+        }
+
+        LogicalDeliveryAcknowledgement
+        deliver_ordered_logical_request_with_cancel(
+                const LogicalDeliveryRequest& request,
+                const CodecBounds* bounds = nullptr,
+                const CancellationToken* cancel_token = nullptr) override {
+            return deliver_logical_message(
+                LogicalDeliveryProtocolCodec::encode_delivery_request(
+                    request, effective_logical_bounds(bounds)),
+                cancel_token);
+        }
+
         void request_cancel() override {
             m_client.request_cancel();
         }
@@ -413,6 +538,26 @@ namespace sync {
         }
 
     private:
+        const CodecBounds* effective_logical_bounds(
+                const CodecBounds* bounds) const {
+            return bounds != nullptr ? bounds : &m_bounds;
+        }
+
+        LogicalDeliveryAcknowledgement deliver_logical_message(
+                const std::vector<std::uint8_t>& body,
+                const CancellationToken* cancel_token) {
+            clear_last_retry_hint();
+            const CancellationToken token = cancel_token != nullptr
+                ? *cancel_token
+                : CancellationToken();
+            const HttpSyncResponse response = m_client.post(
+                HttpSyncRoutes::logical_delivery_target(),
+                HttpSyncRoutes::content_type(), body, token);
+            require_ok_response(response, "logical delivery");
+            return LogicalDeliveryProtocolCodec::decode_acknowledgement(
+                response.body, &m_bounds);
+        }
+
         void require_ok_response(const HttpSyncResponse& response,
                                  const char* operation) const {
             if (response.status_code != 200) {

--- a/include/mdbx_containers/sync/transport/HttpTransport.hpp
+++ b/include/mdbx_containers/sync/transport/HttpTransport.hpp
@@ -380,20 +380,16 @@ namespace sync {
                         body, &m_bounds);
                 LogicalDeliveryAcknowledgement acknowledgement;
                 if (type == LogicalDeliveryProtocolCodec::MessageType::Delivery) {
-                    acknowledgement =
-                        m_engine.apply_ordered_logical_delivery_envelope(
-                            LogicalDeliveryProtocolCodec::decode_delivery(
-                                body, &m_bounds),
-                            &m_bounds);
+                    return make_error(
+                        400, "receiver-bound logical delivery request required");
                 } else if (type ==
                            LogicalDeliveryProtocolCodec::MessageType::DeliveryRequest) {
                     const LogicalDeliveryRequest request =
                         LogicalDeliveryProtocolCodec::decode_delivery_request(
                             body, &m_bounds);
                     acknowledgement =
-                        m_engine.apply_ordered_logical_delivery_envelope(
-                            request.envelope, &request.sender_capabilities,
-                            &m_bounds);
+                        m_engine.apply_ordered_logical_delivery_request(
+                            request, &m_bounds);
                 } else {
                     return make_error(
                         400, "unexpected logical delivery message type");

--- a/include/mdbx_containers/sync/transport/WebSocketTransport.hpp
+++ b/include/mdbx_containers/sync/transport/WebSocketTransport.hpp
@@ -12,6 +12,7 @@
 /// fragmentation/reassembly, backpressure, retries, and socket cancellation.
 
 #include <cstdint>
+#include <cstring>
 #include <stdexcept>
 #include <vector>
 
@@ -117,6 +118,9 @@ namespace sync {
         /// those failures to their close/error policy.
         std::vector<std::uint8_t> handle_binary_message(
                 const std::vector<std::uint8_t>& binary_message) const {
+            if (is_logical_delivery_message(binary_message)) {
+                return handle_logical_delivery(binary_message);
+            }
             const TransportMessageType type =
                 TransportMessageCodec::peek_message_type(
                     binary_message, &m_bounds);
@@ -134,6 +138,15 @@ namespace sync {
         }
 
     private:
+        static bool is_logical_delivery_message(
+                const std::vector<std::uint8_t>& binary_message) {
+            return binary_message.size() >=
+                       LogicalDeliveryProtocolCodec::magic_size() &&
+                   std::memcmp(&binary_message[0],
+                               LogicalDeliveryProtocolCodec::magic(),
+                               LogicalDeliveryProtocolCodec::magic_size()) == 0;
+        }
+
         std::vector<std::uint8_t> handle_pull(
                 const std::vector<std::uint8_t>& binary_message) const {
             const PullRequest request =
@@ -152,6 +165,42 @@ namespace sync {
             const PushResponse response = m_engine.handle_push(request);
             return TransportMessageCodec::encode_push_response(
                 response, &m_bounds);
+        }
+
+        std::vector<std::uint8_t> handle_logical_delivery(
+                const std::vector<std::uint8_t>& binary_message) const {
+            const LogicalDeliveryProtocolCodec::MessageType type =
+                LogicalDeliveryProtocolCodec::peek_message_type(
+                    binary_message, &m_bounds);
+            switch (type) {
+                case LogicalDeliveryProtocolCodec::MessageType::HelloRequest:
+                    LogicalDeliveryProtocolCodec::decode_hello_request(
+                        binary_message, &m_bounds);
+                    return LogicalDeliveryProtocolCodec::encode_hello(
+                        m_engine.logical_delivery_hello(), &m_bounds);
+                case LogicalDeliveryProtocolCodec::MessageType::Delivery:
+                    return LogicalDeliveryProtocolCodec::encode_acknowledgement(
+                        m_engine.apply_ordered_logical_delivery_envelope(
+                            LogicalDeliveryProtocolCodec::decode_delivery(
+                                binary_message, &m_bounds),
+                            &m_bounds),
+                        &m_bounds);
+                case LogicalDeliveryProtocolCodec::MessageType::DeliveryRequest: {
+                    const LogicalDeliveryRequest request =
+                        LogicalDeliveryProtocolCodec::decode_delivery_request(
+                            binary_message, &m_bounds);
+                    return LogicalDeliveryProtocolCodec::encode_acknowledgement(
+                        m_engine.apply_ordered_logical_delivery_envelope(
+                            request.envelope, &request.sender_capabilities,
+                            &m_bounds),
+                        &m_bounds);
+                }
+                case LogicalDeliveryProtocolCodec::MessageType::Hello:
+                case LogicalDeliveryProtocolCodec::MessageType::Acknowledgement:
+                    throw std::runtime_error(
+                        "WebSocket sync server received logical response message");
+            }
+            throw std::runtime_error("Unexpected logical delivery message type");
         }
 
         SyncEngine& m_engine;
@@ -188,6 +237,63 @@ namespace sync {
                 response_message, &m_bounds);
         }
 
+        bool supports_logical_delivery() const override {
+            return true;
+        }
+
+        LogicalDeliveryHello logical_delivery_hello() override {
+            return logical_delivery_hello_with_cancel(nullptr);
+        }
+
+        LogicalDeliveryHello logical_delivery_hello_with_cancel(
+                const CancellationToken* cancel_token = nullptr) override {
+            const CancellationToken token = cancel_token != nullptr
+                ? *cancel_token
+                : CancellationToken();
+            return LogicalDeliveryProtocolCodec::decode_hello(
+                m_channel.exchange_binary(
+                    LogicalDeliveryProtocolCodec::encode_hello_request(
+                        &m_bounds),
+                    token),
+                &m_bounds);
+        }
+
+        LogicalDeliveryAcknowledgement deliver_ordered_logical_delivery(
+                const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds = nullptr) override {
+            return deliver_ordered_logical_delivery_with_cancel(
+                envelope, bounds, nullptr);
+        }
+
+        LogicalDeliveryAcknowledgement
+        deliver_ordered_logical_delivery_with_cancel(
+                const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds = nullptr,
+                const CancellationToken* cancel_token = nullptr) override {
+            return deliver_logical_message(
+                LogicalDeliveryProtocolCodec::encode_delivery(
+                    envelope, effective_logical_bounds(bounds)),
+                cancel_token);
+        }
+
+        LogicalDeliveryAcknowledgement deliver_ordered_logical_request(
+                const LogicalDeliveryRequest& request,
+                const CodecBounds* bounds = nullptr) override {
+            return deliver_ordered_logical_request_with_cancel(
+                request, bounds, nullptr);
+        }
+
+        LogicalDeliveryAcknowledgement
+        deliver_ordered_logical_request_with_cancel(
+                const LogicalDeliveryRequest& request,
+                const CodecBounds* bounds = nullptr,
+                const CancellationToken* cancel_token = nullptr) override {
+            return deliver_logical_message(
+                LogicalDeliveryProtocolCodec::encode_delivery_request(
+                    request, effective_logical_bounds(bounds)),
+                cancel_token);
+        }
+
         void request_cancel() override {
             m_channel.request_cancel();
         }
@@ -197,6 +303,22 @@ namespace sync {
         }
 
     private:
+        const CodecBounds* effective_logical_bounds(
+                const CodecBounds* bounds) const {
+            return bounds != nullptr ? bounds : &m_bounds;
+        }
+
+        LogicalDeliveryAcknowledgement deliver_logical_message(
+                const std::vector<std::uint8_t>& request_message,
+                const CancellationToken* cancel_token) {
+            const CancellationToken token = cancel_token != nullptr
+                ? *cancel_token
+                : CancellationToken();
+            return LogicalDeliveryProtocolCodec::decode_acknowledgement(
+                m_channel.exchange_binary(request_message, token),
+                &m_bounds);
+        }
+
         IWebSocketSyncChannel& m_channel;
         CodecBounds m_bounds;
     };

--- a/include/mdbx_containers/sync/transport/WebSocketTransport.hpp
+++ b/include/mdbx_containers/sync/transport/WebSocketTransport.hpp
@@ -179,20 +179,15 @@ namespace sync {
                     return LogicalDeliveryProtocolCodec::encode_hello(
                         m_engine.logical_delivery_hello(), &m_bounds);
                 case LogicalDeliveryProtocolCodec::MessageType::Delivery:
-                    return LogicalDeliveryProtocolCodec::encode_acknowledgement(
-                        m_engine.apply_ordered_logical_delivery_envelope(
-                            LogicalDeliveryProtocolCodec::decode_delivery(
-                                binary_message, &m_bounds),
-                            &m_bounds),
-                        &m_bounds);
+                    throw std::runtime_error(
+                        "receiver-bound logical delivery request required");
                 case LogicalDeliveryProtocolCodec::MessageType::DeliveryRequest: {
                     const LogicalDeliveryRequest request =
                         LogicalDeliveryProtocolCodec::decode_delivery_request(
                             binary_message, &m_bounds);
                     return LogicalDeliveryProtocolCodec::encode_acknowledgement(
-                        m_engine.apply_ordered_logical_delivery_envelope(
-                            request.envelope, &request.sender_capabilities,
-                            &m_bounds),
+                        m_engine.apply_ordered_logical_delivery_request(
+                            request, &m_bounds),
                         &m_bounds);
                 }
                 case LogicalDeliveryProtocolCodec::MessageType::Hello:

--- a/tests/test_http_transport.cpp
+++ b/tests/test_http_transport.cpp
@@ -263,6 +263,11 @@ void test_http_server_status_mapping() {
     require_true(response.status_code == 400,
                  "malformed body must be rejected");
 
+    request.target = mdbxc::sync::HttpSyncRoutes::logical_delivery_target();
+    response = server.handle(request);
+    require_true(response.status_code == 400,
+                 "malformed logical delivery body must be rejected");
+
     mdbxc::sync::CodecBounds bounds;
     bounds.max_transport_message_bytes = 16;
     mdbxc::sync::HttpSyncServer bounded_server(engine, bounds);
@@ -274,6 +279,56 @@ void test_http_server_status_mapping() {
 
     db->disconnect();
     cleanup(path);
+}
+
+void test_http_peer_delivers_ordered_logical_outbox() {
+    const std::string source_path = "test_http_transport_logical_source.mdbx";
+    const std::string replica_path = "test_http_transport_logical_replica.mdbx";
+    cleanup(source_path);
+    cleanup(replica_path);
+
+    std::shared_ptr<mdbxc::Connection> source = open_db(source_path);
+    std::shared_ptr<mdbxc::Connection> replica = open_db(replica_path);
+    const mdbxc::sync::DbId db_id = make_node(0xD5);
+    mdbxc::sync::SyncEngine source_engine(source);
+    mdbxc::sync::SyncEngine replica_engine(replica);
+    source_engine.initialize_local_identity(make_node(0x51), db_id);
+    replica_engine.initialize_local_identity(make_node(0x61), db_id);
+
+    mdbxc::sync::LogicalChangeFrame frame;
+    source_engine.enqueue_logical_delivery(db_id, frame);
+
+    mdbxc::sync::HttpSyncServer replica_server(replica_engine);
+    LoopbackHttpClient client(replica_server);
+    mdbxc::sync::HttpSyncPeer peer(client);
+    mdbxc::sync::CancellationSource logical_cancel;
+    const mdbxc::sync::CancellationToken logical_token = logical_cancel.token();
+    const mdbxc::sync::LogicalDeliveryHello hello =
+        peer.logical_delivery_hello_with_cancel(&logical_token);
+    require_true(hello.db_uuid == db_id,
+                 "HTTP logical hello db uuid mismatch");
+    require_true(client.last_target() ==
+                     mdbxc::sync::HttpSyncRoutes::logical_hello_target(),
+                 "HTTP logical hello target mismatch");
+    require_true(client.last_token_cancellable(),
+                 "HTTP logical hello did not receive cancellation token");
+    const mdbxc::sync::LogicalDeliveryDispatchResult result =
+        source_engine.deliver_pending_logical_deliveries(peer, db_id);
+    require_true(result.ok, "HTTP logical delivery failed: " + result.error);
+    require_true(result.delivered == 1u,
+                 "HTTP logical delivery count mismatch");
+    require_true(result.acknowledged_through == 1u,
+                 "HTTP logical acknowledgement mismatch");
+    require_true(client.last_target() ==
+                     mdbxc::sync::HttpSyncRoutes::logical_delivery_target(),
+                 "HTTP logical delivery target mismatch");
+    require_true(source_engine.pending_logical_deliveries(db_id).empty(),
+                 "HTTP logical delivery did not remove acknowledged outbox entry");
+
+    source->disconnect();
+    replica->disconnect();
+    cleanup(source_path);
+    cleanup(replica_path);
 }
 
 void test_http_peer_rejects_transport_error() {
@@ -304,5 +359,6 @@ int main() {
     test_http_peer_pull_and_push_roundtrip();
     test_http_server_status_mapping();
     test_http_peer_rejects_transport_error();
+    test_http_peer_delivers_ordered_logical_outbox();
     return 0;
 }

--- a/tests/test_http_transport.cpp
+++ b/tests/test_http_transport.cpp
@@ -290,13 +290,14 @@ void test_http_peer_delivers_ordered_logical_outbox() {
     std::shared_ptr<mdbxc::Connection> source = open_db(source_path);
     std::shared_ptr<mdbxc::Connection> replica = open_db(replica_path);
     const mdbxc::sync::DbId db_id = make_node(0xD5);
+    const mdbxc::sync::NodeId replica_node = make_node(0x61);
     mdbxc::sync::SyncEngine source_engine(source);
     mdbxc::sync::SyncEngine replica_engine(replica);
     source_engine.initialize_local_identity(make_node(0x51), db_id);
-    replica_engine.initialize_local_identity(make_node(0x61), db_id);
+    replica_engine.initialize_local_identity(replica_node, db_id);
 
     mdbxc::sync::LogicalChangeFrame frame;
-    source_engine.enqueue_logical_delivery(db_id, frame);
+    source_engine.enqueue_logical_delivery(db_id, replica_node, frame);
 
     mdbxc::sync::HttpSyncServer replica_server(replica_engine);
     LoopbackHttpClient client(replica_server);
@@ -313,7 +314,8 @@ void test_http_peer_delivers_ordered_logical_outbox() {
     require_true(client.last_token_cancellable(),
                  "HTTP logical hello did not receive cancellation token");
     const mdbxc::sync::LogicalDeliveryDispatchResult result =
-        source_engine.deliver_pending_logical_deliveries(peer, db_id);
+        source_engine.deliver_pending_logical_deliveries(peer, db_id,
+                                                         replica_node);
     require_true(result.ok, "HTTP logical delivery failed: " + result.error);
     require_true(result.delivered == 1u,
                  "HTTP logical delivery count mismatch");
@@ -322,7 +324,7 @@ void test_http_peer_delivers_ordered_logical_outbox() {
     require_true(client.last_target() ==
                      mdbxc::sync::HttpSyncRoutes::logical_delivery_target(),
                  "HTTP logical delivery target mismatch");
-    require_true(source_engine.pending_logical_deliveries(db_id).empty(),
+    require_true(source_engine.pending_logical_deliveries(db_id, replica_node).empty(),
                  "HTTP logical delivery did not remove acknowledged outbox entry");
 
     source->disconnect();

--- a/tests/test_key_ordered_multi_value_destructive_adapter.cpp
+++ b/tests/test_key_ordered_multi_value_destructive_adapter.cpp
@@ -401,7 +401,7 @@ void test_destructive_capture_coalesces_and_commits_to_outbox() {
             throw std::runtime_error("append/erase was not coalesced");
         }
         const mdbxc::sync::LogicalDeliveryEnvelope envelope =
-            session->commit_to_outbox(engine, destination);
+            session->commit_to_outbox(engine, destination, destination);
         if (envelope.origin_sequence != 1u ||
             !envelope.frame.changes.empty()) {
             throw std::runtime_error("empty destructive delivery is incorrect");
@@ -419,7 +419,7 @@ void test_destructive_capture_coalesces_and_commits_to_outbox() {
             throw std::runtime_error("ordered capture id allocation is incorrect");
         }
         const mdbxc::sync::LogicalDeliveryEnvelope envelope =
-            session->commit_to_outbox(engine, destination);
+            session->commit_to_outbox(engine, destination, destination);
         if (envelope.origin_sequence != 2u ||
             envelope.frame.changes.size() != 1u) {
             throw std::runtime_error("destructive outbox delivery is incorrect");
@@ -471,7 +471,7 @@ void test_destructive_capture_rolls_back_injected_native_commit_failure() {
         mdbxc::detail::fail_next_transaction_commit_for_test(MDBX_MAP_FULL);
         bool commit_failed = false;
         try {
-            failed_session->commit_to_outbox(engine, destination);
+            failed_session->commit_to_outbox(engine, destination, destination);
         } catch (const mdbxc::MdbxException&) {
             commit_failed = true;
         }
@@ -490,7 +490,7 @@ void test_destructive_capture_rolls_back_injected_native_commit_failure() {
             reuse_rejected = true;
         }
         if (!reuse_rejected || !table.find(10).empty() ||
-            !engine.pending_logical_deliveries(destination).empty()) {
+            !engine.pending_logical_deliveries(destination, destination).empty()) {
             throw std::runtime_error(
                 "native commit failure leaked destructive capture state");
         }
@@ -501,10 +501,10 @@ void test_destructive_capture_rolls_back_injected_native_commit_failure() {
     const mdbxc::sync::OrderedElementId clean_id =
         clean_session->append(10, "committed");
     const mdbxc::sync::LogicalDeliveryEnvelope envelope =
-        clean_session->commit_to_outbox(engine, destination);
+        clean_session->commit_to_outbox(engine, destination, destination);
     if (clean_id.sequence != 1u || envelope.origin_sequence != 1u ||
         table.find(10).size() != 1u || table.find(10)[0] != "committed" ||
-        engine.pending_logical_deliveries(destination).size() != 1u) {
+        engine.pending_logical_deliveries(destination, destination).size() != 1u) {
         throw std::runtime_error(
             "native commit failure did not roll back table, state, and outbox");
     }
@@ -545,7 +545,7 @@ void test_destructive_capture_resolves_bounded_broad_erasure() {
         session->append(1, "same");
         session->append(1, "same");
         session->append(2, "other");
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
 
     const mdbxc::sync::BroadEraseBounds bounds = { 4u, 64u };
@@ -558,7 +558,7 @@ void test_destructive_capture_resolves_bounded_broad_erasure() {
             throw std::runtime_error("bounded broad erasure selection is incorrect");
         }
         const mdbxc::sync::LogicalDeliveryEnvelope envelope =
-            session->commit_to_outbox(engine, destination);
+            session->commit_to_outbox(engine, destination, destination);
         if (envelope.frame.changes.size() != 3u) {
             throw std::runtime_error("broad erasure did not emit exact erase changes");
         }
@@ -620,7 +620,7 @@ void test_destructive_capture_resolves_bounded_broad_erasure() {
         session->append(1, "middle");
         session->append(1, "same");
         session->append(1, "last");
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
     {
         std::unique_ptr<adapter_type::LogicalCaptureSession> session =
@@ -629,7 +629,7 @@ void test_destructive_capture_resolves_bounded_broad_erasure() {
             throw std::runtime_error(
                 "broad erasure did not select every repeated value");
         }
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
     {
         const std::vector<std::string> values = table.find(1);
@@ -650,7 +650,7 @@ void test_destructive_capture_resolves_bounded_broad_erasure() {
                 "broad erasure did not coalesce a pending append");
         }
         const mdbxc::sync::LogicalDeliveryEnvelope envelope =
-            session->commit_to_outbox(engine, destination);
+            session->commit_to_outbox(engine, destination, destination);
         if (!envelope.frame.changes.empty() || !table.find(3).empty()) {
             throw std::runtime_error(
                 "coalesced broad erasure leaked a physical or logical record");
@@ -690,7 +690,7 @@ void test_destructive_capture_bounds_post_selection_mutation_scans() {
             adapter.begin_capture_session();
         session->append(1, "first");
         session->append(1, "second");
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
 
     std::size_t selection_limit = 0u;
@@ -776,7 +776,7 @@ void test_destructive_capture_clears_bounded_tombstone_heavy_table() {
         third = session->append(2, "third");
         session->append(2, "fourth");
         session->append(3, "fifth");
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
     {
         std::unique_ptr<adapter_type::LogicalCaptureSession> session =
@@ -784,7 +784,7 @@ void test_destructive_capture_clears_bounded_tombstone_heavy_table() {
         session->erase(first);
         session->erase(second);
         session->erase(third);
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
     if (table.count() != 2u || table.find(2).size() != 1u ||
         table.find(3).size() != 1u) {
@@ -814,7 +814,7 @@ void test_destructive_capture_clears_bounded_tombstone_heavy_table() {
             throw std::runtime_error("ordered broad clear selected the wrong ids");
         }
         const mdbxc::sync::LogicalDeliveryEnvelope envelope =
-            session->commit_to_outbox(engine, destination);
+            session->commit_to_outbox(engine, destination, destination);
         if (envelope.frame.changes.size() != 2u) {
             throw std::runtime_error("ordered broad clear emitted the wrong changes");
         }
@@ -834,7 +834,7 @@ void test_destructive_capture_clears_bounded_tombstone_heavy_table() {
         std::unique_ptr<adapter_type::LogicalCaptureSession> session =
             adapter.begin_capture_session();
         session->append(4, "survives");
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
     {
         std::unique_ptr<adapter_type::LogicalCaptureSession> session =
@@ -942,13 +942,13 @@ void test_destructive_capture_clear_rejects_complete_schema_corruption() {
         std::unique_ptr<adapter_type::LogicalCaptureSession> session =
             adapter.begin_capture_session();
         tombstone_id = session->append(8, "tombstone");
-        session->commit_to_outbox(engine, make_node(0xB6u));
+        session->commit_to_outbox(engine, make_node(0xB6u), make_node(0xB6u));
     }
     {
         std::unique_ptr<adapter_type::LogicalCaptureSession> session =
             adapter.begin_capture_session();
         session->erase(tombstone_id);
-        session->commit_to_outbox(engine, make_node(0xB6u));
+        session->commit_to_outbox(engine, make_node(0xB6u), make_node(0xB6u));
     }
     insert_raw_index_record(
         connection, by_key, IntKeyCodec::encode(8), tombstone_id);
@@ -999,7 +999,7 @@ void test_destructive_capture_clear_checks_tombstone_only_origin_high_water() {
         std::unique_ptr<adapter_type::LogicalCaptureSession> session =
             adapter.begin_capture_session();
         session->append(1, "live");
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
 
     mdbxc::sync::OrderedElementId tombstone_id;
@@ -1074,7 +1074,7 @@ void test_destructive_capture_trusted_clear_avoids_repeated_state_scans() {
         for (std::size_t i = 0u; i < 64u; ++i) {
             ids.push_back(session->append(1, "value"));
         }
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
     {
         std::unique_ptr<adapter_type::LogicalCaptureSession> session =
@@ -1082,7 +1082,7 @@ void test_destructive_capture_trusted_clear_avoids_repeated_state_scans() {
         for (std::size_t i = 0u; i + 1u < ids.size(); ++i) {
             session->erase(ids[i]);
         }
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
 
     {
@@ -1092,7 +1092,7 @@ void test_destructive_capture_trusted_clear_avoids_repeated_state_scans() {
         if (session->clear(bounds) != 1u) {
             throw std::runtime_error("trusted ordered clear selected the wrong id");
         }
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
     if (!table.empty()) {
         throw std::runtime_error(
@@ -1133,7 +1133,7 @@ void test_destructive_capture_uses_transaction_bound_key_index_proof() {
         session->append(1, "first");
         session->append(1, "second");
         session->append(1, "third");
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
 
     {
@@ -1160,7 +1160,7 @@ void test_destructive_capture_uses_transaction_bound_key_index_proof() {
             throw std::runtime_error(
                 "trusted ordered selector removed the wrong number of values");
         }
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
     const std::vector<std::string> remaining = table.find(1);
     if (remaining.size() != 2u || remaining[0] != "first" ||
@@ -1223,7 +1223,7 @@ void test_destructive_capture_key_index_proof_rejects_corruption() {
         std::unique_ptr<adapter_type::LogicalCaptureSession> session =
             adapter.begin_capture_session();
         session->append(1, "value");
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
 
     {
@@ -1308,7 +1308,7 @@ void test_destructive_capture_key_index_proof_rejects_cross_session() {
             adapter.begin_capture_session();
         session->append(1, "first");
         session->append(1, "second");
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
 
     mdbxc::sync::OrderedElementKeyIndexProof proof;
@@ -1375,7 +1375,7 @@ void test_destructive_capture_key_index_proof_respects_size_bound() {
             adapter.begin_capture_session();
         session->append(1, "first");
         session->append(1, "second");
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
 
     std::unique_ptr<adapter_type::LogicalCaptureSession> session =
@@ -2097,7 +2097,7 @@ void test_destructive_capture_replaces_bounded_live_set() {
         std::unique_ptr<adapter_type::LogicalCaptureSession> session =
             adapter.begin_capture_session();
         session->append(1, "old");
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
     {
         std::vector<table_type::value_type> desired;
@@ -2114,7 +2114,7 @@ void test_destructive_capture_replaces_bounded_live_set() {
             throw std::runtime_error(
                 "bounded destructive replacement produced wrong local state");
         }
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
     if (table.find(3).size() != 2u || table.find(3)[0] != "new" ||
         table.find(3)[1] != "new" || table.find(4).size() != 1u ||
@@ -2152,14 +2152,14 @@ void test_destructive_capture_replaces_bounded_live_set() {
             throw std::runtime_error(
                 "empty destructive replacement did not capture exact erases");
         }
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
 
     {
         std::unique_ptr<adapter_type::LogicalCaptureSession> session =
             adapter.begin_capture_session();
         session->append(5, "after-replace");
-        session->commit_to_outbox(engine, destination);
+        session->commit_to_outbox(engine, destination, destination);
     }
     if (table.find(5).size() != 1u || table.find(5)[0] != "after-replace") {
         throw std::runtime_error(
@@ -2220,7 +2220,7 @@ void test_destructive_replacement_round_trips_to_replica() {
         std::unique_ptr<adapter_type::LogicalCaptureSession> session =
             source_adapter.begin_capture_session();
         session->append(1, "old");
-        initial = session->commit_to_outbox(source_engine, replica_db);
+        initial = session->commit_to_outbox(source_engine, replica_db, replica_db);
     }
     const mdbxc::sync::LogicalDeliveryAcknowledgement initial_ack =
         replica_engine.apply_ordered_logical_delivery_envelope(initial);
@@ -2241,7 +2241,7 @@ void test_destructive_replacement_round_trips_to_replica() {
         std::unique_ptr<adapter_type::LogicalCaptureSession> session =
             source_adapter.begin_capture_session();
         session->replace_with(desired, bounds);
-        replacement = session->commit_to_outbox(source_engine, replica_db);
+        replacement = session->commit_to_outbox(source_engine, replica_db, replica_db);
     }
     const mdbxc::sync::LogicalDeliveryAcknowledgement replacement_ack =
         replica_engine.apply_ordered_logical_delivery_envelope(replacement);

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -295,6 +295,7 @@ public:
     mdbxc::sync::LogicalDeliveryEnvelope enqueue_logical_delivery(
             MDBX_txn*,
             const mdbxc::sync::DbId&,
+            const mdbxc::sync::NodeId&,
             const mdbxc::sync::LogicalChangeFrame&,
             const mdbxc::sync::CodecBounds*) override {
         throw std::runtime_error("logical delivery outbox failure");
@@ -1492,7 +1493,7 @@ void test_key_ordered_multi_value_logical_capture_commits_to_outbox() {
         session->append(7, "created");
         session->insert(7, "sent");
         const mdbxc::sync::LogicalDeliveryEnvelope envelope =
-            session->commit_to_outbox(engine, destination);
+            session->commit_to_outbox(engine, destination, destination);
         MDBXC_TEST_ASSERT(envelope.destination_db_uuid == destination);
         MDBXC_TEST_ASSERT(envelope.origin_node_id == node);
         MDBXC_TEST_ASSERT(envelope.origin_sequence == 1u);
@@ -1510,7 +1511,7 @@ void test_key_ordered_multi_value_logical_capture_commits_to_outbox() {
     MDBXC_TEST_ASSERT(values[0] == "created");
     MDBXC_TEST_ASSERT(values[1] == "sent");
     const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending =
-        engine.pending_logical_deliveries(destination);
+        engine.pending_logical_deliveries(destination, destination);
     MDBXC_TEST_ASSERT(pending.size() == 1u);
     MDBXC_TEST_ASSERT(pending[0].frame.changes.size() == 2u);
 
@@ -1570,19 +1571,20 @@ void test_key_ordered_multi_value_logical_capture_delivers_and_replays() {
         session->append(11, "first");
         session->append(11, "first");
         session->insert(11, "second");
-        envelope = session->commit_to_outbox(source_engine, replica_db_uuid);
+        envelope = session->commit_to_outbox(source_engine, replica_db_uuid,
+                                             replica_node);
 
         MDBXC_TEST_ASSERT(
-            source_engine.pending_logical_deliveries(replica_db_uuid).size() ==
+            source_engine.pending_logical_deliveries(replica_db_uuid, replica_node).size() ==
             1u);
         mdbxc::sync::DirectLogicalDeliveryPeer peer(replica_engine);
         const mdbxc::sync::LogicalDeliveryDispatchResult dispatched =
             source_engine.deliver_pending_logical_deliveries(
-                peer, replica_db_uuid);
+                peer, replica_db_uuid, replica_node);
         MDBXC_TEST_ASSERT(dispatched.ok);
         MDBXC_TEST_ASSERT(dispatched.delivered == 1u);
         MDBXC_TEST_ASSERT(
-            source_engine.pending_logical_deliveries(replica_db_uuid).empty());
+            source_engine.pending_logical_deliveries(replica_db_uuid, replica_node).empty());
         const std::vector<std::string> values = replica_table.find(11);
         MDBXC_TEST_ASSERT(values.size() == 3u);
         MDBXC_TEST_ASSERT(values[0] == "first");
@@ -1697,7 +1699,7 @@ void test_key_ordered_multi_value_logical_capture_rolls_back_outbox_failure() {
             adapter.begin_capture_session();
         session->append(8, "eight");
         try {
-            session->commit_to_outbox(outbox, destination);
+            session->commit_to_outbox(outbox, destination, destination);
         } catch (const std::runtime_error&) {
             outbox_failure = true;
         }
@@ -1710,7 +1712,7 @@ void test_key_ordered_multi_value_logical_capture_rolls_back_outbox_failure() {
             commit_rejected = true;
         }
         try {
-            session->commit_to_outbox(outbox, destination);
+            session->commit_to_outbox(outbox, destination, destination);
         } catch (const std::logic_error&) {
             retry_rejected = true;
         }
@@ -1721,7 +1723,7 @@ void test_key_ordered_multi_value_logical_capture_rolls_back_outbox_failure() {
     MDBXC_TEST_ASSERT(commit_rejected);
     MDBXC_TEST_ASSERT(retry_rejected);
     MDBXC_TEST_ASSERT(table.empty());
-    MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(destination).empty());
+    MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(destination, destination).empty());
 
     conn->disconnect();
     cleanup(path);
@@ -1852,7 +1854,7 @@ void test_key_ordered_multi_value_logical_capture_discards_destructor_rollback()
     }
 
     MDBXC_TEST_ASSERT(table.empty());
-    MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(destination).empty());
+    MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(destination, destination).empty());
 
     conn->disconnect();
     cleanup(path);
@@ -2637,7 +2639,8 @@ void test_key_multi_value_logical_reconcile_rolls_back_late_codec_failure() {
     }
     MDBXC_TEST_ASSERT(commit_rejected);
     MDBXC_TEST_ASSERT(changes.empty());
-    MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(make_node(0xE4)).empty());
+    MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(
+        make_node(0xE4), make_node(0xE4)).empty());
 
     connection->disconnect();
     cleanup(path);
@@ -2671,7 +2674,7 @@ void test_key_multi_value_logical_capture_session_commits_to_outbox() {
             adapter.begin_capture_session();
         session->insert(7, "seven");
         const mdbxc::sync::LogicalDeliveryEnvelope envelope =
-            session->commit_to_outbox(engine, destination);
+            session->commit_to_outbox(engine, destination, destination);
         MDBXC_TEST_ASSERT(envelope.destination_db_uuid == destination);
         MDBXC_TEST_ASSERT(envelope.origin_node_id == node);
         MDBXC_TEST_ASSERT(envelope.origin_sequence == 1u);
@@ -2679,7 +2682,7 @@ void test_key_multi_value_logical_capture_session_commits_to_outbox() {
 
     MDBXC_TEST_ASSERT(table.count(7, "seven") == 1u);
     const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending =
-        engine.pending_logical_deliveries(destination);
+        engine.pending_logical_deliveries(destination, destination);
     MDBXC_TEST_ASSERT(pending.size() == 1u);
     MDBXC_TEST_ASSERT(pending[0].frame.changes.size() == 1u);
     MDBXC_TEST_ASSERT(pending[0].frame.changes[0].opcode ==
@@ -2721,7 +2724,7 @@ void test_key_multi_value_logical_capture_session_rolls_back_on_outbox_failure()
             adapter.begin_capture_session();
         session->insert(8, "eight");
         try {
-            session->commit_to_outbox(outbox, make_node(0xDB));
+            session->commit_to_outbox(outbox, make_node(0xDB), make_node(0xDB));
         } catch (const std::runtime_error&) {
             caught = true;
         }
@@ -2736,7 +2739,7 @@ void test_key_multi_value_logical_capture_session_rolls_back_on_outbox_failure()
         MDBXC_TEST_ASSERT(changes.empty());
 
         try {
-            session->commit_to_outbox(outbox, make_node(0xDB));
+            session->commit_to_outbox(outbox, make_node(0xDB), make_node(0xDB));
         } catch (const std::logic_error&) {
             retry_rejected = true;
         }
@@ -2746,7 +2749,8 @@ void test_key_multi_value_logical_capture_session_rolls_back_on_outbox_failure()
     MDBXC_TEST_ASSERT(retry_rejected);
     MDBXC_TEST_ASSERT(table.count() == 0u);
     MDBXC_TEST_ASSERT(
-        engine.pending_logical_deliveries(make_node(0xDB)).empty());
+        engine.pending_logical_deliveries(
+            make_node(0xDB), make_node(0xDB)).empty());
 
     conn->disconnect();
     cleanup(path);
@@ -2992,7 +2996,7 @@ void test_key_table_logical_capture_session_rolls_back_when_outbox_fails() {
             adapter.begin_capture_session();
         MDBXC_TEST_ASSERT(session->insert(8));
         try {
-            session->commit_to_outbox(outbox, make_node(0xD6));
+            session->commit_to_outbox(outbox, make_node(0xD6), make_node(0xD6));
         } catch (const std::runtime_error&) {
             caught = true;
         }
@@ -3007,7 +3011,7 @@ void test_key_table_logical_capture_session_rolls_back_when_outbox_fails() {
         MDBXC_TEST_ASSERT(changes.empty());
 
         try {
-            session->commit_to_outbox(outbox, make_node(0xD6));
+            session->commit_to_outbox(outbox, make_node(0xD6), make_node(0xD6));
         } catch (const std::logic_error&) {
             retry_rejected = true;
         }
@@ -3017,7 +3021,8 @@ void test_key_table_logical_capture_session_rolls_back_when_outbox_fails() {
     MDBXC_TEST_ASSERT(retry_rejected);
     MDBXC_TEST_ASSERT(!table.contains(8));
     MDBXC_TEST_ASSERT(
-        engine.pending_logical_deliveries(make_node(0xD6)).empty());
+        engine.pending_logical_deliveries(
+            make_node(0xD6), make_node(0xD6)).empty());
 
     conn->disconnect();
     cleanup(path);
@@ -3663,7 +3668,7 @@ void test_key_value_logical_capture_session_commits_to_outbox_atomically() {
             adapter.begin_capture_session();
         session->insert_or_assign(7, "seven");
         const mdbxc::sync::LogicalDeliveryEnvelope envelope =
-            session->commit_to_outbox(engine, destination);
+            session->commit_to_outbox(engine, destination, destination);
         MDBXC_TEST_ASSERT(envelope.destination_db_uuid == destination);
         MDBXC_TEST_ASSERT(envelope.origin_node_id == node);
         MDBXC_TEST_ASSERT(envelope.origin_sequence == 1u);
@@ -3673,7 +3678,7 @@ void test_key_value_logical_capture_session_commits_to_outbox_atomically() {
     MDBXC_TEST_ASSERT(found.first);
     MDBXC_TEST_ASSERT(found.second == "seven");
     const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending =
-        engine.pending_logical_deliveries(destination);
+        engine.pending_logical_deliveries(destination, destination);
     MDBXC_TEST_ASSERT(pending.size() == 1u);
     MDBXC_TEST_ASSERT(pending[0].frame.changes.size() == 1u);
     MDBXC_TEST_ASSERT(pending[0].frame.changes[0].opcode ==
@@ -3712,7 +3717,7 @@ void test_key_value_logical_capture_session_rolls_back_when_outbox_fails() {
             adapter.begin_capture_session();
         session->insert_or_assign(8, "eight");
         try {
-            session->commit_to_outbox(outbox, make_node(0xDA));
+            session->commit_to_outbox(outbox, make_node(0xDA), make_node(0xDA));
         } catch (const std::runtime_error&) {
             caught = true;
         }
@@ -3727,7 +3732,7 @@ void test_key_value_logical_capture_session_rolls_back_when_outbox_fails() {
         MDBXC_TEST_ASSERT(changes.empty());
 
         try {
-            session->commit_to_outbox(outbox, make_node(0xDA));
+            session->commit_to_outbox(outbox, make_node(0xDA), make_node(0xDA));
         } catch (const std::logic_error&) {
             retry_rejected = true;
         }
@@ -3737,7 +3742,8 @@ void test_key_value_logical_capture_session_rolls_back_when_outbox_fails() {
     MDBXC_TEST_ASSERT(retry_rejected);
     MDBXC_TEST_ASSERT(!table.contains(8));
     MDBXC_TEST_ASSERT(
-        engine.pending_logical_deliveries(make_node(0xDA)).empty());
+        engine.pending_logical_deliveries(
+            make_node(0xDA), make_node(0xDA)).empty());
 
     conn->disconnect();
     cleanup(path);
@@ -5404,7 +5410,8 @@ void test_logical_outbox_persists_ordered_destination_streams() {
                 conn->transaction(mdbxc::TransactionMode::WRITABLE);
             mdbxc::sync::LogicalOutboxStore outbox(conn->env_handle());
             const mdbxc::sync::LogicalDeliveryEnvelope rolled_back =
-                outbox.enqueue(txn.handle(), destination_a, local_node,
+                outbox.enqueue(txn.handle(), destination_a, destination_a,
+                               local_node,
                                make_outbox_test_frame("app.outbox.rollback", 1u));
             MDBXC_TEST_ASSERT(rolled_back.origin_sequence == 1u);
             txn.rollback();
@@ -5412,13 +5419,13 @@ void test_logical_outbox_persists_ordered_destination_streams() {
 
         const mdbxc::sync::LogicalDeliveryEnvelope first =
             engine.enqueue_logical_delivery(
-                destination_a, make_outbox_test_frame("app.outbox.a", 2u));
+                destination_a, destination_a, make_outbox_test_frame("app.outbox.a", 2u));
         const mdbxc::sync::LogicalDeliveryEnvelope second =
             engine.enqueue_logical_delivery(
-                destination_a, make_outbox_test_frame("app.outbox.a", 3u));
+                destination_a, destination_a, make_outbox_test_frame("app.outbox.a", 3u));
         const mdbxc::sync::LogicalDeliveryEnvelope other_destination =
             engine.enqueue_logical_delivery(
-                destination_b, make_outbox_test_frame("app.outbox.b", 4u));
+                destination_b, destination_b, make_outbox_test_frame("app.outbox.b", 4u));
         MDBXC_TEST_ASSERT(first.origin_sequence == 1u);
         MDBXC_TEST_ASSERT(second.origin_sequence == 2u);
         MDBXC_TEST_ASSERT(other_destination.origin_sequence == 1u);
@@ -5426,16 +5433,16 @@ void test_logical_outbox_persists_ordered_destination_streams() {
         MDBXC_TEST_ASSERT(first.frame_id == "mdbxc-ordered-1");
 
         const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending_a =
-            engine.pending_logical_deliveries(destination_a);
+            engine.pending_logical_deliveries(destination_a, destination_a);
         const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending_b =
-            engine.pending_logical_deliveries(destination_b);
+            engine.pending_logical_deliveries(destination_b, destination_b);
         MDBXC_TEST_ASSERT(pending_a.size() == 2u);
         MDBXC_TEST_ASSERT(pending_a[0].origin_sequence == 1u);
         MDBXC_TEST_ASSERT(pending_a[1].origin_sequence == 2u);
         MDBXC_TEST_ASSERT(pending_b.size() == 1u);
         MDBXC_TEST_ASSERT(pending_b[0].origin_sequence == 1u);
-        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_a) == 2u);
-        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_b) == 1u);
+        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_a, destination_a) == 2u);
+        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_b, destination_b) == 1u);
 
         bool origin_mismatch_caught = false;
         {
@@ -5443,7 +5450,8 @@ void test_logical_outbox_persists_ordered_destination_streams() {
                 conn->transaction(mdbxc::TransactionMode::WRITABLE);
             mdbxc::sync::LogicalOutboxStore outbox(conn->env_handle());
             try {
-                outbox.enqueue(txn.handle(), destination_a, make_node(0x92),
+                outbox.enqueue(txn.handle(), destination_a, destination_a,
+                               make_node(0x92),
                                make_outbox_test_frame("app.outbox.bad", 5u));
             } catch (const std::invalid_argument&) {
                 origin_mismatch_caught = true;
@@ -5451,18 +5459,18 @@ void test_logical_outbox_persists_ordered_destination_streams() {
             txn.rollback();
         }
         MDBXC_TEST_ASSERT(origin_mismatch_caught);
-        MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(destination_a).size() ==
+        MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(destination_a, destination_a).size() ==
                           2u);
 
         MDBXC_TEST_ASSERT(
-            engine.acknowledge_logical_deliveries(destination_a, 1u) == 1u);
+            engine.acknowledge_logical_deliveries(destination_a, destination_a, 1u) == 1u);
         MDBXC_TEST_ASSERT(
-            engine.logical_delivery_acknowledged_through(destination_a) == 1u);
-        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_a) == 2u);
+            engine.logical_delivery_acknowledged_through(destination_a, destination_a) == 1u);
+        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_a, destination_a) == 2u);
         MDBXC_TEST_ASSERT(
-            engine.acknowledge_logical_deliveries(destination_a, 1u) == 0u);
+            engine.acknowledge_logical_deliveries(destination_a, destination_a, 1u) == 0u);
         const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> after_ack =
-            engine.pending_logical_deliveries(destination_a);
+            engine.pending_logical_deliveries(destination_a, destination_a);
         MDBXC_TEST_ASSERT(after_ack.size() == 1u);
         MDBXC_TEST_ASSERT(after_ack[0].origin_sequence == 2u);
 
@@ -5479,23 +5487,23 @@ void test_logical_outbox_persists_ordered_destination_streams() {
         engine.initialize_local_identity(local_node, local_db);
 
         const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending =
-            engine.pending_logical_deliveries(destination_a);
+            engine.pending_logical_deliveries(destination_a, destination_a);
         MDBXC_TEST_ASSERT(pending.size() == 1u);
         MDBXC_TEST_ASSERT(pending[0].origin_sequence == 2u);
         MDBXC_TEST_ASSERT(
-            engine.logical_delivery_acknowledged_through(destination_a) == 1u);
-        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_a) == 2u);
+            engine.logical_delivery_acknowledged_through(destination_a, destination_a) == 1u);
+        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_a, destination_a) == 2u);
         const mdbxc::sync::LogicalDeliveryEnvelope next =
             engine.enqueue_logical_delivery(
-                destination_a, make_outbox_test_frame("app.outbox.a", 5u));
+                destination_a, destination_a, make_outbox_test_frame("app.outbox.a", 5u));
         MDBXC_TEST_ASSERT(next.origin_sequence == 3u);
-        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_a) == 3u);
+        MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(destination_a, destination_a) == 3u);
         MDBXC_TEST_ASSERT(
-            engine.acknowledge_logical_deliveries(destination_a, 3u) == 2u);
+            engine.acknowledge_logical_deliveries(destination_a, destination_a, 3u) == 2u);
         MDBXC_TEST_ASSERT(
-            engine.pending_logical_deliveries(destination_a).empty());
+            engine.pending_logical_deliveries(destination_a, destination_a).empty());
         MDBXC_TEST_ASSERT(
-            engine.logical_delivery_acknowledged_through(destination_a) == 3u);
+            engine.logical_delivery_acknowledged_through(destination_a, destination_a) == 3u);
 
         conn->disconnect();
     }
@@ -5518,11 +5526,11 @@ void test_logical_outbox_acknowledgement_gap_preserves_caller_transaction() {
     mdbxc::sync::SyncEngine engine(conn);
     engine.initialize_local_identity(local_node, local_db);
     engine.enqueue_logical_delivery(
-        destination, make_outbox_test_frame("app.outbox.gap", 1u));
+        destination, destination, make_outbox_test_frame("app.outbox.gap", 1u));
     engine.enqueue_logical_delivery(
-        destination, make_outbox_test_frame("app.outbox.gap", 2u));
+        destination, destination, make_outbox_test_frame("app.outbox.gap", 2u));
     engine.enqueue_logical_delivery(
-        destination, make_outbox_test_frame("app.outbox.gap", 3u));
+        destination, destination, make_outbox_test_frame("app.outbox.gap", 3u));
 
     {
         mdbxc::Transaction txn =
@@ -5530,9 +5538,10 @@ void test_logical_outbox_acknowledgement_gap_preserves_caller_transaction() {
         mdbxc::sync::LogicalOutboxStore outbox(conn->env_handle());
         const MDBX_dbi dbi = outbox.handle(txn.handle());
         std::vector<std::uint8_t> key;
-        key.reserve(2u + destination.size() + 8u);
+        key.reserve(2u + destination.size() + destination.size() + 8u);
+        key.push_back(2u);
         key.push_back(1u);
-        key.push_back(1u);
+        key.insert(key.end(), destination.begin(), destination.end());
         key.insert(key.end(), destination.begin(), destination.end());
         mdbxc::sync::detail::append_u64_be(key, 2u);
         MDBX_val raw_key = {
@@ -5550,7 +5559,8 @@ void test_logical_outbox_acknowledgement_gap_preserves_caller_transaction() {
         mdbxc::sync::LogicalOutboxStore outbox(conn->env_handle());
         bool rejected = false;
         try {
-            outbox.acknowledge_through(txn.handle(), destination, 3u);
+            outbox.acknowledge_through(txn.handle(), destination, destination,
+                                       3u);
         } catch (const std::runtime_error&) {
             rejected = true;
         }
@@ -5559,9 +5569,9 @@ void test_logical_outbox_acknowledgement_gap_preserves_caller_transaction() {
     }
 
     MDBXC_TEST_ASSERT(
-        engine.logical_delivery_acknowledged_through(destination) == 0u);
+        engine.logical_delivery_acknowledged_through(destination, destination) == 0u);
     const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending =
-        engine.pending_logical_deliveries(destination);
+        engine.pending_logical_deliveries(destination, destination);
     MDBXC_TEST_ASSERT(pending.size() == 2u);
     MDBXC_TEST_ASSERT(pending[0].origin_sequence == 1u);
     MDBXC_TEST_ASSERT(pending[1].origin_sequence == 3u);
@@ -5585,11 +5595,11 @@ void test_logical_outbox_acknowledgement_missing_tail_preserves_caller_transacti
     mdbxc::sync::SyncEngine engine(conn);
     engine.initialize_local_identity(local_node, local_db);
     engine.enqueue_logical_delivery(
-        destination, make_outbox_test_frame("app.outbox.missing-tail", 1u));
+        destination, destination, make_outbox_test_frame("app.outbox.missing-tail", 1u));
     engine.enqueue_logical_delivery(
-        destination, make_outbox_test_frame("app.outbox.missing-tail", 2u));
+        destination, destination, make_outbox_test_frame("app.outbox.missing-tail", 2u));
     engine.enqueue_logical_delivery(
-        destination, make_outbox_test_frame("app.outbox.missing-tail", 3u));
+        destination, destination, make_outbox_test_frame("app.outbox.missing-tail", 3u));
 
     {
         mdbxc::Transaction txn =
@@ -5597,9 +5607,10 @@ void test_logical_outbox_acknowledgement_missing_tail_preserves_caller_transacti
         mdbxc::sync::LogicalOutboxStore outbox(conn->env_handle());
         const MDBX_dbi dbi = outbox.handle(txn.handle());
         std::vector<std::uint8_t> key;
-        key.reserve(2u + destination.size() + 8u);
+        key.reserve(2u + destination.size() + destination.size() + 8u);
+        key.push_back(2u);
         key.push_back(1u);
-        key.push_back(1u);
+        key.insert(key.end(), destination.begin(), destination.end());
         key.insert(key.end(), destination.begin(), destination.end());
         mdbxc::sync::detail::append_u64_be(key, 3u);
         MDBX_val raw_key = {
@@ -5617,7 +5628,8 @@ void test_logical_outbox_acknowledgement_missing_tail_preserves_caller_transacti
         mdbxc::sync::LogicalOutboxStore outbox(conn->env_handle());
         bool rejected = false;
         try {
-            outbox.acknowledge_through(txn.handle(), destination, 3u);
+            outbox.acknowledge_through(txn.handle(), destination, destination,
+                                       3u);
         } catch (const std::runtime_error&) {
             rejected = true;
         }
@@ -5626,9 +5638,9 @@ void test_logical_outbox_acknowledgement_missing_tail_preserves_caller_transacti
     }
 
     MDBXC_TEST_ASSERT(
-        engine.logical_delivery_acknowledged_through(destination) == 0u);
+        engine.logical_delivery_acknowledged_through(destination, destination) == 0u);
     const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending =
-        engine.pending_logical_deliveries(destination);
+        engine.pending_logical_deliveries(destination, destination);
     MDBXC_TEST_ASSERT(pending.size() == 2u);
     MDBXC_TEST_ASSERT(pending[0].origin_sequence == 1u);
     MDBXC_TEST_ASSERT(pending[1].origin_sequence == 2u);
@@ -5825,16 +5837,17 @@ void test_ordered_logical_delivery_dispatch_cleans_outbox_and_markers() {
     const std::vector<std::uint8_t> payload;
     mdbxc::sync::LogicalChangeFrame frame;
     frame.changes.push_back(mdbxc::sync::LogicalChange(ref, 1u, 0u, payload));
-    sender.enqueue_logical_delivery(receiver_db, frame);
-    sender.enqueue_logical_delivery(receiver_db, frame);
+    sender.enqueue_logical_delivery(receiver_db, receiver_node, frame);
+    sender.enqueue_logical_delivery(receiver_db, receiver_node, frame);
 
     mdbxc::sync::DirectLogicalDeliveryPeer peer(receiver);
     const mdbxc::sync::LogicalDeliveryDispatchResult dispatched =
-        sender.deliver_pending_logical_deliveries(peer, receiver_db);
+        sender.deliver_pending_logical_deliveries(peer, receiver_db,
+                                                  receiver_node);
     MDBXC_TEST_ASSERT(dispatched.ok);
     MDBXC_TEST_ASSERT(dispatched.delivered == 2u);
     MDBXC_TEST_ASSERT(dispatched.acknowledged_through == 2u);
-    MDBXC_TEST_ASSERT(sender.pending_logical_deliveries(receiver_db).empty());
+    MDBXC_TEST_ASSERT(sender.pending_logical_deliveries(receiver_db, receiver_node).empty());
     MDBXC_TEST_ASSERT(apply_calls == 2);
 
     MDBXC_TEST_ASSERT(
@@ -5896,16 +5909,16 @@ void test_cumulative_logical_delivery_acknowledgement_recovers_after_restart() {
     {
         mdbxc::sync::SyncEngine sender(sender_conn);
         sender.initialize_local_identity(sender_node, sender_db);
-        sender.enqueue_logical_delivery(receiver_db, frame);
-        sender.enqueue_logical_delivery(receiver_db, frame);
-        pending = sender.pending_logical_deliveries(receiver_db);
+        sender.enqueue_logical_delivery(receiver_db, receiver_node, frame);
+        sender.enqueue_logical_delivery(receiver_db, receiver_node, frame);
+        pending = sender.pending_logical_deliveries(receiver_db, receiver_node);
         MDBXC_TEST_ASSERT(pending.size() == 2u);
         MDBXC_TEST_ASSERT(receiver.apply_ordered_logical_delivery_envelope(
             pending[0]).ok);
         MDBXC_TEST_ASSERT(receiver.apply_ordered_logical_delivery_envelope(
             pending[1]).ok);
         MDBXC_TEST_ASSERT(apply_calls == 2);
-        MDBXC_TEST_ASSERT(sender.logical_delivery_known_tail(receiver_db) == 2u);
+        MDBXC_TEST_ASSERT(sender.logical_delivery_known_tail(receiver_db, receiver_node) == 2u);
     }
     sender_conn->disconnect();
     sender_conn.reset();
@@ -5917,15 +5930,15 @@ void test_cumulative_logical_delivery_acknowledgement_recovers_after_restart() {
         mdbxc::sync::DirectLogicalDeliveryPeer peer(receiver);
         const mdbxc::sync::LogicalDeliveryDispatchResult dispatched =
             restarted_sender.deliver_pending_logical_deliveries(
-                peer, receiver_db, 1u);
+                peer, receiver_db, receiver_node, 1u);
         MDBXC_TEST_ASSERT(dispatched.ok);
         MDBXC_TEST_ASSERT(dispatched.delivered == 1u);
         MDBXC_TEST_ASSERT(dispatched.acknowledged_through == 2u);
         MDBXC_TEST_ASSERT(
-            restarted_sender.logical_delivery_acknowledged_through(receiver_db) ==
+            restarted_sender.logical_delivery_acknowledged_through(receiver_db, receiver_node) ==
             2u);
         MDBXC_TEST_ASSERT(
-            restarted_sender.pending_logical_deliveries(receiver_db).empty());
+            restarted_sender.pending_logical_deliveries(receiver_db, receiver_node).empty());
         MDBXC_TEST_ASSERT(apply_calls == 2);
     }
 
@@ -5960,18 +5973,18 @@ void test_ordered_logical_delivery_loopback_cleans_outbox() {
             adapter.begin_capture_session();
         session->insert_or_assign(11, "eleven");
         const mdbxc::sync::LogicalDeliveryEnvelope envelope =
-            session->commit_to_outbox(engine, local_db);
+            session->commit_to_outbox(engine, local_db, node);
         MDBXC_TEST_ASSERT(envelope.origin_sequence == 1u);
     }
 
-    MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(local_db).size() == 1u);
+    MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(local_db, node).size() == 1u);
     mdbxc::sync::DirectLogicalDeliveryPeer peer(engine);
     const mdbxc::sync::LogicalDeliveryDispatchResult dispatched =
-        engine.deliver_pending_logical_deliveries(peer, local_db);
+        engine.deliver_pending_logical_deliveries(peer, local_db, node);
     MDBXC_TEST_ASSERT(dispatched.ok);
     MDBXC_TEST_ASSERT(dispatched.delivered == 1u);
     MDBXC_TEST_ASSERT(dispatched.acknowledged_through == 1u);
-    MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(local_db).empty());
+    MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(local_db, node).empty());
     const std::pair<bool, std::string> found = table.find_compat(11);
     MDBXC_TEST_ASSERT(found.first);
     MDBXC_TEST_ASSERT(found.second == "eleven");
@@ -5997,7 +6010,7 @@ void test_ordered_logical_delivery_dispatch_rejects_invalid_acknowledgements() {
     mdbxc::sync::SyncEngine engine(conn);
     engine.initialize_local_identity(sender_node, sender_db);
     engine.enqueue_logical_delivery(
-        destination, make_outbox_test_frame("app.invalid_ack", 1u));
+        destination, peer_node, make_outbox_test_frame("app.invalid_ack", 1u));
 
     const InvalidLogicalDeliveryPeer::Mode modes[] = {
         InvalidLogicalDeliveryPeer::FailedCurrentDelivery,
@@ -6010,16 +6023,87 @@ void test_ordered_logical_delivery_dispatch_rejects_invalid_acknowledgements() {
          i < sizeof(modes) / sizeof(modes[0]); ++i) {
         InvalidLogicalDeliveryPeer peer(peer_node, destination, modes[i]);
         const mdbxc::sync::LogicalDeliveryDispatchResult result =
-            engine.deliver_pending_logical_deliveries(peer, destination);
+            engine.deliver_pending_logical_deliveries(peer, destination,
+                                                      peer_node);
         MDBXC_TEST_ASSERT(!result.ok);
-        MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(destination).size() ==
+        MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(destination, peer_node).size() ==
                           1u);
         MDBXC_TEST_ASSERT(
-            engine.logical_delivery_acknowledged_through(destination) == 0u);
+            engine.logical_delivery_acknowledged_through(destination, peer_node) == 0u);
     }
 
     conn->disconnect();
     cleanup(path);
+}
+
+void test_ordered_logical_delivery_acknowledges_each_receiver_independently() {
+    const std::string source_path = "test_logical_fanout_source.mdbx";
+    const std::string receiver_b_path = "test_logical_fanout_b.mdbx";
+    const std::string receiver_c_path = "test_logical_fanout_c.mdbx";
+    cleanup(source_path);
+    cleanup(receiver_b_path);
+    cleanup(receiver_c_path);
+
+    mdbxc::Config source_cfg;
+    source_cfg.pathname = source_path;
+    source_cfg.max_dbs = 20;
+    source_cfg.no_subdir = true;
+    mdbxc::Config receiver_b_cfg = source_cfg;
+    receiver_b_cfg.pathname = receiver_b_path;
+    mdbxc::Config receiver_c_cfg = source_cfg;
+    receiver_c_cfg.pathname = receiver_c_path;
+
+    const mdbxc::sync::NodeId source_node = make_node(0xA1);
+    const mdbxc::sync::NodeId receiver_b_node = make_node(0xB1);
+    const mdbxc::sync::NodeId receiver_c_node = make_node(0xC1);
+    const mdbxc::sync::DbId replication_db = make_node(0xD1);
+    std::shared_ptr<mdbxc::Connection> source_conn =
+        mdbxc::Connection::create(source_cfg);
+    std::shared_ptr<mdbxc::Connection> receiver_b_conn =
+        mdbxc::Connection::create(receiver_b_cfg);
+    std::shared_ptr<mdbxc::Connection> receiver_c_conn =
+        mdbxc::Connection::create(receiver_c_cfg);
+    mdbxc::sync::SyncEngine source(source_conn);
+    mdbxc::sync::SyncEngine receiver_b(receiver_b_conn);
+    mdbxc::sync::SyncEngine receiver_c(receiver_c_conn);
+    source.initialize_local_identity(source_node, replication_db);
+    receiver_b.initialize_local_identity(receiver_b_node, replication_db);
+    receiver_c.initialize_local_identity(receiver_c_node, replication_db);
+
+    const mdbxc::sync::LogicalChangeFrame frame;
+    source.enqueue_logical_delivery(replication_db, receiver_b_node, frame);
+    source.enqueue_logical_delivery(replication_db, receiver_c_node, frame);
+    MDBXC_TEST_ASSERT(source.logical_delivery_known_tail(
+        replication_db, receiver_b_node) == 1u);
+    MDBXC_TEST_ASSERT(source.logical_delivery_known_tail(
+        replication_db, receiver_c_node) == 1u);
+
+    mdbxc::sync::DirectLogicalDeliveryPeer peer_b(receiver_b);
+    const mdbxc::sync::LogicalDeliveryDispatchResult delivered_b =
+        source.deliver_pending_logical_deliveries(
+            peer_b, replication_db, receiver_b_node);
+    MDBXC_TEST_ASSERT(delivered_b.ok);
+    MDBXC_TEST_ASSERT(delivered_b.delivered == 1u);
+    MDBXC_TEST_ASSERT(source.pending_logical_deliveries(
+        replication_db, receiver_b_node).empty());
+    MDBXC_TEST_ASSERT(source.pending_logical_deliveries(
+        replication_db, receiver_c_node).size() == 1u);
+
+    mdbxc::sync::DirectLogicalDeliveryPeer peer_c(receiver_c);
+    const mdbxc::sync::LogicalDeliveryDispatchResult delivered_c =
+        source.deliver_pending_logical_deliveries(
+            peer_c, replication_db, receiver_c_node);
+    MDBXC_TEST_ASSERT(delivered_c.ok);
+    MDBXC_TEST_ASSERT(delivered_c.delivered == 1u);
+    MDBXC_TEST_ASSERT(source.pending_logical_deliveries(
+        replication_db, receiver_c_node).empty());
+
+    source_conn->disconnect();
+    receiver_b_conn->disconnect();
+    receiver_c_conn->disconnect();
+    cleanup(source_path);
+    cleanup(receiver_b_path);
+    cleanup(receiver_c_path);
 }
 
 } // namespace
@@ -6111,5 +6195,6 @@ int main() {
     test_cumulative_logical_delivery_acknowledgement_recovers_after_restart();
     test_ordered_logical_delivery_loopback_cleans_outbox();
     test_ordered_logical_delivery_dispatch_rejects_invalid_acknowledgements();
+    test_ordered_logical_delivery_acknowledges_each_receiver_independently();
     return 0;
 }

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -308,6 +308,7 @@ public:
         FailedCurrentDelivery,
         SuccessfulRetryableDelivery,
         WrongDestination,
+        WrongReceiver,
         WrongOrigin,
         AckBeyondDelivery
     };
@@ -330,8 +331,23 @@ public:
     deliver_ordered_logical_delivery(
             const mdbxc::sync::LogicalDeliveryEnvelope& envelope,
             const mdbxc::sync::CodecBounds*) override {
+        return make_acknowledgement(envelope, m_hello.node_id);
+    }
+
+    mdbxc::sync::LogicalDeliveryAcknowledgement
+    deliver_ordered_logical_request(
+            const mdbxc::sync::LogicalDeliveryRequest& request,
+            const mdbxc::sync::CodecBounds*) override {
+        return make_acknowledgement(request.envelope, request.receiver_node_id);
+    }
+
+private:
+    mdbxc::sync::LogicalDeliveryAcknowledgement make_acknowledgement(
+            const mdbxc::sync::LogicalDeliveryEnvelope& envelope,
+            const mdbxc::sync::NodeId& receiver) const {
         mdbxc::sync::LogicalDeliveryAcknowledgement acknowledgement;
         acknowledgement.destination_db_uuid = envelope.destination_db_uuid;
+        acknowledgement.receiver_node_id = receiver;
         acknowledgement.origin_node_id = envelope.origin_node_id;
         acknowledgement.acknowledged_through = envelope.origin_sequence;
         switch (m_mode) {
@@ -346,6 +362,9 @@ public:
         case WrongDestination:
             acknowledgement.destination_db_uuid = make_node(0xEE);
             break;
+        case WrongReceiver:
+            acknowledgement.receiver_node_id = make_node(0xED);
+            break;
         case WrongOrigin:
             acknowledgement.origin_node_id = make_node(0xEF);
             break;
@@ -356,7 +375,6 @@ public:
         return acknowledgement;
     }
 
-private:
     mdbxc::sync::LogicalDeliveryHello m_hello;
     Mode m_mode;
 };
@@ -5511,7 +5529,7 @@ void test_logical_outbox_persists_ordered_destination_streams() {
     cleanup(path);
 }
 
-void test_logical_outbox_acknowledgement_gap_preserves_caller_transaction() {
+void test_logical_outbox_acknowledgement_accepts_recovered_sparse_route() {
     const std::string path = "test_logical_outbox_acknowledgement_gap.mdbx";
     cleanup(path);
 
@@ -5539,8 +5557,8 @@ void test_logical_outbox_acknowledgement_gap_preserves_caller_transaction() {
         const MDBX_dbi dbi = outbox.handle(txn.handle());
         std::vector<std::uint8_t> key;
         key.reserve(2u + destination.size() + destination.size() + 8u);
+        key.push_back(3u);
         key.push_back(2u);
-        key.push_back(1u);
         key.insert(key.end(), destination.begin(), destination.end());
         key.insert(key.end(), destination.begin(), destination.end());
         mdbxc::sync::detail::append_u64_be(key, 2u);
@@ -5557,24 +5575,16 @@ void test_logical_outbox_acknowledgement_gap_preserves_caller_transaction() {
         mdbxc::Transaction txn =
             conn->transaction(mdbxc::TransactionMode::WRITABLE);
         mdbxc::sync::LogicalOutboxStore outbox(conn->env_handle());
-        bool rejected = false;
-        try {
-            outbox.acknowledge_through(txn.handle(), destination, destination,
-                                       3u);
-        } catch (const std::runtime_error&) {
-            rejected = true;
-        }
-        MDBXC_TEST_ASSERT(rejected);
+        MDBXC_TEST_ASSERT(outbox.acknowledge_through(
+            txn.handle(), destination, destination, 3u) == 2u);
         txn.commit();
     }
 
     MDBXC_TEST_ASSERT(
-        engine.logical_delivery_acknowledged_through(destination, destination) == 0u);
+        engine.logical_delivery_acknowledged_through(destination, destination) == 3u);
     const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending =
         engine.pending_logical_deliveries(destination, destination);
-    MDBXC_TEST_ASSERT(pending.size() == 2u);
-    MDBXC_TEST_ASSERT(pending[0].origin_sequence == 1u);
-    MDBXC_TEST_ASSERT(pending[1].origin_sequence == 3u);
+    MDBXC_TEST_ASSERT(pending.empty());
 
     conn->disconnect();
     cleanup(path);
@@ -5608,8 +5618,8 @@ void test_logical_outbox_acknowledgement_missing_tail_preserves_caller_transacti
         const MDBX_dbi dbi = outbox.handle(txn.handle());
         std::vector<std::uint8_t> key;
         key.reserve(2u + destination.size() + destination.size() + 8u);
+        key.push_back(3u);
         key.push_back(2u);
-        key.push_back(1u);
         key.insert(key.end(), destination.begin(), destination.end());
         key.insert(key.end(), destination.begin(), destination.end());
         mdbxc::sync::detail::append_u64_be(key, 3u);
@@ -5742,7 +5752,7 @@ void test_ordered_logical_delivery_enforces_receiver_frontier() {
     MDBXC_TEST_ASSERT(receiver_ahead_duplicate.ok);
     MDBXC_TEST_ASSERT(receiver_ahead_duplicate.acknowledged_through == 1u);
     mdbxc::sync::validate_logical_delivery_acknowledgement_for_delivery(
-        receiver_ahead_duplicate, first);
+        receiver_ahead_duplicate, first, local_node);
     const std::vector<std::uint8_t> encoded_receiver_ahead_duplicate =
         mdbxc::sync::LogicalDeliveryProtocolCodec::encode_acknowledgement(
             receiver_ahead_duplicate);
@@ -5751,7 +5761,7 @@ void test_ordered_logical_delivery_enforces_receiver_frontier() {
             mdbxc::sync::LogicalDeliveryProtocolCodec::decode_acknowledgement(
                 encoded_receiver_ahead_duplicate);
     mdbxc::sync::validate_logical_delivery_acknowledgement_for_delivery(
-        decoded_receiver_ahead_duplicate, first);
+        decoded_receiver_ahead_duplicate, first, local_node);
     MDBXC_TEST_ASSERT(apply_calls == 2);
 
     mdbxc::sync::LogicalDeliveryCapabilities cumulative_sender;
@@ -5763,7 +5773,7 @@ void test_ordered_logical_delivery_enforces_receiver_frontier() {
     MDBXC_TEST_ASSERT(cumulative_duplicate.ok);
     MDBXC_TEST_ASSERT(cumulative_duplicate.acknowledged_through == 2u);
     mdbxc::sync::validate_logical_delivery_acknowledgement_for_sender(
-        cumulative_duplicate, first, 2u, true);
+        cumulative_duplicate, first, local_node, 2u, true);
     MDBXC_TEST_ASSERT(apply_calls == 2);
 
     const std::size_t pruned =
@@ -6016,6 +6026,7 @@ void test_ordered_logical_delivery_dispatch_rejects_invalid_acknowledgements() {
         InvalidLogicalDeliveryPeer::FailedCurrentDelivery,
         InvalidLogicalDeliveryPeer::SuccessfulRetryableDelivery,
         InvalidLogicalDeliveryPeer::WrongDestination,
+        InvalidLogicalDeliveryPeer::WrongReceiver,
         InvalidLogicalDeliveryPeer::WrongOrigin,
         InvalidLogicalDeliveryPeer::AckBeyondDelivery
     };
@@ -6036,10 +6047,60 @@ void test_ordered_logical_delivery_dispatch_rejects_invalid_acknowledgements() {
     cleanup(path);
 }
 
-void test_ordered_logical_delivery_acknowledges_each_receiver_independently() {
-    const std::string source_path = "test_logical_fanout_source.mdbx";
-    const std::string receiver_b_path = "test_logical_fanout_b.mdbx";
-    const std::string receiver_c_path = "test_logical_fanout_c.mdbx";
+void test_logical_outbox_rejects_entries_above_default_codec_bounds() {
+    const std::string path = "test_logical_outbox_default_bounds.mdbx";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 16;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId local_node = make_node(0x92);
+    const mdbxc::sync::DbId local_db = make_node(0xA2);
+    const mdbxc::sync::DbId destination = make_node(0xB2);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(local_node, local_db);
+
+    mdbxc::sync::CodecBounds narrower_bounds;
+    narrower_bounds.max_logical_schema_id_len = 64u;
+    const mdbxc::sync::LogicalDeliveryEnvelope accepted =
+        engine.enqueue_logical_delivery(
+            destination, destination,
+            make_outbox_test_frame(std::string(64u, 'a'), 1u),
+            &narrower_bounds);
+    MDBXC_TEST_ASSERT(accepted.origin_sequence == 1u);
+    MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(
+        destination, destination).size() == 1u);
+
+    mdbxc::sync::CodecBounds broader_bounds;
+    ++broader_bounds.max_logical_schema_id_len;
+    bool default_bound_rejected = false;
+    try {
+        engine.enqueue_logical_delivery(
+            destination, destination,
+            make_outbox_test_frame(
+                std::string(broader_bounds.max_logical_schema_id_len, 'b'),
+                2u),
+            &broader_bounds);
+    } catch (const std::length_error&) {
+        default_bound_rejected = true;
+    }
+    MDBXC_TEST_ASSERT(default_bound_rejected);
+    MDBXC_TEST_ASSERT(engine.logical_delivery_known_tail(
+        destination, destination) == 1u);
+    MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(
+        destination, destination).size() == 1u);
+
+    conn->disconnect();
+    cleanup(path);
+}
+
+void test_ordered_logical_delivery_rejects_fresh_receiver_route_gap() {
+    const std::string source_path = "test_logical_receiver_route_source.mdbx";
+    const std::string receiver_b_path = "test_logical_receiver_route_b.mdbx";
+    const std::string receiver_c_path = "test_logical_receiver_route_c.mdbx";
     cleanup(source_path);
     cleanup(receiver_b_path);
     cleanup(receiver_c_path);
@@ -6071,12 +6132,16 @@ void test_ordered_logical_delivery_acknowledges_each_receiver_independently() {
     receiver_c.initialize_local_identity(receiver_c_node, replication_db);
 
     const mdbxc::sync::LogicalChangeFrame frame;
-    source.enqueue_logical_delivery(replication_db, receiver_b_node, frame);
-    source.enqueue_logical_delivery(replication_db, receiver_c_node, frame);
+    const mdbxc::sync::LogicalDeliveryEnvelope first =
+        source.enqueue_logical_delivery(replication_db, receiver_b_node, frame);
+    const mdbxc::sync::LogicalDeliveryEnvelope second =
+        source.enqueue_logical_delivery(replication_db, receiver_c_node, frame);
+    MDBXC_TEST_ASSERT(first.origin_sequence == 1u);
+    MDBXC_TEST_ASSERT(second.origin_sequence == 2u);
     MDBXC_TEST_ASSERT(source.logical_delivery_known_tail(
         replication_db, receiver_b_node) == 1u);
     MDBXC_TEST_ASSERT(source.logical_delivery_known_tail(
-        replication_db, receiver_c_node) == 1u);
+        replication_db, receiver_c_node) == 2u);
 
     mdbxc::sync::DirectLogicalDeliveryPeer peer_b(receiver_b);
     const mdbxc::sync::LogicalDeliveryDispatchResult delivered_b =
@@ -6093,10 +6158,11 @@ void test_ordered_logical_delivery_acknowledges_each_receiver_independently() {
     const mdbxc::sync::LogicalDeliveryDispatchResult delivered_c =
         source.deliver_pending_logical_deliveries(
             peer_c, replication_db, receiver_c_node);
-    MDBXC_TEST_ASSERT(delivered_c.ok);
-    MDBXC_TEST_ASSERT(delivered_c.delivered == 1u);
+    MDBXC_TEST_ASSERT(!delivered_c.ok);
+    MDBXC_TEST_ASSERT(delivered_c.retryable);
+    MDBXC_TEST_ASSERT(delivered_c.delivered == 0u);
     MDBXC_TEST_ASSERT(source.pending_logical_deliveries(
-        replication_db, receiver_c_node).empty());
+        replication_db, receiver_c_node).size() == 1u);
 
     source_conn->disconnect();
     receiver_b_conn->disconnect();
@@ -6104,6 +6170,65 @@ void test_ordered_logical_delivery_acknowledges_each_receiver_independently() {
     cleanup(source_path);
     cleanup(receiver_b_path);
     cleanup(receiver_c_path);
+}
+
+void test_ordered_logical_delivery_request_rejects_wrong_receiver_before_apply() {
+    const std::string path = "test_ordered_logical_wrong_receiver.mdbx";
+    const std::string dbi_name = "ordered_logical_wrong_receiver";
+    const std::string schema_id = "app.ordered_logical_wrong_receiver.v1";
+    cleanup(path);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 20;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+
+    const mdbxc::sync::NodeId origin_node = make_node(0xA3);
+    const mdbxc::sync::NodeId requested_receiver = make_node(0xB3);
+    const mdbxc::sync::NodeId actual_receiver = make_node(0xC3);
+    const mdbxc::sync::DbId replication_db = make_node(0xD3);
+    mdbxc::sync::SyncEngine receiver(conn);
+    receiver.initialize_local_identity(actual_receiver, replication_db);
+    receiver.register_logical_schema(schema_id, make_record(dbi_name));
+
+    mdbxc::KeyValueTable<int, std::string> table(conn, dbi_name);
+    int apply_calls = 0;
+    CountingDeliveryLogicalAdapter adapter(table, schema_id, apply_calls);
+    receiver.register_logical_adapter(adapter);
+
+    mdbxc::sync::LogicalSchemaRef ref;
+    ref.schema_id = schema_id;
+    ref.kind = mdbxc::sync::LogicalTableKind::KeyValue;
+    ref.schema_version = 1u;
+    mdbxc::sync::LogicalDeliveryRequest request;
+    request.receiver_node_id = requested_receiver;
+    request.envelope.destination_db_uuid = replication_db;
+    request.envelope.origin_node_id = origin_node;
+    request.envelope.origin_sequence = 1u;
+    request.envelope.frame_id = "wrong-receiver";
+    request.envelope.frame.changes.push_back(mdbxc::sync::LogicalChange(
+        ref, 1u, 0u, std::vector<std::uint8_t>()));
+
+    const mdbxc::sync::LogicalDeliveryAcknowledgement acknowledgement =
+        receiver.apply_ordered_logical_delivery_request(request);
+    MDBXC_TEST_ASSERT(!acknowledgement.ok);
+    MDBXC_TEST_ASSERT(!acknowledgement.retryable);
+    MDBXC_TEST_ASSERT(acknowledgement.destination_db_uuid == replication_db);
+    MDBXC_TEST_ASSERT(acknowledgement.receiver_node_id == actual_receiver);
+    MDBXC_TEST_ASSERT(acknowledgement.origin_node_id == origin_node);
+    MDBXC_TEST_ASSERT(acknowledgement.acknowledged_through == 0u);
+    MDBXC_TEST_ASSERT(apply_calls == 0);
+    MDBXC_TEST_ASSERT(!table.find_compat(1).first);
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        mdbxc::sync::LogicalDeliveryOrderStore order(conn->env_handle());
+        MDBXC_TEST_ASSERT(order.last_applied(txn.handle(), origin_node) == 0u);
+    }
+
+    conn->disconnect();
+    cleanup(path);
 }
 
 } // namespace
@@ -6188,13 +6313,15 @@ int main() {
     test_key_value_logical_adapter_decodes_literal_little_endian_payload();
     test_key_value_logical_apply_does_not_recapture_incoming_change();
     test_logical_outbox_persists_ordered_destination_streams();
-    test_logical_outbox_acknowledgement_gap_preserves_caller_transaction();
+    test_logical_outbox_rejects_entries_above_default_codec_bounds();
+    test_logical_outbox_acknowledgement_accepts_recovered_sparse_route();
     test_logical_outbox_acknowledgement_missing_tail_preserves_caller_transaction();
     test_ordered_logical_delivery_enforces_receiver_frontier();
     test_ordered_logical_delivery_dispatch_cleans_outbox_and_markers();
     test_cumulative_logical_delivery_acknowledgement_recovers_after_restart();
     test_ordered_logical_delivery_loopback_cleans_outbox();
     test_ordered_logical_delivery_dispatch_rejects_invalid_acknowledgements();
-    test_ordered_logical_delivery_acknowledges_each_receiver_independently();
+    test_ordered_logical_delivery_rejects_fresh_receiver_route_gap();
+    test_ordered_logical_delivery_request_rejects_wrong_receiver_before_apply();
     return 0;
 }

--- a/tests/test_logical_delivery_protocol.cpp
+++ b/tests/test_logical_delivery_protocol.cpp
@@ -72,6 +72,7 @@ public:
         ++m_calls;
         mdbxc::sync::LogicalDeliveryAcknowledgement out;
         out.destination_db_uuid = envelope.destination_db_uuid;
+        out.receiver_node_id = m_hello.node_id;
         out.origin_node_id = envelope.origin_node_id;
         out.acknowledged_through = envelope.origin_sequence;
         return out;
@@ -136,6 +137,7 @@ void test_delivery_and_acknowledgement_round_trip() {
 
     mdbxc::sync::LogicalDeliveryAcknowledgement acknowledgement;
     acknowledgement.destination_db_uuid = envelope.destination_db_uuid;
+    acknowledgement.receiver_node_id = make_node(0x90);
     acknowledgement.origin_node_id = envelope.origin_node_id;
     acknowledgement.acknowledged_through = 6u;
     acknowledgement.ok = false;
@@ -149,6 +151,8 @@ void test_delivery_and_acknowledgement_round_trip() {
             encoded_ack);
     MDBXC_TEST_ASSERT(decoded_ack.destination_db_uuid ==
                       acknowledgement.destination_db_uuid);
+    MDBXC_TEST_ASSERT(decoded_ack.receiver_node_id ==
+                      acknowledgement.receiver_node_id);
     MDBXC_TEST_ASSERT(decoded_ack.origin_node_id ==
                       acknowledgement.origin_node_id);
     MDBXC_TEST_ASSERT(decoded_ack.acknowledged_through == 6u);
@@ -168,6 +172,7 @@ void test_stateless_requests_round_trip() {
         hello_request);
 
     mdbxc::sync::LogicalDeliveryRequest request;
+    request.receiver_node_id = make_node(0x90);
     request.envelope = make_envelope();
     request.sender_capabilities.flags = static_cast<std::uint64_t>(
         mdbxc::sync::LogicalDeliveryCapability::OrderedDelivery) |
@@ -184,6 +189,7 @@ void test_stateless_requests_round_trip() {
             encoded);
     MDBXC_TEST_ASSERT(decoded.envelope.origin_sequence ==
                       request.envelope.origin_sequence);
+    MDBXC_TEST_ASSERT(decoded.receiver_node_id == request.receiver_node_id);
     MDBXC_TEST_ASSERT(decoded.envelope.frame_id == request.envelope.frame_id);
     MDBXC_TEST_ASSERT(decoded.sender_capabilities.flags ==
                       request.sender_capabilities.flags);
@@ -215,6 +221,7 @@ void test_protocol_rejects_invalid_header_and_acknowledgement() {
 
     mdbxc::sync::LogicalDeliveryAcknowledgement acknowledgement;
     acknowledgement.destination_db_uuid = make_node(0x70);
+    acknowledgement.receiver_node_id = make_node(0x90);
     acknowledgement.origin_node_id = make_node(0x80);
     acknowledgement.ok = true;
     acknowledgement.retryable = true;
@@ -226,42 +233,52 @@ void test_protocol_rejects_invalid_header_and_acknowledgement() {
 
 void test_acknowledgement_matches_its_delivery() {
     const mdbxc::sync::LogicalDeliveryEnvelope envelope = make_envelope();
+    const mdbxc::sync::NodeId receiver = make_node(0x90);
     mdbxc::sync::LogicalDeliveryAcknowledgement acknowledgement;
     acknowledgement.destination_db_uuid = envelope.destination_db_uuid;
+    acknowledgement.receiver_node_id = receiver;
     acknowledgement.origin_node_id = envelope.origin_node_id;
     acknowledgement.acknowledged_through = envelope.origin_sequence;
     mdbxc::sync::validate_logical_delivery_acknowledgement_for_delivery(
-        acknowledgement, envelope);
+        acknowledgement, envelope, receiver);
 
     acknowledgement.ok = false;
     acknowledgement.retryable = true;
     acknowledgement.error = "retry";
-    MDBXC_TEST_ASSERT(throws_runtime_error([&acknowledgement, &envelope]() {
+    MDBXC_TEST_ASSERT(throws_runtime_error([&acknowledgement, &envelope, &receiver]() {
         mdbxc::sync::validate_logical_delivery_acknowledgement_for_delivery(
-            acknowledgement, envelope);
+            acknowledgement, envelope, receiver);
     }));
 
     acknowledgement.acknowledged_through = envelope.origin_sequence - 1u;
     mdbxc::sync::validate_logical_delivery_acknowledgement_for_delivery(
-        acknowledgement, envelope);
+        acknowledgement, envelope, receiver);
 }
 
 void test_cumulative_acknowledgement_respects_sender_tail() {
     const mdbxc::sync::LogicalDeliveryEnvelope envelope = make_envelope();
+    const mdbxc::sync::NodeId receiver = make_node(0x90);
     mdbxc::sync::LogicalDeliveryAcknowledgement acknowledgement;
     acknowledgement.destination_db_uuid = envelope.destination_db_uuid;
+    acknowledgement.receiver_node_id = receiver;
     acknowledgement.origin_node_id = envelope.origin_node_id;
     acknowledgement.acknowledged_through = envelope.origin_sequence + 2u;
 
     mdbxc::sync::validate_logical_delivery_acknowledgement_for_sender(
-        acknowledgement, envelope, envelope.origin_sequence + 2u, true);
-    MDBXC_TEST_ASSERT(throws_runtime_error([&acknowledgement, &envelope]() {
+        acknowledgement, envelope, receiver, envelope.origin_sequence + 2u, true);
+    acknowledgement.receiver_node_id = make_node(0x91);
+    MDBXC_TEST_ASSERT(throws_runtime_error([&acknowledgement, &envelope, &receiver]() {
         mdbxc::sync::validate_logical_delivery_acknowledgement_for_sender(
-            acknowledgement, envelope, envelope.origin_sequence + 1u, true);
+            acknowledgement, envelope, receiver, envelope.origin_sequence + 2u, true);
     }));
-    MDBXC_TEST_ASSERT(throws_runtime_error([&acknowledgement, &envelope]() {
+    acknowledgement.receiver_node_id = receiver;
+    MDBXC_TEST_ASSERT(throws_runtime_error([&acknowledgement, &envelope, &receiver]() {
         mdbxc::sync::validate_logical_delivery_acknowledgement_for_sender(
-            acknowledgement, envelope, envelope.origin_sequence + 2u, false);
+            acknowledgement, envelope, receiver, envelope.origin_sequence + 1u, true);
+    }));
+    MDBXC_TEST_ASSERT(throws_runtime_error([&acknowledgement, &envelope, &receiver]() {
+        mdbxc::sync::validate_logical_delivery_acknowledgement_for_sender(
+            acknowledgement, envelope, receiver, envelope.origin_sequence + 2u, false);
     }));
 }
 
@@ -318,26 +335,29 @@ void test_default_outer_message_bound_includes_protocol_overhead() {
     }));
 }
 
-void test_legacy_peer_receives_request_through_default_forwarding() {
+void test_legacy_peer_rejects_receiver_bound_request() {
     const mdbxc::sync::LogicalDeliveryEnvelope envelope = make_envelope();
     mdbxc::sync::LogicalDeliveryHello hello;
     hello.node_id = make_node(0x91);
     hello.db_uuid = envelope.destination_db_uuid;
     LegacyLogicalDeliveryPeer peer(hello);
     mdbxc::sync::LogicalDeliveryRequest request;
+    request.receiver_node_id = hello.node_id;
     request.envelope = envelope;
     request.sender_capabilities.flags = static_cast<std::uint64_t>(
         mdbxc::sync::LogicalDeliveryCapability::OrderedDelivery);
 
     const mdbxc::sync::LogicalDeliveryAcknowledgement acknowledgement =
         peer.deliver_ordered_logical_request(request);
-    MDBXC_TEST_ASSERT(peer.calls() == 1u);
+    MDBXC_TEST_ASSERT(peer.calls() == 0u);
     MDBXC_TEST_ASSERT(acknowledgement.destination_db_uuid ==
                       envelope.destination_db_uuid);
+    MDBXC_TEST_ASSERT(acknowledgement.receiver_node_id == hello.node_id);
     MDBXC_TEST_ASSERT(acknowledgement.origin_node_id ==
                       envelope.origin_node_id);
-    MDBXC_TEST_ASSERT(acknowledgement.acknowledged_through ==
-                      envelope.origin_sequence);
+    MDBXC_TEST_ASSERT(!acknowledgement.ok);
+    MDBXC_TEST_ASSERT(acknowledgement.error.find("receiver-bound") !=
+                      std::string::npos);
 }
 
 } // namespace
@@ -350,6 +370,6 @@ int main() {
     test_acknowledgement_matches_its_delivery();
     test_cumulative_acknowledgement_respects_sender_tail();
     test_default_outer_message_bound_includes_protocol_overhead();
-    test_legacy_peer_receives_request_through_default_forwarding();
+    test_legacy_peer_rejects_receiver_bound_request();
     return 0;
 }

--- a/tests/test_logical_delivery_protocol.cpp
+++ b/tests/test_logical_delivery_protocol.cpp
@@ -147,6 +147,51 @@ void test_delivery_and_acknowledgement_round_trip() {
     MDBXC_TEST_ASSERT(decoded_ack.error == acknowledgement.error);
 }
 
+void test_stateless_requests_round_trip() {
+    const std::vector<std::uint8_t> hello_request =
+        mdbxc::sync::LogicalDeliveryProtocolCodec::encode_hello_request();
+    MDBXC_TEST_ASSERT(
+        mdbxc::sync::LogicalDeliveryProtocolCodec::peek_message_type(
+            hello_request) ==
+        mdbxc::sync::LogicalDeliveryProtocolCodec::MessageType::HelloRequest);
+    mdbxc::sync::LogicalDeliveryProtocolCodec::decode_hello_request(
+        hello_request);
+
+    mdbxc::sync::LogicalDeliveryRequest request;
+    request.envelope = make_envelope();
+    request.sender_capabilities.flags = static_cast<std::uint64_t>(
+        mdbxc::sync::LogicalDeliveryCapability::OrderedDelivery) |
+        static_cast<std::uint64_t>(
+            mdbxc::sync::LogicalDeliveryCapability::CumulativeAcknowledgement);
+    const std::vector<std::uint8_t> encoded =
+        mdbxc::sync::LogicalDeliveryProtocolCodec::encode_delivery_request(
+            request);
+    MDBXC_TEST_ASSERT(
+        mdbxc::sync::LogicalDeliveryProtocolCodec::peek_message_type(encoded) ==
+        mdbxc::sync::LogicalDeliveryProtocolCodec::MessageType::DeliveryRequest);
+    const mdbxc::sync::LogicalDeliveryRequest decoded =
+        mdbxc::sync::LogicalDeliveryProtocolCodec::decode_delivery_request(
+            encoded);
+    MDBXC_TEST_ASSERT(decoded.envelope.origin_sequence ==
+                      request.envelope.origin_sequence);
+    MDBXC_TEST_ASSERT(decoded.envelope.frame_id == request.envelope.frame_id);
+    MDBXC_TEST_ASSERT(decoded.sender_capabilities.flags ==
+                      request.sender_capabilities.flags);
+
+    std::vector<std::uint8_t> trailing_hello = hello_request;
+    trailing_hello.push_back(0u);
+    MDBXC_TEST_ASSERT(throws_runtime_error([&trailing_hello]() {
+        mdbxc::sync::LogicalDeliveryProtocolCodec::decode_hello_request(
+            trailing_hello);
+    }));
+    std::vector<std::uint8_t> truncated = encoded;
+    truncated.pop_back();
+    MDBXC_TEST_ASSERT(throws_runtime_error([&truncated]() {
+        mdbxc::sync::LogicalDeliveryProtocolCodec::decode_delivery_request(
+            truncated);
+    }));
+}
+
 void test_protocol_rejects_invalid_header_and_acknowledgement() {
     mdbxc::sync::LogicalDeliveryHello hello;
     hello.node_id = make_node(0x50);
@@ -237,6 +282,7 @@ void test_legacy_peer_receives_request_through_default_forwarding() {
 int main() {
     test_hello_round_trip_and_capability_negotiation();
     test_delivery_and_acknowledgement_round_trip();
+    test_stateless_requests_round_trip();
     test_protocol_rejects_invalid_header_and_acknowledgement();
     test_acknowledgement_matches_its_delivery();
     test_cumulative_acknowledgement_respects_sender_tail();

--- a/tests/test_logical_delivery_protocol.cpp
+++ b/tests/test_logical_delivery_protocol.cpp
@@ -45,6 +45,16 @@ bool throws_runtime_error(Fn fn) {
     return false;
 }
 
+template <typename Fn>
+bool throws_length_error(Fn fn) {
+    try {
+        fn();
+    } catch (const std::length_error&) {
+        return true;
+    }
+    return false;
+}
+
 class LegacyLogicalDeliveryPeer : public mdbxc::sync::ILogicalDeliveryPeer {
 public:
     explicit LegacyLogicalDeliveryPeer(const mdbxc::sync::LogicalDeliveryHello& hello)
@@ -255,6 +265,59 @@ void test_cumulative_acknowledgement_respects_sender_tail() {
     }));
 }
 
+void test_default_outer_message_bound_includes_protocol_overhead() {
+    mdbxc::sync::CodecBounds defaults;
+    mdbxc::sync::LogicalDeliveryEnvelope exact = make_envelope();
+    const mdbxc::sync::LogicalChange change = exact.frame.changes[0];
+    exact.frame.changes.clear();
+    const std::size_t base_size =
+        mdbxc::sync::LogicalDeliveryProtocolCodec::encode_delivery(exact).size();
+    mdbxc::sync::LogicalDeliveryEnvelope one_empty_change = exact;
+    mdbxc::sync::LogicalChange empty_change = change;
+    empty_change.payload.clear();
+    one_empty_change.frame.changes.push_back(empty_change);
+    const std::size_t change_overhead =
+        mdbxc::sync::LogicalDeliveryProtocolCodec::encode_delivery(
+            one_empty_change).size() - base_size;
+    const std::size_t remaining =
+        defaults.max_transport_message_bytes - base_size;
+    const std::size_t change_count = 1u +
+        (remaining + defaults.max_value_len + change_overhead - 1u) /
+        (defaults.max_value_len + change_overhead);
+    std::size_t payload_left = remaining - change_count * change_overhead;
+    MDBXC_TEST_ASSERT(payload_left <= change_count * defaults.max_value_len);
+    for (std::size_t i = 0u; i < change_count; ++i) {
+        mdbxc::sync::LogicalChange part = change;
+        const std::size_t payload_size = payload_left > defaults.max_value_len
+            ? defaults.max_value_len
+            : payload_left;
+        part.payload.assign(payload_size, 0x5Au);
+        exact.frame.changes.push_back(part);
+        payload_left -= payload_size;
+    }
+    MDBXC_TEST_ASSERT(payload_left == 0u);
+    const std::vector<std::uint8_t> exact_encoded =
+        mdbxc::sync::LogicalDeliveryProtocolCodec::encode_delivery(exact);
+    MDBXC_TEST_ASSERT(exact_encoded.size() ==
+                      defaults.max_transport_message_bytes);
+
+    mdbxc::sync::LogicalDeliveryEnvelope too_large = exact;
+    too_large.frame.changes[too_large.frame.changes.size() - 1u]
+        .payload.push_back(0x5Bu);
+    MDBXC_TEST_ASSERT(throws_length_error([&too_large]() {
+        mdbxc::sync::LogicalDeliveryProtocolCodec::encode_delivery(too_large);
+    }));
+
+    mdbxc::sync::CodecBounds larger = defaults;
+    ++larger.max_transport_message_bytes;
+    const std::vector<std::uint8_t> oversized =
+        mdbxc::sync::LogicalDeliveryProtocolCodec::encode_delivery(
+            too_large, &larger);
+    MDBXC_TEST_ASSERT(throws_length_error([&oversized]() {
+        mdbxc::sync::LogicalDeliveryProtocolCodec::decode_delivery(oversized);
+    }));
+}
+
 void test_legacy_peer_receives_request_through_default_forwarding() {
     const mdbxc::sync::LogicalDeliveryEnvelope envelope = make_envelope();
     mdbxc::sync::LogicalDeliveryHello hello;
@@ -286,6 +349,7 @@ int main() {
     test_protocol_rejects_invalid_header_and_acknowledgement();
     test_acknowledgement_matches_its_delivery();
     test_cumulative_acknowledgement_respects_sender_tail();
+    test_default_outer_message_bound_includes_protocol_overhead();
     test_legacy_peer_receives_request_through_default_forwarding();
     return 0;
 }

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -2004,7 +2004,7 @@ void test_engine_rejects_complete_snapshot_with_logical_outbox_state() {
     engine.initialize_local_identity(source_node, db_id);
     KeyValueTable<std::string, std::string> documents(conn, "documents");
     documents.insert_or_assign("document", "raw-value");
-    engine.enqueue_logical_delivery(destination, sync::LogicalChangeFrame());
+    engine.enqueue_logical_delivery(destination, destination, sync::LogicalChangeFrame());
     {
         auto txn = conn->transaction(TransactionMode::READ_ONLY);
         sync::SchemaRegistryStore schemas(conn->env_handle());
@@ -2302,7 +2302,7 @@ void test_engine_rejects_complete_snapshot_with_malformed_outbox_envelope() {
     engine.initialize_local_identity(source_node, db_id);
     KeyValueTable<std::string, std::string> documents(conn, "documents");
     documents.insert_or_assign("document", "raw-value");
-    engine.enqueue_logical_delivery(destination, sync::LogicalChangeFrame());
+    engine.enqueue_logical_delivery(destination, destination, sync::LogicalChangeFrame());
     {
         auto txn = conn->transaction(TransactionMode::WRITABLE);
         sync::LogicalOutboxStore outbox(conn->env_handle());

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -254,6 +254,7 @@ public:
         (void)bounds;
         mdbxc::sync::LogicalDeliveryAcknowledgement acknowledgement;
         acknowledgement.destination_db_uuid = request.envelope.destination_db_uuid;
+        acknowledgement.receiver_node_id = request.receiver_node_id;
         acknowledgement.origin_node_id = request.envelope.origin_node_id;
         acknowledgement.ok = false;
         acknowledgement.retryable = true;

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -2912,7 +2912,7 @@ void test_worker_delivers_pending_logical_outbox_after_raw_sync() {
     replica.initialize_local_identity(replica_node, db_id);
 
     sync::LogicalChangeFrame frame;
-    source.enqueue_logical_delivery(db_id, frame);
+    source.enqueue_logical_delivery(db_id, replica_node, frame);
     sync::DirectSyncPeer peer(&replica);
     RecordingWorkerObserver observer;
     sync::SyncWorkerOptions options;
@@ -2923,8 +2923,8 @@ void test_worker_delivers_pending_logical_outbox_after_raw_sync() {
     if (!result.ok || result.pages_pulled != 1u ||
         result.logical_deliveries_delivered != 1u ||
         result.logical_acknowledged_through != 1u ||
-        !source.pending_logical_deliveries(db_id).empty() ||
-        source.logical_delivery_acknowledged_through(db_id) != 1u) {
+        !source.pending_logical_deliveries(db_id, replica_node).empty() ||
+        source.logical_delivery_acknowledged_through(db_id, replica_node) != 1u) {
         throw std::runtime_error(
             "worker did not deliver and acknowledge the logical outbox");
     }
@@ -2963,11 +2963,12 @@ void test_worker_preserves_outbox_after_unavailable_or_retryable_logical_deliver
     cleanup(source_path);
 
     const sync::DbId db_id = make_node(0xDE);
+    const sync::NodeId retryable_node = make_node(0xE1);
     std::shared_ptr<Connection> source_conn = open_env(source_path);
     sync::SyncEngine source(source_conn);
     source.initialize_local_identity(make_node(0xAE), db_id);
     sync::LogicalChangeFrame frame;
-    source.enqueue_logical_delivery(db_id, frame);
+    source.enqueue_logical_delivery(db_id, retryable_node, frame);
 
     sync::SyncWorkerOptions options;
     options.enable_logical_delivery = true;
@@ -2976,7 +2977,7 @@ void test_worker_preserves_outbox_after_unavailable_or_retryable_logical_deliver
     const sync::SyncWorkerRoundResult unavailable =
         unavailable_worker.run_once();
     if (unavailable.ok || unavailable.sync_error_retryable ||
-        source.pending_logical_deliveries(db_id).size() != 1u) {
+        source.pending_logical_deliveries(db_id, retryable_node).size() != 1u) {
         throw std::runtime_error(
             "worker did not preserve outbox for an unsupported logical peer");
     }
@@ -2986,7 +2987,7 @@ void test_worker_preserves_outbox_after_unavailable_or_retryable_logical_deliver
     const sync::SyncWorkerRoundResult retryable = retryable_worker.run_once();
     if (retryable.ok || !retryable.sync_error_retryable ||
         retryable.logical_deliveries_delivered != 0u ||
-        source.pending_logical_deliveries(db_id).size() != 1u) {
+        source.pending_logical_deliveries(db_id, retryable_node).size() != 1u) {
         throw std::runtime_error(
             "worker did not preserve outbox after retryable logical failure");
     }

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -2957,6 +2957,31 @@ void test_worker_delivers_pending_logical_outbox_after_raw_sync() {
     cleanup(replica_path);
 }
 
+void test_worker_allows_raw_only_peer_when_logical_outbox_is_empty() {
+    using namespace mdbxc;
+    const std::string path = "test_worker_empty_logical_outbox.mdbx";
+    cleanup(path);
+
+    const sync::DbId db_id = make_node(0xDF);
+    std::shared_ptr<Connection> conn = open_env(path);
+    sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(make_node(0xAF), db_id);
+
+    EmptyPeer peer;
+    sync::SyncWorkerOptions options;
+    options.enable_logical_delivery = true;
+    sync::SyncWorker worker(engine, peer, options);
+    const sync::SyncWorkerRoundResult result = worker.run_once();
+    if (!result.ok || result.pages_pulled != 1u ||
+        result.logical_deliveries_delivered != 0u) {
+        throw std::runtime_error(
+            "raw-only peer failed with an empty logical outbox");
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 void test_worker_preserves_outbox_after_unavailable_or_retryable_logical_delivery() {
     using namespace mdbxc;
     const std::string source_path =
@@ -3089,6 +3114,8 @@ int main() {
           &test_worker_rejects_manifest_only_snapshot_fallback },
         { "test_worker_delivers_pending_logical_outbox_after_raw_sync",
           &test_worker_delivers_pending_logical_outbox_after_raw_sync },
+        { "test_worker_allows_raw_only_peer_when_logical_outbox_is_empty",
+          &test_worker_allows_raw_only_peer_when_logical_outbox_is_empty },
         { "test_worker_preserves_outbox_after_unavailable_or_retryable_logical_delivery",
           &test_worker_preserves_outbox_after_unavailable_or_retryable_logical_delivery },
         { "test_worker_rejects_logical_complete_snapshot_fallback",

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -215,6 +215,56 @@ private:
     mdbxc::sync::PullResponse m_response;
 };
 
+class RetryableLogicalPeer : public mdbxc::sync::ISyncPeer {
+public:
+    explicit RetryableLogicalPeer(const mdbxc::sync::DbId& db_id)
+        : m_db_id(db_id) {}
+
+    mdbxc::sync::PullResponse pull(
+            const mdbxc::sync::PullRequest& request) override {
+        (void)request;
+        return mdbxc::sync::PullResponse();
+    }
+
+    mdbxc::sync::PushResponse push(
+            const mdbxc::sync::PushRequest& request) override {
+        (void)request;
+        return mdbxc::sync::PushResponse();
+    }
+
+    bool supports_logical_delivery() const override {
+        return true;
+    }
+
+    mdbxc::sync::LogicalDeliveryHello logical_delivery_hello() override {
+        mdbxc::sync::LogicalDeliveryHello hello;
+        hello.node_id = make_node(0xE1);
+        hello.db_uuid = m_db_id;
+        hello.capabilities.flags = static_cast<std::uint64_t>(
+            mdbxc::sync::LogicalDeliveryCapability::OrderedDelivery) |
+            static_cast<std::uint64_t>(
+                mdbxc::sync::LogicalDeliveryCapability::CumulativeAcknowledgement);
+        return hello;
+    }
+
+    mdbxc::sync::LogicalDeliveryAcknowledgement
+    deliver_ordered_logical_request(
+            const mdbxc::sync::LogicalDeliveryRequest& request,
+            const mdbxc::sync::CodecBounds* bounds = nullptr) override {
+        (void)bounds;
+        mdbxc::sync::LogicalDeliveryAcknowledgement acknowledgement;
+        acknowledgement.destination_db_uuid = request.envelope.destination_db_uuid;
+        acknowledgement.origin_node_id = request.envelope.origin_node_id;
+        acknowledgement.ok = false;
+        acknowledgement.retryable = true;
+        acknowledgement.error = "retryable logical delivery failure";
+        return acknowledgement;
+    }
+
+private:
+    mdbxc::sync::DbId m_db_id;
+};
+
 class BlockingPeer : public mdbxc::sync::ISyncPeer {
 public:
     explicit BlockingPeer(const mdbxc::sync::PullResponse& response)
@@ -2844,6 +2894,107 @@ void test_worker_rejects_manifest_only_snapshot_fallback() {
     cleanup(replica_path);
 }
 
+void test_worker_delivers_pending_logical_outbox_after_raw_sync() {
+    using namespace mdbxc;
+    const std::string source_path = "test_worker_logical_delivery_source.mdbx";
+    const std::string replica_path = "test_worker_logical_delivery_replica.mdbx";
+    cleanup(source_path);
+    cleanup(replica_path);
+
+    const sync::NodeId source_node = make_node(0xAD);
+    const sync::NodeId replica_node = make_node(0xBD);
+    const sync::DbId db_id = make_node(0xDD);
+    std::shared_ptr<Connection> source_conn = open_env(source_path);
+    std::shared_ptr<Connection> replica_conn = open_env(replica_path);
+    sync::SyncEngine source(source_conn);
+    sync::SyncEngine replica(replica_conn);
+    source.initialize_local_identity(source_node, db_id);
+    replica.initialize_local_identity(replica_node, db_id);
+
+    sync::LogicalChangeFrame frame;
+    source.enqueue_logical_delivery(db_id, frame);
+    sync::DirectSyncPeer peer(&replica);
+    RecordingWorkerObserver observer;
+    sync::SyncWorkerOptions options;
+    options.enable_logical_delivery = true;
+    options.observer = &observer;
+    sync::SyncWorker worker(source, peer, options);
+    const sync::SyncWorkerRoundResult result = worker.run_once();
+    if (!result.ok || result.pages_pulled != 1u ||
+        result.logical_deliveries_delivered != 1u ||
+        result.logical_acknowledged_through != 1u ||
+        !source.pending_logical_deliveries(db_id).empty() ||
+        source.logical_delivery_acknowledged_through(db_id) != 1u) {
+        throw std::runtime_error(
+            "worker did not deliver and acknowledge the logical outbox");
+    }
+    {
+        auto txn = replica_conn->transaction(TransactionMode::READ_ONLY);
+        sync::LogicalDeliveryOrderStore order(replica_conn->env_handle());
+        if (order.last_applied(txn.handle(), source_node) != 1u) {
+            throw std::runtime_error(
+                "worker logical delivery did not advance receiver order frontier");
+        }
+    }
+    const std::vector<sync::SyncWorkerStageEvent> stages = observer.stages();
+    bool started = false;
+    bool finished = false;
+    for (std::size_t i = 0u; i < stages.size(); ++i) {
+        started = started || stages[i].stage ==
+            sync::SyncWorkerStage::LogicalDeliveryStarted;
+        finished = finished || stages[i].stage ==
+            sync::SyncWorkerStage::LogicalDeliveryFinished;
+    }
+    if (!started || !finished) {
+        throw std::runtime_error(
+            "worker did not report logical delivery stages");
+    }
+
+    source_conn->disconnect();
+    replica_conn->disconnect();
+    cleanup(source_path);
+    cleanup(replica_path);
+}
+
+void test_worker_preserves_outbox_after_unavailable_or_retryable_logical_delivery() {
+    using namespace mdbxc;
+    const std::string source_path =
+        "test_worker_logical_delivery_failure_source.mdbx";
+    cleanup(source_path);
+
+    const sync::DbId db_id = make_node(0xDE);
+    std::shared_ptr<Connection> source_conn = open_env(source_path);
+    sync::SyncEngine source(source_conn);
+    source.initialize_local_identity(make_node(0xAE), db_id);
+    sync::LogicalChangeFrame frame;
+    source.enqueue_logical_delivery(db_id, frame);
+
+    sync::SyncWorkerOptions options;
+    options.enable_logical_delivery = true;
+    EmptyPeer unavailable_peer;
+    sync::SyncWorker unavailable_worker(source, unavailable_peer, options);
+    const sync::SyncWorkerRoundResult unavailable =
+        unavailable_worker.run_once();
+    if (unavailable.ok || unavailable.sync_error_retryable ||
+        source.pending_logical_deliveries(db_id).size() != 1u) {
+        throw std::runtime_error(
+            "worker did not preserve outbox for an unsupported logical peer");
+    }
+
+    RetryableLogicalPeer retryable_peer(db_id);
+    sync::SyncWorker retryable_worker(source, retryable_peer, options);
+    const sync::SyncWorkerRoundResult retryable = retryable_worker.run_once();
+    if (retryable.ok || !retryable.sync_error_retryable ||
+        retryable.logical_deliveries_delivered != 0u ||
+        source.pending_logical_deliveries(db_id).size() != 1u) {
+        throw std::runtime_error(
+            "worker did not preserve outbox after retryable logical failure");
+    }
+
+    source_conn->disconnect();
+    cleanup(source_path);
+}
+
 void test_worker_rejects_logical_complete_snapshot_fallback() {
     using namespace mdbxc;
     const std::string source_path = "test_worker_logical_snapshot_source.mdbx";
@@ -2934,6 +3085,10 @@ int main() {
           &test_worker_snapshot_recovery_preserves_remote_origin_cursor },
         { "test_worker_rejects_manifest_only_snapshot_fallback",
           &test_worker_rejects_manifest_only_snapshot_fallback },
+        { "test_worker_delivers_pending_logical_outbox_after_raw_sync",
+          &test_worker_delivers_pending_logical_outbox_after_raw_sync },
+        { "test_worker_preserves_outbox_after_unavailable_or_retryable_logical_delivery",
+          &test_worker_preserves_outbox_after_unavailable_or_retryable_logical_delivery },
         { "test_worker_rejects_logical_complete_snapshot_fallback",
           &test_worker_rejects_logical_complete_snapshot_fallback },
         { "test_worker_run_once_drains_paginated_pull",

--- a/tests/test_websocket_transport.cpp
+++ b/tests/test_websocket_transport.cpp
@@ -257,13 +257,14 @@ void test_websocket_peer_delivers_ordered_logical_outbox() {
     std::shared_ptr<mdbxc::Connection> source = open_db(source_path);
     std::shared_ptr<mdbxc::Connection> replica = open_db(replica_path);
     const mdbxc::sync::DbId db_id = make_node(0xD6);
+    const mdbxc::sync::NodeId replica_node = make_node(0x62);
     mdbxc::sync::SyncEngine source_engine(source);
     mdbxc::sync::SyncEngine replica_engine(replica);
     source_engine.initialize_local_identity(make_node(0x52), db_id);
-    replica_engine.initialize_local_identity(make_node(0x62), db_id);
+    replica_engine.initialize_local_identity(replica_node, db_id);
 
     mdbxc::sync::LogicalChangeFrame frame;
-    source_engine.enqueue_logical_delivery(db_id, frame);
+    source_engine.enqueue_logical_delivery(db_id, replica_node, frame);
 
     mdbxc::sync::WebSocketSyncServer replica_server(replica_engine);
     LoopbackWebSocketChannel channel(replica_server);
@@ -279,7 +280,8 @@ void test_websocket_peer_delivers_ordered_logical_outbox() {
     require_true(channel.last_token_cancellable(),
                  "WebSocket logical hello did not receive cancellation token");
     const mdbxc::sync::LogicalDeliveryDispatchResult result =
-        source_engine.deliver_pending_logical_deliveries(peer, db_id);
+        source_engine.deliver_pending_logical_deliveries(peer, db_id,
+                                                         replica_node);
     require_true(result.ok, "WebSocket logical delivery failed: " + result.error);
     require_true(result.delivered == 1u,
                  "WebSocket logical delivery count mismatch");
@@ -287,7 +289,7 @@ void test_websocket_peer_delivers_ordered_logical_outbox() {
                  "WebSocket logical acknowledgement mismatch");
     require_true(channel.last_was_logical(),
                  "WebSocket logical delivery used raw protocol magic");
-    require_true(source_engine.pending_logical_deliveries(db_id).empty(),
+    require_true(source_engine.pending_logical_deliveries(db_id, replica_node).empty(),
                  "WebSocket logical delivery did not remove acknowledged outbox entry");
 
     source->disconnect();

--- a/tests/test_websocket_transport.cpp
+++ b/tests/test_websocket_transport.cpp
@@ -3,6 +3,7 @@
 
 #include <cstdio>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -57,19 +58,27 @@ public:
     explicit LoopbackWebSocketChannel(
             mdbxc::sync::WebSocketSyncServer& server)
         : m_server(server),
-          m_exchange_count(0),
-          m_cancel_count(0),
-          m_last_token_cancellable(false),
-          m_last_type(mdbxc::sync::TransportMessageType::PullRequest) {}
+           m_exchange_count(0),
+           m_cancel_count(0),
+           m_last_token_cancellable(false),
+           m_last_was_logical(false),
+           m_last_type(mdbxc::sync::TransportMessageType::PullRequest) {}
 
     std::vector<std::uint8_t> exchange_binary(
             const std::vector<std::uint8_t>& binary_message,
             const mdbxc::sync::CancellationToken& cancel_token) override {
         ++m_exchange_count;
         m_last_token_cancellable = cancel_token.can_be_cancelled();
-        m_last_type =
-            mdbxc::sync::TransportMessageCodec::peek_message_type(
-                binary_message);
+        m_last_was_logical = binary_message.size() >=
+                mdbxc::sync::LogicalDeliveryProtocolCodec::magic_size() &&
+            std::memcmp(&binary_message[0],
+                        mdbxc::sync::LogicalDeliveryProtocolCodec::magic(),
+                        mdbxc::sync::LogicalDeliveryProtocolCodec::magic_size()) == 0;
+        if (!m_last_was_logical) {
+            m_last_type =
+                mdbxc::sync::TransportMessageCodec::peek_message_type(
+                    binary_message);
+        }
         return m_server.handle_binary_message(binary_message);
     }
 
@@ -89,6 +98,7 @@ public:
     std::size_t exchange_count() const { return m_exchange_count; }
     std::size_t cancel_count() const { return m_cancel_count; }
     bool last_token_cancellable() const { return m_last_token_cancellable; }
+    bool last_was_logical() const { return m_last_was_logical; }
     mdbxc::sync::TransportMessageType last_type() const {
         return m_last_type;
     }
@@ -98,6 +108,7 @@ private:
     std::size_t m_exchange_count;
     std::size_t m_cancel_count;
     bool m_last_token_cancellable;
+    bool m_last_was_logical;
     mdbxc::sync::TransportMessageType m_last_type;
     mdbxc::sync::SyncTransportRetryHint m_last_retry_hint;
 };
@@ -233,6 +244,56 @@ void test_websocket_server_rejects_response_messages() {
 
     db->disconnect();
     cleanup(path);
+}
+
+void test_websocket_peer_delivers_ordered_logical_outbox() {
+    const std::string source_path =
+        "test_websocket_transport_logical_source.mdbx";
+    const std::string replica_path =
+        "test_websocket_transport_logical_replica.mdbx";
+    cleanup(source_path);
+    cleanup(replica_path);
+
+    std::shared_ptr<mdbxc::Connection> source = open_db(source_path);
+    std::shared_ptr<mdbxc::Connection> replica = open_db(replica_path);
+    const mdbxc::sync::DbId db_id = make_node(0xD6);
+    mdbxc::sync::SyncEngine source_engine(source);
+    mdbxc::sync::SyncEngine replica_engine(replica);
+    source_engine.initialize_local_identity(make_node(0x52), db_id);
+    replica_engine.initialize_local_identity(make_node(0x62), db_id);
+
+    mdbxc::sync::LogicalChangeFrame frame;
+    source_engine.enqueue_logical_delivery(db_id, frame);
+
+    mdbxc::sync::WebSocketSyncServer replica_server(replica_engine);
+    LoopbackWebSocketChannel channel(replica_server);
+    mdbxc::sync::WebSocketSyncPeer peer(channel);
+    mdbxc::sync::CancellationSource logical_cancel;
+    const mdbxc::sync::CancellationToken logical_token = logical_cancel.token();
+    const mdbxc::sync::LogicalDeliveryHello hello =
+        peer.logical_delivery_hello_with_cancel(&logical_token);
+    require_true(hello.db_uuid == db_id,
+                 "WebSocket logical hello db uuid mismatch");
+    require_true(channel.last_was_logical(),
+                 "WebSocket logical hello used raw protocol magic");
+    require_true(channel.last_token_cancellable(),
+                 "WebSocket logical hello did not receive cancellation token");
+    const mdbxc::sync::LogicalDeliveryDispatchResult result =
+        source_engine.deliver_pending_logical_deliveries(peer, db_id);
+    require_true(result.ok, "WebSocket logical delivery failed: " + result.error);
+    require_true(result.delivered == 1u,
+                 "WebSocket logical delivery count mismatch");
+    require_true(result.acknowledged_through == 1u,
+                 "WebSocket logical acknowledgement mismatch");
+    require_true(channel.last_was_logical(),
+                 "WebSocket logical delivery used raw protocol magic");
+    require_true(source_engine.pending_logical_deliveries(db_id).empty(),
+                 "WebSocket logical delivery did not remove acknowledged outbox entry");
+
+    source->disconnect();
+    replica->disconnect();
+    cleanup(source_path);
+    cleanup(replica_path);
 }
 
 void test_websocket_server_rejects_malformed_messages() {
@@ -450,6 +511,7 @@ void test_websocket_server_middleware_preserves_close_code() {
 int main() {
     test_websocket_peer_pull_and_push_roundtrip();
     test_websocket_server_rejects_response_messages();
+    test_websocket_peer_delivers_ordered_logical_outbox();
     test_websocket_server_rejects_malformed_messages();
     test_websocket_authenticated_node_policy();
     test_websocket_authenticated_node_policy_rejects_invalid_body();


### PR DESCRIPTION
## What changed

- Added a separate, capability-negotiated logical delivery protocol for direct, HTTP, and WebSocket peers.
- Added opt-in SyncWorker dispatch after raw pull pages drain, durable cumulative ACK handling, and cancellation-aware peer hooks.
- Added EN/RU user documentation and updated sync design/readiness records.

## Why

Logical adapter sessions can already atomically publish ordered envelopes to the durable outbox. This makes that outbox reachable over the existing peer transports without changing raw pull/push wire compatibility.

## Validation

- C++17 and C++11 focused sync/header/transport suites passed.
- Covered logical protocol round trips, HTTP/WebSocket routes and cancellation tokens, worker ACK/retry/unsupported-peer behavior, ordered adapters, and VectorStore logical adapter.