### PR TITLE
fix(sync): account logical recovery container storage

### DIFF
--- a/docs/sync-recovery-RU.md
+++ b/docs/sync-recovery-RU.md
@@ -114,12 +114,16 @@ replay acknowledgement, а не второе изменение; следующ�
 применяется обычно. Повреждённый baseline, отсутствующий adapter или не fresh
 logical state получателя откатывают final transaction.
 
-Source materialization bounds покрывают и physical snapshot operations, и
-fixed/variable footprint logical baseline records. Receiver применяет тот же
-combined bound к staged physical pages и final baseline до открытия destination
-write transaction. `LogicalRecoveryPeer` принимает cooperative cancellation
-token для recovery call; cancellation даёт retryable response и отбрасывает
-неопубликованную source session. Этот контракт поддерживает `DirectSyncPeer`.
+Source materialization bounds покрывают physical snapshot operations и
+учитываемое logical-baseline representation: fixed records, dynamic container
+elements и serialized variable payloads. Receiver применяет тот же combined
+bound к staged physical pages и final baseline до открытия destination write
+transaction. Это structural materialization accounting limit, а не гарантированный
+process-heap ceiling: allocator overhead, container capacities и temporary
+copies зависят от реализации. `LogicalRecoveryPeer` принимает cooperative
+cancellation token для recovery call; cancellation даёт retryable response и
+отбрасывает неопубликованную source session. Этот контракт поддерживает
+`DirectSyncPeer`.
 
 ## Процедура оператора
 

--- a/docs/sync-recovery.md
+++ b/docs/sync-recovery.md
@@ -115,13 +115,16 @@ a replay acknowledgement rather than a second mutation; the next source
 sequence then applies normally. A malformed baseline, missing adapter, or
 non-fresh logical receiver state aborts the final transaction.
 
-The source's materialization bounds cover both physical snapshot operations and
-the fixed and variable footprint of logical baseline records. The receiver
-applies the same combined bound to its staged physical pages and final baseline
-before opening the destination write transaction. `LogicalRecoveryPeer` accepts
-cooperative cancellation for a recovery call; cancellation produces a retryable
-response and discards the unpublished source session. `DirectSyncPeer`
-implements this contract.
+The source's materialization bounds cover physical snapshot operations and the
+accounted logical-baseline representation: fixed records, dynamic container
+elements, and serialized variable payloads. The receiver applies the same
+combined bound to its staged physical pages and final baseline before opening
+the destination write transaction. This is a structural materialization
+accounting limit, not a guaranteed process-heap ceiling: allocator overhead,
+container capacities, and temporary copies remain implementation-dependent.
+`LogicalRecoveryPeer` accepts cooperative cancellation for a recovery call;
+cancellation produces a retryable response and discards the unpublished source
+session. `DirectSyncPeer` implements this contract.
 
 ## Operator Procedure
 

--- a/include/mdbx_containers/sync/engine/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/engine/SyncEngine.hpp
@@ -1822,11 +1822,37 @@ namespace sync {
             total += static_cast<std::uint64_t>(additional);
         }
 
+        static void add_logical_recovery_baseline_element_bytes(
+                std::uint64_t& total,
+                std::size_t count,
+                std::size_t element_size) {
+            const std::uint64_t max =
+                (std::numeric_limits<std::uint64_t>::max)();
+            const std::uint64_t element_count =
+                static_cast<std::uint64_t>(count);
+            const std::uint64_t bytes_per_element =
+                static_cast<std::uint64_t>(element_size);
+            if (bytes_per_element != 0u &&
+                element_count > max / bytes_per_element) {
+                throw std::length_error(
+                    "logical recovery baseline size overflow");
+            }
+            const std::uint64_t additional =
+                element_count * bytes_per_element;
+            if (total > max - additional) {
+                throw std::length_error(
+                    "logical recovery baseline size overflow");
+            }
+            total += additional;
+        }
+
         static std::uint64_t logical_recovery_schema_bytes(
                 const LogicalSchemaRegistryEntry& entry) {
             std::uint64_t bytes = 0u;
             add_logical_recovery_baseline_bytes(bytes,
                                                 sizeof(LogicalSchemaRegistryEntry));
+            add_logical_recovery_baseline_element_bytes(bytes,
+                entry.record.dbi_names.size(), sizeof(std::string));
             add_logical_recovery_baseline_bytes(bytes, entry.schema_id.size());
             add_logical_recovery_baseline_bytes(bytes,
                                                 entry.record.dbi_name.size());
@@ -1855,6 +1881,8 @@ namespace sync {
             std::uint64_t bytes = 0u;
             add_logical_recovery_baseline_bytes(bytes,
                                                 sizeof(LogicalDeliveryEnvelope));
+            add_logical_recovery_baseline_element_bytes(bytes,
+                envelope.frame.changes.size(), sizeof(LogicalChange));
             add_logical_recovery_baseline_bytes(bytes, encoded.size());
             return bytes;
         }

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -3160,6 +3160,100 @@ void test_engine_recovery_counts_fixed_logical_baseline_records_in_byte_budget()
     cleanup(receiver_path);
 }
 
+void test_engine_recovery_counts_schema_dbi_name_storage_in_byte_budget() {
+    using namespace mdbxc;
+    const std::string source_path =
+        "test_engine_logical_recovery_schema_name_budget.mdbx";
+    cleanup(source_path);
+
+    const sync::NodeId source_node = make_node(0x95);
+    const sync::NodeId requester_node = make_node(0xA5);
+    const sync::DbId db_id = make_node(0xD5);
+    const std::size_t owned_dbi_count = 32u;
+    sync::FullSnapshotExportOptions options;
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
+    options.max_materialized_operations = 64u;
+    options.max_materialized_bytes = 1024u;
+
+    std::shared_ptr<Connection> source_conn = open_env(source_path);
+    sync::SyncEngine source(source_conn, sync::ConflictPolicy::Reject, options);
+    source.initialize_local_identity(source_node, db_id);
+    KeyValueTable<std::string, std::string> documents(source_conn, "documents");
+    documents.insert_or_assign("document", "value");
+
+    sync::LogicalSchemaRecord record;
+    record.dbi_name = "documents";
+    record.kind = sync::LogicalTableKind::KeyValue;
+    record.schema_version = 1u;
+    record.dbi_names.push_back(record.dbi_name);
+    for (std::size_t i = 1u; i < owned_dbi_count; ++i) {
+        record.dbi_names.push_back(
+            std::string("owned-") + std::to_string(static_cast<unsigned long long>(i)));
+    }
+    source.register_logical_schema("app.recovery.schema-budget", record);
+
+    sync::LogicalRecoveryRequest request;
+    request.requester = requester_node;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    const sync::LogicalRecoveryResponse response =
+        source.handle_logical_recovery(request);
+    if (response.ok || response.error_code != sync::SyncResponseErrorCode::BatchTooLarge) {
+        throw std::runtime_error(
+            "logical recovery omitted schema DBI name storage from byte budget");
+    }
+
+    source_conn->disconnect();
+    cleanup(source_path);
+}
+
+void test_engine_recovery_counts_outbox_change_storage_in_byte_budget() {
+    using namespace mdbxc;
+    const std::string source_path =
+        "test_engine_logical_recovery_outbox_change_budget.mdbx";
+    cleanup(source_path);
+
+    const sync::NodeId source_node = make_node(0x96);
+    const sync::NodeId requester_node = make_node(0xA6);
+    const sync::DbId db_id = make_node(0xD6);
+    const std::size_t change_count = 32u;
+    sync::FullSnapshotExportOptions options;
+    options.replacement_scope = sync::FullSnapshotScope::CompleteUserDatabase;
+    options.max_materialized_operations = 64u;
+    options.max_materialized_bytes = 3072u;
+
+    std::shared_ptr<Connection> source_conn = open_env(source_path);
+    sync::SyncEngine source(source_conn, sync::ConflictPolicy::Reject, options);
+    source.initialize_local_identity(source_node, db_id);
+    KeyValueTable<std::string, std::string> documents(source_conn, "documents");
+    documents.insert_or_assign("document", "value");
+
+    sync::LogicalSchemaRef schema;
+    schema.schema_id = "app.recovery.outbox-budget";
+    schema.kind = sync::LogicalTableKind::KeyValue;
+    schema.schema_version = 1u;
+    sync::LogicalChangeFrame frame;
+    for (std::size_t i = 0u; i < change_count; ++i) {
+        frame.changes.push_back(sync::LogicalChange(
+            schema, 1u, 0u, std::vector<std::uint8_t>()));
+    }
+    source.enqueue_logical_delivery(db_id, requester_node, frame);
+
+    sync::LogicalRecoveryRequest request;
+    request.requester = requester_node;
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 8192u;
+    const sync::LogicalRecoveryResponse response =
+        source.handle_logical_recovery(request);
+    if (response.ok || response.error_code != sync::SyncResponseErrorCode::BatchTooLarge) {
+        throw std::runtime_error(
+            "logical recovery omitted outbox change storage from byte budget");
+    }
+
+    source_conn->disconnect();
+    cleanup(source_path);
+}
+
 void test_engine_cancels_direct_logical_recovery_materialization() {
     using namespace mdbxc;
     const std::string source_path =
@@ -3895,6 +3989,10 @@ int main() {
           &test_engine_recovery_preserves_global_origin_sequence_across_receiver_cutover },
         { "test_engine_recovery_counts_fixed_logical_baseline_records_in_byte_budget",
           &test_engine_recovery_counts_fixed_logical_baseline_records_in_byte_budget },
+        { "test_engine_recovery_counts_schema_dbi_name_storage_in_byte_budget",
+          &test_engine_recovery_counts_schema_dbi_name_storage_in_byte_budget },
+        { "test_engine_recovery_counts_outbox_change_storage_in_byte_budget",
+          &test_engine_recovery_counts_outbox_change_storage_in_byte_budget },
         { "test_engine_cancels_direct_logical_recovery_materialization",
           &test_engine_cancels_direct_logical_recovery_materialization },
         { "test_engine_changelog_page_rejects_full_snapshot_request",


### PR DESCRIPTION
## Summary
- include dynamic dbi_names and logical-change array storage in logical recovery materialization accounting
- add source-side budget regressions for both cases
- clarify the EN/RU recovery-limit contract as portable accounting rather than an exact process-heap ceiling

## Verification
- 	est_sync_engine on C++11 and C++17
- header_domain_mdbx_containers_sync_engine_hpp on C++11 and C++17