### PR TITLE
[codex] add immutable vector exact scan

### DIFF
--- a/benchmarks/README-vector-exact-scan.md
+++ b/benchmarks/README-vector-exact-scan.md
@@ -1,0 +1,53 @@
+# Vector Exact-Scan Benchmark
+
+`vector_exact_scan_benchmark` measures the scalar in-memory exact scan provided
+by `VectorExactScan`. It seeds a `VectorCollection`, measures one explicit
+snapshot rebuild, then measures query scans over that immutable snapshot.
+MDBX seed time is reported separately and is not included in search time.
+
+## Build
+
+```bash
+cmake -S . -B tmp/build-vector-bench \
+    -DMDBXC_DEPS_MODE=BUNDLED \
+    -DMDBXC_BUILD_TESTS=OFF \
+    -DMDBXC_BUILD_EXAMPLES=OFF \
+    -DMDBXC_BUILD_BENCHMARKS=ON \
+    -DCMAKE_CXX_STANDARD=17
+
+cmake --build tmp/build-vector-bench --target vector_exact_scan_benchmark
+```
+
+## Scenarios
+
+```bash
+tmp/build-vector-bench/bin/benchmarks/vector_exact_scan_benchmark --preset quick
+tmp/build-vector-bench/bin/benchmarks/vector_exact_scan_benchmark --preset realistic
+tmp/build-vector-bench/bin/benchmarks/vector_exact_scan_benchmark --list-presets
+```
+
+On Windows use the `.exe` suffix.
+
+| Preset | Records | Dimension | Queries | Purpose |
+| --- | ---: | ---: | ---: | --- |
+| `quick` | 2,000 | 128 | 64 | Short local smoke and broad change comparison. |
+| `realistic` | 50,000 | 384 | 512 | Larger manual scalar baseline. |
+
+Each preset runs `COSINE`, `DOT`, and `L2` with a fixed deterministic PRNG
+seed. It is a scalar correctness and baseline tool, not an ANN, SIMD, or
+cross-library comparison.
+
+## CSV Output
+
+| Column | Meaning |
+| --- | --- |
+| `scenario` | Selected preset. |
+| `metric` | `cosine`, `dot`, or `l2`. |
+| `records` | Number of vectors materialized into the snapshot. |
+| `dimension` | Float components per vector. |
+| `queries` | Number of exact top-10 searches. |
+| `seed_ms` | Time spent writing collection records to MDBX. |
+| `rebuild_ms` | Time spent materializing the immutable in-memory snapshot. |
+| `search_ms` | Time spent only in scalar `VectorExactScan::search()` calls. |
+| `queries_per_second` | `queries / search_ms`. |
+| `total_matches` | Sum of returned matches; a basic output-consumption check. |

--- a/benchmarks/vector_exact_scan_benchmark.cpp
+++ b/benchmarks/vector_exact_scan_benchmark.cpp
@@ -1,0 +1,186 @@
+/// \file vector_exact_scan_benchmark.cpp
+/// \brief Manual CSV baseline for \ref mdbxc::VectorExactScan.
+
+#include <mdbx_containers/vector.hpp>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct Scenario {
+    const char* name;
+    std::size_t records;
+    std::uint32_t dimension;
+    std::size_t queries;
+};
+
+struct CleanupGuard {
+    explicit CleanupGuard(const std::string& path_value) : path(path_value) {}
+
+    ~CleanupGuard() {
+        std::remove(path.c_str());
+        std::remove((path + "-lck").c_str());
+    }
+
+    std::string path;
+};
+
+std::uint32_t next_random(std::uint32_t& state) {
+    state ^= state << 13u;
+    state ^= state >> 17u;
+    state ^= state << 5u;
+    return state;
+}
+
+float next_float(std::uint32_t& state) {
+    const std::uint32_t value = next_random(state) & 0xFFFFu;
+    return static_cast<float>(value) / 32767.5f - 1.0f;
+}
+
+double elapsed_ms(const std::chrono::steady_clock::time_point& started) {
+    return std::chrono::duration_cast<std::chrono::duration<double, std::milli> >(
+        std::chrono::steady_clock::now() - started).count();
+}
+
+const char* metric_name(mdbxc::VectorMetric metric) {
+    if (metric == mdbxc::VectorMetric::COSINE) return "cosine";
+    if (metric == mdbxc::VectorMetric::DOT) return "dot";
+    return "l2";
+}
+
+mdbxc::VectorCollectionDescriptor make_descriptor(
+        const std::string& collection_id,
+        std::uint32_t dimension,
+        mdbxc::VectorMetric metric) {
+    mdbxc::VectorCollectionDescriptor descriptor;
+    descriptor.collection_id = collection_id;
+    descriptor.dimension = dimension;
+    descriptor.metric = metric;
+    descriptor.normalization = mdbxc::VectorNormalization::None;
+    descriptor.vector_codec_id = "raw-f32";
+    descriptor.vector_codec_version = 1u;
+    descriptor.signature_encoder_id = "none";
+    descriptor.signature_encoder_version = 1u;
+    descriptor.block_layout_version = 1u;
+    return descriptor;
+}
+
+mdbxc::Embedding make_embedding(std::uint32_t dimension, std::uint32_t& random_state) {
+    mdbxc::Embedding embedding;
+    embedding.dim = dimension;
+    embedding.values.resize(dimension);
+    for (std::size_t index = 0u; index < embedding.values.size(); ++index) {
+        embedding.values[index] = next_float(random_state);
+    }
+    return embedding;
+}
+
+void seed_collection(mdbxc::VectorCollection& collection,
+                     const Scenario& scenario,
+                     std::uint32_t& random_state) {
+    for (std::size_t record_index = 0u; record_index < scenario.records; ++record_index) {
+        collection.insert_or_assign(
+            std::string("record-") + std::to_string(record_index),
+            make_embedding(scenario.dimension, random_state));
+    }
+}
+
+void run_metric(const Scenario& scenario,
+                const std::shared_ptr<mdbxc::Connection>& connection,
+                mdbxc::VectorMetric metric,
+                std::uint32_t& random_state) {
+    const std::string collection_id =
+        std::string("benchmark-") + scenario.name + '-' + metric_name(metric);
+    mdbxc::VectorCollection collection(
+        connection, make_descriptor(collection_id, scenario.dimension, metric));
+
+    const std::chrono::steady_clock::time_point seed_started =
+        std::chrono::steady_clock::now();
+    seed_collection(collection, scenario, random_state);
+    const double seed_ms = elapsed_ms(seed_started);
+
+    const std::chrono::steady_clock::time_point rebuild_started =
+        std::chrono::steady_clock::now();
+    const mdbxc::VectorExactScan scan(collection);
+    const double rebuild_ms = elapsed_ms(rebuild_started);
+
+    const std::chrono::steady_clock::time_point search_started =
+        std::chrono::steady_clock::now();
+    std::size_t total_matches = 0u;
+    for (std::size_t query_index = 0u; query_index < scenario.queries; ++query_index) {
+        total_matches += scan.search(
+            make_embedding(scenario.dimension, random_state), 10u).size();
+    }
+    const double search_ms = elapsed_ms(search_started);
+    const double queries_per_second = search_ms == 0.0 ? 0.0 :
+        static_cast<double>(scenario.queries) * 1000.0 / search_ms;
+
+    std::cout << scenario.name << ',' << metric_name(metric) << ','
+              << scenario.records << ',' << scenario.dimension << ','
+              << scenario.queries << ',' << seed_ms << ',' << rebuild_ms << ','
+              << search_ms << ',' << queries_per_second << ',' << total_matches << '\n';
+}
+
+Scenario select_scenario(int argc, char** argv) {
+    const Scenario quick = {"quick", 2000u, 128u, 64u};
+    const Scenario realistic = {"realistic", 50000u, 384u, 512u};
+    if (argc == 1) return quick;
+    if (argc == 2 && std::string(argv[1]) == "--preset") {
+        throw std::invalid_argument("missing preset name");
+    }
+    if (argc == 2 && std::string(argv[1]) == "--list-presets") {
+        std::cout << "quick\nrealistic\n";
+        std::exit(0);
+    }
+    if (argc == 3 && std::string(argv[1]) == "--preset") {
+        const std::string preset(argv[2]);
+        if (preset == quick.name) return quick;
+        if (preset == realistic.name) return realistic;
+        throw std::invalid_argument("unknown preset: " + preset);
+    }
+    throw std::invalid_argument(
+        "usage: vector_exact_scan_benchmark [--list-presets | --preset quick|realistic]");
+}
+
+void run(const Scenario& scenario) {
+    const std::string path = "benchmark_vector_exact_scan.mdbx";
+    CleanupGuard cleanup(path);
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 32;
+    config.no_subdir = true;
+    config.relative_to_exe = false;
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+
+    std::uint32_t random_state = 0x51A7E5EDu;
+    std::cout << "scenario,metric,records,dimension,queries,seed_ms,rebuild_ms,"
+                 "search_ms,queries_per_second,total_matches\n";
+    run_metric(scenario, connection, mdbxc::VectorMetric::COSINE, random_state);
+    run_metric(scenario, connection, mdbxc::VectorMetric::DOT, random_state);
+    run_metric(scenario, connection, mdbxc::VectorMetric::L2, random_state);
+    connection->disconnect();
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        run(select_scenario(argc, argv));
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "FAIL vector_exact_scan_benchmark: " << error.what() << '\n';
+    } catch (...) {
+        std::cerr << "FAIL vector_exact_scan_benchmark: non-std exception\n";
+    }
+    return 1;
+}

--- a/include/mdbx_containers/vector.hpp
+++ b/include/mdbx_containers/vector.hpp
@@ -13,5 +13,6 @@
 #include "vector/VectorStore.hpp"
 #include "vector/VectorCollectionDescriptor.hpp"
 #include "vector/VectorCollection.hpp"
+#include "vector/VectorExactScan.hpp"
 
 #endif // MDBX_CONTAINERS_HEADER_VECTOR_HPP_INCLUDED

--- a/include/mdbx_containers/vector/VectorCollection.hpp
+++ b/include/mdbx_containers/vector/VectorCollection.hpp
@@ -15,6 +15,8 @@
 
 namespace mdbxc {
 
+    class VectorExactScan;
+
     /// \brief Persistent vector records governed by an immutable descriptor.
     /// \details This storage foundation deliberately has no search index. It
     /// preserves caller-owned opaque record ids and validates the collection
@@ -77,6 +79,8 @@ namespace mdbxc {
         const VectorCollectionDescriptor& descriptor() const noexcept;
 
     private:
+        friend class VectorExactScan;
+
         typedef KeyValueTable<std::string, Embedding> RecordsTable;
 
         VectorCollectionDescriptor m_descriptor;

--- a/include/mdbx_containers/vector/VectorExactScan.hpp
+++ b/include/mdbx_containers/vector/VectorExactScan.hpp
@@ -1,0 +1,81 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_VECTOR_VECTOR_EXACT_SCAN_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_VECTOR_VECTOR_EXACT_SCAN_HPP_INCLUDED
+
+/// \file VectorExactScan.hpp
+/// \brief Immutable scalar exact-search snapshot for \ref VectorCollection.
+
+#include "VectorCollection.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace mdbxc {
+
+    /// \brief Stable record id and scalar metric score from \ref VectorExactScan.
+    struct VectorExactMatch {
+        std::string record_id; ///< Caller-owned opaque record id.
+        float score = 0.0f; ///< Metric score; larger values rank first.
+    };
+
+    /// \brief Immutable in-memory exact-search snapshot of a vector collection.
+    /// \details Copies collection records into contiguous storage. Changes made
+    /// to the collection after construction are not visible until \ref rebuild
+    /// is called. Cosine snapshots normalize candidates internally; zero-norm
+    /// vectors retain an all-zero representation.
+    /// \thread_safety Not thread-safe. Synchronize rebuild and search externally.
+    class VectorExactScan {
+    public:
+        /// \brief Materializes an exact-search snapshot from a collection.
+        /// \param collection Persistent vector collection to read.
+        /// \throws std::invalid_argument if a materialized record is incompatible.
+        explicit VectorExactScan(const VectorCollection& collection);
+
+        /// \brief Replaces the current snapshot with collection records.
+        /// \param collection Persistent vector collection to read.
+        /// \throws std::invalid_argument if a materialized record is incompatible.
+        void rebuild(const VectorCollection& collection);
+
+        /// \brief Searches the immutable snapshot with a scalar exact scan.
+        /// \param query Query embedding whose dimension matches the collection.
+        /// \param top_k Maximum number of matches to return.
+        /// \return Matches ordered by descending score, then ascending binary id.
+        /// NaN scores are ordered after all numeric scores and then by binary id.
+        /// \throws std::invalid_argument if \p query is invalid or has a mismatched dimension.
+        /// \complexity O(N*dimension + N*log(top_k)).
+        std::vector<VectorExactMatch> search(const Embedding& query,
+                                              std::size_t top_k) const;
+
+        /// \brief Returns the number of records captured in the snapshot.
+        /// \return Number of snapshot records.
+        std::size_t size() const noexcept;
+
+        /// \brief Returns whether the snapshot has no captured records.
+        /// \return \c true when no records are captured.
+        bool empty() const noexcept;
+
+        /// \brief Returns the fixed vector dimension captured by the snapshot.
+        /// \return Descriptor dimension used for search validation.
+        std::uint32_t dimension() const noexcept;
+
+        /// \brief Returns the scoring metric captured by the snapshot.
+        /// \return Descriptor metric used by \ref search.
+        VectorMetric metric() const noexcept;
+
+    private:
+        VectorMetric m_metric = VectorMetric::COSINE;
+        std::uint32_t m_dimension = 0u;
+        std::vector<std::string> m_record_ids;
+        std::vector<float> m_values;
+
+        static void normalize(float* values, std::size_t dimension);
+        float compute_score(const float* query, const float* candidate) const;
+    };
+
+} // namespace mdbxc
+
+#include "VectorExactScan.ipp"
+
+#endif // MDBX_CONTAINERS_HEADER_VECTOR_VECTOR_EXACT_SCAN_HPP_INCLUDED

--- a/include/mdbx_containers/vector/VectorExactScan.ipp
+++ b/include/mdbx_containers/vector/VectorExactScan.ipp
@@ -1,0 +1,155 @@
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+namespace mdbxc {
+
+    inline VectorExactScan::VectorExactScan(const VectorCollection& collection) {
+        rebuild(collection);
+    }
+
+    inline void VectorExactScan::normalize(float* values, std::size_t dimension) {
+        float squared_norm = 0.0f;
+        for (std::size_t index = 0u; index < dimension; ++index) {
+            squared_norm += values[index] * values[index];
+        }
+        const float norm = std::sqrt(squared_norm);
+        if (norm == 0.0f) {
+            std::fill(values, values + dimension, 0.0f);
+            return;
+        }
+        for (std::size_t index = 0u; index < dimension; ++index) {
+            values[index] /= norm;
+        }
+    }
+
+    inline void VectorExactScan::rebuild(const VectorCollection& collection) {
+        const VectorCollectionDescriptor& descriptor = collection.descriptor();
+        std::vector<std::pair<std::string, Embedding> > records;
+        collection.m_records->load(records);
+
+        std::vector<std::string> record_ids;
+        std::vector<float> values;
+        if (records.size() >
+                (std::numeric_limits<std::size_t>::max)() /
+                    static_cast<std::size_t>(descriptor.dimension)) {
+            throw std::length_error("Vector exact scan snapshot is too large");
+        }
+        record_ids.reserve(records.size());
+        values.reserve(records.size() * static_cast<std::size_t>(descriptor.dimension));
+        for (std::size_t record_index = 0u; record_index < records.size(); ++record_index) {
+            const std::string& record_id = records[record_index].first;
+            const Embedding& embedding = records[record_index].second;
+            if (record_id.empty()) {
+                throw std::invalid_argument("Vector exact scan record id must not be empty");
+            }
+            embedding.validate();
+            if (embedding.dim != descriptor.dimension) {
+                throw std::invalid_argument(
+                    "Vector exact scan record dimension does not match collection descriptor");
+            }
+            record_ids.push_back(record_id);
+            const std::size_t value_offset = values.size();
+            values.insert(values.end(), embedding.values.begin(), embedding.values.end());
+            if (descriptor.metric == VectorMetric::COSINE) {
+                normalize(values.data() + value_offset, descriptor.dimension);
+            }
+        }
+
+        m_metric = descriptor.metric;
+        m_dimension = descriptor.dimension;
+        m_record_ids.swap(record_ids);
+        m_values.swap(values);
+    }
+
+    inline float VectorExactScan::compute_score(const float* query,
+                                                 const float* candidate) const {
+        if (m_metric == VectorMetric::COSINE || m_metric == VectorMetric::DOT) {
+            float dot_product = 0.0f;
+            for (std::size_t index = 0u; index < m_dimension; ++index) {
+                dot_product += query[index] * candidate[index];
+            }
+            return dot_product;
+        }
+
+        float squared_distance = 0.0f;
+        for (std::size_t index = 0u; index < m_dimension; ++index) {
+            const float difference = query[index] - candidate[index];
+            squared_distance += difference * difference;
+        }
+        return -squared_distance;
+    }
+
+    inline std::vector<VectorExactMatch> VectorExactScan::search(
+            const Embedding& query,
+            std::size_t top_k) const {
+        query.validate();
+        if (query.dim != m_dimension) {
+            throw std::invalid_argument(
+                "Vector exact scan query dimension does not match collection descriptor");
+        }
+        if (top_k == 0u || m_record_ids.empty()) {
+            return std::vector<VectorExactMatch>();
+        }
+
+        std::vector<float> prepared_query(query.values);
+        if (m_metric == VectorMetric::COSINE) {
+            normalize(prepared_query.data(), prepared_query.size());
+        }
+
+        std::vector<VectorExactMatch> matches;
+        matches.reserve(m_record_ids.size());
+        for (std::size_t record_index = 0u;
+             record_index < m_record_ids.size();
+             ++record_index) {
+            VectorExactMatch match;
+            match.record_id = m_record_ids[record_index];
+            match.score = compute_score(
+                prepared_query.data(),
+                m_values.data() + record_index * static_cast<std::size_t>(m_dimension));
+            matches.push_back(std::move(match));
+        }
+
+        if (top_k > matches.size()) {
+            top_k = matches.size();
+        }
+        std::partial_sort(
+            matches.begin(), matches.begin() + top_k, matches.end(),
+            [](const VectorExactMatch& left, const VectorExactMatch& right) {
+                const bool left_is_nan = std::isnan(left.score);
+                const bool right_is_nan = std::isnan(right.score);
+                if (left_is_nan != right_is_nan) {
+                    return !left_is_nan;
+                }
+                if (left_is_nan) {
+                    return left.record_id < right.record_id;
+                }
+                if (left.score != right.score) {
+                    return left.score > right.score;
+                }
+                return left.record_id < right.record_id;
+            });
+        matches.resize(top_k);
+        return matches;
+    }
+
+    inline std::size_t VectorExactScan::size() const noexcept {
+        return m_record_ids.size();
+    }
+
+    inline bool VectorExactScan::empty() const noexcept {
+        return m_record_ids.empty();
+    }
+
+    inline std::uint32_t VectorExactScan::dimension() const noexcept {
+        return m_dimension;
+    }
+
+    inline VectorMetric VectorExactScan::metric() const noexcept {
+        return m_metric;
+    }
+
+} // namespace mdbxc

--- a/include/mdbx_containers/vector/VectorExactScan.ipp
+++ b/include/mdbx_containers/vector/VectorExactScan.ipp
@@ -12,17 +12,19 @@ namespace mdbxc {
     }
 
     inline void VectorExactScan::normalize(float* values, std::size_t dimension) {
-        float squared_norm = 0.0f;
+        double squared_norm = 0.0;
         for (std::size_t index = 0u; index < dimension; ++index) {
-            squared_norm += values[index] * values[index];
+            const double component = static_cast<double>(values[index]);
+            squared_norm += component * component;
         }
-        const float norm = std::sqrt(squared_norm);
-        if (norm == 0.0f) {
+        const double norm = std::sqrt(squared_norm);
+        if (norm == 0.0) {
             std::fill(values, values + dimension, 0.0f);
             return;
         }
         for (std::size_t index = 0u; index < dimension; ++index) {
-            values[index] /= norm;
+            values[index] = static_cast<float>(
+                static_cast<double>(values[index]) / norm);
         }
     }
 

--- a/tests/test_vector_exact_scan.cpp
+++ b/tests/test_vector_exact_scan.cpp
@@ -1,0 +1,192 @@
+#include "test_assert.hpp"
+
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mdbx_containers/vector.hpp>
+
+namespace {
+
+mdbxc::Config make_config(const std::string& path) {
+    mdbxc::Config config;
+    config.pathname = path;
+    config.max_dbs = 32;
+    config.no_subdir = true;
+    config.relative_to_exe = false;
+    return config;
+}
+
+mdbxc::Embedding make_embedding(float first, float second) {
+    mdbxc::Embedding embedding;
+    embedding.dim = 2u;
+    embedding.values.push_back(first);
+    embedding.values.push_back(second);
+    return embedding;
+}
+
+mdbxc::VectorCollectionDescriptor make_descriptor(
+        const std::string& collection_id,
+        mdbxc::VectorMetric metric) {
+    mdbxc::VectorCollectionDescriptor descriptor;
+    descriptor.collection_id = collection_id;
+    descriptor.dimension = 2u;
+    descriptor.metric = metric;
+    descriptor.normalization = mdbxc::VectorNormalization::None;
+    descriptor.vector_codec_id = "raw-f32";
+    descriptor.vector_codec_version = 1u;
+    descriptor.signature_encoder_id = "none";
+    descriptor.signature_encoder_version = 1u;
+    descriptor.block_layout_version = 1u;
+    return descriptor;
+}
+
+bool approximately_equal(float left, float right) {
+    return std::fabs(left - right) < 0.0001f;
+}
+
+bool search_rejects_dimension(const mdbxc::VectorExactScan& scan) {
+    mdbxc::Embedding wrong_dimension;
+    wrong_dimension.dim = 3u;
+    wrong_dimension.values.push_back(1.0f);
+    wrong_dimension.values.push_back(0.0f);
+    wrong_dimension.values.push_back(0.0f);
+    try {
+        scan.search(wrong_dimension, 1u);
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+    return false;
+}
+
+void verify_metric(mdbxc::VectorMetric metric,
+                   const std::string& collection_id,
+                   const std::shared_ptr<mdbxc::Connection>& connection) {
+    mdbxc::VectorCollection collection(
+        connection, make_descriptor(collection_id, metric));
+    collection.insert_or_assign("best", make_embedding(2.0f, 0.0f));
+    collection.insert_or_assign("next", make_embedding(1.0f, 0.0f));
+    collection.insert_or_assign("other", make_embedding(0.0f, 1.0f));
+
+    const mdbxc::VectorExactScan scan(collection);
+    const std::vector<mdbxc::VectorExactMatch> matches =
+        scan.search(make_embedding(1.0f, 0.0f), 3u);
+    MDBXC_TEST_ASSERT(matches.size() == 3u);
+    if (metric == mdbxc::VectorMetric::COSINE) {
+        MDBXC_TEST_ASSERT(matches[0].record_id == "best");
+        MDBXC_TEST_ASSERT(matches[1].record_id == "next");
+        MDBXC_TEST_ASSERT(matches[2].record_id == "other");
+        MDBXC_TEST_ASSERT(approximately_equal(matches[0].score, 1.0f));
+        MDBXC_TEST_ASSERT(approximately_equal(matches[1].score, 1.0f));
+        MDBXC_TEST_ASSERT(approximately_equal(matches[2].score, 0.0f));
+    } else if (metric == mdbxc::VectorMetric::DOT) {
+        MDBXC_TEST_ASSERT(matches[0].record_id == "best");
+        MDBXC_TEST_ASSERT(matches[1].record_id == "next");
+        MDBXC_TEST_ASSERT(matches[2].record_id == "other");
+        MDBXC_TEST_ASSERT(approximately_equal(matches[0].score, 2.0f));
+        MDBXC_TEST_ASSERT(approximately_equal(matches[1].score, 1.0f));
+        MDBXC_TEST_ASSERT(approximately_equal(matches[2].score, 0.0f));
+    } else {
+        MDBXC_TEST_ASSERT(matches[0].record_id == "next");
+        MDBXC_TEST_ASSERT(matches[1].record_id == "best");
+        MDBXC_TEST_ASSERT(matches[2].record_id == "other");
+        MDBXC_TEST_ASSERT(approximately_equal(matches[0].score, 0.0f));
+        MDBXC_TEST_ASSERT(approximately_equal(matches[1].score, -1.0f));
+        MDBXC_TEST_ASSERT(approximately_equal(matches[2].score, -2.0f));
+    }
+    MDBXC_TEST_ASSERT(search_rejects_dimension(scan));
+}
+
+} // namespace
+
+int main() {
+    const mdbxc::Config config = make_config("vector_exact_scan_test.mdbx");
+    const std::shared_ptr<mdbxc::Connection> connection =
+        mdbxc::Connection::create(config);
+
+    verify_metric(mdbxc::VectorMetric::COSINE, "exact-cosine", connection);
+    verify_metric(mdbxc::VectorMetric::DOT, "exact-dot", connection);
+    verify_metric(mdbxc::VectorMetric::L2, "exact-l2", connection);
+
+    {
+        mdbxc::VectorCollection empty_collection(
+            connection, make_descriptor("exact-empty", mdbxc::VectorMetric::DOT));
+        const mdbxc::VectorExactScan empty_scan(empty_collection);
+        MDBXC_TEST_ASSERT(empty_scan.empty());
+        MDBXC_TEST_ASSERT(empty_scan.size() == 0u);
+        MDBXC_TEST_ASSERT(empty_scan.dimension() == 2u);
+        MDBXC_TEST_ASSERT(empty_scan.search(make_embedding(1.0f, 0.0f), 1u).empty());
+    }
+
+    {
+        mdbxc::VectorCollection tie_collection(
+            connection, make_descriptor("exact-ties", mdbxc::VectorMetric::DOT));
+        tie_collection.insert_or_assign("record-c", make_embedding(1.0f, 0.0f));
+        tie_collection.insert_or_assign("record-a", make_embedding(1.0f, 0.0f));
+        tie_collection.insert_or_assign("record-b", make_embedding(1.0f, 0.0f));
+        const mdbxc::VectorExactScan tie_scan(tie_collection);
+        const std::vector<mdbxc::VectorExactMatch> matches =
+            tie_scan.search(make_embedding(1.0f, 0.0f), 3u);
+        MDBXC_TEST_ASSERT(matches[0].record_id == "record-a");
+        MDBXC_TEST_ASSERT(matches[1].record_id == "record-b");
+        MDBXC_TEST_ASSERT(matches[2].record_id == "record-c");
+        MDBXC_TEST_ASSERT(tie_scan.search(make_embedding(1.0f, 0.0f), 0u).empty());
+        MDBXC_TEST_ASSERT(tie_scan.search(make_embedding(1.0f, 0.0f), 100u).size() == 3u);
+    }
+
+    {
+        mdbxc::VectorCollection binary_id_collection(
+            connection, make_descriptor("exact-binary-id", mdbxc::VectorMetric::DOT));
+        const std::string first_id("record\0a", 8u);
+        const std::string second_id("record\0b", 8u);
+        binary_id_collection.insert_or_assign(second_id, make_embedding(1.0f, 0.0f));
+        binary_id_collection.insert_or_assign(first_id, make_embedding(1.0f, 0.0f));
+        const mdbxc::VectorExactScan binary_id_scan(binary_id_collection);
+        const std::vector<mdbxc::VectorExactMatch> matches =
+            binary_id_scan.search(make_embedding(1.0f, 0.0f), 2u);
+        MDBXC_TEST_ASSERT(matches[0].record_id == first_id);
+        MDBXC_TEST_ASSERT(matches[1].record_id == second_id);
+    }
+
+    {
+        mdbxc::VectorCollection nan_collection(
+            connection, make_descriptor("exact-nan-order", mdbxc::VectorMetric::DOT));
+        const float nan_value = (std::numeric_limits<float>::quiet_NaN)();
+        nan_collection.insert_or_assign("nan-b", make_embedding(nan_value, 0.0f));
+        nan_collection.insert_or_assign("finite", make_embedding(1.0f, 0.0f));
+        nan_collection.insert_or_assign("nan-a", make_embedding(nan_value, 0.0f));
+        const mdbxc::VectorExactScan nan_scan(nan_collection);
+        const std::vector<mdbxc::VectorExactMatch> matches =
+            nan_scan.search(make_embedding(1.0f, 0.0f), 3u);
+        MDBXC_TEST_ASSERT(matches[0].record_id == "finite");
+        MDBXC_TEST_ASSERT(matches[1].record_id == "nan-a");
+        MDBXC_TEST_ASSERT(matches[2].record_id == "nan-b");
+        MDBXC_TEST_ASSERT(std::isnan(matches[1].score));
+        MDBXC_TEST_ASSERT(std::isnan(matches[2].score));
+    }
+
+    {
+        mdbxc::VectorCollection collection(
+            connection, make_descriptor("exact-snapshot", mdbxc::VectorMetric::DOT));
+        collection.insert_or_assign("old", make_embedding(1.0f, 0.0f));
+        mdbxc::VectorExactScan scan(collection);
+        collection.erase("old");
+        collection.insert_or_assign("new", make_embedding(3.0f, 0.0f));
+
+        std::vector<mdbxc::VectorExactMatch> matches =
+            scan.search(make_embedding(1.0f, 0.0f), 1u);
+        MDBXC_TEST_ASSERT(matches.size() == 1u);
+        MDBXC_TEST_ASSERT(matches[0].record_id == "old");
+
+        scan.rebuild(collection);
+        matches = scan.search(make_embedding(1.0f, 0.0f), 1u);
+        MDBXC_TEST_ASSERT(matches.size() == 1u);
+        MDBXC_TEST_ASSERT(matches[0].record_id == "new");
+    }
+
+    connection->disconnect();
+    return 0;
+}

--- a/tests/test_vector_exact_scan.cpp
+++ b/tests/test_vector_exact_scan.cpp
@@ -62,6 +62,21 @@ bool search_rejects_dimension(const mdbxc::VectorExactScan& scan) {
     return false;
 }
 
+void verify_cosine_self_similarity(
+        const std::shared_ptr<mdbxc::Connection>& connection,
+        const std::string& collection_id,
+        float magnitude) {
+    mdbxc::VectorCollection collection(
+        connection, make_descriptor(collection_id, mdbxc::VectorMetric::COSINE));
+    const mdbxc::Embedding embedding = make_embedding(magnitude, 0.0f);
+    collection.insert_or_assign("self", embedding);
+    const mdbxc::VectorExactScan scan(collection);
+    const std::vector<mdbxc::VectorExactMatch> matches = scan.search(embedding, 1u);
+    MDBXC_TEST_ASSERT(matches.size() == 1u);
+    MDBXC_TEST_ASSERT(matches[0].record_id == "self");
+    MDBXC_TEST_ASSERT(approximately_equal(matches[0].score, 1.0f));
+}
+
 void verify_metric(mdbxc::VectorMetric metric,
                    const std::string& collection_id,
                    const std::shared_ptr<mdbxc::Connection>& connection) {
@@ -110,6 +125,10 @@ int main() {
     verify_metric(mdbxc::VectorMetric::COSINE, "exact-cosine", connection);
     verify_metric(mdbxc::VectorMetric::DOT, "exact-dot", connection);
     verify_metric(mdbxc::VectorMetric::L2, "exact-l2", connection);
+    verify_cosine_self_similarity(
+        connection, "exact-cosine-max", (std::numeric_limits<float>::max)());
+    verify_cosine_self_similarity(
+        connection, "exact-cosine-min", (std::numeric_limits<float>::min)());
 
     {
         mdbxc::VectorCollection empty_collection(


### PR DESCRIPTION
## Summary

- add `VectorExactScan`, an immutable contiguous snapshot over `VectorCollection`
- provide deterministic scalar exact search for COSINE, DOT, and negative squared L2
- preserve opaque binary-safe string record IDs and require explicit `rebuild()` for refresh
- add correctness coverage and a deterministic CSV benchmark with separate seed, rebuild, and search timings

## Motivation

`VectorCollection` provides descriptor-validated persistent identity and vector storage, but intentionally has no search surface. This PR adds the smallest exact-search layer needed as a correctness oracle and local performance baseline before any candidate-index or SIMD work.

The snapshot accesses collection records through a narrow friendship instead of widening the persistent collection API. Search ties are ordered by binary record ID. Numeric scores rank ahead of NaN scores so the partial-sort comparator remains a strict weak ordering for every storable float payload.

## Validation

- MinGW GCC 15.2, C++17: `test_vector_exact_scan`, `header_vector_umbrella_test`, and `vector_store_test`
- MinGW GCC 15.2, C++11: the same test set
- `vector_exact_scan_benchmark --preset quick` for COSINE, DOT, and L2 CSV output
