### PR TITLE
[codex] Add descriptor-driven vector collection

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -347,6 +347,9 @@ for (const auto& r : results) {
 normalization, версии vector codec, signature encoder и block layout. Record id
 -- непустые непрозрачные последовательности байтов `std::string`, включая
 встроенные NUL-байты.
+Версия 1 хранит только vector codec `raw-f32`/`1`, signature encoder `none`/`1`
+и block layout version `1`. `normalization` фиксирует provenance pipeline и не
+преобразует сохранённые значения.
 
 Сейчас collection предоставляет только durable insert-or-replace, read, erase
 и count. В нём пока нет RAM index, exact-search API, ANN backend или

--- a/README-RU.md
+++ b/README-RU.md
@@ -338,6 +338,37 @@ for (const auto& r : results) {
 }
 ```
 
+### Descriptor-driven vector collection
+
+`VectorCollection` -- отдельная persistent-основа для vector backend, которым
+нужны стабильные record id, принадлежащие приложению. Descriptor сохраняется
+при первом открытии и при каждом последующем открытии должен точно совпадать
+до открытия или изменения vector records. Он включает dimension, metric,
+normalization, версии vector codec, signature encoder и block layout. Record id
+-- непустые непрозрачные последовательности байтов `std::string`, включая
+встроенные NUL-байты.
+
+Сейчас collection предоставляет только durable insert-or-replace, read, erase
+и count. В нём пока нет RAM index, exact-search API, ANN backend или
+logical-sync adapter. `VectorStore` остаётся неизменным supported embedded
+exact-search MVP.
+
+```cpp
+mdbxc::VectorCollectionDescriptor descriptor;
+descriptor.collection_id = "knowledge-v1";
+descriptor.dimension = 3;
+descriptor.metric = mdbxc::VectorMetric::COSINE;
+descriptor.normalization = mdbxc::VectorNormalization::None;
+descriptor.vector_codec_id = "raw-f32";
+descriptor.vector_codec_version = 1;
+descriptor.signature_encoder_id = "none";
+descriptor.signature_encoder_version = 1;
+descriptor.block_layout_version = 1;
+
+mdbxc::VectorCollection collection(cfg, descriptor);
+collection.insert_or_assign("document:42", e1);
+```
+
 ### Hash-indexed key-value store
 
 ```cpp

--- a/README.md
+++ b/README.md
@@ -304,6 +304,36 @@ for (const auto& r : results) {
 }
 ```
 
+### Descriptor-driven vector collection
+
+`VectorCollection` is a separate persistent foundation for vector backends
+that need application-owned stable record ids. Its descriptor is stored on
+first open and must match exactly on every subsequent open before vector
+records are opened or mutated. It includes dimension, metric, normalization,
+vector codec, signature encoder, and block-layout versions. Record ids are
+non-empty opaque `std::string` byte sequences, including embedded NUL bytes.
+
+This collection currently provides durable insert-or-replace, read, erase, and
+count operations only. It has no RAM index, exact-search API, ANN backend, or
+logical-sync adapter yet. `VectorStore` remains unchanged as the supported
+embedded exact-search MVP.
+
+```cpp
+mdbxc::VectorCollectionDescriptor descriptor;
+descriptor.collection_id = "knowledge-v1";
+descriptor.dimension = 3;
+descriptor.metric = mdbxc::VectorMetric::COSINE;
+descriptor.normalization = mdbxc::VectorNormalization::None;
+descriptor.vector_codec_id = "raw-f32";
+descriptor.vector_codec_version = 1;
+descriptor.signature_encoder_id = "none";
+descriptor.signature_encoder_version = 1;
+descriptor.block_layout_version = 1;
+
+mdbxc::VectorCollection collection(cfg, descriptor);
+collection.insert_or_assign("document:42", e1);
+```
+
 ### Hash-indexed key-value store
 
 ```cpp

--- a/README.md
+++ b/README.md
@@ -312,6 +312,9 @@ first open and must match exactly on every subsequent open before vector
 records are opened or mutated. It includes dimension, metric, normalization,
 vector codec, signature encoder, and block-layout versions. Record ids are
 non-empty opaque `std::string` byte sequences, including embedded NUL bytes.
+Version 1 stores only the `raw-f32`/`1` vector codec, `none`/`1` signature
+encoder, and block layout version `1`. `normalization` records pipeline
+provenance and does not transform stored values.
 
 This collection currently provides durable insert-or-replace, read, erase, and
 count operations only. It has no RAM index, exact-search API, ANN backend, or

--- a/include/mdbx_containers/vector.hpp
+++ b/include/mdbx_containers/vector.hpp
@@ -11,5 +11,7 @@
 #include "vector/SearchResult.hpp"
 #include "vector/FlatVectorIndex.hpp"
 #include "vector/VectorStore.hpp"
+#include "vector/VectorCollectionDescriptor.hpp"
+#include "vector/VectorCollection.hpp"
 
 #endif // MDBX_CONTAINERS_HEADER_VECTOR_HPP_INCLUDED

--- a/include/mdbx_containers/vector/VectorCollection.hpp
+++ b/include/mdbx_containers/vector/VectorCollection.hpp
@@ -19,6 +19,8 @@ namespace mdbxc {
     /// \details This storage foundation deliberately has no search index. It
     /// preserves caller-owned opaque record ids and validates the collection
     /// descriptor before opening the records DBI.
+    /// \thread_safety Not thread-safe. Synchronize simultaneous operations on
+    /// one instance externally, or use a separate instance per worker thread.
     class VectorCollection {
     public:
         /// \brief Opens a collection using a new connection.

--- a/include/mdbx_containers/vector/VectorCollection.hpp
+++ b/include/mdbx_containers/vector/VectorCollection.hpp
@@ -1,0 +1,100 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_VECTOR_VECTOR_COLLECTION_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_VECTOR_VECTOR_COLLECTION_HPP_INCLUDED
+
+/// \file VectorCollection.hpp
+/// \brief Descriptor-validated vector records with caller-owned stable ids.
+
+#include "../KeyValueTable.hpp"
+#include "../ValueTable.hpp"
+#include "Embedding.hpp"
+#include "VectorCollectionDescriptor.hpp"
+
+#include <memory>
+#include <string>
+
+namespace mdbxc {
+
+    /// \brief Persistent vector records governed by an immutable descriptor.
+    /// \details This storage foundation deliberately has no search index. It
+    /// preserves caller-owned opaque record ids and validates the collection
+    /// descriptor before opening the records DBI.
+    class VectorCollection {
+    public:
+        /// \brief Opens a collection using a new connection.
+        /// \param config MDBX environment configuration.
+        /// \param descriptor Persistent collection compatibility contract.
+        /// \throws std::invalid_argument if \p descriptor is invalid.
+        /// \throws std::invalid_argument if an existing descriptor differs.
+        VectorCollection(const Config& config,
+                         const VectorCollectionDescriptor& descriptor);
+
+        /// \brief Opens a collection using an existing connection.
+        /// \param connection Shared MDBX connection.
+        /// \param descriptor Persistent collection compatibility contract.
+        /// \throws std::invalid_argument if \p connection or \p descriptor is invalid.
+        /// \throws std::invalid_argument if an existing descriptor differs.
+        VectorCollection(std::shared_ptr<Connection> connection,
+                         const VectorCollectionDescriptor& descriptor);
+
+        VectorCollection(const VectorCollection&) = delete;
+        VectorCollection& operator=(const VectorCollection&) = delete;
+        VectorCollection(VectorCollection&&) = delete;
+        VectorCollection& operator=(VectorCollection&&) = delete;
+
+        /// \brief Inserts or replaces an embedding using a caller-owned id.
+        /// \param record_id Non-empty opaque stable record id.
+        /// \param embedding Embedding whose dimension matches the descriptor.
+        /// \throws std::invalid_argument if an argument is invalid.
+        void insert_or_assign(const std::string& record_id,
+                              const Embedding& embedding);
+
+        /// \brief Looks up an embedding by caller-owned id.
+        /// \param record_id Non-empty opaque stable record id.
+        /// \param out Destination for a found embedding.
+        /// \return \c true when a record was found.
+        /// \throws std::invalid_argument if \p record_id is empty.
+        bool try_get(const std::string& record_id, Embedding& out) const;
+
+        /// \brief Removes an embedding by caller-owned id.
+        /// \param record_id Non-empty opaque stable record id.
+        /// \return \c true when a record was removed.
+        /// \throws std::invalid_argument if \p record_id is empty.
+        bool erase(const std::string& record_id);
+
+        /// \brief Returns the number of stored vector records.
+        /// \return Number of records.
+        std::size_t count() const;
+
+        /// \brief Returns whether no vector records are stored.
+        /// \return \c true when the collection has no records.
+        bool empty() const;
+
+        /// \brief Returns the immutable persistent descriptor.
+        /// \return Collection descriptor.
+        const VectorCollectionDescriptor& descriptor() const noexcept;
+
+    private:
+        typedef KeyValueTable<std::string, Embedding> RecordsTable;
+
+        VectorCollectionDescriptor m_descriptor;
+        std::shared_ptr<Connection> m_connection;
+        ValueTable<VectorCollectionDescriptor> m_descriptor_table;
+        std::unique_ptr<RecordsTable> m_records;
+
+        static VectorCollectionDescriptor validated_descriptor(
+            const VectorCollectionDescriptor& descriptor);
+        static std::shared_ptr<Connection> require_connection(
+            std::shared_ptr<Connection> connection);
+        static std::string descriptor_table_name(const std::string& collection_id);
+        static std::string records_table_name(const std::string& collection_id);
+        static void validate_record_id(const std::string& record_id);
+        void verify_or_persist_descriptor();
+        void validate_embedding(const Embedding& embedding) const;
+    };
+
+} // namespace mdbxc
+
+#include "VectorCollection.ipp"
+
+#endif // MDBX_CONTAINERS_HEADER_VECTOR_VECTOR_COLLECTION_HPP_INCLUDED

--- a/include/mdbx_containers/vector/VectorCollection.ipp
+++ b/include/mdbx_containers/vector/VectorCollection.ipp
@@ -45,14 +45,18 @@ namespace mdbxc {
     }
 
     inline void VectorCollection::verify_or_persist_descriptor() {
-        VectorCollectionDescriptor existing;
-        if (m_descriptor_table.try_get(existing)) {
-            if (existing != m_descriptor) {
-                throw std::invalid_argument("Vector collection descriptor mismatch");
-            }
+        if (m_descriptor_table.insert(m_descriptor)) {
             return;
         }
-        m_descriptor_table.set(m_descriptor);
+
+        VectorCollectionDescriptor existing;
+        if (!m_descriptor_table.try_get(existing)) {
+            throw std::runtime_error(
+                "Vector collection descriptor disappeared after create race");
+        }
+        if (existing != m_descriptor) {
+            throw std::invalid_argument("Vector collection descriptor mismatch");
+        }
     }
 
     inline void VectorCollection::validate_record_id(const std::string& record_id) {

--- a/include/mdbx_containers/vector/VectorCollection.ipp
+++ b/include/mdbx_containers/vector/VectorCollection.ipp
@@ -1,0 +1,103 @@
+#include <stdexcept>
+#include <utility>
+
+namespace mdbxc {
+
+    inline VectorCollectionDescriptor VectorCollection::validated_descriptor(
+            const VectorCollectionDescriptor& descriptor) {
+        descriptor.validate();
+        return descriptor;
+    }
+
+    inline std::shared_ptr<Connection> VectorCollection::require_connection(
+            std::shared_ptr<Connection> connection) {
+        if (!connection) {
+            throw std::invalid_argument("VectorCollection connection cannot be null");
+        }
+        return connection;
+    }
+
+    inline std::string VectorCollection::descriptor_table_name(
+            const std::string& collection_id) {
+        return "vector_collection_" + collection_id + "_descriptor";
+    }
+
+    inline std::string VectorCollection::records_table_name(
+            const std::string& collection_id) {
+        return "vector_collection_" + collection_id + "_records";
+    }
+
+    inline VectorCollection::VectorCollection(
+            const Config& config,
+            const VectorCollectionDescriptor& descriptor)
+        : VectorCollection(Connection::create(config), descriptor) {}
+
+    inline VectorCollection::VectorCollection(
+            std::shared_ptr<Connection> connection,
+            const VectorCollectionDescriptor& descriptor)
+        : m_descriptor(validated_descriptor(descriptor))
+        , m_connection(require_connection(std::move(connection)))
+        , m_descriptor_table(m_connection,
+                             descriptor_table_name(m_descriptor.collection_id)) {
+        verify_or_persist_descriptor();
+        m_records.reset(new RecordsTable(
+            m_connection, records_table_name(m_descriptor.collection_id)));
+    }
+
+    inline void VectorCollection::verify_or_persist_descriptor() {
+        VectorCollectionDescriptor existing;
+        if (m_descriptor_table.try_get(existing)) {
+            if (existing != m_descriptor) {
+                throw std::invalid_argument("Vector collection descriptor mismatch");
+            }
+            return;
+        }
+        m_descriptor_table.set(m_descriptor);
+    }
+
+    inline void VectorCollection::validate_record_id(const std::string& record_id) {
+        if (record_id.empty()) {
+            throw std::invalid_argument("Vector collection record id must not be empty");
+        }
+    }
+
+    inline void VectorCollection::validate_embedding(const Embedding& embedding) const {
+        embedding.validate();
+        if (embedding.dim != m_descriptor.dimension) {
+            throw std::invalid_argument(
+                "Vector collection embedding dimension does not match descriptor");
+        }
+    }
+
+    inline void VectorCollection::insert_or_assign(
+            const std::string& record_id,
+            const Embedding& embedding) {
+        validate_record_id(record_id);
+        validate_embedding(embedding);
+        m_records->insert_or_assign(record_id, embedding);
+    }
+
+    inline bool VectorCollection::try_get(const std::string& record_id,
+                                           Embedding& out) const {
+        validate_record_id(record_id);
+        return m_records->try_get(record_id, out, nullptr);
+    }
+
+    inline bool VectorCollection::erase(const std::string& record_id) {
+        validate_record_id(record_id);
+        return m_records->erase(record_id);
+    }
+
+    inline std::size_t VectorCollection::count() const {
+        return m_records->count();
+    }
+
+    inline bool VectorCollection::empty() const {
+        return m_records->empty();
+    }
+
+    inline const VectorCollectionDescriptor& VectorCollection::descriptor() const noexcept {
+        return m_descriptor;
+    }
+
+} // namespace mdbxc

--- a/include/mdbx_containers/vector/VectorCollectionDescriptor.hpp
+++ b/include/mdbx_containers/vector/VectorCollectionDescriptor.hpp
@@ -1,0 +1,241 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_VECTOR_VECTOR_COLLECTION_DESCRIPTOR_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_VECTOR_VECTOR_COLLECTION_DESCRIPTOR_HPP_INCLUDED
+
+/// \file VectorCollectionDescriptor.hpp
+/// \brief Persistent compatibility descriptor for \ref VectorCollection.
+
+#include "VectorMetric.hpp"
+
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace mdbxc {
+
+    /// \brief Normalization contract persisted with a vector collection.
+    enum class VectorNormalization : std::uint32_t {
+        None = 0,
+        UnitL2 = 1
+    };
+
+    /// \brief Versioned persistent compatibility contract for one vector collection.
+    /// \details All fields are immutable after the collection is created. Opening
+    /// the same collection with a different descriptor fails before the records
+    /// table is opened or mutated.
+    struct VectorCollectionDescriptor {
+        std::string collection_id;
+        std::uint32_t descriptor_version = 1u;
+        std::uint32_t dimension = 0u;
+        VectorMetric metric = VectorMetric::COSINE;
+        VectorNormalization normalization = VectorNormalization::None;
+        std::string vector_codec_id;
+        std::uint32_t vector_codec_version = 0u;
+        std::string signature_encoder_id;
+        std::uint32_t signature_encoder_version = 0u;
+        std::uint32_t block_layout_version = 0u;
+
+        /// \brief Validates descriptor fields before persistence or use.
+        /// \throws std::invalid_argument if a field is unsupported or incomplete.
+        void validate() const {
+            validate_collection_id(collection_id);
+            if (descriptor_version != 1u) {
+                throw std::invalid_argument("Unsupported vector collection descriptor version");
+            }
+            if (dimension == 0u) {
+                throw std::invalid_argument("Vector collection dimension must be non-zero");
+            }
+            if (!is_known_metric(metric)) {
+                throw std::invalid_argument("Vector collection metric is invalid");
+            }
+            if (!is_known_normalization(normalization)) {
+                throw std::invalid_argument("Vector collection normalization is invalid");
+            }
+            validate_codec(vector_codec_id, vector_codec_version, "vector codec");
+            validate_codec(signature_encoder_id, signature_encoder_version,
+                           "signature encoder");
+            if (block_layout_version == 0u) {
+                throw std::invalid_argument(
+                    "Vector collection block layout version must be non-zero");
+            }
+        }
+
+        /// \brief Serializes the descriptor as a versioned little-endian record.
+        /// \return Binary representation suitable for persistent storage.
+        /// \throws std::invalid_argument if the descriptor is invalid.
+        std::vector<std::uint8_t> to_bytes() const {
+            validate();
+            std::vector<std::uint8_t> out;
+            append_u32(out, descriptor_magic());
+            append_u32(out, descriptor_version);
+            append_u32(out, dimension);
+            append_u32(out, static_cast<std::uint32_t>(metric));
+            append_u32(out, static_cast<std::uint32_t>(normalization));
+            append_string(out, collection_id);
+            append_string(out, vector_codec_id);
+            append_u32(out, vector_codec_version);
+            append_string(out, signature_encoder_id);
+            append_u32(out, signature_encoder_version);
+            append_u32(out, block_layout_version);
+            return out;
+        }
+
+        /// \brief Restores a descriptor from \ref to_bytes output.
+        /// \param data Serialized bytes.
+        /// \param len Number of serialized bytes.
+        /// \return Decoded descriptor.
+        /// \throws std::runtime_error if the record is malformed or unsupported.
+        static VectorCollectionDescriptor from_bytes(const void* data,
+                                                     std::size_t len) {
+            if (data == nullptr) {
+                throw std::runtime_error("Vector collection descriptor data is null");
+            }
+            const std::uint8_t* bytes = static_cast<const std::uint8_t*>(data);
+            std::size_t pos = 0u;
+            if (read_u32(bytes, len, pos) != descriptor_magic()) {
+                throw std::runtime_error("Vector collection descriptor magic mismatch");
+            }
+
+            VectorCollectionDescriptor descriptor;
+            descriptor.descriptor_version = read_u32(bytes, len, pos);
+            descriptor.dimension = read_u32(bytes, len, pos);
+            descriptor.metric = static_cast<VectorMetric>(read_u32(bytes, len, pos));
+            descriptor.normalization =
+                static_cast<VectorNormalization>(read_u32(bytes, len, pos));
+            descriptor.collection_id = read_string(bytes, len, pos);
+            descriptor.vector_codec_id = read_string(bytes, len, pos);
+            descriptor.vector_codec_version = read_u32(bytes, len, pos);
+            descriptor.signature_encoder_id = read_string(bytes, len, pos);
+            descriptor.signature_encoder_version = read_u32(bytes, len, pos);
+            descriptor.block_layout_version = read_u32(bytes, len, pos);
+            if (pos != len) {
+                throw std::runtime_error("Vector collection descriptor trailing bytes");
+            }
+            try {
+                descriptor.validate();
+            } catch (const std::invalid_argument&) {
+                throw std::runtime_error("Vector collection descriptor is invalid");
+            }
+            return descriptor;
+        }
+
+        /// \brief Compares every persistent compatibility field.
+        /// \param other Descriptor to compare.
+        /// \return \c true when both descriptors are identical.
+        bool operator==(const VectorCollectionDescriptor& other) const {
+            return collection_id == other.collection_id &&
+                   descriptor_version == other.descriptor_version &&
+                   dimension == other.dimension &&
+                   metric == other.metric &&
+                   normalization == other.normalization &&
+                   vector_codec_id == other.vector_codec_id &&
+                   vector_codec_version == other.vector_codec_version &&
+                   signature_encoder_id == other.signature_encoder_id &&
+                   signature_encoder_version == other.signature_encoder_version &&
+                   block_layout_version == other.block_layout_version;
+        }
+
+        /// \brief Compares every persistent compatibility field.
+        /// \param other Descriptor to compare.
+        /// \return \c true when at least one field differs.
+        bool operator!=(const VectorCollectionDescriptor& other) const {
+            return !(*this == other);
+        }
+
+    private:
+        static std::uint32_t descriptor_magic() {
+            return 0x4C4F4356u;
+        }
+
+        static bool is_known_metric(VectorMetric value) {
+            return value == VectorMetric::COSINE || value == VectorMetric::DOT ||
+                   value == VectorMetric::L2;
+        }
+
+        static bool is_known_normalization(VectorNormalization value) {
+            return value == VectorNormalization::None ||
+                   value == VectorNormalization::UnitL2;
+        }
+
+        static void validate_collection_id(const std::string& value) {
+            if (value.empty()) {
+                throw std::invalid_argument("Vector collection id must not be empty");
+            }
+            for (std::size_t i = 0; i < value.size(); ++i) {
+                const char c = value[i];
+                if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+                    (c >= '0' && c <= '9') || c == '_' || c == '-') {
+                    continue;
+                }
+                throw std::invalid_argument(
+                    "Vector collection id contains unsupported character");
+            }
+        }
+
+        static void validate_codec(const std::string& id,
+                                   std::uint32_t version,
+                                   const char* name) {
+            if (id.empty()) {
+                throw std::invalid_argument(std::string("Vector collection ") + name +
+                                            " id must not be empty");
+            }
+            if (version == 0u) {
+                throw std::invalid_argument(std::string("Vector collection ") + name +
+                                            " version must be non-zero");
+            }
+        }
+
+        static void append_string(std::vector<std::uint8_t>& out,
+                                  const std::string& value) {
+            if (value.size() > std::numeric_limits<std::uint32_t>::max()) {
+                throw std::length_error("Vector collection descriptor string is too large");
+            }
+            append_u32(out, static_cast<std::uint32_t>(value.size()));
+            out.insert(out.end(), value.begin(), value.end());
+        }
+
+        static void require(std::size_t total,
+                            std::size_t pos,
+                            std::size_t size) {
+            if (pos > total || size > total - pos) {
+                throw std::runtime_error("Vector collection descriptor decode underrun");
+            }
+        }
+
+        static std::uint32_t read_u32(const std::uint8_t* data,
+                                      std::size_t total,
+                                      std::size_t& pos) {
+            require(total, pos, 4u);
+            const std::uint32_t value =
+                static_cast<std::uint32_t>(data[pos]) |
+                (static_cast<std::uint32_t>(data[pos + 1u]) << 8u) |
+                (static_cast<std::uint32_t>(data[pos + 2u]) << 16u) |
+                (static_cast<std::uint32_t>(data[pos + 3u]) << 24u);
+            pos += 4u;
+            return value;
+        }
+
+        static void append_u32(std::vector<std::uint8_t>& out,
+                               std::uint32_t value) {
+            out.push_back(static_cast<std::uint8_t>(value & 0xFFu));
+            out.push_back(static_cast<std::uint8_t>((value >> 8u) & 0xFFu));
+            out.push_back(static_cast<std::uint8_t>((value >> 16u) & 0xFFu));
+            out.push_back(static_cast<std::uint8_t>((value >> 24u) & 0xFFu));
+        }
+
+        static std::string read_string(const std::uint8_t* data,
+                                       std::size_t total,
+                                       std::size_t& pos) {
+            const std::uint32_t size = read_u32(data, total, pos);
+            require(total, pos, size);
+            const char* begin = reinterpret_cast<const char*>(data + pos);
+            pos += size;
+            return std::string(begin, begin + size);
+        }
+    };
+
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_VECTOR_VECTOR_COLLECTION_DESCRIPTOR_HPP_INCLUDED

--- a/include/mdbx_containers/vector/VectorCollectionDescriptor.hpp
+++ b/include/mdbx_containers/vector/VectorCollectionDescriptor.hpp
@@ -15,7 +15,9 @@
 
 namespace mdbxc {
 
-    /// \brief Normalization contract persisted with a vector collection.
+    /// \brief Normalization provenance persisted with a vector collection.
+    /// \details Describes the pipeline that produced stored vectors. It does
+    /// not cause \ref VectorCollection to transform or normalize values.
     enum class VectorNormalization : std::uint32_t {
         None = 0,
         UnitL2 = 1
@@ -53,12 +55,18 @@ namespace mdbxc {
             if (!is_known_normalization(normalization)) {
                 throw std::invalid_argument("Vector collection normalization is invalid");
             }
-            validate_codec(vector_codec_id, vector_codec_version, "vector codec");
-            validate_codec(signature_encoder_id, signature_encoder_version,
-                           "signature encoder");
-            if (block_layout_version == 0u) {
+            if (vector_codec_id != "raw-f32" || vector_codec_version != 1u) {
                 throw std::invalid_argument(
-                    "Vector collection block layout version must be non-zero");
+                    "Vector collection requires the raw-f32 vector codec version 1");
+            }
+            if (signature_encoder_id != "none" ||
+                signature_encoder_version != 1u) {
+                throw std::invalid_argument(
+                    "Vector collection requires the none signature encoder version 1");
+            }
+            if (block_layout_version != 1u) {
+                throw std::invalid_argument(
+                    "Vector collection requires block layout version 1");
             }
         }
 
@@ -171,19 +179,6 @@ namespace mdbxc {
                 }
                 throw std::invalid_argument(
                     "Vector collection id contains unsupported character");
-            }
-        }
-
-        static void validate_codec(const std::string& id,
-                                   std::uint32_t version,
-                                   const char* name) {
-            if (id.empty()) {
-                throw std::invalid_argument(std::string("Vector collection ") + name +
-                                            " id must not be empty");
-            }
-            if (version == 0u) {
-                throw std::invalid_argument(std::string("Vector collection ") + name +
-                                            " version must be non-zero");
             }
         }
 

--- a/tests/test_vector_collection.cpp
+++ b/tests/test_vector_collection.cpp
@@ -53,6 +53,15 @@ bool throws_invalid_argument_for_empty_id(
     return false;
 }
 
+bool rejects_invalid_descriptor(mdbxc::VectorCollectionDescriptor descriptor) {
+    try {
+        descriptor.validate();
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+    return false;
+}
+
 } // namespace
 
 int main() {
@@ -78,6 +87,20 @@ int main() {
             rejected = true;
         }
         MDBXC_TEST_ASSERT(rejected);
+    }
+
+    {
+        mdbxc::VectorCollectionDescriptor unsupported_codec = descriptor;
+        unsupported_codec.vector_codec_id = "pq-8bit";
+        MDBXC_TEST_ASSERT(rejects_invalid_descriptor(unsupported_codec));
+
+        mdbxc::VectorCollectionDescriptor unsupported_signature = descriptor;
+        unsupported_signature.signature_encoder_id = "mih-256";
+        MDBXC_TEST_ASSERT(rejects_invalid_descriptor(unsupported_signature));
+
+        mdbxc::VectorCollectionDescriptor unsupported_layout = descriptor;
+        unsupported_layout.block_layout_version = 2u;
+        MDBXC_TEST_ASSERT(rejects_invalid_descriptor(unsupported_layout));
     }
 
     {

--- a/tests/test_vector_collection.cpp
+++ b/tests/test_vector_collection.cpp
@@ -1,0 +1,153 @@
+#include "test_assert.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mdbx_containers/vector.hpp>
+
+namespace {
+
+mdbxc::Config make_config(const std::string& path) {
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 32;
+    config.no_subdir = true;
+    config.relative_to_exe = false;
+    return config;
+}
+
+mdbxc::Embedding make_embedding(float first, float second, float third) {
+    mdbxc::Embedding embedding;
+    embedding.dim = 3u;
+    embedding.values.push_back(first);
+    embedding.values.push_back(second);
+    embedding.values.push_back(third);
+    return embedding;
+}
+
+mdbxc::VectorCollectionDescriptor make_descriptor(const std::string& collection_id) {
+    mdbxc::VectorCollectionDescriptor descriptor;
+    descriptor.collection_id = collection_id;
+    descriptor.dimension = 3u;
+    descriptor.metric = mdbxc::VectorMetric::COSINE;
+    descriptor.normalization = mdbxc::VectorNormalization::None;
+    descriptor.vector_codec_id = "raw-f32";
+    descriptor.vector_codec_version = 1u;
+    descriptor.signature_encoder_id = "none";
+    descriptor.signature_encoder_version = 1u;
+    descriptor.block_layout_version = 1u;
+    return descriptor;
+}
+
+bool throws_invalid_argument_for_empty_id(
+        mdbxc::VectorCollection& collection,
+        const mdbxc::Embedding& embedding) {
+    try {
+        collection.insert_or_assign(std::string(), embedding);
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+    return false;
+}
+
+} // namespace
+
+int main() {
+    const mdbxc::Config config = make_config("vector_collection_test.mdbx");
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+    const mdbxc::VectorCollectionDescriptor descriptor =
+        make_descriptor("knowledge-v1");
+
+    {
+        const std::vector<std::uint8_t> bytes = descriptor.to_bytes();
+        const mdbxc::VectorCollectionDescriptor restored =
+            mdbxc::VectorCollectionDescriptor::from_bytes(bytes.data(), bytes.size());
+        MDBXC_TEST_ASSERT(restored == descriptor);
+
+        std::vector<std::uint8_t> trailing = bytes;
+        trailing.push_back(0u);
+        bool rejected = false;
+        try {
+            mdbxc::VectorCollectionDescriptor::from_bytes(
+                trailing.data(), trailing.size());
+        } catch (const std::runtime_error&) {
+            rejected = true;
+        }
+        MDBXC_TEST_ASSERT(rejected);
+    }
+
+    {
+        mdbxc::VectorCollection collection(connection, descriptor);
+        const mdbxc::Embedding first = make_embedding(1.0f, 0.0f, 0.0f);
+        const mdbxc::Embedding replacement = make_embedding(0.0f, 1.0f, 0.0f);
+        const std::string binary_record_id("record\0binary", 13u);
+        collection.insert_or_assign("record-a", first);
+        collection.insert_or_assign("record-a", replacement);
+        collection.insert_or_assign(binary_record_id, first);
+
+        mdbxc::Embedding restored;
+        MDBXC_TEST_ASSERT(collection.try_get("record-a", restored));
+        MDBXC_TEST_ASSERT(restored.values == replacement.values);
+        MDBXC_TEST_ASSERT(collection.try_get(binary_record_id, restored));
+        MDBXC_TEST_ASSERT(collection.count() == 2u);
+        MDBXC_TEST_ASSERT(throws_invalid_argument_for_empty_id(collection, first));
+        MDBXC_TEST_ASSERT(!collection.erase("missing-record"));
+        MDBXC_TEST_ASSERT(collection.erase("record-a"));
+        MDBXC_TEST_ASSERT(collection.erase(binary_record_id));
+        MDBXC_TEST_ASSERT(collection.empty());
+    }
+
+    {
+        mdbxc::VectorCollection collection(connection, descriptor);
+        const mdbxc::Embedding embedding = make_embedding(1.0f, 0.0f, 0.0f);
+        collection.insert_or_assign("record-a", embedding);
+
+        mdbxc::Embedding wrong_dimension;
+        wrong_dimension.dim = 2u;
+        wrong_dimension.values.push_back(1.0f);
+        wrong_dimension.values.push_back(0.0f);
+        bool rejected = false;
+        try {
+            collection.insert_or_assign("record-a", wrong_dimension);
+        } catch (const std::invalid_argument&) {
+            rejected = true;
+        }
+        MDBXC_TEST_ASSERT(rejected);
+
+        mdbxc::Embedding restored;
+        MDBXC_TEST_ASSERT(collection.try_get("record-a", restored));
+        MDBXC_TEST_ASSERT(restored.values == embedding.values);
+
+        mdbxc::VectorCollectionDescriptor mismatched = descriptor;
+        mismatched.dimension = 4u;
+        rejected = false;
+        try {
+            mdbxc::VectorCollection invalid(connection, mismatched);
+            (void)invalid;
+        } catch (const std::invalid_argument&) {
+            rejected = true;
+        }
+        MDBXC_TEST_ASSERT(rejected);
+
+        MDBXC_TEST_ASSERT(collection.try_get("record-a", restored));
+        MDBXC_TEST_ASSERT(restored.values == embedding.values);
+    }
+
+    {
+        mdbxc::VectorStore legacy(connection, "knowledge-v1");
+        legacy.clear();
+        legacy.add(make_embedding(0.0f, 0.0f, 1.0f), "legacy");
+
+        mdbxc::VectorCollection collection(connection, descriptor);
+        mdbxc::Embedding restored;
+        MDBXC_TEST_ASSERT(collection.try_get("record-a", restored));
+        MDBXC_TEST_ASSERT(legacy.count() == 1u);
+    }
+
+    connection->disconnect();
+    return 0;
+}


### PR DESCRIPTION
## Summary

Add `VectorCollection`, a descriptor-driven vector storage foundation with caller-owned opaque record ids.

The collection persists and verifies dimension, metric, normalization, codec, encoder, and block-layout compatibility before it opens record storage. The legacy `VectorStore` API and four-DBI lifecycle remain unchanged.

## Validation

- C++17: `test_vector_collection`, `header_vector_umbrella_test`, `vector_store_test`
- C++11: `test_vector_collection`, `header_vector_umbrella_test`, `vector_store_test`