### PR TITLE
[codex] Add logical-aware fresh recovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -540,6 +540,11 @@ if(MDBXC_BUILD_TESTS)
             MDBXC_TEST_INJECT_TRANSACTION_COMMIT_FAILURE=1)
     endif()
 
+    if(TARGET test_sync_engine)
+        target_compile_definitions(test_sync_engine PRIVATE
+            MDBXC_TEST_LOGICAL_RECOVERY_MATERIALIZATION_CHECKPOINT=1)
+    endif()
+
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
             ((CMAKE_CXX_COMPILER_ID MATCHES "Clang") AND
              NOT CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC"))

--- a/docs/sync-recovery-RU.md
+++ b/docs/sync-recovery-RU.md
@@ -87,7 +87,11 @@ HTTP- и WebSocket-binding не считаются capable для logical recove
 - logical schema markers;
 - replay markers и pruning watermarks;
 - ordered-delivery receiver frontiers;
-- source outbox tail и ещё не подтверждённые envelopes для этой БД.
+- source outbox tail и ещё не подтверждённые envelopes для конкретного
+  requesting receiver node.
+
+Pending source suffix непрерывен и заканчивается на known tail этого receiver.
+Он не общий с другой репликой, даже если у неё тот же database identity.
 
 Получатель требует совместимый in-memory adapter для каждой schema из
 baseline. Физические страницы staging'уются в памяти. На final page он
@@ -100,6 +104,13 @@ transaction. Source outbox не копируется как local outbox пол�
 replay acknowledgement, а не второе изменение; следующий source sequence
 применяется обычно. Повреждённый baseline, отсутствующий adapter или не fresh
 logical state получателя откатывают final transaction.
+
+Source materialization bounds покрывают и physical snapshot operations, и
+logical baseline records. Receiver применяет тот же combined bound к staged
+physical pages и final baseline до открытия destination write transaction.
+`LogicalRecoveryPeer` принимает cooperative cancellation token для recovery
+call; cancellation даёт retryable response и отбрасывает неопубликованную
+source session. Этот контракт поддерживает `DirectSyncPeer`.
 
 ## Процедура оператора
 

--- a/docs/sync-recovery-RU.md
+++ b/docs/sync-recovery-RU.md
@@ -93,6 +93,15 @@ HTTP- и WebSocket-binding не считаются capable для logical recove
 Pending source suffix непрерывен и заканчивается на known tail этого receiver.
 Он не общий с другой репликой, даже если у неё тот же database identity.
 
+У упорядоченного logical event одна глобальная identity на database и origin:
+`(DbId, origin_node_id, origin_sequence)`. Source не выделяет новый
+`origin_sequence`, когда в v0.1 переносится единственный receiver route. Pending
+outbox entries и acknowledgements остаются receiver-specific. Поэтому route с
+receiver B на fresh receiver C переносится только через logical-aware recovery
+из B в C. Он импортирует ordered frontiers B, после чего C принимает следующий
+global event от source. Отправка более позднего event сразу на не
+восстановленный C fail-closed отклоняется как ordered sequence gap.
+
 Получатель требует совместимый in-memory adapter для каждой schema из
 baseline. Физические страницы staging'уются в памяти. На final page он
 проверяет baseline, заменяет user DBI, bootstrap'ит raw cursor,
@@ -106,11 +115,11 @@ replay acknowledgement, а не второе изменение; следующ�
 logical state получателя откатывают final transaction.
 
 Source materialization bounds покрывают и physical snapshot operations, и
-logical baseline records. Receiver применяет тот же combined bound к staged
-physical pages и final baseline до открытия destination write transaction.
-`LogicalRecoveryPeer` принимает cooperative cancellation token для recovery
-call; cancellation даёт retryable response и отбрасывает неопубликованную
-source session. Этот контракт поддерживает `DirectSyncPeer`.
+fixed/variable footprint logical baseline records. Receiver применяет тот же
+combined bound к staged physical pages и final baseline до открытия destination
+write transaction. `LogicalRecoveryPeer` принимает cooperative cancellation
+token для recovery call; cancellation даёт retryable response и отбрасывает
+неопубликованную source session. Этот контракт поддерживает `DirectSyncPeer`.
 
 ## Процедура оператора
 

--- a/docs/sync-recovery-RU.md
+++ b/docs/sync-recovery-RU.md
@@ -56,7 +56,7 @@ in-memory staging; persisted importer resume сейчас не реализов�
 
 ## Граница логического состояния
 
-`CompleteUserDatabase` предназначен только для raw sync. Источник отклоняет его
+Raw `CompleteUserDatabase` предназначен только для raw sync. Источник отклоняет его
 с `SnapshotLogicalStateUnsupported`, когда находит любой persistent logical-sync
 state, в том числе:
 
@@ -67,8 +67,39 @@ state, в том числе:
 
 Raw-копия adapter-owned user DBI без logical delivery state не могла бы
 безопасно продолжить logical replication. `ManifestOnly` также не обещает
-восстановления или bootstrap logical state. Будущий logical snapshot protocol
-должен атомарно переносить logical schema, replay, ordering и recovery state.
+восстановления или bootstrap logical state.
+
+## Logical-aware recovery для fresh replica
+
+`SyncWorkerOptions::enable_logical_recovery_fallback` - отдельный, по
+умолчанию выключенный путь для fresh replica после `SnapshotRequired`. Он
+использует отдельный peer contract `LogicalRecoveryRequest` /
+`LogicalRecoveryResponse` и не меняет raw `PullRequest`, `FullSnapshotChunk`
+или raw complete snapshot guard.
+
+На данном этапе transport-neutral вариант доступен через `DirectSyncPeer`.
+HTTP- и WebSocket-binding не считаются capable для logical recovery, пока не
+реализуют тот же отдельный wire contract.
+
+Источник берёт один stable read baseline, в который входят:
+
+- complete non-reserved user-DBI snapshot и raw applied-cursor tail;
+- logical schema markers;
+- replay markers и pruning watermarks;
+- ordered-delivery receiver frontiers;
+- source outbox tail и ещё не подтверждённые envelopes для этой БД.
+
+Получатель требует совместимый in-memory adapter для каждой schema из
+baseline. Физические страницы staging'уются в памяти. На final page он
+проверяет baseline, заменяет user DBI, bootstrap'ит raw cursor,
+восстанавливает logical metadata и создаёт replay markers для source
+envelopes, которые ещё не были acknowledged. Всё это commit'ится одной MDBX
+transaction. Source outbox не копируется как local outbox получателя.
+
+Благодаря этому повторная отправка старого pending source envelope получает
+replay acknowledgement, а не второе изменение; следующий source sequence
+применяется обычно. Повреждённый baseline, отсутствующий adapter или не fresh
+logical state получателя откатывают final transaction.
 
 ## Процедура оператора
 
@@ -80,8 +111,9 @@ Raw-копия adapter-owned user DBI без logical delivery state не мог�
    `SyncWorkerOptions::enable_full_snapshot_fallback`, либо ведите явный
    snapshot request из application code.
 4. Считайте `SnapshotLogicalStateUnsupported` сменой recovery method, а не
-   retryable transport error. Для него нужен application-specific logical
-   recovery process.
+   retryable transport error. Для fresh receiver с capable peer используйте
+   explicit logical-aware fallback; в остальных случаях нужен
+   application-specific logical recovery process.
 5. Используйте `ManifestOnly` только тогда, когда замена перечисленных
    физических DBI является нужной application operation и корректно оставить
    global replication cursor без изменений.

--- a/docs/sync-recovery.md
+++ b/docs/sync-recovery.md
@@ -94,6 +94,15 @@ The pending source suffix is contiguous and ends at that receiver's known tail.
 It is not shared with another replica that happens to use the same database
 identity.
 
+An ordered logical event has one global identity per database and origin:
+`(DbId, origin_node_id, origin_sequence)`. The source does not allocate a new
+`origin_sequence` when its v0.1 single receiver route moves. Pending outbox
+entries and acknowledgements remain receiver-specific. Therefore, move a route
+from receiver B to a fresh receiver C only by first performing logical-aware
+recovery from B to C. That imports B's ordered frontiers, so C can accept the
+next global event from the source. Sending a later event directly to an
+unrecovered C fails closed as an ordered sequence gap.
+
 The receiver requires a matching in-memory adapter for every baseline schema.
 It stages all physical pages in memory. On the final page it verifies the
 baseline, replaces user DBIs, bootstraps the raw cursor, restores logical
@@ -107,11 +116,12 @@ sequence then applies normally. A malformed baseline, missing adapter, or
 non-fresh logical receiver state aborts the final transaction.
 
 The source's materialization bounds cover both physical snapshot operations and
-logical baseline records. The receiver applies the same combined bound to its
-staged physical pages and final baseline before opening the destination write
-transaction. `LogicalRecoveryPeer` accepts cooperative cancellation for a
-recovery call; cancellation produces a retryable response and discards the
-unpublished source session. `DirectSyncPeer` implements this contract.
+the fixed and variable footprint of logical baseline records. The receiver
+applies the same combined bound to its staged physical pages and final baseline
+before opening the destination write transaction. `LogicalRecoveryPeer` accepts
+cooperative cancellation for a recovery call; cancellation produces a retryable
+response and discards the unpublished source session. `DirectSyncPeer`
+implements this contract.
 
 ## Operator Procedure
 

--- a/docs/sync-recovery.md
+++ b/docs/sync-recovery.md
@@ -87,7 +87,12 @@ The source captures one stable read baseline consisting of:
 - logical schema markers;
 - replay markers and pruning watermarks;
 - ordered-delivery receiver frontiers;
-- the source outbox tail and still-pending envelopes for this database.
+- the source outbox tail and still-pending envelopes for this requesting
+  receiver node.
+
+The pending source suffix is contiguous and ends at that receiver's known tail.
+It is not shared with another replica that happens to use the same database
+identity.
 
 The receiver requires a matching in-memory adapter for every baseline schema.
 It stages all physical pages in memory. On the final page it verifies the
@@ -100,6 +105,13 @@ This last rule makes a subsequent redelivery of an old pending source envelope
 a replay acknowledgement rather than a second mutation; the next source
 sequence then applies normally. A malformed baseline, missing adapter, or
 non-fresh logical receiver state aborts the final transaction.
+
+The source's materialization bounds cover both physical snapshot operations and
+logical baseline records. The receiver applies the same combined bound to its
+staged physical pages and final baseline before opening the destination write
+transaction. `LogicalRecoveryPeer` accepts cooperative cancellation for a
+recovery call; cancellation produces a retryable response and discards the
+unpublished source session. `DirectSyncPeer` implements this contract.
 
 ## Operator Procedure
 

--- a/docs/sync-recovery.md
+++ b/docs/sync-recovery.md
@@ -56,7 +56,7 @@ implemented, so a later retry starts a new source session.
 
 ## Logical-State Boundary
 
-`CompleteUserDatabase` is raw-sync-only. The source rejects it with
+Raw `CompleteUserDatabase` is raw-sync-only. The source rejects it with
 `SnapshotLogicalStateUnsupported` when it finds any persistent logical-sync
 state, including:
 
@@ -67,8 +67,39 @@ state, including:
 
 A raw copy of adapter-owned user DBIs without that logical delivery state could
 not safely continue logical replication. `ManifestOnly` likewise makes no
-claim to repair or bootstrap logical state. A future logical snapshot protocol
-must transfer logical schema, replay, ordering, and recovery state atomically.
+claim to repair or bootstrap logical state.
+
+## Logical-Aware Fresh Recovery
+
+`SyncWorkerOptions::enable_logical_recovery_fallback` is a separate, disabled
+by-default path for a fresh replica after `SnapshotRequired`. It uses the
+dedicated `LogicalRecoveryRequest` / `LogicalRecoveryResponse` peer contract;
+it does not change raw `PullRequest`, `FullSnapshotChunk`, or the raw complete
+snapshot guard.
+
+The current transport-neutral implementation is available through
+`DirectSyncPeer`. HTTP and WebSocket bindings are intentionally not treated as
+logical-recovery capable until they implement the same separate wire contract.
+
+The source captures one stable read baseline consisting of:
+
+- the complete non-reserved user-DBI snapshot and raw applied-cursor tail;
+- logical schema markers;
+- replay markers and pruning watermarks;
+- ordered-delivery receiver frontiers;
+- the source outbox tail and still-pending envelopes for this database.
+
+The receiver requires a matching in-memory adapter for every baseline schema.
+It stages all physical pages in memory. On the final page it verifies the
+baseline, replaces user DBIs, bootstraps the raw cursor, restores logical
+metadata, and creates replay markers for source envelopes that were still
+unacknowledged. All of those changes commit in one MDBX transaction. The
+receiver does not copy the source outbox as its own local outbox.
+
+This last rule makes a subsequent redelivery of an old pending source envelope
+a replay acknowledgement rather than a second mutation; the next source
+sequence then applies normally. A malformed baseline, missing adapter, or
+non-fresh logical receiver state aborts the final transaction.
 
 ## Operator Procedure
 
@@ -80,8 +111,9 @@ must transfer logical schema, replay, ordering, and recovery state atomically.
    `SyncWorkerOptions::enable_full_snapshot_fallback`, or drive the explicit
    snapshot request from application code.
 4. Treat `SnapshotLogicalStateUnsupported` as a change of recovery method, not
-   as a retryable transport error. Use an application-specific logical recovery
-   process instead.
+   as a retryable transport error. For a fresh receiver and a capable peer, use
+   the explicit logical-aware fallback; otherwise use an application-specific
+   logical recovery process.
 5. Use `ManifestOnly` only when replacing the listed physical DBIs is the
    intended application operation and leaving the global replication cursor
    unchanged is correct.

--- a/guides/sync-v0.1-readiness.md
+++ b/guides/sync-v0.1-readiness.md
@@ -169,10 +169,11 @@ tables.
 - Extend logical-frame capability negotiation only when a new adapter requires
   a compatibility distinction beyond the existing schema marker and adapter
   registry fail-closed checks.
-- Design logical-aware recovery separately from raw complete snapshots. Raw
-  `CompleteUserDatabase` snapshots intentionally reject persistent logical
-  state; a future baseline protocol must preserve schema, outbox, replay, and
-  order-frontier invariants together.
+- Extend the transport-neutral `LogicalRecoveryRequest` /
+  `LogicalRecoveryResponse` baseline path to HTTP and WebSocket. Raw
+  `CompleteUserDatabase` snapshots intentionally continue to reject persistent
+  logical state; the DirectSyncPeer baseline already preserves schema, replay,
+  order-frontier, and source-outbox recovery invariants atomically.
 - Extend `KeyMultiValueTable` logical capture only after every added bulk or
   reconcile operation has explicit multiset replay semantics and round-trip
   coverage. Raw capture remains disabled.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1623,14 +1623,20 @@ not claim to repair or bootstrap logical replication.
 logical-aware fresh-replica path. It reuses bounded physical snapshot pages but
 delivers their final page with an immutable baseline containing schema markers,
 replay markers and watermarks, ordered receiver frontiers, and the source
-outbox tail plus pending envelopes. The importer creates replay markers for
-those pending source envelopes, restores the source frontier, and never copies
-the source outbox as receiver-local work. The final physical replacement, raw
-cursor bootstrap, and logical metadata restoration share one MDBX transaction.
-Missing matching destination adapters, corrupt baseline metadata, or existing
-logical receiver state abort that transaction. This capability is currently
-implemented by `DirectSyncPeer`; raw transports remain incapable until they
-implement the distinct logical-recovery wire contract.
+outbox tail plus pending envelopes for the requesting receiver node. The
+pending suffix must be contiguous and end at that receiver's known tail. The
+importer creates replay markers for those pending source envelopes, restores
+the source frontier, and never copies the source outbox as receiver-local work.
+The final physical replacement, raw cursor bootstrap, and logical metadata
+restoration share one MDBX transaction. Missing matching destination adapters,
+corrupt baseline metadata, or existing logical receiver state abort that
+transaction. Source materialization and receiver staging use one shared budget
+for physical operations and logical baseline records; source enumeration spends
+that budget before retaining each logical record. `LogicalRecoveryPeer` also
+accepts a cooperative cancellation token: a cancelled materialization returns a
+retryable failure and publishes no snapshot session. This capability is
+currently implemented by `DirectSyncPeer`; raw transports remain incapable
+until they implement the distinct logical-recovery wire contract.
 
 `SyncEngine::apply_full_snapshot_chunk()` stages all pages in bounded process
 memory and validates immutable page-zero metadata on every continuation. Only

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -2185,3 +2185,13 @@ When HLC or similar lands in v0.2, it goes in as opaque bytes inside
 - Public sync API stability after the first external transport adapter.
 - `PeerRegistry` for multi-peer fan-out — single peer per sync invocation
   in v0.1.
+
+In v0.1 one capture/session commit atomically publishes an ordered envelope for
+exactly one receiver; atomic multi-recipient fan-out is deferred. Moving that
+single receiver to another replica requires logical-aware recovery first: the
+new receiver must import the origin frontier before it can accept the next
+globally sequenced event. Sending a new route to a fresh receiver fails closed
+with an ordered-delivery gap.
+
+Before the first external sync release, logical-store layouts and logical wire
+codec versions do not carry a persistent compatibility or migration guarantee.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1610,16 +1610,27 @@ rejected. Unknown, expired, or mismatched continuations or a different requester
 return `SnapshotSessionInvalid`; bounded session capacity returns retryable
 `SnapshotSessionBusy`.
 
-`CompleteUserDatabase` is currently a raw-sync-only recovery scope. Before a
+Raw `CompleteUserDatabase` is a raw-sync-only recovery scope. Before a
 session is materialized, the source rejects any persistent logical-sync state
 with `SnapshotLogicalStateUnsupported`: schema markers, replay markers or
 pruning watermarks, ordered-delivery frontiers, and durable outbox metadata or
 entries. A physical copy of logical adapter DBIs without this state cannot
 safely continue logical delivery.
 `ManifestOnly` is likewise only a manual physical replacement tool: it does
-not claim to repair or bootstrap logical replication. A future logical snapshot
-protocol must atomically define the logical schema, delivery, replay, and
-recovery state it transfers.
+not claim to repair or bootstrap logical replication.
+
+`LogicalRecoveryRequest` / `LogicalRecoveryResponse` define the separate
+logical-aware fresh-replica path. It reuses bounded physical snapshot pages but
+delivers their final page with an immutable baseline containing schema markers,
+replay markers and watermarks, ordered receiver frontiers, and the source
+outbox tail plus pending envelopes. The importer creates replay markers for
+those pending source envelopes, restores the source frontier, and never copies
+the source outbox as receiver-local work. The final physical replacement, raw
+cursor bootstrap, and logical metadata restoration share one MDBX transaction.
+Missing matching destination adapters, corrupt baseline metadata, or existing
+logical receiver state abort that transaction. This capability is currently
+implemented by `DirectSyncPeer`; raw transports remain incapable until they
+implement the distinct logical-recovery wire contract.
 
 `SyncEngine::apply_full_snapshot_chunk()` stages all pages in bounded process
 memory and validates immutable page-zero metadata on every continuation. Only

--- a/include/mdbx_containers/sync/engine/DirectSyncPeer.hpp
+++ b/include/mdbx_containers/sync/engine/DirectSyncPeer.hpp
@@ -43,8 +43,14 @@ namespace sync {
 
         LogicalRecoveryResponse logical_recovery(
                 const LogicalRecoveryRequest& request) override {
+            return logical_recovery_with_cancel(request, nullptr);
+        }
+
+        LogicalRecoveryResponse logical_recovery_with_cancel(
+                const LogicalRecoveryRequest& request,
+                const CancellationToken* cancel_token = nullptr) override {
             assert(m_remote != nullptr);
-            return m_remote->handle_logical_recovery(request);
+            return m_remote->handle_logical_recovery(request, cancel_token);
         }
 
         LogicalDeliveryHello logical_delivery_hello() override {

--- a/include/mdbx_containers/sync/engine/DirectSyncPeer.hpp
+++ b/include/mdbx_containers/sync/engine/DirectSyncPeer.hpp
@@ -37,6 +37,16 @@ namespace sync {
             return true;
         }
 
+        bool supports_logical_recovery() const override {
+            return true;
+        }
+
+        LogicalRecoveryResponse logical_recovery(
+                const LogicalRecoveryRequest& request) override {
+            assert(m_remote != nullptr);
+            return m_remote->handle_logical_recovery(request);
+        }
+
         LogicalDeliveryHello logical_delivery_hello() override {
             return logical_delivery_hello_with_cancel(nullptr);
         }

--- a/include/mdbx_containers/sync/engine/ISyncPeer.hpp
+++ b/include/mdbx_containers/sync/engine/ISyncPeer.hpp
@@ -35,7 +35,8 @@ namespace sync {
     /// must allow \c request_cancel() to be called concurrently with
     /// \c pull() / \c push() and tolerate calls that race with operation
     /// startup or completion.
-    class ISyncPeer : public ILogicalDeliveryPeer {
+    class ISyncPeer : public ILogicalDeliveryPeer,
+                      public ILogicalRecoveryPeer {
     public:
         virtual ~ISyncPeer() {}
 

--- a/include/mdbx_containers/sync/engine/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/engine/SyncEngine.hpp
@@ -26,6 +26,9 @@
 #include <chrono>
 #include <cstdint>
 #include <cstring>
+#if defined(MDBXC_TEST_LOGICAL_RECOVERY_MATERIALIZATION_CHECKPOINT)
+#include <functional>
+#endif
 #include <limits>
 #include <map>
 #include <memory>
@@ -399,6 +402,19 @@ namespace sync {
             }
             return out;
         }
+
+#if defined(MDBXC_TEST_LOGICAL_RECOVERY_MATERIALIZATION_CHECKPOINT)
+        /// \brief Installs a test-only barrier before logical recovery scans.
+        void set_logical_recovery_materialization_checkpoint_for_testing(
+                const std::function<void()>& checkpoint) {
+            m_logical_recovery_materialization_checkpoint = checkpoint;
+        }
+
+        /// \brief Removes the test-only logical recovery barrier.
+        void clear_logical_recovery_materialization_checkpoint_for_testing() {
+            m_logical_recovery_materialization_checkpoint = std::function<void()>();
+        }
+#endif
 
         /// \brief Registers or verifies a persistent logical table schema.
         /// \details This is the normal lifecycle entry point for application
@@ -2168,6 +2184,11 @@ namespace sync {
 
             MaterializationBudget materialization_budget(options);
             if (logical_recovery) {
+#if defined(MDBXC_TEST_LOGICAL_RECOVERY_MATERIALIZATION_CHECKPOINT)
+                if (m_logical_recovery_materialization_checkpoint) {
+                    m_logical_recovery_materialization_checkpoint();
+                }
+#endif
                 collect_logical_recovery_baseline(
                     txn.handle(), *session, materialization_budget, cancel_token);
             }
@@ -3591,6 +3612,9 @@ namespace sync {
                                     m_full_snapshot_sessions;
         std::uint64_t               m_next_full_snapshot_session_id = 0u;
         std::size_t                  m_full_snapshot_creating = 0u;
+#if defined(MDBXC_TEST_LOGICAL_RECOVERY_MATERIALIZATION_CHECKPOINT)
+        std::function<void()>        m_logical_recovery_materialization_checkpoint;
+#endif
         FullSnapshotImportOptions    m_full_snapshot_import_options;
         mutable std::mutex           m_full_snapshot_import_mutex;
         std::unique_ptr<FullSnapshotImportSession>

--- a/include/mdbx_containers/sync/engine/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/engine/SyncEngine.hpp
@@ -122,6 +122,31 @@ namespace sync {
             std::uint64_t chunk_index = 0u;
         };
 
+        struct MaterializationBudget {
+            explicit MaterializationBudget(
+                    const FullSnapshotExportOptions& options)
+                : operations_left(options.max_materialized_operations),
+                  bytes_left(options.max_materialized_bytes) {}
+
+            void consume(std::uint64_t operations, std::uint64_t bytes,
+                         const char* context) {
+                if (operations > operations_left || bytes > bytes_left) {
+                    throw std::length_error(context);
+                }
+                operations_left -= operations;
+                bytes_left -= bytes;
+            }
+
+            std::uint64_t operations_left;
+            std::uint64_t bytes_left;
+        };
+
+        class FullSnapshotCancelled : public std::runtime_error {
+        public:
+            FullSnapshotCancelled()
+                : std::runtime_error("full snapshot materialization cancelled") {}
+        };
+
         struct FullSnapshotSession {
             NodeId source_node_id{};
             DbId source_db_uuid{};
@@ -337,7 +362,16 @@ namespace sync {
         /// distinct API so only a peer that opted into logical recovery can
         /// receive a CompleteUserDatabase baseline from a logical source.
         LogicalRecoveryResponse handle_logical_recovery(
-                const LogicalRecoveryRequest& request) {
+                const LogicalRecoveryRequest& request,
+                const CancellationToken* cancel_token = nullptr) {
+            if (cancel_token != nullptr &&
+                cancel_token->is_cancellation_requested()) {
+                LogicalRecoveryResponse cancelled;
+                cancelled.ok = false;
+                cancelled.error = "logical recovery cancelled";
+                cancelled.error_retryable = true;
+                return cancelled;
+            }
             PullRequest snapshot_request;
             snapshot_request.requester = request.requester;
             snapshot_request.request_full_snapshot = true;
@@ -349,7 +383,7 @@ namespace sync {
 
             LogicalRecoveryBaseline baseline;
             const PullResponse snapshot_response = handle_full_snapshot_pull(
-                snapshot_request, true, &baseline);
+                snapshot_request, true, &baseline, cancel_token);
             LogicalRecoveryResponse out;
             out.ok = snapshot_response.ok;
             out.has_more = snapshot_response.has_more;
@@ -1611,27 +1645,18 @@ namespace sync {
 
         static void append_full_snapshot_operation(
                 FullSnapshotSession& session,
-                const FullSnapshotExportOptions& options,
+                MaterializationBudget& budget,
                 const std::string& dbi_name,
                 std::uint32_t dbi_flags,
                 ChangeOpType op_type,
                 const MDBX_val* key,
-                const MDBX_val* value,
-                std::uint64_t& materialized_bytes) {
-            if (static_cast<std::uint64_t>(session.operations.size()) >=
-                options.max_materialized_operations) {
-                throw std::length_error(
-                    "full snapshot exceeds max_materialized_operations");
-            }
+                const MDBX_val* value) {
             MDBX_val empty = { nullptr, 0u };
             const MDBX_val& actual_key = key == nullptr ? empty : *key;
             const MDBX_val& actual_value = value == nullptr ? empty : *value;
             const std::uint64_t add = snapshot_materialized_bytes_for(
                 dbi_name, actual_key, actual_value);
-            if (add > options.max_materialized_bytes - materialized_bytes) {
-                throw std::length_error(
-                    "full snapshot exceeds max_materialized_bytes");
-            }
+            budget.consume(1u, add, "full snapshot exceeds materialization budget");
 
             ChangeOp op;
             op.op_type = op_type;
@@ -1648,7 +1673,13 @@ namespace sync {
                 op.value.assign(bytes, bytes + actual_value.iov_len);
             }
             session.operations.push_back(std::move(op));
-            materialized_bytes += add;
+        }
+
+        static void throw_if_cancelled(const CancellationToken* cancel_token) {
+            if (cancel_token != nullptr &&
+                cancel_token->is_cancellation_requested()) {
+                throw FullSnapshotCancelled();
+            }
         }
 
         std::string next_full_snapshot_id_locked() {
@@ -1699,7 +1730,8 @@ namespace sync {
         void collect_logical_recovery_baseline(
                 MDBX_txn* txn,
                 FullSnapshotSession& session,
-                const FullSnapshotExportOptions& options) const {
+                MaterializationBudget& budget,
+                const CancellationToken* cancel_token) const {
             SchemaRegistryStore schemas(m_conn->env_handle());
             LogicalDeliveryStore delivery(m_conn->env_handle());
             LogicalDeliveryOrderStore order(m_conn->env_handle());
@@ -1708,73 +1740,157 @@ namespace sync {
                 session.source_node_id;
             session.logical_recovery_baseline.source_db_uuid =
                 session.source_db_uuid;
-            session.logical_recovery_baseline.schemas =
-                schemas.list_entries(txn);
-            session.logical_recovery_baseline.delivery_markers =
-                delivery.list_markers(txn);
-            session.logical_recovery_baseline.delivery_watermarks =
-                delivery.list_watermarks(txn);
-            session.logical_recovery_baseline.delivery_order =
-                order.list_entries(txn);
-            session.logical_recovery_baseline.source_outbox_pending =
-                outbox.list_pending(txn, session.source_db_uuid);
+            session.logical_recovery_baseline.snapshot_id = session.snapshot_id;
+            budget.consume(0u, session.snapshot_id.size(),
+                "logical recovery baseline exceeds materialization budget");
+            schemas.for_each_entry(txn,
+                [&session, &budget, cancel_token](
+                        const LogicalSchemaRegistryEntry& entry) {
+                    throw_if_cancelled(cancel_token);
+                    budget.consume(1u, logical_recovery_schema_bytes(entry),
+                        "logical recovery baseline exceeds materialization budget");
+                    session.logical_recovery_baseline.schemas.push_back(entry);
+                });
+            delivery.for_each_marker(txn,
+                [&session, &budget, cancel_token](
+                        const LogicalDeliveryMarkerInfo& marker) {
+                    throw_if_cancelled(cancel_token);
+                    budget.consume(1u, logical_recovery_marker_bytes(marker),
+                        "logical recovery baseline exceeds materialization budget");
+                    session.logical_recovery_baseline.delivery_markers.push_back(marker);
+                });
+            delivery.for_each_watermark(txn,
+                [&session, &budget, cancel_token](
+                        const LogicalDeliveryWatermarkInfo& watermark) {
+                    throw_if_cancelled(cancel_token);
+                    budget.consume(1u, 0u,
+                        "logical recovery baseline exceeds materialization budget");
+                    session.logical_recovery_baseline.delivery_watermarks.push_back(
+                        watermark);
+                });
+            order.for_each_entry(txn,
+                [&session, &budget, cancel_token](
+                        const LogicalDeliveryOrderEntry& entry) {
+                    throw_if_cancelled(cancel_token);
+                    budget.consume(1u, 0u,
+                        "logical recovery baseline exceeds materialization budget");
+                    session.logical_recovery_baseline.delivery_order.push_back(entry);
+                });
+            outbox.for_each_pending(txn, session.source_db_uuid,
+                session.requester,
+                [&session, &budget, cancel_token](
+                        const LogicalDeliveryEnvelope& envelope) {
+                    throw_if_cancelled(cancel_token);
+                    budget.consume(1u, logical_recovery_outbox_bytes(envelope),
+                        "logical recovery baseline exceeds materialization budget");
+                    session.logical_recovery_baseline.source_outbox_pending.push_back(
+                        envelope);
+                });
             session.logical_recovery_baseline.source_outbox_known_tail =
-                outbox.known_tail(txn, session.source_db_uuid);
-            validate_logical_recovery_baseline_bounds(
-                session.logical_recovery_baseline, options);
+                outbox.known_tail(txn, session.source_db_uuid,
+                                  session.requester);
         }
 
         static void add_logical_recovery_baseline_bytes(
                 std::uint64_t& total,
-                std::size_t additional,
-                const FullSnapshotExportOptions& options) {
-            if (additional > options.max_materialized_bytes - total) {
+                std::size_t additional) {
+            const std::uint64_t max =
+                (std::numeric_limits<std::uint64_t>::max)();
+            if (additional > max || total > max -
+                    static_cast<std::uint64_t>(additional)) {
                 throw std::length_error(
-                    "logical recovery baseline exceeds max_materialized_bytes");
+                    "logical recovery baseline size overflow");
             }
             total += static_cast<std::uint64_t>(additional);
         }
 
-        static void validate_logical_recovery_baseline_bounds(
-                const LogicalRecoveryBaseline& baseline,
-                const FullSnapshotExportOptions& options) {
-            const std::uint64_t entry_count =
-                static_cast<std::uint64_t>(baseline.schemas.size()) +
-                static_cast<std::uint64_t>(baseline.delivery_markers.size()) +
-                static_cast<std::uint64_t>(baseline.delivery_watermarks.size()) +
-                static_cast<std::uint64_t>(baseline.delivery_order.size()) +
-                static_cast<std::uint64_t>(baseline.source_outbox_pending.size());
-            if (entry_count > options.max_materialized_operations) {
-                throw std::length_error(
-                    "logical recovery baseline exceeds max_materialized_operations");
-            }
+        static std::uint64_t logical_recovery_schema_bytes(
+                const LogicalSchemaRegistryEntry& entry) {
             std::uint64_t bytes = 0u;
-            add_logical_recovery_baseline_bytes(bytes, baseline.snapshot_id.size(),
-                                                options);
-            for (std::size_t i = 0u; i < baseline.schemas.size(); ++i) {
-                const LogicalSchemaRegistryEntry& entry = baseline.schemas[i];
-                add_logical_recovery_baseline_bytes(bytes, entry.schema_id.size(),
-                                                    options);
+            add_logical_recovery_baseline_bytes(bytes, entry.schema_id.size());
+            add_logical_recovery_baseline_bytes(bytes,
+                                                entry.record.dbi_name.size());
+            for (std::size_t i = 0u; i < entry.record.dbi_names.size(); ++i) {
                 add_logical_recovery_baseline_bytes(bytes,
-                    entry.record.dbi_name.size(), options);
-                for (std::size_t j = 0u; j < entry.record.dbi_names.size(); ++j) {
-                    add_logical_recovery_baseline_bytes(bytes,
-                        entry.record.dbi_names[j].size(), options);
+                    entry.record.dbi_names[i].size());
+            }
+            return bytes;
+        }
+
+        static std::uint64_t logical_recovery_marker_bytes(
+                const LogicalDeliveryMarkerInfo& marker) {
+            std::uint64_t bytes = 0u;
+            add_logical_recovery_baseline_bytes(bytes, marker.frame_id.size());
+            add_logical_recovery_baseline_bytes(bytes,
+                                                marker.encoded_frame.size());
+            return bytes;
+        }
+
+        static std::uint64_t logical_recovery_outbox_bytes(
+                const LogicalDeliveryEnvelope& envelope) {
+            const std::vector<std::uint8_t> encoded =
+                LogicalDeliveryEnvelopeCodec::encode(envelope);
+            if (encoded.size() > (std::numeric_limits<std::uint64_t>::max)()) {
+                throw std::length_error("logical recovery baseline size overflow");
+            }
+            return static_cast<std::uint64_t>(encoded.size());
+        }
+
+        static std::uint64_t logical_recovery_baseline_entry_count(
+                const LogicalRecoveryBaseline& baseline) {
+            const std::uint64_t max =
+                (std::numeric_limits<std::uint64_t>::max)();
+            const std::size_t counts[] = {
+                baseline.schemas.size(),
+                baseline.delivery_markers.size(),
+                baseline.delivery_watermarks.size(),
+                baseline.delivery_order.size(),
+                baseline.source_outbox_pending.size()
+            };
+            std::uint64_t total = 0u;
+            for (std::size_t i = 0u; i < sizeof(counts) / sizeof(counts[0]); ++i) {
+                if (counts[i] > max || total > max -
+                        static_cast<std::uint64_t>(counts[i])) {
+                    throw std::length_error("logical recovery baseline size overflow");
                 }
+                total += static_cast<std::uint64_t>(counts[i]);
+            }
+            return total;
+        }
+
+        static std::uint64_t logical_recovery_baseline_bytes(
+                const LogicalRecoveryBaseline& baseline) {
+            std::uint64_t bytes = 0u;
+            add_logical_recovery_baseline_bytes(bytes, baseline.snapshot_id.size());
+            for (std::size_t i = 0u; i < baseline.schemas.size(); ++i) {
+                const std::uint64_t entry_bytes =
+                    logical_recovery_schema_bytes(baseline.schemas[i]);
+                if (bytes > (std::numeric_limits<std::uint64_t>::max)() -
+                        entry_bytes) {
+                    throw std::length_error("logical recovery baseline size overflow");
+                }
+                bytes += entry_bytes;
             }
             for (std::size_t i = 0u; i < baseline.delivery_markers.size(); ++i) {
-                add_logical_recovery_baseline_bytes(bytes,
-                    baseline.delivery_markers[i].frame_id.size(), options);
-                add_logical_recovery_baseline_bytes(bytes,
-                    baseline.delivery_markers[i].encoded_frame.size(), options);
+                const std::uint64_t entry_bytes =
+                    logical_recovery_marker_bytes(baseline.delivery_markers[i]);
+                if (bytes > (std::numeric_limits<std::uint64_t>::max)() -
+                        entry_bytes) {
+                    throw std::length_error("logical recovery baseline size overflow");
+                }
+                bytes += entry_bytes;
             }
             for (std::size_t i = 0u;
                  i < baseline.source_outbox_pending.size(); ++i) {
-                const std::vector<std::uint8_t> encoded =
-                    LogicalDeliveryEnvelopeCodec::encode(
-                        baseline.source_outbox_pending[i]);
-                add_logical_recovery_baseline_bytes(bytes, encoded.size(), options);
+                const std::uint64_t entry_bytes = logical_recovery_outbox_bytes(
+                    baseline.source_outbox_pending[i]);
+                if (bytes > (std::numeric_limits<std::uint64_t>::max)() -
+                        entry_bytes) {
+                    throw std::length_error("logical recovery baseline size overflow");
+                }
+                bytes += entry_bytes;
             }
+            return bytes;
         }
 
         static bool logical_schema_record_matches_adapter(
@@ -1859,6 +1975,33 @@ namespace sync {
                 }
                 previous_pending = envelope.origin_sequence;
             }
+            if (!baseline.source_outbox_pending.empty() &&
+                previous_pending != baseline.source_outbox_known_tail) {
+                throw std::invalid_argument(
+                    "logical recovery pending outbox does not reach known tail");
+            }
+        }
+
+        void validate_logical_recovery_import_bounds(
+                const FullSnapshotImportSession& session,
+                const LogicalRecoveryBaseline& baseline) const {
+            const std::uint64_t baseline_entries =
+                logical_recovery_baseline_entry_count(baseline);
+            const std::uint64_t baseline_bytes =
+                logical_recovery_baseline_bytes(baseline);
+            const std::uint64_t staged_operations =
+                static_cast<std::uint64_t>(session.operations.size());
+            const std::uint64_t max_operations =
+                m_full_snapshot_import_options.max_staged_operations;
+            const std::uint64_t max_bytes =
+                m_full_snapshot_import_options.max_staged_bytes;
+            if (staged_operations > max_operations ||
+                session.staged_bytes > max_bytes ||
+                baseline_entries > max_operations - staged_operations ||
+                baseline_bytes > max_bytes - session.staged_bytes) {
+                throw std::length_error(
+                    "logical recovery import exceeds staged materialization budget");
+            }
         }
 
         void require_fresh_logical_recovery_target(MDBX_txn* txn) const {
@@ -1920,15 +2063,20 @@ namespace sync {
         std::shared_ptr<FullSnapshotSession> materialize_full_snapshot(
                 const FullSnapshotExportOptions& options,
                 const NodeId& requester,
-                bool logical_recovery = false) const {
+                bool logical_recovery,
+                const std::string& snapshot_id,
+                const CancellationToken* cancel_token) const {
+            throw_if_cancelled(cancel_token);
             std::shared_ptr<FullSnapshotSession> session(
                 new FullSnapshotSession());
             session->requester = requester;
+            session->snapshot_id = snapshot_id;
             session->replacement_scope = options.replacement_scope;
             session->logical_recovery = logical_recovery;
             session->last_access = std::chrono::steady_clock::now();
 
             auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
+            throw_if_cancelled(cancel_token);
             MetaStore meta(m_conn->env_handle());
             meta.open(txn.handle());
             session->source_node_id = meta.get_node_id(txn.handle());
@@ -1955,6 +2103,8 @@ namespace sync {
                     "complete full snapshot source has no user DBIs");
             }
 
+            throw_if_cancelled(cancel_token);
+
             if (options.replacement_scope ==
                     FullSnapshotScope::CompleteUserDatabase) {
                 const MDBX_dbi changelog_dbi = open_changelog_ro(txn.handle());
@@ -1972,13 +2122,13 @@ namespace sync {
                 }
             }
 
+            MaterializationBudget materialization_budget(options);
             if (logical_recovery) {
-                collect_logical_recovery_baseline(txn.handle(), *session,
-                                                  options);
+                collect_logical_recovery_baseline(
+                    txn.handle(), *session, materialization_budget, cancel_token);
             }
-
-            std::uint64_t materialized_bytes = 0u;
             for (std::size_t i = 0u; i < session->manifest.size(); ++i) {
+                throw_if_cancelled(cancel_token);
                 const FullSnapshotManifestEntry& entry = session->manifest[i];
                 MDBX_dbi dbi = 0;
                 const MDBX_db_flags_t open_flags =
@@ -2005,9 +2155,9 @@ namespace sync {
                         entry.dbi_name);
                 }
 
-                append_full_snapshot_operation(*session, options,
+                append_full_snapshot_operation(*session, materialization_budget,
                     entry.dbi_name, actual_flags, ChangeOpType::ClearTable,
-                    nullptr, nullptr, materialized_bytes);
+                    nullptr, nullptr);
 
                 MDBX_cursor* raw = nullptr;
                 check_mdbx(mdbx_cursor_open(txn.handle(), dbi, &raw),
@@ -2017,9 +2167,10 @@ namespace sync {
                 MDBX_val value;
                 rc = mdbx_cursor_get(raw, &key, &value, MDBX_FIRST);
                 while (rc == MDBX_SUCCESS) {
-                    append_full_snapshot_operation(*session, options,
+                    throw_if_cancelled(cancel_token);
+                    append_full_snapshot_operation(*session, materialization_budget,
                         entry.dbi_name, actual_flags, ChangeOpType::Put,
-                        &key, &value, materialized_bytes);
+                        &key, &value);
                     rc = mdbx_cursor_get(raw, &key, &value, MDBX_NEXT);
                 }
                 if (rc != MDBX_NOTFOUND) {
@@ -2122,8 +2273,16 @@ namespace sync {
         PullResponse handle_full_snapshot_pull(
                 const PullRequest& request,
                 bool logical_recovery = false,
-                LogicalRecoveryBaseline* final_baseline = nullptr) {
+                LogicalRecoveryBaseline* final_baseline = nullptr,
+                const CancellationToken* cancel_token = nullptr) {
             PullResponse out;
+            if (cancel_token != nullptr &&
+                cancel_token->is_cancellation_requested()) {
+                out.ok = false;
+                out.error = "full snapshot materialization cancelled";
+                out.error_retryable = true;
+                return out;
+            }
             if (request.full_snapshot_id.empty() !=
                 request.full_snapshot_continuation.empty()) {
                 out.ok = false;
@@ -2144,6 +2303,7 @@ namespace sync {
             std::uint64_t chunk_index = 0u;
             if (request.full_snapshot_id.empty()) {
                 FullSnapshotExportOptions options;
+                std::string snapshot_id;
                 {
                     std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
                     prune_expired_full_snapshot_sessions_locked();
@@ -2173,10 +2333,20 @@ namespace sync {
                         return out;
                     }
                     ++m_full_snapshot_creating;
+                    snapshot_id = next_full_snapshot_id_locked();
                 }
                 try {
                     session = materialize_full_snapshot(
-                        options, request.requester, logical_recovery);
+                        options, request.requester, logical_recovery, snapshot_id,
+                        cancel_token);
+                    throw_if_cancelled(cancel_token);
+                } catch (const FullSnapshotCancelled& e) {
+                    std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
+                    --m_full_snapshot_creating;
+                    out.ok = false;
+                    out.error = e.what();
+                    out.error_retryable = true;
+                    return out;
                 } catch (const FullSnapshotLogicalStateUnsupported& e) {
                     std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
                     --m_full_snapshot_creating;
@@ -2184,6 +2354,13 @@ namespace sync {
                     out.error = e.what();
                     out.error_code =
                         SyncResponseErrorCode::SnapshotLogicalStateUnsupported;
+                    return out;
+                } catch (const std::length_error& e) {
+                    std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
+                    --m_full_snapshot_creating;
+                    out.ok = false;
+                    out.error = e.what();
+                    out.error_code = SyncResponseErrorCode::BatchTooLarge;
                     return out;
                 } catch (...) {
                     std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
@@ -2194,11 +2371,6 @@ namespace sync {
                     std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
                     --m_full_snapshot_creating;
                     prune_expired_full_snapshot_sessions_locked();
-                    session->snapshot_id = next_full_snapshot_id_locked();
-                    if (logical_recovery) {
-                        session->logical_recovery_baseline.snapshot_id =
-                            session->snapshot_id;
-                    }
                     m_full_snapshot_sessions[session->snapshot_id] = session;
                 }
             } else {
@@ -2535,6 +2707,8 @@ namespace sync {
                 if (logical_recovery) {
                     validate_logical_recovery_baseline(session,
                                                        *logical_baseline);
+                    validate_logical_recovery_import_bounds(session,
+                                                            *logical_baseline);
                     require_fresh_logical_recovery_target(txn.handle());
                 }
 

--- a/include/mdbx_containers/sync/engine/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/engine/SyncEngine.hpp
@@ -1741,7 +1741,9 @@ namespace sync {
             session.logical_recovery_baseline.source_db_uuid =
                 session.source_db_uuid;
             session.logical_recovery_baseline.snapshot_id = session.snapshot_id;
-            budget.consume(0u, session.snapshot_id.size(),
+            budget.consume(0u,
+                logical_recovery_baseline_header_bytes(
+                    session.logical_recovery_baseline),
                 "logical recovery baseline exceeds materialization budget");
             schemas.for_each_entry(txn,
                 [&session, &budget, cancel_token](
@@ -1763,7 +1765,7 @@ namespace sync {
                 [&session, &budget, cancel_token](
                         const LogicalDeliveryWatermarkInfo& watermark) {
                     throw_if_cancelled(cancel_token);
-                    budget.consume(1u, 0u,
+                    budget.consume(1u, logical_recovery_watermark_bytes(watermark),
                         "logical recovery baseline exceeds materialization budget");
                     session.logical_recovery_baseline.delivery_watermarks.push_back(
                         watermark);
@@ -1772,7 +1774,7 @@ namespace sync {
                 [&session, &budget, cancel_token](
                         const LogicalDeliveryOrderEntry& entry) {
                     throw_if_cancelled(cancel_token);
-                    budget.consume(1u, 0u,
+                    budget.consume(1u, logical_recovery_order_bytes(entry),
                         "logical recovery baseline exceeds materialization budget");
                     session.logical_recovery_baseline.delivery_order.push_back(entry);
                 });
@@ -1807,6 +1809,8 @@ namespace sync {
         static std::uint64_t logical_recovery_schema_bytes(
                 const LogicalSchemaRegistryEntry& entry) {
             std::uint64_t bytes = 0u;
+            add_logical_recovery_baseline_bytes(bytes,
+                                                sizeof(LogicalSchemaRegistryEntry));
             add_logical_recovery_baseline_bytes(bytes, entry.schema_id.size());
             add_logical_recovery_baseline_bytes(bytes,
                                                 entry.record.dbi_name.size());
@@ -1820,6 +1824,8 @@ namespace sync {
         static std::uint64_t logical_recovery_marker_bytes(
                 const LogicalDeliveryMarkerInfo& marker) {
             std::uint64_t bytes = 0u;
+            add_logical_recovery_baseline_bytes(bytes,
+                                                sizeof(LogicalDeliveryMarkerInfo));
             add_logical_recovery_baseline_bytes(bytes, marker.frame_id.size());
             add_logical_recovery_baseline_bytes(bytes,
                                                 marker.encoded_frame.size());
@@ -1830,10 +1836,30 @@ namespace sync {
                 const LogicalDeliveryEnvelope& envelope) {
             const std::vector<std::uint8_t> encoded =
                 LogicalDeliveryEnvelopeCodec::encode(envelope);
-            if (encoded.size() > (std::numeric_limits<std::uint64_t>::max)()) {
-                throw std::length_error("logical recovery baseline size overflow");
-            }
-            return static_cast<std::uint64_t>(encoded.size());
+            std::uint64_t bytes = 0u;
+            add_logical_recovery_baseline_bytes(bytes,
+                                                sizeof(LogicalDeliveryEnvelope));
+            add_logical_recovery_baseline_bytes(bytes, encoded.size());
+            return bytes;
+        }
+
+        static std::uint64_t logical_recovery_watermark_bytes(
+                const LogicalDeliveryWatermarkInfo&) {
+            return sizeof(LogicalDeliveryWatermarkInfo);
+        }
+
+        static std::uint64_t logical_recovery_order_bytes(
+                const LogicalDeliveryOrderEntry&) {
+            return sizeof(LogicalDeliveryOrderEntry);
+        }
+
+        static std::uint64_t logical_recovery_baseline_header_bytes(
+                const LogicalRecoveryBaseline& baseline) {
+            std::uint64_t bytes = 0u;
+            add_logical_recovery_baseline_bytes(bytes,
+                                                sizeof(LogicalRecoveryBaseline));
+            add_logical_recovery_baseline_bytes(bytes, baseline.snapshot_id.size());
+            return bytes;
         }
 
         static std::uint64_t logical_recovery_baseline_entry_count(
@@ -1860,8 +1886,7 @@ namespace sync {
 
         static std::uint64_t logical_recovery_baseline_bytes(
                 const LogicalRecoveryBaseline& baseline) {
-            std::uint64_t bytes = 0u;
-            add_logical_recovery_baseline_bytes(bytes, baseline.snapshot_id.size());
+            std::uint64_t bytes = logical_recovery_baseline_header_bytes(baseline);
             for (std::size_t i = 0u; i < baseline.schemas.size(); ++i) {
                 const std::uint64_t entry_bytes =
                     logical_recovery_schema_bytes(baseline.schemas[i]);
@@ -1874,6 +1899,25 @@ namespace sync {
             for (std::size_t i = 0u; i < baseline.delivery_markers.size(); ++i) {
                 const std::uint64_t entry_bytes =
                     logical_recovery_marker_bytes(baseline.delivery_markers[i]);
+                if (bytes > (std::numeric_limits<std::uint64_t>::max)() -
+                        entry_bytes) {
+                    throw std::length_error("logical recovery baseline size overflow");
+                }
+                bytes += entry_bytes;
+            }
+            for (std::size_t i = 0u;
+                 i < baseline.delivery_watermarks.size(); ++i) {
+                const std::uint64_t entry_bytes = logical_recovery_watermark_bytes(
+                    baseline.delivery_watermarks[i]);
+                if (bytes > (std::numeric_limits<std::uint64_t>::max)() -
+                        entry_bytes) {
+                    throw std::length_error("logical recovery baseline size overflow");
+                }
+                bytes += entry_bytes;
+            }
+            for (std::size_t i = 0u; i < baseline.delivery_order.size(); ++i) {
+                const std::uint64_t entry_bytes = logical_recovery_order_bytes(
+                    baseline.delivery_order[i]);
                 if (bytes > (std::numeric_limits<std::uint64_t>::max)() -
                         entry_bytes) {
                     throw std::length_error("logical recovery baseline size overflow");

--- a/include/mdbx_containers/sync/engine/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/engine/SyncEngine.hpp
@@ -132,6 +132,8 @@ namespace sync {
                 FullSnapshotScope::ManifestOnly;
             std::vector<FullSnapshotManifestEntry> manifest;
             std::vector<ChangeOp> operations;
+            bool logical_recovery = false;
+            LogicalRecoveryBaseline logical_recovery_baseline;
             std::map<std::string, FullSnapshotContinuation> continuations;
             std::chrono::steady_clock::time_point last_access;
             std::mutex mutex;
@@ -164,6 +166,7 @@ namespace sync {
             std::uint64_t staged_bytes = 0u;
             std::vector<ChangeOp> operations;
             std::map<std::string, ReplacementState> replacement_state;
+            bool logical_recovery = false;
         };
 
     public:
@@ -283,9 +286,8 @@ namespace sync {
                 std::lock_guard<std::mutex> lock(
                     m_full_snapshot_import_mutex);
                 try {
-                    result = apply_full_snapshot_chunk_locked(chunk,
-                                                              notification,
-                                                              notification_ready);
+                    result = apply_full_snapshot_chunk_locked(
+                        chunk, nullptr, false, notification, notification_ready);
                 } catch (...) {
                     m_full_snapshot_import_session.reset();
                     throw;
@@ -295,6 +297,73 @@ namespace sync {
                 m_conn->notify_sync_apply_observers(notification);
             }
             return result;
+        }
+
+        /// \brief Stages or atomically applies one logical-aware recovery page.
+        /// \details The final page carries its immutable logical baseline. The
+        /// user-DBI replacement and logical schema/replay/order state commit in
+        /// the same MDBX transaction; malformed metadata therefore leaves the
+        /// destination unchanged.
+        FullSnapshotImportResult apply_logical_recovery_chunk(
+                const FullSnapshotChunk& chunk,
+                const LogicalRecoveryBaseline* baseline = nullptr) {
+            FullSnapshotCodec::validate(chunk);
+            if (chunk.has_more ? baseline != nullptr : baseline == nullptr) {
+                throw std::invalid_argument(
+                    "logical recovery baseline must accompany only the final page");
+            }
+            FullSnapshotImportResult result;
+            Connection::SyncApplyNotification notification;
+            bool notification_ready = false;
+            {
+                std::lock_guard<std::mutex> lock(
+                    m_full_snapshot_import_mutex);
+                try {
+                    result = apply_full_snapshot_chunk_locked(
+                        chunk, baseline, true, notification, notification_ready);
+                } catch (...) {
+                    m_full_snapshot_import_session.reset();
+                    throw;
+                }
+            }
+            if (result.completed && notification_ready) {
+                m_conn->notify_sync_apply_observers(notification);
+            }
+            return result;
+        }
+
+        /// \brief Serves one page of the explicit logical-aware recovery path.
+        /// \details This does not alter raw \c handle_pull semantics. It is a
+        /// distinct API so only a peer that opted into logical recovery can
+        /// receive a CompleteUserDatabase baseline from a logical source.
+        LogicalRecoveryResponse handle_logical_recovery(
+                const LogicalRecoveryRequest& request) {
+            PullRequest snapshot_request;
+            snapshot_request.requester = request.requester;
+            snapshot_request.request_full_snapshot = true;
+            snapshot_request.full_snapshot_id = request.snapshot_id;
+            snapshot_request.full_snapshot_continuation = request.continuation;
+            snapshot_request.max_bytes = request.max_bytes;
+            snapshot_request.max_single_batch_bytes =
+                request.max_single_batch_bytes;
+
+            LogicalRecoveryBaseline baseline;
+            const PullResponse snapshot_response = handle_full_snapshot_pull(
+                snapshot_request, true, &baseline);
+            LogicalRecoveryResponse out;
+            out.ok = snapshot_response.ok;
+            out.has_more = snapshot_response.has_more;
+            out.error = snapshot_response.error;
+            out.error_code = snapshot_response.error_code;
+            out.error_retryable = snapshot_response.error_retryable;
+            if (snapshot_response.ok) {
+                out.snapshot_chunk = snapshot_response.snapshot_chunk;
+                out.has_baseline = !snapshot_response.has_more;
+                if (out.has_baseline) {
+                    out.baseline = baseline;
+                }
+            }
+            return out;
         }
 
         /// \brief Registers or verifies a persistent logical table schema.
@@ -1627,13 +1696,236 @@ namespace sync {
             }
         }
 
+        void collect_logical_recovery_baseline(
+                MDBX_txn* txn,
+                FullSnapshotSession& session,
+                const FullSnapshotExportOptions& options) const {
+            SchemaRegistryStore schemas(m_conn->env_handle());
+            LogicalDeliveryStore delivery(m_conn->env_handle());
+            LogicalDeliveryOrderStore order(m_conn->env_handle());
+            LogicalOutboxStore outbox(m_conn->env_handle());
+            session.logical_recovery_baseline.source_node_id =
+                session.source_node_id;
+            session.logical_recovery_baseline.source_db_uuid =
+                session.source_db_uuid;
+            session.logical_recovery_baseline.schemas =
+                schemas.list_entries(txn);
+            session.logical_recovery_baseline.delivery_markers =
+                delivery.list_markers(txn);
+            session.logical_recovery_baseline.delivery_watermarks =
+                delivery.list_watermarks(txn);
+            session.logical_recovery_baseline.delivery_order =
+                order.list_entries(txn);
+            session.logical_recovery_baseline.source_outbox_pending =
+                outbox.list_pending(txn, session.source_db_uuid);
+            session.logical_recovery_baseline.source_outbox_known_tail =
+                outbox.known_tail(txn, session.source_db_uuid);
+            validate_logical_recovery_baseline_bounds(
+                session.logical_recovery_baseline, options);
+        }
+
+        static void add_logical_recovery_baseline_bytes(
+                std::uint64_t& total,
+                std::size_t additional,
+                const FullSnapshotExportOptions& options) {
+            if (additional > options.max_materialized_bytes - total) {
+                throw std::length_error(
+                    "logical recovery baseline exceeds max_materialized_bytes");
+            }
+            total += static_cast<std::uint64_t>(additional);
+        }
+
+        static void validate_logical_recovery_baseline_bounds(
+                const LogicalRecoveryBaseline& baseline,
+                const FullSnapshotExportOptions& options) {
+            const std::uint64_t entry_count =
+                static_cast<std::uint64_t>(baseline.schemas.size()) +
+                static_cast<std::uint64_t>(baseline.delivery_markers.size()) +
+                static_cast<std::uint64_t>(baseline.delivery_watermarks.size()) +
+                static_cast<std::uint64_t>(baseline.delivery_order.size()) +
+                static_cast<std::uint64_t>(baseline.source_outbox_pending.size());
+            if (entry_count > options.max_materialized_operations) {
+                throw std::length_error(
+                    "logical recovery baseline exceeds max_materialized_operations");
+            }
+            std::uint64_t bytes = 0u;
+            add_logical_recovery_baseline_bytes(bytes, baseline.snapshot_id.size(),
+                                                options);
+            for (std::size_t i = 0u; i < baseline.schemas.size(); ++i) {
+                const LogicalSchemaRegistryEntry& entry = baseline.schemas[i];
+                add_logical_recovery_baseline_bytes(bytes, entry.schema_id.size(),
+                                                    options);
+                add_logical_recovery_baseline_bytes(bytes,
+                    entry.record.dbi_name.size(), options);
+                for (std::size_t j = 0u; j < entry.record.dbi_names.size(); ++j) {
+                    add_logical_recovery_baseline_bytes(bytes,
+                        entry.record.dbi_names[j].size(), options);
+                }
+            }
+            for (std::size_t i = 0u; i < baseline.delivery_markers.size(); ++i) {
+                add_logical_recovery_baseline_bytes(bytes,
+                    baseline.delivery_markers[i].frame_id.size(), options);
+                add_logical_recovery_baseline_bytes(bytes,
+                    baseline.delivery_markers[i].encoded_frame.size(), options);
+            }
+            for (std::size_t i = 0u;
+                 i < baseline.source_outbox_pending.size(); ++i) {
+                const std::vector<std::uint8_t> encoded =
+                    LogicalDeliveryEnvelopeCodec::encode(
+                        baseline.source_outbox_pending[i]);
+                add_logical_recovery_baseline_bytes(bytes, encoded.size(), options);
+            }
+        }
+
+        static bool logical_schema_record_matches_adapter(
+                const LogicalSchemaRegistryEntry& entry,
+                const ILogicalTableAdapter& adapter) {
+            const LogicalSchemaRef ref = adapter.schema_ref();
+            if (!is_logical_schema_ref_complete(ref) ||
+                ref.schema_id != entry.schema_id ||
+                ref.kind != entry.record.kind ||
+                ref.schema_version != entry.record.schema_version ||
+                entry.record.dbi_name != adapter.primary_dbi()) {
+                return false;
+            }
+            std::vector<std::string> adapter_dbis;
+            std::vector<std::string> record_dbis;
+            return canonical_logical_dbi_names(adapter.affected_dbis(),
+                                               adapter_dbis) &&
+                canonical_logical_dbi_names(entry.record.dbi_names,
+                                            record_dbis) &&
+                adapter_dbis == record_dbis;
+        }
+
+        void validate_logical_recovery_baseline(
+                const FullSnapshotImportSession& session,
+                const LogicalRecoveryBaseline& baseline) const {
+            if (compare_node_id(baseline.source_node_id,
+                                session.source_node_id) != 0 ||
+                compare_node_id(baseline.source_db_uuid,
+                                session.source_db_uuid) != 0 ||
+                baseline.snapshot_id != session.snapshot_id) {
+                throw std::invalid_argument(
+                    "logical recovery baseline does not match snapshot identity");
+            }
+            std::map<std::string, bool> seen_schemas;
+            for (std::size_t i = 0u; i < baseline.schemas.size(); ++i) {
+                const LogicalSchemaRegistryEntry& entry = baseline.schemas[i];
+                if (entry.schema_id.empty() ||
+                    !seen_schemas.insert(std::make_pair(entry.schema_id, true)).second) {
+                    throw std::invalid_argument(
+                        "logical recovery baseline has duplicate or empty schema id");
+                }
+                ILogicalTableAdapter* adapter =
+                    m_logical_registry.find(entry.schema_id);
+                if (adapter == nullptr ||
+                    !logical_schema_record_matches_adapter(entry, *adapter)) {
+                    throw std::logic_error(
+                        "logical recovery destination adapter does not match baseline");
+                }
+            }
+            for (std::size_t i = 0u; i < baseline.delivery_markers.size(); ++i) {
+                const LogicalDeliveryMarkerInfo& marker =
+                    baseline.delivery_markers[i];
+                if (compare_node_id(marker.destination_db_uuid,
+                                    session.source_db_uuid) != 0) {
+                    throw std::invalid_argument(
+                        "logical recovery marker destination does not match snapshot db_uuid");
+                }
+            }
+            for (std::size_t i = 0u; i < baseline.delivery_order.size(); ++i) {
+                if (compare_node_id(baseline.delivery_order[i].origin_node_id,
+                                    session.source_node_id) == 0) {
+                    throw std::invalid_argument(
+                        "logical recovery baseline contains a source self frontier");
+                }
+            }
+            std::uint64_t previous_pending = 0u;
+            for (std::size_t i = 0u;
+                 i < baseline.source_outbox_pending.size(); ++i) {
+                const LogicalDeliveryEnvelope& envelope =
+                    baseline.source_outbox_pending[i];
+                validate_logical_delivery_envelope(envelope);
+                if (compare_node_id(envelope.destination_db_uuid,
+                                    session.source_db_uuid) != 0 ||
+                    compare_node_id(envelope.origin_node_id,
+                                    session.source_node_id) != 0 ||
+                    envelope.origin_sequence >
+                        baseline.source_outbox_known_tail ||
+                    (previous_pending != 0u && envelope.origin_sequence !=
+                        previous_pending + 1u)) {
+                    throw std::invalid_argument(
+                        "logical recovery source outbox baseline is invalid");
+                }
+                previous_pending = envelope.origin_sequence;
+            }
+        }
+
+        void require_fresh_logical_recovery_target(MDBX_txn* txn) const {
+            SchemaRegistryStore schemas(m_conn->env_handle());
+            LogicalDeliveryStore delivery(m_conn->env_handle());
+            LogicalDeliveryOrderStore order(m_conn->env_handle());
+            LogicalOutboxStore outbox(m_conn->env_handle());
+            if (schemas.has_entries(txn) || delivery.has_persistent_state(txn) ||
+                order.has_entries(txn) || outbox.has_persistent_state(txn)) {
+                throw std::logic_error(
+                    "logical recovery destination has persistent logical state");
+            }
+        }
+
+        void apply_logical_recovery_baseline(
+                MDBX_txn* txn,
+                const FullSnapshotImportSession& session,
+                const LogicalRecoveryBaseline& baseline) {
+            validate_logical_recovery_baseline(session, baseline);
+            require_fresh_logical_recovery_target(txn);
+
+            SchemaRegistryStore schemas(m_conn->env_handle());
+            LogicalDeliveryStore delivery(m_conn->env_handle());
+            LogicalDeliveryOrderStore order(m_conn->env_handle());
+            for (std::size_t i = 0u; i < baseline.schemas.size(); ++i) {
+                const LogicalSchemaRegistryEntry& entry = baseline.schemas[i];
+                ILogicalTableAdapter* adapter =
+                    m_logical_registry.find(entry.schema_id);
+                adapter->verify_storage(txn);
+                schemas.register_or_verify(txn, entry.schema_id, entry.record);
+            }
+            for (std::size_t i = 0u; i < baseline.delivery_markers.size(); ++i) {
+                delivery.restore_marker(txn, baseline.delivery_markers[i]);
+            }
+            for (std::size_t i = 0u; i < baseline.delivery_watermarks.size(); ++i) {
+                delivery.restore_watermark(txn,
+                                           baseline.delivery_watermarks[i]);
+            }
+            for (std::size_t i = 0u;
+                 i < baseline.source_outbox_pending.size(); ++i) {
+                if (!delivery.try_mark_applied(
+                        txn, baseline.source_outbox_pending[i])) {
+                    throw std::runtime_error(
+                        "logical recovery source outbox marker conflicts");
+                }
+            }
+            for (std::size_t i = 0u; i < baseline.delivery_order.size(); ++i) {
+                order.restore_entry(txn, baseline.delivery_order[i]);
+            }
+            if (baseline.source_outbox_known_tail != 0u) {
+                LogicalDeliveryOrderEntry source_frontier;
+                source_frontier.origin_node_id = session.source_node_id;
+                source_frontier.acknowledged_through =
+                    baseline.source_outbox_known_tail;
+                order.restore_entry(txn, source_frontier);
+            }
+        }
+
         std::shared_ptr<FullSnapshotSession> materialize_full_snapshot(
                 const FullSnapshotExportOptions& options,
-                const NodeId& requester) const {
+                const NodeId& requester,
+                bool logical_recovery = false) const {
             std::shared_ptr<FullSnapshotSession> session(
                 new FullSnapshotSession());
             session->requester = requester;
             session->replacement_scope = options.replacement_scope;
+            session->logical_recovery = logical_recovery;
             session->last_access = std::chrono::steady_clock::now();
 
             auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
@@ -1647,7 +1939,7 @@ namespace sync {
                     "full snapshot source identity is not initialized");
             }
 
-            if (options.replacement_scope ==
+            if (!logical_recovery && options.replacement_scope ==
                 FullSnapshotScope::CompleteUserDatabase) {
                 require_raw_only_complete_snapshot_source(txn.handle());
             }
@@ -1678,6 +1970,11 @@ namespace sync {
                     }
                     merge_sync_cursor_max(session->source_tail, changelog_tail);
                 }
+            }
+
+            if (logical_recovery) {
+                collect_logical_recovery_baseline(txn.handle(), *session,
+                                                  options);
             }
 
             std::uint64_t materialized_bytes = 0u;
@@ -1822,7 +2119,10 @@ namespace sync {
             return out;
         }
 
-        PullResponse handle_full_snapshot_pull(const PullRequest& request) {
+        PullResponse handle_full_snapshot_pull(
+                const PullRequest& request,
+                bool logical_recovery = false,
+                LogicalRecoveryBaseline* final_baseline = nullptr) {
             PullResponse out;
             if (request.full_snapshot_id.empty() !=
                 request.full_snapshot_continuation.empty()) {
@@ -1855,6 +2155,15 @@ namespace sync {
                             SyncResponseErrorCode::SnapshotNotConfigured;
                         return out;
                     }
+                    if (logical_recovery && options.replacement_scope !=
+                            FullSnapshotScope::CompleteUserDatabase) {
+                        out.ok = false;
+                        out.error =
+                            "logical recovery requires CompleteUserDatabase snapshot export";
+                        out.error_code =
+                            SyncResponseErrorCode::SnapshotNotConfigured;
+                        return out;
+                    }
                     if (m_full_snapshot_sessions.size() +
                         m_full_snapshot_creating >= options.max_active_sessions) {
                         out.ok = false;
@@ -1866,7 +2175,8 @@ namespace sync {
                     ++m_full_snapshot_creating;
                 }
                 try {
-                    session = materialize_full_snapshot(options, request.requester);
+                    session = materialize_full_snapshot(
+                        options, request.requester, logical_recovery);
                 } catch (const FullSnapshotLogicalStateUnsupported& e) {
                     std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
                     --m_full_snapshot_creating;
@@ -1885,6 +2195,10 @@ namespace sync {
                     --m_full_snapshot_creating;
                     prune_expired_full_snapshot_sessions_locked();
                     session->snapshot_id = next_full_snapshot_id_locked();
+                    if (logical_recovery) {
+                        session->logical_recovery_baseline.snapshot_id =
+                            session->snapshot_id;
+                    }
                     m_full_snapshot_sessions[session->snapshot_id] = session;
                 }
             } else {
@@ -1900,6 +2214,12 @@ namespace sync {
                     return out;
                 }
                 session = it->second;
+                if (session->logical_recovery != logical_recovery) {
+                    out.ok = false;
+                    out.error = "full snapshot session belongs to another protocol";
+                    out.error_code = SyncResponseErrorCode::SnapshotSessionInvalid;
+                    return out;
+                }
             }
 
             std::lock_guard<std::mutex> lock(session->mutex);
@@ -1937,8 +2257,13 @@ namespace sync {
                 session->last_access = std::chrono::steady_clock::now();
             }
             try {
-                return make_full_snapshot_page(*session, request,
-                                               start_operation, chunk_index);
+                PullResponse page = make_full_snapshot_page(
+                    *session, request, start_operation, chunk_index);
+                if (logical_recovery && page.ok && !page.has_more &&
+                    final_baseline != nullptr) {
+                    *final_baseline = session->logical_recovery_baseline;
+                }
+                return page;
             } catch (const std::length_error& e) {
                 out.ok = false;
                 out.error = e.what();
@@ -2144,6 +2469,8 @@ namespace sync {
 
         FullSnapshotImportResult apply_full_snapshot_chunk_locked(
                 const FullSnapshotChunk& chunk,
+                const LogicalRecoveryBaseline* logical_baseline,
+                bool logical_recovery,
                 Connection::SyncApplyNotification& notification,
                 bool& notification_ready) {
             if (chunk.replacement_scope != FullSnapshotScope::ManifestOnly &&
@@ -2166,6 +2493,7 @@ namespace sync {
                 session->replacement_scope = chunk.replacement_scope;
                 session->manifest_version = chunk.manifest_version;
                 session->manifest = chunk.manifest;
+                session->logical_recovery = logical_recovery;
                 for (std::size_t i = 0u; i < session->manifest.size(); ++i) {
                     session->replacement_state[session->manifest[i].dbi_name] =
                         FullSnapshotImportSession::ReplacementState::NotSeen;
@@ -2176,9 +2504,17 @@ namespace sync {
             FullSnapshotImportSession& session =
                 *m_full_snapshot_import_session;
             if (chunk.chunk_index != session.next_chunk_index ||
-                !full_snapshot_metadata_matches(session, chunk)) {
+                !full_snapshot_metadata_matches(session, chunk) ||
+                session.logical_recovery != logical_recovery) {
                 throw std::invalid_argument(
                     "full snapshot chunk does not match the active import session");
+            }
+            if ((!logical_recovery && logical_baseline != nullptr) ||
+                (logical_recovery &&
+                 (chunk.has_more ? logical_baseline != nullptr :
+                                   logical_baseline == nullptr))) {
+                throw std::invalid_argument(
+                    "logical recovery baseline does not match snapshot finality");
             }
             append_full_snapshot_import_chunk(session, chunk);
             ++session.next_chunk_index;
@@ -2196,6 +2532,11 @@ namespace sync {
                 MetaStore meta(m_conn->env_handle());
                 meta.open(txn.handle());
                 require_fresh_full_snapshot_target(txn.handle(), meta, session);
+                if (logical_recovery) {
+                    validate_logical_recovery_baseline(session,
+                                                       *logical_baseline);
+                    require_fresh_logical_recovery_target(txn.handle());
+                }
 
                 std::vector<std::string> affected_dbi_names;
                 for (std::size_t i = 0u; i < session.manifest.size(); ++i) {
@@ -2219,6 +2560,10 @@ namespace sync {
                         applied.set_last_applied_seq(txn.handle(), it->first,
                                                      it->second);
                     }
+                }
+                if (logical_recovery) {
+                    apply_logical_recovery_baseline(txn.handle(), session,
+                                                    *logical_baseline);
                 }
                 txn.commit();
                 result.completed = true;

--- a/include/mdbx_containers/sync/engine/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/engine/SyncWorker.hpp
@@ -93,6 +93,14 @@ namespace sync {
         /// partially replicated database.
         bool enable_full_snapshot_fallback = false;
 
+        /// \brief Requests logical-aware fresh-replica recovery after
+        /// \c SnapshotRequired.
+        /// \details Disabled by default. This is a separate peer capability
+        /// and commits the final physical snapshot page together with schema,
+        /// replay, and ordered-delivery metadata. It never relaxes the raw
+        /// CompleteUserDatabase logical-state guard.
+        bool enable_logical_recovery_fallback = false;
+
         /// \brief Sends this engine's queued logical deliveries after raw sync.
         /// \details Disabled by default, preserving the raw-only worker contract.
         /// When enabled, the worker sends only the outbox prefix addressed to
@@ -630,9 +638,15 @@ namespace sync {
                     }
                     if (!response.ok) {
                         if (response.error_code ==
-                                SyncResponseErrorCode::SnapshotRequired &&
-                            m_options.enable_full_snapshot_fallback) {
-                            return run_full_snapshot_fallback(request, result);
+                                SyncResponseErrorCode::SnapshotRequired) {
+                            if (m_options.enable_logical_recovery_fallback &&
+                                m_peer.supports_logical_recovery()) {
+                                return run_logical_recovery_fallback(request,
+                                                                     result);
+                            }
+                            if (m_options.enable_full_snapshot_fallback) {
+                                return run_full_snapshot_fallback(request, result);
+                            }
                         }
                         result.ok = false;
                         result.error = response.error.empty()
@@ -836,6 +850,122 @@ namespace sync {
                 if (remaining != 0u) {
                     --remaining;
                 }
+            }
+        }
+
+        SyncWorkerRoundResult run_logical_recovery_fallback(
+                const PullRequest& incremental_request,
+                SyncWorkerRoundResult result) {
+            m_engine.discard_full_snapshot_import();
+            FullSnapshotImportResetGuard reset_guard(m_engine);
+            LogicalRecoveryRequest request;
+            request.requester = incremental_request.requester;
+            request.max_bytes = incremental_request.max_bytes;
+            request.max_single_batch_bytes =
+                incremental_request.max_single_batch_bytes;
+
+            for (;;) {
+                if (stop_requested()) {
+                    result.has_more = true;
+                    return result;
+                }
+
+                LogicalRecoveryResponse response;
+                {
+                    CancellationToken cancel_token;
+                    PeerCallGuard peer_call(*this, cancel_token);
+                    if (!peer_call.active()) {
+                        result.has_more = true;
+                        return result;
+                    }
+                    notify_stage_changed(make_stage_event(
+                        SyncWorkerStage::PullStarted, result));
+                    response = m_peer.logical_recovery(request);
+                }
+                {
+                    SyncWorkerStageEvent event = make_stage_event(
+                        SyncWorkerStage::PullFinished, result);
+                    event.has_more = response.has_more;
+                    event.ok = response.ok;
+                    event.error = response.error;
+                    event.sync_error_code = response.error_code;
+                    event.sync_error_retryable = response.error_retryable;
+                    notify_stage_changed(event);
+                }
+                if (!response.ok) {
+                    m_engine.discard_full_snapshot_import();
+                    result.ok = false;
+                    result.error = response.error.empty()
+                        ? "logical recovery pull failed"
+                        : response.error;
+                    result.retry_hint = m_peer.last_retry_hint();
+                    result.sync_error_code = response.error_code;
+                    result.sync_error_retryable = response.error_retryable;
+                    return result;
+                }
+                if (response.snapshot_chunk.replacement_scope !=
+                        FullSnapshotScope::CompleteUserDatabase ||
+                    response.has_more != response.snapshot_chunk.has_more ||
+                    response.has_baseline == response.has_more) {
+                    m_engine.discard_full_snapshot_import();
+                    result.ok = false;
+                    result.error = "logical recovery returned an invalid response shape";
+                    result.sync_error_code =
+                        SyncResponseErrorCode::SnapshotSessionInvalid;
+                    return result;
+                }
+                ++result.pages_pulled;
+                if (stop_requested() || !begin_apply_stage() ||
+                    !enter_apply_gate()) {
+                    m_engine.discard_full_snapshot_import();
+                    result.has_more = response.has_more;
+                    return result;
+                }
+                {
+                    SyncWorkerStageEvent event = make_stage_event(
+                        SyncWorkerStage::ApplyStarted, result);
+                    event.has_more = response.has_more;
+                    notify_stage_changed(event);
+                }
+                const LogicalRecoveryBaseline* baseline = response.has_baseline
+                    ? &response.baseline : nullptr;
+                const FullSnapshotImportResult imported =
+                    m_engine.apply_logical_recovery_chunk(
+                        response.snapshot_chunk, baseline);
+                {
+                    SyncWorkerStageEvent event = make_stage_event(
+                        SyncWorkerStage::ApplyFinished, result);
+                    event.has_more = response.has_more;
+                    event.ok = true;
+                    notify_stage_changed(event);
+                }
+                if (response.has_more && imported.completed) {
+                    m_engine.discard_full_snapshot_import();
+                    result.ok = false;
+                    result.error =
+                        "logical recovery importer completed before final page";
+                    return result;
+                }
+                if (!response.has_more && !imported.completed) {
+                    m_engine.discard_full_snapshot_import();
+                    result.ok = false;
+                    result.error =
+                        "logical recovery importer did not complete final page";
+                    return result;
+                }
+
+                result.has_more = response.has_more;
+                if (!response.has_more) {
+                    result.progress = make_progress_estimate(
+                        response.snapshot_chunk.source_tail,
+                        m_engine.applied_cursor(), result.batches_applied);
+                    result.sync_error_code = SyncResponseErrorCode::None;
+                    result.sync_error_retryable = false;
+                    reset_guard.dismiss();
+                    return result;
+                }
+                request.snapshot_id = response.snapshot_chunk.snapshot_id;
+                request.continuation = response.snapshot_chunk.continuation;
             }
         }
 

--- a/include/mdbx_containers/sync/engine/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/engine/SyncWorker.hpp
@@ -880,7 +880,8 @@ namespace sync {
                     }
                     notify_stage_changed(make_stage_event(
                         SyncWorkerStage::PullStarted, result));
-                    response = m_peer.logical_recovery(request);
+                    response = m_peer.logical_recovery_with_cancel(
+                        request, &cancel_token);
                 }
                 {
                     SyncWorkerStageEvent event = make_stage_event(

--- a/include/mdbx_containers/sync/logical.hpp
+++ b/include/mdbx_containers/sync/logical.hpp
@@ -24,6 +24,8 @@
 #include "logical/stores/LogicalDeliveryOrderStore.hpp"
 #include "logical/stores/LogicalOutboxStore.hpp"
 #include "logical/logical_schema_validation.hpp"
+#include "logical/logical_recovery.hpp"
+#include "logical/ILogicalRecoveryPeer.hpp"
 #endif
 
 #endif // MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_HPP_INCLUDED

--- a/include/mdbx_containers/sync/logical/ILogicalRecoveryPeer.hpp
+++ b/include/mdbx_containers/sync/logical/ILogicalRecoveryPeer.hpp
@@ -12,6 +12,8 @@
 namespace mdbxc {
 namespace sync {
 
+    class CancellationToken;
+
     /// \brief Capability-gated peer for the separate logical recovery route.
     class ILogicalRecoveryPeer {
     public:
@@ -23,6 +25,16 @@ namespace sync {
                 const LogicalRecoveryRequest&) {
             throw std::logic_error(
                 "Sync peer does not support logical recovery");
+        }
+
+        /// \brief Performs logical recovery with optional cancellation.
+        /// \details The default preserves existing peers that do not own an
+        /// interruptible recovery transport operation.
+        virtual LogicalRecoveryResponse logical_recovery_with_cancel(
+                const LogicalRecoveryRequest& request,
+                const CancellationToken* cancel_token = nullptr) {
+            (void)cancel_token;
+            return logical_recovery(request);
         }
     };
 

--- a/include/mdbx_containers/sync/logical/ILogicalRecoveryPeer.hpp
+++ b/include/mdbx_containers/sync/logical/ILogicalRecoveryPeer.hpp
@@ -1,0 +1,32 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_ILOGICAL_RECOVERY_PEER_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_ILOGICAL_RECOVERY_PEER_HPP_INCLUDED
+
+/// \file logical/ILogicalRecoveryPeer.hpp
+/// \brief Optional peer contract for logical-aware fresh-replica recovery.
+
+#include <stdexcept>
+
+#include "logical_recovery.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Capability-gated peer for the separate logical recovery route.
+    class ILogicalRecoveryPeer {
+    public:
+        virtual ~ILogicalRecoveryPeer() {}
+
+        virtual bool supports_logical_recovery() const { return false; }
+
+        virtual LogicalRecoveryResponse logical_recovery(
+                const LogicalRecoveryRequest&) {
+            throw std::logic_error(
+                "Sync peer does not support logical recovery");
+        }
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_ILOGICAL_RECOVERY_PEER_HPP_INCLUDED

--- a/include/mdbx_containers/sync/logical/logical_recovery.hpp
+++ b/include/mdbx_containers/sync/logical/logical_recovery.hpp
@@ -1,0 +1,69 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_LOGICAL_RECOVERY_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_LOGICAL_RECOVERY_HPP_INCLUDED
+
+/// \file logical/logical_recovery.hpp
+/// \brief Explicit baseline DTOs for logical-aware fresh-replica recovery.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "../protocol.hpp"
+#include "../protocol/FullSnapshotProtocol.hpp"
+#include "stores/LogicalDeliveryOrderStore.hpp"
+#include "stores/LogicalDeliveryStore.hpp"
+#include "stores/SchemaRegistryStore.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Immutable logical metadata captured with one physical snapshot.
+    /// \details The physical user-DBI snapshot remains represented by
+    /// \c FullSnapshotChunk pages. This DTO supplies the state that raw
+    /// snapshots intentionally exclude: schema markers, replay identity,
+    /// ordered receiver frontiers, and the source outbox tail for the recovered
+    /// destination. It is committed with the final physical replacement page.
+    struct LogicalRecoveryBaseline {
+        NodeId source_node_id{};
+        DbId source_db_uuid{};
+        std::string snapshot_id;
+        std::vector<LogicalSchemaRegistryEntry> schemas;
+        std::vector<LogicalDeliveryMarkerInfo> delivery_markers;
+        std::vector<LogicalDeliveryWatermarkInfo> delivery_watermarks;
+        std::vector<LogicalDeliveryOrderEntry> delivery_order;
+        /// \brief Source envelopes still awaiting this recovered destination.
+        /// They become receiver replay markers, not receiver outbox entries.
+        std::vector<LogicalDeliveryEnvelope> source_outbox_pending;
+        std::uint64_t source_outbox_known_tail = 0u;
+    };
+
+    /// \brief One paged logical-aware recovery request.
+    /// \details This is intentionally separate from raw \c PullRequest so a
+    /// raw peer cannot accidentally bypass the CompleteUserDatabase logical
+    /// state guard.
+    struct LogicalRecoveryRequest {
+        NodeId requester{};
+        std::string snapshot_id;
+        std::string continuation;
+        std::uint64_t max_bytes = 4ULL * 1024ULL * 1024ULL;
+        std::uint64_t max_single_batch_bytes = 4ULL * 1024ULL * 1024ULL;
+    };
+
+    /// \brief One logical-aware recovery page or structured failure.
+    struct LogicalRecoveryResponse {
+        bool ok = true;
+        bool has_more = false;
+        FullSnapshotChunk snapshot_chunk;
+        /// \brief Present exactly on the final successful page.
+        bool has_baseline = false;
+        LogicalRecoveryBaseline baseline;
+        std::string error;
+        SyncResponseErrorCode error_code = SyncResponseErrorCode::None;
+        bool error_retryable = false;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_LOGICAL_RECOVERY_HPP_INCLUDED

--- a/include/mdbx_containers/sync/logical/stores/LogicalDeliveryOrderStore.hpp
+++ b/include/mdbx_containers/sync/logical/stores/LogicalDeliveryOrderStore.hpp
@@ -115,19 +115,17 @@ namespace sync {
             return found;
         }
 
-        /// \brief Lists every persisted ordered-delivery frontier.
-        /// \details All entries are decoded before returning. This is used by
-        /// the logical recovery baseline, which transfers receiver ordering
-        /// state as data rather than treating it as an implicit local cache.
-        std::vector<LogicalDeliveryOrderEntry> list_entries(
-                MDBX_txn* txn) const {
+        /// \brief Visits every persisted ordered-delivery frontier.
+        /// \details The visitor runs while the MDBX cursor is open and may
+        /// stop enumeration by throwing.
+        template <typename Visitor>
+        void for_each_entry(MDBX_txn* txn, Visitor visitor) const {
             txn = checked_txn(txn,
-                              "LogicalDeliveryOrderStore::list_entries");
+                              "LogicalDeliveryOrderStore::for_each_entry");
             open_existing(txn);
             MDBX_cursor* cursor = nullptr;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
                        "LogicalDeliveryOrderStore cursor open failed");
-            std::vector<LogicalDeliveryOrderEntry> out;
             try {
                 MDBX_val key;
                 MDBX_val value;
@@ -136,7 +134,7 @@ namespace sync {
                     LogicalDeliveryOrderEntry entry;
                     entry.origin_node_id = decode_origin(key);
                     entry.acknowledged_through = decode_value(value);
-                    out.push_back(entry);
+                    visitor(entry);
                     rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
                 }
                 if (rc != MDBX_NOTFOUND) {
@@ -148,6 +146,18 @@ namespace sync {
                 throw;
             }
             mdbx_cursor_close(cursor);
+        }
+
+        /// \brief Lists every persisted ordered-delivery frontier.
+        /// \details All entries are decoded before returning. This is used by
+        /// the logical recovery baseline, which transfers receiver ordering
+        /// state as data rather than treating it as an implicit local cache.
+        std::vector<LogicalDeliveryOrderEntry> list_entries(
+                MDBX_txn* txn) const {
+            std::vector<LogicalDeliveryOrderEntry> out;
+            for_each_entry(txn, [&out](const LogicalDeliveryOrderEntry& entry) {
+                out.push_back(entry);
+            });
             return out;
         }
 

--- a/include/mdbx_containers/sync/logical/stores/LogicalDeliveryOrderStore.hpp
+++ b/include/mdbx_containers/sync/logical/stores/LogicalDeliveryOrderStore.hpp
@@ -18,6 +18,12 @@
 namespace mdbxc {
 namespace sync {
 
+    /// \brief One persisted ordered-delivery frontier.
+    struct LogicalDeliveryOrderEntry {
+        NodeId origin_node_id{};
+        std::uint64_t acknowledged_through = 0u;
+    };
+
     /// \brief Persists the highest contiguous ordered delivery per origin.
     class LogicalDeliveryOrderStore {
     public:
@@ -107,6 +113,73 @@ namespace sync {
             }
             mdbx_cursor_close(cursor);
             return found;
+        }
+
+        /// \brief Lists every persisted ordered-delivery frontier.
+        /// \details All entries are decoded before returning. This is used by
+        /// the logical recovery baseline, which transfers receiver ordering
+        /// state as data rather than treating it as an implicit local cache.
+        std::vector<LogicalDeliveryOrderEntry> list_entries(
+                MDBX_txn* txn) const {
+            txn = checked_txn(txn,
+                              "LogicalDeliveryOrderStore::list_entries");
+            open_existing(txn);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "LogicalDeliveryOrderStore cursor open failed");
+            std::vector<LogicalDeliveryOrderEntry> out;
+            try {
+                MDBX_val key;
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    LogicalDeliveryOrderEntry entry;
+                    entry.origin_node_id = decode_origin(key);
+                    entry.acknowledged_through = decode_value(value);
+                    out.push_back(entry);
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc,
+                               "LogicalDeliveryOrderStore cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return out;
+        }
+
+        /// \brief Restores one exact frontier into an otherwise empty store.
+        /// \details Recovery must not silently merge a baseline with local
+        /// receiver history. Repeating the same entry is idempotent; a
+        /// different existing frontier is rejected.
+        void restore_entry(MDBX_txn* txn,
+                           const LogicalDeliveryOrderEntry& entry) {
+            txn = checked_txn(txn,
+                              "LogicalDeliveryOrderStore::restore_entry");
+            validate_origin(entry.origin_node_id);
+            if (entry.acknowledged_through == 0u) {
+                throw std::invalid_argument(
+                    "LogicalDeliveryOrderStore restored sequence is zero");
+            }
+            open_for_write(txn);
+            const std::uint64_t existing = last_applied(
+                txn, entry.origin_node_id);
+            if (existing != 0u && existing != entry.acknowledged_through) {
+                throw std::runtime_error(
+                    "LogicalDeliveryOrderStore recovery frontier mismatch");
+            }
+            if (existing == entry.acknowledged_through) {
+                return;
+            }
+            MDBX_val key = make_key(entry.origin_node_id);
+            const std::vector<std::uint8_t> encoded =
+                encode_value(entry.acknowledged_through);
+            MDBX_val value = make_val(encoded);
+            check_mdbx(mdbx_put(txn, m_dbi, &key, &value, MDBX_NOOVERWRITE),
+                       "LogicalDeliveryOrderStore recovery write failed");
         }
 
     private:

--- a/include/mdbx_containers/sync/logical/stores/LogicalDeliveryStore.hpp
+++ b/include/mdbx_containers/sync/logical/stores/LogicalDeliveryStore.hpp
@@ -168,29 +168,31 @@ namespace sync {
             return found;
         }
 
-        /// \brief Lists persisted logical delivery marker identities.
-        /// \param limit Maximum number of markers to return, or zero for all.
-        std::vector<LogicalDeliveryMarkerInfo> list_markers(
-                MDBX_txn* txn,
-                std::size_t limit = 0) const {
-            txn = checked_txn(txn, "LogicalDeliveryStore::list_markers");
+        /// \brief Visits persisted logical delivery marker identities.
+        /// \details The visitor runs while the MDBX cursor is open and may
+        /// throw to stop enumeration without retaining later markers.
+        template <typename Visitor>
+        void for_each_marker(MDBX_txn* txn, Visitor visitor,
+                             std::size_t limit = 0u) const {
+            txn = checked_txn(txn, "LogicalDeliveryStore::for_each_marker");
             open_const(txn);
             MDBX_cursor* cursor = nullptr;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
                        "LogicalDeliveryStore cursor open failed");
-            std::vector<LogicalDeliveryMarkerInfo> out;
+            std::size_t visited = 0u;
             try {
                 MDBX_val key;
                 MDBX_val value;
                 int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
                 while (rc == MDBX_SUCCESS) {
-                    out.push_back(decode_and_validate_marker(key, value));
-                    if (limit != 0 && out.size() >= limit) {
+                    visitor(decode_and_validate_marker(key, value));
+                    ++visited;
+                    if (limit != 0u && visited >= limit) {
                         break;
                     }
                     rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
                 }
-                if (rc != MDBX_NOTFOUND && (limit == 0 || out.size() < limit)) {
+                if (rc != MDBX_NOTFOUND && (limit == 0u || visited < limit)) {
                     check_mdbx(rc, "LogicalDeliveryStore cursor read failed");
                 }
             } catch (...) {
@@ -198,21 +200,31 @@ namespace sync {
                 throw;
             }
             mdbx_cursor_close(cursor);
+        }
+
+        /// \brief Lists persisted logical delivery marker identities.
+        /// \param limit Maximum number of markers to return, or zero for all.
+        std::vector<LogicalDeliveryMarkerInfo> list_markers(
+                MDBX_txn* txn,
+                std::size_t limit = 0) const {
+            std::vector<LogicalDeliveryMarkerInfo> out;
+            for_each_marker(txn,
+                [&out](const LogicalDeliveryMarkerInfo& marker) {
+                    out.push_back(marker);
+                }, limit);
             return out;
         }
 
-        /// \brief Lists every persisted replay-pruning watermark.
+        /// \brief Visits every persisted replay-pruning watermark.
         /// \details The optional watermark DBI remains absent when no marker
-        /// has ever been pruned. Recovery preserves that absence as an empty
-        /// result instead of creating it while reading.
-        std::vector<LogicalDeliveryWatermarkInfo> list_watermarks(
-                MDBX_txn* txn) const {
+        /// has ever been pruned. The visitor is not called when it is absent.
+        template <typename Visitor>
+        void for_each_watermark(MDBX_txn* txn, Visitor visitor) const {
             txn = checked_txn(txn,
-                              "LogicalDeliveryStore::list_watermarks");
+                              "LogicalDeliveryStore::for_each_watermark");
             open_const(txn);
-            std::vector<LogicalDeliveryWatermarkInfo> out;
             if (!open_watermark_if_exists(txn)) {
-                return out;
+                return;
             }
             MDBX_cursor* cursor = nullptr;
             check_mdbx(mdbx_cursor_open(txn, m_watermark_dbi, &cursor),
@@ -225,7 +237,7 @@ namespace sync {
                     LogicalDeliveryWatermarkInfo info;
                     info.origin_node_id = decode_watermark_origin(key);
                     info.sequence = decode_watermark(value);
-                    out.push_back(info);
+                    visitor(info);
                     rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
                 }
                 if (rc != MDBX_NOTFOUND) {
@@ -237,6 +249,19 @@ namespace sync {
                 throw;
             }
             mdbx_cursor_close(cursor);
+        }
+
+        /// \brief Lists every persisted replay-pruning watermark.
+        /// \details The optional watermark DBI remains absent when no marker
+        /// has ever been pruned. Recovery preserves that absence as an empty
+        /// result instead of creating it while reading.
+        std::vector<LogicalDeliveryWatermarkInfo> list_watermarks(
+                MDBX_txn* txn) const {
+            std::vector<LogicalDeliveryWatermarkInfo> out;
+            for_each_watermark(txn,
+                [&out](const LogicalDeliveryWatermarkInfo& watermark) {
+                    out.push_back(watermark);
+                });
             return out;
         }
 

--- a/include/mdbx_containers/sync/logical/stores/LogicalDeliveryStore.hpp
+++ b/include/mdbx_containers/sync/logical/stores/LogicalDeliveryStore.hpp
@@ -20,9 +20,8 @@ namespace mdbxc {
 namespace sync {
 
     /// \brief Read-only metadata decoded from an applied delivery marker.
-    /// \details The inspection record intentionally exposes only delivery
-    /// identity and stored frame metadata. It is not a pruning contract and
-    /// does not expose or decode the nested logical frame payload.
+    /// \details Recovery also retains the canonical nested frame bytes so a
+    /// recovered receiver can preserve duplicate-delivery identity exactly.
     struct LogicalDeliveryMarkerInfo {
         DbId destination_db_uuid{};        ///< Destination database id.
         NodeId origin_node_id{};           ///< Delivery origin node.
@@ -30,6 +29,13 @@ namespace sync {
         std::string frame_id;              ///< Stable sender frame id.
         std::uint16_t frame_codec_version = 0; ///< Nested frame codec version.
         std::uint32_t frame_bytes_size = 0;    ///< Stored nested frame bytes.
+        std::vector<std::uint8_t> encoded_frame; ///< Canonical nested frame.
+    };
+
+    /// \brief One durable replay-pruning boundary.
+    struct LogicalDeliveryWatermarkInfo {
+        NodeId origin_node_id{};
+        std::uint64_t sequence = 0u;
     };
 
     /// \brief Tracks applied logical delivery envelopes.
@@ -195,6 +201,45 @@ namespace sync {
             return out;
         }
 
+        /// \brief Lists every persisted replay-pruning watermark.
+        /// \details The optional watermark DBI remains absent when no marker
+        /// has ever been pruned. Recovery preserves that absence as an empty
+        /// result instead of creating it while reading.
+        std::vector<LogicalDeliveryWatermarkInfo> list_watermarks(
+                MDBX_txn* txn) const {
+            txn = checked_txn(txn,
+                              "LogicalDeliveryStore::list_watermarks");
+            open_const(txn);
+            std::vector<LogicalDeliveryWatermarkInfo> out;
+            if (!open_watermark_if_exists(txn)) {
+                return out;
+            }
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_watermark_dbi, &cursor),
+                       "LogicalDeliveryStore watermark cursor open failed");
+            try {
+                MDBX_val key;
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    LogicalDeliveryWatermarkInfo info;
+                    info.origin_node_id = decode_watermark_origin(key);
+                    info.sequence = decode_watermark(value);
+                    out.push_back(info);
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc,
+                               "LogicalDeliveryStore watermark cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return out;
+        }
+
         /// \brief Returns the persisted replay-pruning watermark for \p origin.
         /// \return Zero when no markers for \p origin have been pruned or
         /// the optional watermark DBI has not been created yet.
@@ -328,6 +373,66 @@ namespace sync {
             }
             check_mdbx(rc, "LogicalDeliveryStore write failed");
             return true;
+        }
+
+        /// \brief Restores one exact replay marker into a logical baseline.
+        /// \details The nested frame is decoded before writing so malformed
+        /// source metadata cannot be persisted by a recovery import.
+        void restore_marker(MDBX_txn* txn,
+                            const LogicalDeliveryMarkerInfo& marker,
+                            const CodecBounds* bounds = nullptr) {
+            txn = checked_txn(txn,
+                              "LogicalDeliveryStore::restore_marker");
+            validate_recovery_marker(marker, bounds);
+            open_marker_checked(txn);
+            const std::vector<std::uint8_t> key = make_marker_key(marker);
+            const std::vector<std::uint8_t> value =
+                make_marker_value(marker);
+            MDBX_val k = {
+                const_cast<std::uint8_t*>(key.empty() ? nullptr : &key[0]),
+                key.size()
+            };
+            MDBX_val v = {
+                const_cast<std::uint8_t*>(
+                    value.empty() ? nullptr : &value[0]),
+                value.size()
+            };
+            const int rc = mdbx_put(txn, m_dbi, &k, &v, MDBX_NOOVERWRITE);
+            if (rc == MDBX_KEYEXIST) {
+                MDBX_val existing;
+                check_mdbx(mdbx_get(txn, m_dbi, &k, &existing),
+                           "LogicalDeliveryStore recovery marker read failed");
+                if (existing.iov_len != value.size() ||
+                    (value.size() != 0u &&
+                     std::memcmp(existing.iov_base, &value[0], value.size()) != 0)) {
+                    throw std::runtime_error(
+                        "LogicalDeliveryStore recovery marker mismatch");
+                }
+                return;
+            }
+            check_mdbx(rc, "LogicalDeliveryStore recovery marker write failed");
+        }
+
+        /// \brief Restores one exact replay-pruning watermark.
+        void restore_watermark(MDBX_txn* txn,
+                               const LogicalDeliveryWatermarkInfo& watermark) {
+            txn = checked_txn(txn,
+                              "LogicalDeliveryStore::restore_watermark");
+            if (is_zero_sync_id(watermark.origin_node_id) ||
+                watermark.sequence == 0u) {
+                throw std::invalid_argument(
+                    "LogicalDeliveryStore recovery watermark is invalid");
+            }
+            const std::uint64_t existing = read_watermark(
+                txn, watermark.origin_node_id);
+            if (existing != 0u && existing != watermark.sequence) {
+                throw std::runtime_error(
+                    "LogicalDeliveryStore recovery watermark mismatch");
+            }
+            if (existing == 0u) {
+                write_watermark(txn, watermark.origin_node_id,
+                                watermark.sequence);
+            }
         }
 
     private:
@@ -470,6 +575,21 @@ namespace sync {
             return key;
         }
 
+        static std::vector<std::uint8_t> make_marker_key(
+                const LogicalDeliveryMarkerInfo& marker) {
+            const std::vector<std::uint8_t> frame_id_digest =
+                make_frame_id_digest(marker.frame_id);
+            std::vector<std::uint8_t> key;
+            key.reserve(2u + marker.origin_node_id.size() + 8u +
+                        frame_id_digest.size());
+            detail::append_u16_le(key, marker_key_version());
+            key.insert(key.end(), marker.origin_node_id.begin(),
+                       marker.origin_node_id.end());
+            detail::append_u64_le(key, marker.origin_sequence);
+            key.insert(key.end(), frame_id_digest.begin(), frame_id_digest.end());
+            return key;
+        }
+
         static std::vector<std::uint8_t> make_marker_value(
                 const LogicalDeliveryEnvelope& envelope,
                 const CodecBounds* bounds) {
@@ -512,6 +632,54 @@ namespace sync {
                 out, static_cast<std::uint32_t>(frame_bytes.size()));
             out.insert(out.end(), frame_bytes.begin(), frame_bytes.end());
             return out;
+        }
+
+        static std::vector<std::uint8_t> make_marker_value(
+                const LogicalDeliveryMarkerInfo& marker) {
+            std::vector<std::uint8_t> out;
+            out.reserve(2u + marker.destination_db_uuid.size() +
+                        marker.origin_node_id.size() + 8u + 4u +
+                        marker.frame_id.size() + 2u + 4u +
+                        marker.encoded_frame.size());
+            detail::append_u16_le(out, marker_value_version());
+            out.insert(out.end(), marker.destination_db_uuid.begin(),
+                       marker.destination_db_uuid.end());
+            out.insert(out.end(), marker.origin_node_id.begin(),
+                       marker.origin_node_id.end());
+            detail::append_u64_le(out, marker.origin_sequence);
+            detail::append_u32_le(out,
+                static_cast<std::uint32_t>(marker.frame_id.size()));
+            out.insert(out.end(), marker.frame_id.begin(), marker.frame_id.end());
+            detail::append_u16_le(out, marker.frame_codec_version);
+            detail::append_u32_le(out,
+                static_cast<std::uint32_t>(marker.encoded_frame.size()));
+            out.insert(out.end(), marker.encoded_frame.begin(),
+                       marker.encoded_frame.end());
+            return out;
+        }
+
+        static void validate_recovery_marker(
+                const LogicalDeliveryMarkerInfo& marker,
+                const CodecBounds* bounds) {
+            if (is_zero_sync_id(marker.destination_db_uuid) ||
+                is_zero_sync_id(marker.origin_node_id) ||
+                marker.origin_sequence == 0u || marker.frame_id.empty() ||
+                marker.frame_codec_version !=
+                    LogicalChangeFrameCodec::codec_version() ||
+                marker.frame_bytes_size != marker.encoded_frame.size()) {
+                throw std::invalid_argument(
+                    "LogicalDeliveryStore recovery marker is invalid");
+            }
+            if (marker.frame_id.size() >
+                    static_cast<std::size_t>(
+                        (std::numeric_limits<std::uint32_t>::max)()) ||
+                marker.encoded_frame.size() >
+                    static_cast<std::size_t>(
+                        (std::numeric_limits<std::uint32_t>::max)())) {
+                throw std::length_error(
+                    "LogicalDeliveryStore recovery marker exceeds u32 bounds");
+            }
+            (void)LogicalChangeFrameCodec::decode(marker.encoded_frame, bounds);
         }
 
         static void assert_marker_value_matches(
@@ -686,7 +854,9 @@ namespace sync {
             out.frame_codec_version = read_marker_u16(cur);
             out.frame_bytes_size = read_marker_u32(cur);
             require_bytes(cur, out.frame_bytes_size,
-                          "LogicalDeliveryStore marker value underrun");
+                           "LogicalDeliveryStore marker value underrun");
+            out.encoded_frame.assign(cur.data + cur.pos,
+                                     cur.data + cur.pos + out.frame_bytes_size);
             cur.pos += out.frame_bytes_size;
             if (cur.pos != cur.size) {
                 throw std::runtime_error(

--- a/include/mdbx_containers/sync/logical/stores/SchemaRegistryStore.hpp
+++ b/include/mdbx_containers/sync/logical/stores/SchemaRegistryStore.hpp
@@ -188,15 +188,16 @@ namespace sync {
             return out;
         }
 
-        /// \brief Lists all schema markers with fully decoded records.
-        std::vector<LogicalSchemaRegistryEntry> list_entries(
-                MDBX_txn* txn) const {
-            txn = checked_txn(txn, "SchemaRegistryStore::list_entries");
+        /// \brief Visits all schema markers with fully decoded records.
+        /// \details The visitor runs while the MDBX cursor is open. It may
+        /// throw to stop enumeration without accumulating the remaining state.
+        template <typename Visitor>
+        void for_each_entry(MDBX_txn* txn, Visitor visitor) const {
+            txn = checked_txn(txn, "SchemaRegistryStore::for_each_entry");
             open_const(txn);
             MDBX_cursor* cursor = nullptr;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
                        "SchemaRegistryStore cursor open failed");
-            std::vector<LogicalSchemaRegistryEntry> out;
             try {
                 MDBX_val key;
                 MDBX_val value;
@@ -210,7 +211,7 @@ namespace sync {
                     const char* data = static_cast<const char*>(key.iov_base);
                     entry.schema_id.assign(data, data + key.iov_len);
                     decode_record(value, entry.schema_id, entry.record);
-                    out.push_back(entry);
+                    visitor(entry);
                     rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
                 }
                 if (rc != MDBX_NOTFOUND) {
@@ -221,6 +222,15 @@ namespace sync {
                 throw;
             }
             mdbx_cursor_close(cursor);
+        }
+
+        /// \brief Lists all schema markers with fully decoded records.
+        std::vector<LogicalSchemaRegistryEntry> list_entries(
+                MDBX_txn* txn) const {
+            std::vector<LogicalSchemaRegistryEntry> out;
+            for_each_entry(txn, [&out](const LogicalSchemaRegistryEntry& entry) {
+                out.push_back(entry);
+            });
             return out;
         }
 

--- a/include/mdbx_containers/sync/logical/stores/SchemaRegistryStore.hpp
+++ b/include/mdbx_containers/sync/logical/stores/SchemaRegistryStore.hpp
@@ -31,6 +31,12 @@ namespace sync {
         NodeId ordered_delivery_origin_node_id = make_zero_node();
     };
 
+    /// \brief One schema marker together with its stable schema id.
+    struct LogicalSchemaRegistryEntry {
+        std::string schema_id;
+        LogicalSchemaRecord record;
+    };
+
     /// \brief Thin wrapper around \c _mdbxc_sync_schema.
     /// \details Key = logical schema id string bytes. Value =
     /// \c LogicalSchemaRecord with length-prefixed UTF-8 strings.
@@ -169,6 +175,42 @@ namespace sync {
                     LogicalSchemaRecord decoded;
                     decode_record(value, schema_id, decoded);
                     out.push_back(schema_id);
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "SchemaRegistryStore cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return out;
+        }
+
+        /// \brief Lists all schema markers with fully decoded records.
+        std::vector<LogicalSchemaRegistryEntry> list_entries(
+                MDBX_txn* txn) const {
+            txn = checked_txn(txn, "SchemaRegistryStore::list_entries");
+            open_const(txn);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "SchemaRegistryStore cursor open failed");
+            std::vector<LogicalSchemaRegistryEntry> out;
+            try {
+                MDBX_val key;
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    if (key.iov_base == nullptr) {
+                        throw std::runtime_error(
+                            "SchemaRegistryStore schema id is null");
+                    }
+                    LogicalSchemaRegistryEntry entry;
+                    const char* data = static_cast<const char*>(key.iov_base);
+                    entry.schema_id.assign(data, data + key.iov_len);
+                    decode_record(value, entry.schema_id, entry.record);
+                    out.push_back(entry);
                     rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
                 }
                 if (rc != MDBX_NOTFOUND) {

--- a/include/mdbx_containers/sync/protocol/FullSnapshotProtocol.hpp
+++ b/include/mdbx_containers/sync/protocol/FullSnapshotProtocol.hpp
@@ -59,9 +59,11 @@ namespace sync {
     };
 
     /// \brief Receiver-side bounds for one staged full snapshot import.
-    /// \details The initial importer keeps pages only in process memory until
-    /// the final page. These bounds prevent a peer from accumulating an
-    /// unbounded replacement plan before the one atomic destination commit.
+    /// \details The importer keeps pages only in process memory until the
+    /// final page. These bounds prevent a peer from accumulating an unbounded
+    /// replacement plan before the one atomic destination commit. Logical-aware
+    /// recovery spends the same budget on its final logical baseline, including
+    /// schema, replay, ordering, and pending-delivery records.
     struct FullSnapshotImportOptions {
         std::uint64_t max_staged_operations = 1000000u;
         std::uint64_t max_staged_bytes =

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -2982,6 +2982,184 @@ void test_engine_recovers_logical_baseline_atomically() {
     cleanup(rejected_path);
 }
 
+void test_engine_recovery_preserves_global_origin_sequence_across_receiver_cutover() {
+    using namespace mdbxc;
+    const std::string source_path = "test_engine_global_sequence_source.mdbx";
+    const std::string receiver_path = "test_engine_global_sequence_receiver.mdbx";
+    const std::string recovered_path = "test_engine_global_sequence_recovered.mdbx";
+    cleanup(source_path);
+    cleanup(receiver_path);
+    cleanup(recovered_path);
+
+    const sync::NodeId source_node = make_node(0x93);
+    const sync::NodeId receiver_node = make_node(0xA3);
+    const sync::NodeId recovered_node = make_node(0xB3);
+    const sync::DbId db_id = make_node(0xD3);
+    sync::FullSnapshotExportOptions recovery_options;
+    recovery_options.replacement_scope =
+        sync::FullSnapshotScope::CompleteUserDatabase;
+    recovery_options.max_materialized_operations = 32u;
+    recovery_options.max_materialized_bytes = 8192u;
+
+    std::shared_ptr<Connection> source_conn = open_env(source_path);
+    std::shared_ptr<Connection> receiver_conn = open_env(receiver_path);
+    std::shared_ptr<Connection> recovered_conn = open_env(recovered_path);
+    sync::SyncEngine source(source_conn);
+    sync::SyncEngine receiver(
+        receiver_conn, sync::ConflictPolicy::Reject, recovery_options);
+    sync::SyncEngine recovered(recovered_conn);
+    source.initialize_local_identity(source_node, db_id);
+    receiver.initialize_local_identity(receiver_node, db_id);
+    recovered.initialize_local_identity(recovered_node, db_id);
+    KeyValueTable<std::string, std::string> receiver_documents(
+        receiver_conn, "documents");
+    receiver_documents.insert_or_assign("baseline", "value");
+
+    const sync::LogicalChangeFrame frame;
+    const sync::LogicalDeliveryEnvelope first = source.enqueue_logical_delivery(
+        db_id, receiver_node, frame);
+    const sync::LogicalDeliveryEnvelope second = source.enqueue_logical_delivery(
+        db_id, receiver_node, frame);
+    if (first.origin_sequence != 1u || second.origin_sequence != 2u) {
+        throw std::runtime_error("source did not allocate global initial sequence");
+    }
+    sync::DirectLogicalDeliveryPeer receiver_peer(receiver);
+    const sync::LogicalDeliveryDispatchResult delivered_to_receiver =
+        source.deliver_pending_logical_deliveries(
+            receiver_peer, db_id, receiver_node);
+    if (!delivered_to_receiver.ok || delivered_to_receiver.delivered != 2u) {
+        throw std::runtime_error("source did not establish receiver frontier");
+    }
+
+    sync::LogicalRecoveryRequest request;
+    request.requester = recovered_node;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    const sync::LogicalRecoveryResponse response =
+        receiver.handle_logical_recovery(request);
+    if (!response.ok || response.has_more || !response.has_baseline ||
+        !recovered.apply_logical_recovery_chunk(
+            response.snapshot_chunk, &response.baseline).completed) {
+        throw std::runtime_error("logical recovery did not import receiver frontier");
+    }
+    {
+        auto txn = recovered_conn->transaction(TransactionMode::READ_ONLY);
+        sync::LogicalDeliveryOrderStore order(recovered_conn->env_handle());
+        if (order.last_applied(txn.handle(), source_node) != 2u) {
+            throw std::runtime_error("recovery did not preserve source frontier");
+        }
+    }
+
+    const sync::LogicalDeliveryEnvelope after_cutover =
+        source.enqueue_logical_delivery(db_id, recovered_node, frame);
+    if (after_cutover.origin_sequence != 3u) {
+        throw std::runtime_error(
+            "receiver cutover reallocated the origin event sequence");
+    }
+    sync::DirectLogicalDeliveryPeer recovered_peer(recovered);
+    const sync::LogicalDeliveryDispatchResult delivered_to_recovered =
+        source.deliver_pending_logical_deliveries(
+            recovered_peer, db_id, recovered_node);
+    if (!delivered_to_recovered.ok || delivered_to_recovered.delivered != 1u ||
+        !source.pending_logical_deliveries(db_id, recovered_node).empty()) {
+        throw std::runtime_error(
+            "recovered receiver rejected the next global origin event");
+    }
+    {
+        auto txn = recovered_conn->transaction(TransactionMode::READ_ONLY);
+        sync::LogicalDeliveryOrderStore order(recovered_conn->env_handle());
+        if (order.last_applied(txn.handle(), source_node) != 3u) {
+            throw std::runtime_error("recovered receiver did not advance frontier");
+        }
+    }
+
+    source_conn->disconnect();
+    receiver_conn->disconnect();
+    recovered_conn->disconnect();
+    cleanup(source_path);
+    cleanup(receiver_path);
+    cleanup(recovered_path);
+}
+
+void test_engine_recovery_counts_fixed_logical_baseline_records_in_byte_budget() {
+    using namespace mdbxc;
+    const std::string source_path =
+        "test_engine_logical_recovery_fixed_record_budget.mdbx";
+    const std::string receiver_path =
+        "test_engine_logical_recovery_fixed_record_budget_receiver.mdbx";
+    cleanup(source_path);
+    cleanup(receiver_path);
+
+    const sync::NodeId source_node = make_node(0x94);
+    const sync::NodeId requester_node = make_node(0xA4);
+    const sync::NodeId receiver_node = make_node(0xB4);
+    const sync::DbId db_id = make_node(0xD4);
+    sync::FullSnapshotExportOptions options;
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
+    options.max_materialized_operations = 64u;
+    options.max_materialized_bytes = 4096u;
+
+    std::shared_ptr<Connection> source_conn = open_env(source_path);
+    std::shared_ptr<Connection> receiver_conn = open_env(receiver_path);
+    sync::SyncEngine source(source_conn, sync::ConflictPolicy::Reject, options);
+    sync::SyncEngine receiver(receiver_conn);
+    source.initialize_local_identity(source_node, db_id);
+    receiver.initialize_local_identity(receiver_node, db_id);
+    KeyValueTable<std::string, std::string> documents(source_conn, "documents");
+    documents.insert_or_assign("document", "value");
+    {
+        auto txn = source_conn->transaction(TransactionMode::WRITABLE);
+        sync::LogicalDeliveryOrderStore order(source_conn->env_handle());
+        for (std::uint8_t i = 0u; i < 32u; ++i) {
+            order.advance(txn.handle(),
+                          make_node(static_cast<std::uint8_t>(0x40u + i)), 1u);
+        }
+        txn.commit();
+    }
+
+    sync::LogicalRecoveryRequest request;
+    request.requester = requester_node;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    const sync::LogicalRecoveryResponse response =
+        source.handle_logical_recovery(request);
+    if (!response.ok || !response.has_baseline) {
+        throw std::runtime_error(
+            "logical recovery did not materialize frontier-only baseline");
+    }
+
+    sync::FullSnapshotImportOptions import_options;
+    import_options.max_staged_operations = 64u;
+    import_options.max_staged_bytes = 512u;
+    receiver.set_full_snapshot_import_options(import_options);
+    bool rejected_receiver_import = false;
+    try {
+        (void)receiver.apply_logical_recovery_chunk(
+            response.snapshot_chunk, &response.baseline);
+    } catch (const std::length_error&) {
+        rejected_receiver_import = true;
+    }
+    if (!rejected_receiver_import) {
+        throw std::runtime_error(
+            "logical recovery receiver omitted fixed frontier records from byte budget");
+    }
+
+    options.max_materialized_bytes = 512u;
+    source.set_full_snapshot_export_options(options);
+    const sync::LogicalRecoveryResponse bounded_response =
+        source.handle_logical_recovery(request);
+    if (bounded_response.ok || bounded_response.error_code !=
+            sync::SyncResponseErrorCode::BatchTooLarge) {
+        throw std::runtime_error(
+            "logical recovery omitted fixed frontier records from byte budget");
+    }
+
+    source_conn->disconnect();
+    receiver_conn->disconnect();
+    cleanup(source_path);
+    cleanup(receiver_path);
+}
+
 void test_engine_cancels_direct_logical_recovery_materialization() {
     using namespace mdbxc;
     const std::string source_path =
@@ -3688,6 +3866,10 @@ int main() {
           &test_engine_full_snapshot_import_rejects_invalid_replacement_plan },
         { "test_engine_recovers_logical_baseline_atomically",
           &test_engine_recovers_logical_baseline_atomically },
+        { "test_engine_recovery_preserves_global_origin_sequence_across_receiver_cutover",
+          &test_engine_recovery_preserves_global_origin_sequence_across_receiver_cutover },
+        { "test_engine_recovery_counts_fixed_logical_baseline_records_in_byte_budget",
+          &test_engine_recovery_counts_fixed_logical_baseline_records_in_byte_budget },
         { "test_engine_cancels_direct_logical_recovery_materialization",
           &test_engine_cancels_direct_logical_recovery_materialization },
         { "test_engine_changelog_page_rejects_full_snapshot_request",

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -2843,7 +2843,7 @@ void test_engine_recovers_logical_baseline_atomically() {
             source_adapter.begin_capture_session();
         session->insert_or_assign("first", "one");
         const sync::LogicalDeliveryEnvelope envelope =
-            session->commit_to_outbox(source, db_id);
+            session->commit_to_outbox(source, db_id, replica_node);
         if (envelope.origin_sequence != 1u) {
             throw std::runtime_error("logical recovery source did not enqueue sequence one");
         }
@@ -2871,6 +2871,28 @@ void test_engine_recovers_logical_baseline_atomically() {
         throw std::runtime_error("logical recovery source did not return final baseline");
     }
 
+    sync::FullSnapshotExportOptions exact_budget = options;
+    exact_budget.max_materialized_operations = 4u;
+    source.set_full_snapshot_export_options(exact_budget);
+    const sync::LogicalRecoveryResponse exact_budget_response =
+        source.handle_logical_recovery(request);
+    if (!exact_budget_response.ok || !exact_budget_response.has_baseline) {
+        throw std::runtime_error(
+            "logical recovery exact combined materialization budget was rejected");
+    }
+    sync::FullSnapshotExportOptions insufficient_budget = exact_budget;
+    insufficient_budget.max_materialized_operations = 3u;
+    source.set_full_snapshot_export_options(insufficient_budget);
+    const sync::LogicalRecoveryResponse insufficient_budget_response =
+        source.handle_logical_recovery(request);
+    if (insufficient_budget_response.ok ||
+        insufficient_budget_response.error_code !=
+            sync::SyncResponseErrorCode::BatchTooLarge) {
+        throw std::runtime_error(
+            "logical recovery accepted an insufficient combined materialization budget");
+    }
+    source.set_full_snapshot_export_options(options);
+
     sync::LogicalRecoveryBaseline malformed = response.baseline;
     malformed.source_db_uuid = make_node(0xE1);
     bool rejected_baseline = false;
@@ -2884,6 +2906,38 @@ void test_engine_recovers_logical_baseline_atomically() {
                                      std::string("first"))) {
         throw std::runtime_error(
             "malformed logical recovery baseline mutated destination state");
+    }
+
+    sync::LogicalRecoveryBaseline truncated = response.baseline;
+    truncated.source_outbox_known_tail = 2u;
+    bool rejected_truncated_suffix = false;
+    try {
+        (void)rejected.apply_logical_recovery_chunk(
+            response.snapshot_chunk, &truncated);
+    } catch (const std::invalid_argument&) {
+        rejected_truncated_suffix = true;
+    }
+    if (!rejected_truncated_suffix || kv_has(rejected_conn, rejected_documents,
+                                              std::string("first"))) {
+        throw std::runtime_error(
+            "truncated logical recovery suffix mutated destination state");
+    }
+
+    sync::FullSnapshotImportOptions import_limits;
+    import_limits.max_staged_operations = 2u;
+    import_limits.max_staged_bytes = 8192u;
+    rejected.set_full_snapshot_import_options(import_limits);
+    bool rejected_import_budget = false;
+    try {
+        (void)rejected.apply_logical_recovery_chunk(
+            response.snapshot_chunk, &response.baseline);
+    } catch (const std::length_error&) {
+        rejected_import_budget = true;
+    }
+    if (!rejected_import_budget || kv_has(rejected_conn, rejected_documents,
+                                          std::string("first"))) {
+        throw std::runtime_error(
+            "logical recovery baseline exceeded import budget after mutation");
     }
 
     if (!replica.apply_logical_recovery_chunk(
@@ -2907,12 +2961,13 @@ void test_engine_recovers_logical_baseline_atomically() {
         std::unique_ptr<LogicalAdapter::LogicalCaptureSession> session =
             source_adapter.begin_capture_session();
         session->insert_or_assign("second", "two");
-        (void)session->commit_to_outbox(source, db_id);
+        (void)session->commit_to_outbox(source, db_id, replica_node);
     }
     sync::DirectSyncPeer peer(&replica);
     const sync::LogicalDeliveryDispatchResult dispatched =
-        source.deliver_pending_logical_deliveries(peer, db_id);
-    if (!dispatched.ok || !source.pending_logical_deliveries(db_id).empty() ||
+        source.deliver_pending_logical_deliveries(peer, db_id, replica_node);
+    if (!dispatched.ok || !source.pending_logical_deliveries(
+            db_id, replica_node).empty() ||
         kv_or_throw(replica_conn, replica_documents, std::string("second"),
                     "logical recovery continued delivery") != "two") {
         throw std::runtime_error(
@@ -2925,6 +2980,58 @@ void test_engine_recovers_logical_baseline_atomically() {
     cleanup(source_path);
     cleanup(replica_path);
     cleanup(rejected_path);
+}
+
+void test_engine_cancels_direct_logical_recovery_materialization() {
+    using namespace mdbxc;
+    const std::string source_path =
+        "test_engine_cancel_direct_logical_recovery_source.mdbx";
+    cleanup(source_path);
+
+    const sync::NodeId source_node = make_node(0x92);
+    const sync::NodeId replica_node = make_node(0xA2);
+    const sync::DbId db_id = make_node(0xD2);
+    sync::FullSnapshotExportOptions options;
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
+    options.max_materialized_operations = 15000u;
+    options.max_materialized_bytes = 128ULL * 1024ULL * 1024ULL;
+
+    std::shared_ptr<Connection> source_conn = open_env(source_path);
+    sync::SyncEngine source(source_conn, sync::ConflictPolicy::Reject, options);
+    source.initialize_local_identity(source_node, db_id);
+    KeyValueTable<int, std::string> documents(source_conn, "documents");
+    const std::string payload(4096u, 'x');
+    {
+        auto txn = source_conn->transaction(TransactionMode::WRITABLE);
+        for (int i = 0; i < 10000; ++i) {
+            documents.insert_or_assign(i, payload, txn.handle());
+        }
+        txn.commit();
+    }
+
+    sync::DirectSyncPeer peer(&source);
+    sync::LogicalRecoveryRequest request;
+    request.requester = replica_node;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    sync::CancellationSource cancellation;
+    const sync::CancellationToken cancellation_token = cancellation.token();
+    sync::LogicalRecoveryResponse response;
+    std::thread recovery([&peer, &request, &cancellation_token, &response]() {
+        response = peer.logical_recovery_with_cancel(
+            request, &cancellation_token);
+    });
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    cancellation.request_cancel();
+    recovery.join();
+    if (response.ok || !response.error_retryable ||
+        response.error.find("cancelled") == std::string::npos) {
+        throw std::runtime_error(
+            "direct logical recovery did not stop materialization after cancellation");
+    }
+
+    source_conn->disconnect();
+    cleanup(source_path);
 }
 
 void test_engine_changelog_page_rejects_full_snapshot_request() {
@@ -3581,6 +3688,8 @@ int main() {
           &test_engine_full_snapshot_import_rejects_invalid_replacement_plan },
         { "test_engine_recovers_logical_baseline_atomically",
           &test_engine_recovers_logical_baseline_atomically },
+        { "test_engine_cancels_direct_logical_recovery_materialization",
+          &test_engine_cancels_direct_logical_recovery_materialization },
         { "test_engine_changelog_page_rejects_full_snapshot_request",
           &test_engine_changelog_page_rejects_full_snapshot_request },
         { "test_engine_pull_reports_snapshot_required_after_prune",

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -2786,6 +2786,147 @@ void test_engine_full_snapshot_import_rejects_invalid_replacement_plan() {
     cleanup(p);
 }
 
+void test_engine_recovers_logical_baseline_atomically() {
+    using namespace mdbxc;
+    typedef sync::KeyValueLogicalStringCodec<std::string> StringCodec;
+    typedef sync::KeyValueTableLogicalAdapter<
+        std::string, std::string, StringCodec, StringCodec> LogicalAdapter;
+
+    const std::string source_path = "test_engine_logical_recovery_source.mdbx";
+    const std::string replica_path = "test_engine_logical_recovery_replica.mdbx";
+    const std::string rejected_path = "test_engine_logical_recovery_rejected.mdbx";
+    const std::string schema_id = "app.logical_recovery.key_value.v1";
+    cleanup(source_path);
+    cleanup(replica_path);
+    cleanup(rejected_path);
+
+    const sync::NodeId source_node = make_node(0x91);
+    const sync::NodeId replica_node = make_node(0xA1);
+    const sync::NodeId rejected_node = make_node(0xB1);
+    const sync::DbId db_id = make_node(0xD1);
+    sync::FullSnapshotExportOptions options;
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
+    options.max_materialized_operations = 32u;
+    options.max_materialized_bytes = 8192u;
+
+    std::shared_ptr<Connection> source_conn = open_env(source_path);
+    std::shared_ptr<Connection> replica_conn = open_env(replica_path);
+    std::shared_ptr<Connection> rejected_conn = open_env(rejected_path);
+    sync::SyncEngine source(source_conn, sync::ConflictPolicy::Reject, options);
+    sync::SyncEngine replica(replica_conn);
+    sync::SyncEngine rejected(rejected_conn);
+    source.initialize_local_identity(source_node, db_id);
+    replica.initialize_local_identity(replica_node, db_id);
+    rejected.initialize_local_identity(rejected_node, db_id);
+
+    KeyValueTable<std::string, std::string> source_documents(
+        source_conn, "documents");
+    KeyValueTable<std::string, std::string> replica_documents(
+        replica_conn, "documents");
+    KeyValueTable<std::string, std::string> rejected_documents(
+        rejected_conn, "documents");
+    LogicalAdapter source_adapter(source_documents, schema_id);
+    LogicalAdapter replica_adapter(replica_documents, schema_id);
+    LogicalAdapter rejected_adapter(rejected_documents, schema_id);
+    sync::LogicalSchemaRecord record;
+    record.dbi_name = "documents";
+    record.kind = sync::LogicalTableKind::KeyValue;
+    record.schema_version = 1u;
+    record.dbi_names.push_back("documents");
+    source.initialize_logical_adapter_schema(source_adapter, record);
+    source.register_logical_adapter(source_adapter);
+    replica.register_logical_adapter(replica_adapter);
+    rejected.register_logical_adapter(rejected_adapter);
+
+    {
+        std::unique_ptr<LogicalAdapter::LogicalCaptureSession> session =
+            source_adapter.begin_capture_session();
+        session->insert_or_assign("first", "one");
+        const sync::LogicalDeliveryEnvelope envelope =
+            session->commit_to_outbox(source, db_id);
+        if (envelope.origin_sequence != 1u) {
+            throw std::runtime_error("logical recovery source did not enqueue sequence one");
+        }
+    }
+
+    sync::PullRequest raw_request;
+    raw_request.requester = replica_node;
+    raw_request.db_id = db_id;
+    raw_request.request_full_snapshot = true;
+    raw_request.max_bytes = 8192u;
+    raw_request.max_single_batch_bytes = 8192u;
+    const sync::PullResponse raw_rejected = source.handle_pull(raw_request);
+    if (raw_rejected.ok || raw_rejected.error_code !=
+            sync::SyncResponseErrorCode::SnapshotLogicalStateUnsupported) {
+        throw std::runtime_error("logical recovery relaxed the raw snapshot guard");
+    }
+
+    sync::LogicalRecoveryRequest request;
+    request.requester = replica_node;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    const sync::LogicalRecoveryResponse response =
+        source.handle_logical_recovery(request);
+    if (!response.ok || response.has_more || !response.has_baseline) {
+        throw std::runtime_error("logical recovery source did not return final baseline");
+    }
+
+    sync::LogicalRecoveryBaseline malformed = response.baseline;
+    malformed.source_db_uuid = make_node(0xE1);
+    bool rejected_baseline = false;
+    try {
+        (void)rejected.apply_logical_recovery_chunk(
+            response.snapshot_chunk, &malformed);
+    } catch (const std::invalid_argument&) {
+        rejected_baseline = true;
+    }
+    if (!rejected_baseline || kv_has(rejected_conn, rejected_documents,
+                                     std::string("first"))) {
+        throw std::runtime_error(
+            "malformed logical recovery baseline mutated destination state");
+    }
+
+    if (!replica.apply_logical_recovery_chunk(
+            response.snapshot_chunk, &response.baseline).completed ||
+        kv_or_throw(replica_conn, replica_documents, std::string("first"),
+                    "logical recovery first value") != "one") {
+        throw std::runtime_error("logical recovery did not import physical state");
+    }
+    {
+        auto txn = replica_conn->transaction(TransactionMode::READ_ONLY);
+        sync::SchemaRegistryStore schemas(replica_conn->env_handle());
+        sync::LogicalDeliveryOrderStore order(replica_conn->env_handle());
+        if (!schemas.has_entries(txn.handle()) ||
+            order.last_applied(txn.handle(), source_node) != 1u) {
+            throw std::runtime_error(
+                "logical recovery did not restore schema or outbox frontier");
+        }
+    }
+
+    {
+        std::unique_ptr<LogicalAdapter::LogicalCaptureSession> session =
+            source_adapter.begin_capture_session();
+        session->insert_or_assign("second", "two");
+        (void)session->commit_to_outbox(source, db_id);
+    }
+    sync::DirectSyncPeer peer(&replica);
+    const sync::LogicalDeliveryDispatchResult dispatched =
+        source.deliver_pending_logical_deliveries(peer, db_id);
+    if (!dispatched.ok || !source.pending_logical_deliveries(db_id).empty() ||
+        kv_or_throw(replica_conn, replica_documents, std::string("second"),
+                    "logical recovery continued delivery") != "two") {
+        throw std::runtime_error(
+            "logical recovery did not continue ordered delivery after baseline");
+    }
+
+    source_conn->disconnect();
+    replica_conn->disconnect();
+    rejected_conn->disconnect();
+    cleanup(source_path);
+    cleanup(replica_path);
+    cleanup(rejected_path);
+}
+
 void test_engine_changelog_page_rejects_full_snapshot_request() {
     using namespace mdbxc;
     const std::string p = "test_engine_changelog_full_snapshot_request.mdbx";
@@ -3438,6 +3579,8 @@ int main() {
           &test_engine_full_snapshot_import_bounds_fail_closed },
         { "test_engine_full_snapshot_import_rejects_invalid_replacement_plan",
           &test_engine_full_snapshot_import_rejects_invalid_replacement_plan },
+        { "test_engine_recovers_logical_baseline_atomically",
+          &test_engine_recovers_logical_baseline_atomically },
         { "test_engine_changelog_page_rejects_full_snapshot_request",
           &test_engine_changelog_page_rejects_full_snapshot_request },
         { "test_engine_pull_reports_snapshot_required_after_prune",

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -3195,13 +3195,38 @@ void test_engine_cancels_direct_logical_recovery_materialization() {
     sync::CancellationSource cancellation;
     const sync::CancellationToken cancellation_token = cancellation.token();
     sync::LogicalRecoveryResponse response;
+    std::mutex checkpoint_mutex;
+    std::condition_variable checkpoint_condition;
+    bool checkpoint_entered = false;
+    bool checkpoint_released = false;
+    source.set_logical_recovery_materialization_checkpoint_for_testing(
+        [&checkpoint_mutex, &checkpoint_condition, &checkpoint_entered,
+         &checkpoint_released]() {
+            std::unique_lock<std::mutex> lock(checkpoint_mutex);
+            checkpoint_entered = true;
+            checkpoint_condition.notify_one();
+            checkpoint_condition.wait(lock, [&checkpoint_released]() {
+                return checkpoint_released;
+            });
+        });
     std::thread recovery([&peer, &request, &cancellation_token, &response]() {
         response = peer.logical_recovery_with_cancel(
             request, &cancellation_token);
     });
-    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    {
+        std::unique_lock<std::mutex> lock(checkpoint_mutex);
+        checkpoint_condition.wait(lock, [&checkpoint_entered]() {
+            return checkpoint_entered;
+        });
+    }
     cancellation.request_cancel();
+    {
+        std::lock_guard<std::mutex> lock(checkpoint_mutex);
+        checkpoint_released = true;
+    }
+    checkpoint_condition.notify_one();
     recovery.join();
+    source.clear_logical_recovery_materialization_checkpoint_for_testing();
     if (response.ok || !response.error_retryable ||
         response.error.find("cancelled") == std::string::npos) {
         throw std::runtime_error(

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -3103,7 +3103,7 @@ void test_worker_recovers_logical_fresh_replica() {
         std::unique_ptr<LogicalAdapter::LogicalCaptureSession> session =
             source_adapter.begin_capture_session();
         session->insert_or_assign("recovered", "value");
-        (void)session->commit_to_outbox(source, db_id);
+        (void)session->commit_to_outbox(source, db_id, replica_node);
     }
 
     SnapshotRequiredLogicalRecoveryPeer peer(source);

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -266,6 +266,40 @@ private:
     mdbxc::sync::DbId m_db_id;
 };
 
+class SnapshotRequiredLogicalRecoveryPeer : public mdbxc::sync::ISyncPeer {
+public:
+    explicit SnapshotRequiredLogicalRecoveryPeer(mdbxc::sync::SyncEngine& remote)
+        : m_remote(remote) {}
+
+    mdbxc::sync::PullResponse pull(
+            const mdbxc::sync::PullRequest& request) override {
+        (void)request;
+        mdbxc::sync::PullResponse out;
+        out.ok = false;
+        out.error = "retained raw history is unavailable";
+        out.error_code = mdbxc::sync::SyncResponseErrorCode::SnapshotRequired;
+        return out;
+    }
+
+    mdbxc::sync::PushResponse push(
+            const mdbxc::sync::PushRequest& request) override {
+        (void)request;
+        return mdbxc::sync::PushResponse();
+    }
+
+    bool supports_logical_recovery() const override {
+        return true;
+    }
+
+    mdbxc::sync::LogicalRecoveryResponse logical_recovery(
+            const mdbxc::sync::LogicalRecoveryRequest& request) override {
+        return m_remote.handle_logical_recovery(request);
+    }
+
+private:
+    mdbxc::sync::SyncEngine& m_remote;
+};
+
 class BlockingPeer : public mdbxc::sync::ISyncPeer {
 public:
     explicit BlockingPeer(const mdbxc::sync::PullResponse& response)
@@ -3022,6 +3056,84 @@ void test_worker_preserves_outbox_after_unavailable_or_retryable_logical_deliver
     cleanup(source_path);
 }
 
+void test_worker_recovers_logical_fresh_replica() {
+    using namespace mdbxc;
+    typedef sync::KeyValueLogicalStringCodec<std::string> StringCodec;
+    typedef sync::KeyValueTableLogicalAdapter<
+        std::string, std::string, StringCodec, StringCodec> LogicalAdapter;
+
+    const std::string source_path = "test_worker_logical_recovery_source.mdbx";
+    const std::string replica_path = "test_worker_logical_recovery_replica.mdbx";
+    const std::string schema_id = "app.worker.logical_recovery.v1";
+    cleanup(source_path);
+    cleanup(replica_path);
+
+    const sync::NodeId source_node = make_node(0xAF);
+    const sync::NodeId replica_node = make_node(0xBF);
+    const sync::DbId db_id = make_node(0xDF);
+    sync::FullSnapshotExportOptions snapshot_options;
+    snapshot_options.replacement_scope =
+        sync::FullSnapshotScope::CompleteUserDatabase;
+    snapshot_options.max_materialized_operations = 32u;
+    snapshot_options.max_materialized_bytes = 8192u;
+
+    std::shared_ptr<Connection> source_conn = open_env(source_path);
+    std::shared_ptr<Connection> replica_conn = open_env(replica_path);
+    sync::SyncEngine source(
+        source_conn, sync::ConflictPolicy::Reject, snapshot_options);
+    sync::SyncEngine replica(replica_conn);
+    source.initialize_local_identity(source_node, db_id);
+    replica.initialize_local_identity(replica_node, db_id);
+
+    KeyValueTable<std::string, std::string> source_documents(
+        source_conn, "documents");
+    KeyValueTable<std::string, std::string> replica_documents(
+        replica_conn, "documents");
+    LogicalAdapter source_adapter(source_documents, schema_id);
+    LogicalAdapter replica_adapter(replica_documents, schema_id);
+    sync::LogicalSchemaRecord record;
+    record.dbi_name = "documents";
+    record.kind = sync::LogicalTableKind::KeyValue;
+    record.schema_version = 1u;
+    record.dbi_names.push_back("documents");
+    source.initialize_logical_adapter_schema(source_adapter, record);
+    source.register_logical_adapter(source_adapter);
+    replica.register_logical_adapter(replica_adapter);
+    {
+        std::unique_ptr<LogicalAdapter::LogicalCaptureSession> session =
+            source_adapter.begin_capture_session();
+        session->insert_or_assign("recovered", "value");
+        (void)session->commit_to_outbox(source, db_id);
+    }
+
+    SnapshotRequiredLogicalRecoveryPeer peer(source);
+    sync::SyncWorkerOptions options;
+    options.enable_logical_recovery_fallback = true;
+    options.max_bytes = 8192u;
+    options.max_single_batch_bytes = 8192u;
+    sync::SyncWorker worker(replica, peer, options);
+    const sync::SyncWorkerRoundResult result = worker.run_once();
+    if (!result.ok || result.pages_pulled != 1u ||
+        kv_or_throw(replica_conn, replica_documents, std::string("recovered"),
+                    "worker logical recovery value") != "value") {
+        throw std::runtime_error(
+            "worker did not recover a logical fresh replica");
+    }
+    {
+        auto txn = replica_conn->transaction(TransactionMode::READ_ONLY);
+        sync::LogicalDeliveryOrderStore order(replica_conn->env_handle());
+        if (order.last_applied(txn.handle(), source_node) != 1u) {
+            throw std::runtime_error(
+                "worker logical recovery did not restore sender frontier");
+        }
+    }
+
+    source_conn->disconnect();
+    replica_conn->disconnect();
+    cleanup(source_path);
+    cleanup(replica_path);
+}
+
 void test_worker_rejects_logical_complete_snapshot_fallback() {
     using namespace mdbxc;
     const std::string source_path = "test_worker_logical_snapshot_source.mdbx";
@@ -3118,6 +3230,8 @@ int main() {
           &test_worker_allows_raw_only_peer_when_logical_outbox_is_empty },
         { "test_worker_preserves_outbox_after_unavailable_or_retryable_logical_delivery",
           &test_worker_preserves_outbox_after_unavailable_or_retryable_logical_delivery },
+        { "test_worker_recovers_logical_fresh_replica",
+          &test_worker_recovers_logical_fresh_replica },
         { "test_worker_rejects_logical_complete_snapshot_fallback",
           &test_worker_rejects_logical_complete_snapshot_fallback },
         { "test_worker_run_once_drains_paginated_pull",


### PR DESCRIPTION
## Summary
- add a separate logical-recovery peer contract and DirectSyncPeer implementation
- atomically import logical schema, replay, ordered-frontier, and source-outbox recovery state with the final physical snapshot page
- add opt-in SyncWorker fallback while preserving the raw CompleteUserDatabase fail-closed guard

## Verification
- C++17: header_sync_umbrella_test, test_sync_engine, test_sync_worker
- C++11: header_sync_umbrella_test, test_sync_engine, test_sync_worker

## Scope
HTTP and WebSocket remain intentionally incapable of logical recovery until a separate wire binding is added.