### PR TITLE
[codex] Add network logical recovery

### DIFF
--- a/docs/sync-recovery-RU.md
+++ b/docs/sync-recovery-RU.md
@@ -77,9 +77,11 @@ Raw-копия adapter-owned user DBI без logical delivery state не мог�
 `LogicalRecoveryResponse` и не меняет raw `PullRequest`, `FullSnapshotChunk`
 или raw complete snapshot guard.
 
-На данном этапе transport-neutral вариант доступен через `DirectSyncPeer`.
-HTTP- и WebSocket-binding не считаются capable для logical recovery, пока не
-реализуют тот же отдельный wire contract.
+`DirectSyncPeer`, `HttpSyncPeer` и `WebSocketSyncPeer` используют один
+отдельный wire contract logical recovery. В запросе передаются node requester
+и целевой `DbId`; источник отклоняет несовпадающий database до materialization
+snapshot. HTTP bearer и WebSocket session identity policy применяют к этому
+`DbId` существующее per-principal правило доступа к database.
 
 Источник берёт один stable read baseline, в который входят:
 

--- a/docs/sync-recovery.md
+++ b/docs/sync-recovery.md
@@ -77,9 +77,11 @@ dedicated `LogicalRecoveryRequest` / `LogicalRecoveryResponse` peer contract;
 it does not change raw `PullRequest`, `FullSnapshotChunk`, or the raw complete
 snapshot guard.
 
-The current transport-neutral implementation is available through
-`DirectSyncPeer`. HTTP and WebSocket bindings are intentionally not treated as
-logical-recovery capable until they implement the same separate wire contract.
+`DirectSyncPeer`, `HttpSyncPeer`, and `WebSocketSyncPeer` implement the same
+separate logical-recovery wire contract. Its request includes both the
+requester node and target `DbId`; the source rejects a mismatched database
+before materializing a snapshot. HTTP bearer and WebSocket session identity
+policies apply their existing per-principal DB access rule to that `DbId`.
 
 The source captures one stable read baseline consisting of:
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1635,13 +1635,17 @@ for physical operations and logical baseline records; source enumeration spends
 that budget before retaining each logical record. `LogicalRecoveryPeer` also
 accepts a cooperative cancellation token: a cancelled materialization returns a
 retryable failure and publishes no snapshot session. `LogicalRecoveryProtocolCodec`
-is a distinct strict versioned wire contract (`MDBXCLRP`): it carries only
-requests and responses, rejects trailing bytes and inconsistent page shapes,
-and nests the existing bounded `FullSnapshotCodec` for physical pages.
-`DirectSyncPeer`, `HttpSyncPeer`, and `WebSocketSyncPeer` implement this
-capability. HTTP and WebSocket forward a caller cancellation token to their
-client-side socket/post operation; propagation of a remote disconnect into
-source materialization remains concrete-server-backend work and is deferred.
+is a distinct strict versioned wire contract (`MDBXCLRP`): every request carries
+the requester and target `DbId`; it rejects trailing bytes, incompatible codec
+versions, and inconsistent page shapes, and nests the existing bounded
+`FullSnapshotCodec` for physical pages. Sources reject a mismatched `DbId`
+before snapshot materialization. HTTP bearer and WebSocket authenticated-node
+policies apply their existing per-principal DB access checks to this request,
+as they do for raw pull and push. `DirectSyncPeer`, `HttpSyncPeer`, and
+`WebSocketSyncPeer` implement this capability. HTTP and WebSocket forward a
+caller cancellation token to their client-side socket/post operation;
+propagation of a remote disconnect into source materialization remains
+concrete-server-backend work and is deferred.
 
 `SyncEngine::apply_full_snapshot_chunk()` stages all pages in bounded process
 memory and validates immutable page-zero metadata on every continuation. Only

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1634,9 +1634,14 @@ transaction. Source materialization and receiver staging use one shared budget
 for physical operations and logical baseline records; source enumeration spends
 that budget before retaining each logical record. `LogicalRecoveryPeer` also
 accepts a cooperative cancellation token: a cancelled materialization returns a
-retryable failure and publishes no snapshot session. This capability is
-currently implemented by `DirectSyncPeer`; raw transports remain incapable
-until they implement the distinct logical-recovery wire contract.
+retryable failure and publishes no snapshot session. `LogicalRecoveryProtocolCodec`
+is a distinct strict versioned wire contract (`MDBXCLRP`): it carries only
+requests and responses, rejects trailing bytes and inconsistent page shapes,
+and nests the existing bounded `FullSnapshotCodec` for physical pages.
+`DirectSyncPeer`, `HttpSyncPeer`, and `WebSocketSyncPeer` implement this
+capability. HTTP and WebSocket forward a caller cancellation token to their
+client-side socket/post operation; propagation of a remote disconnect into
+source materialization remains concrete-server-backend work and is deferred.
 
 `SyncEngine::apply_full_snapshot_chunk()` stages all pages in bounded process
 memory and validates immutable page-zero metadata on every continuation. Only

--- a/include/mdbx_containers/sync/engine/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/engine/SyncEngine.hpp
@@ -367,6 +367,13 @@ namespace sync {
         LogicalRecoveryResponse handle_logical_recovery(
                 const LogicalRecoveryRequest& request,
                 const CancellationToken* cancel_token = nullptr) {
+            if (!db_id_matches(request.db_id)) {
+                LogicalRecoveryResponse mismatch;
+                mismatch.ok = false;
+                mismatch.error = "db_id mismatch";
+                mismatch.error_code = SyncResponseErrorCode::DbIdMismatch;
+                return mismatch;
+            }
             if (cancel_token != nullptr &&
                 cancel_token->is_cancellation_requested()) {
                 LogicalRecoveryResponse cancelled;
@@ -377,6 +384,7 @@ namespace sync {
             }
             PullRequest snapshot_request;
             snapshot_request.requester = request.requester;
+            snapshot_request.db_id = request.db_id;
             snapshot_request.request_full_snapshot = true;
             snapshot_request.full_snapshot_id = request.snapshot_id;
             snapshot_request.full_snapshot_continuation = request.continuation;

--- a/include/mdbx_containers/sync/engine/SyncWorker.hpp
+++ b/include/mdbx_containers/sync/engine/SyncWorker.hpp
@@ -860,6 +860,7 @@ namespace sync {
             FullSnapshotImportResetGuard reset_guard(m_engine);
             LogicalRecoveryRequest request;
             request.requester = incremental_request.requester;
+            request.db_id = incremental_request.db_id;
             request.max_bytes = incremental_request.max_bytes;
             request.max_single_batch_bytes =
                 incremental_request.max_single_batch_bytes;

--- a/include/mdbx_containers/sync/logical.hpp
+++ b/include/mdbx_containers/sync/logical.hpp
@@ -25,6 +25,7 @@
 #include "logical/stores/LogicalOutboxStore.hpp"
 #include "logical/logical_schema_validation.hpp"
 #include "logical/logical_recovery.hpp"
+#include "logical/LogicalRecoveryProtocol.hpp"
 #include "logical/ILogicalRecoveryPeer.hpp"
 #endif
 

--- a/include/mdbx_containers/sync/logical/LogicalRecoveryProtocol.hpp
+++ b/include/mdbx_containers/sync/logical/LogicalRecoveryProtocol.hpp
@@ -1,0 +1,731 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_LOGICAL_RECOVERY_PROTOCOL_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_LOGICAL_RECOVERY_PROTOCOL_HPP_INCLUDED
+
+/// \file logical/LogicalRecoveryProtocol.hpp
+/// \brief Strict wire codec for paged logical-aware recovery.
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "LogicalDeliveryEnvelopeCodec.hpp"
+#include "logical_recovery.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Strict binary codec for logical recovery requests and responses.
+    /// \details The final successful response carries the logical baseline;
+    /// intermediate pages carry only one physical snapshot chunk. The codec
+    /// rejects inconsistent response shapes before a peer can apply them.
+    class LogicalRecoveryProtocolCodec {
+    public:
+        enum class MessageType : std::uint8_t {
+            Request = 1u,
+            Response = 2u
+        };
+
+        static const std::uint8_t* magic() {
+            static const std::uint8_t value[8] =
+                { 'M', 'D', 'B', 'X', 'C', 'L', 'R', 'P' };
+            return value;
+        }
+
+        static std::size_t magic_size() { return 8u; }
+        static std::uint16_t codec_version() { return 1u; }
+
+        static std::vector<std::uint8_t> encode_request(
+                const LogicalRecoveryRequest& request,
+                const CodecBounds* bounds = nullptr) {
+            const CodecBounds& effective = effective_bounds(bounds);
+            validate_request(request, &effective);
+            std::vector<std::uint8_t> out = make_header(MessageType::Request);
+            append_id(out, request.requester);
+            append_snapshot_token(out, request.snapshot_id, effective);
+            append_snapshot_token(out, request.continuation, effective);
+            append_u64(out, request.max_bytes);
+            append_u64(out, request.max_single_batch_bytes);
+            validate_size(out, effective);
+            return out;
+        }
+
+        static LogicalRecoveryRequest decode_request(
+                const std::vector<std::uint8_t>& encoded,
+                const CodecBounds* bounds = nullptr) {
+            const CodecBounds& effective = effective_bounds(bounds);
+            Cursor cur = make_cursor(encoded, effective);
+            check_header(cur, MessageType::Request);
+            LogicalRecoveryRequest out;
+            read_id(cur, out.requester);
+            out.snapshot_id = read_snapshot_token(cur, effective);
+            out.continuation = read_snapshot_token(cur, effective);
+            out.max_bytes = read_u64(cur);
+            out.max_single_batch_bytes = read_u64(cur);
+            check_consumed(cur);
+            validate_request(out, &effective);
+            return out;
+        }
+
+        static std::vector<std::uint8_t> encode_response(
+                const LogicalRecoveryResponse& response,
+                const CodecBounds* bounds = nullptr) {
+            const CodecBounds& effective = effective_bounds(bounds);
+            validate_response(response, &effective);
+            std::vector<std::uint8_t> out = make_header(MessageType::Response);
+            append_bool(out, response.ok);
+            append_bool(out, response.has_more);
+            append_bool(out, response.has_baseline);
+            append_u16(out, static_cast<std::uint16_t>(response.error_code));
+            append_bool(out, response.error_retryable);
+            append_error(out, response.error, effective);
+            if (response.ok) {
+                append_snapshot_chunk(out, response.snapshot_chunk, effective);
+                if (response.has_baseline) {
+                    append_baseline(out, response.baseline, effective);
+                }
+            }
+            validate_size(out, effective);
+            return out;
+        }
+
+        static LogicalRecoveryResponse decode_response(
+                const std::vector<std::uint8_t>& encoded,
+                const CodecBounds* bounds = nullptr) {
+            const CodecBounds& effective = effective_bounds(bounds);
+            Cursor cur = make_cursor(encoded, effective);
+            check_header(cur, MessageType::Response);
+            LogicalRecoveryResponse out;
+            out.ok = read_bool(cur);
+            out.has_more = read_bool(cur);
+            out.has_baseline = read_bool(cur);
+            out.error_code = read_error_code(cur);
+            out.error_retryable = read_bool(cur);
+            out.error = read_error(cur, effective);
+            if (out.ok) {
+                out.snapshot_chunk = read_snapshot_chunk(cur, effective);
+                if (out.has_baseline) {
+                    out.baseline = read_baseline(cur, effective);
+                }
+            }
+            check_consumed(cur);
+            validate_response(out, &effective);
+            return out;
+        }
+
+        static MessageType peek_message_type(
+                const std::vector<std::uint8_t>& encoded,
+                const CodecBounds* bounds = nullptr) {
+            const CodecBounds& effective = effective_bounds(bounds);
+            Cursor cur = make_cursor(encoded, effective);
+            check_magic_and_version(cur);
+            const std::uint8_t value = read_u8(cur);
+            switch (value) {
+                case static_cast<std::uint8_t>(MessageType::Request):
+                    return MessageType::Request;
+                case static_cast<std::uint8_t>(MessageType::Response):
+                    return MessageType::Response;
+                default:
+                    throw std::runtime_error(
+                        "Invalid logical recovery message type");
+            }
+        }
+
+        static void validate_request(const LogicalRecoveryRequest& request,
+                                     const CodecBounds* bounds = nullptr) {
+            const CodecBounds& effective = effective_bounds(bounds);
+            if (is_zero_sync_id(request.requester)) {
+                throw std::invalid_argument(
+                    "Logical recovery requester identity is incomplete");
+            }
+            if (request.snapshot_id.size() > effective.max_snapshot_id_len ||
+                request.continuation.size() > effective.max_snapshot_id_len) {
+                throw std::length_error(
+                    "logical recovery token exceeds max_snapshot_id_len");
+            }
+            if ((request.snapshot_id.empty()) != request.continuation.empty()) {
+                throw std::invalid_argument(
+                    "logical recovery snapshot id and continuation must both be empty or set");
+            }
+            if (request.max_bytes == 0u || request.max_single_batch_bytes == 0u) {
+                throw std::invalid_argument(
+                    "logical recovery byte limits must be nonzero");
+            }
+        }
+
+        static void validate_response(const LogicalRecoveryResponse& response,
+                                      const CodecBounds* bounds = nullptr) {
+            const CodecBounds& effective = effective_bounds(bounds);
+            if (response.error.size() > effective.max_error_len) {
+                throw std::length_error(
+                    "logical recovery error exceeds max_error_len");
+            }
+            if (!response.ok) {
+                if (response.has_more || response.has_baseline) {
+                    throw std::invalid_argument(
+                        "failed logical recovery response contains recovery state");
+                }
+                return;
+            }
+            if (!response.error.empty() ||
+                response.error_code != SyncResponseErrorCode::None ||
+                response.error_retryable) {
+                throw std::invalid_argument(
+                    "successful logical recovery response contains an error");
+            }
+            FullSnapshotCodec::validate(response.snapshot_chunk, &effective);
+            if (response.has_more != response.snapshot_chunk.has_more) {
+                throw std::invalid_argument(
+                    "logical recovery continuation flags differ");
+            }
+            if (response.has_more == response.has_baseline) {
+                throw std::invalid_argument(
+                    "logical recovery baseline must appear exactly on the final page");
+            }
+            if (response.has_baseline) {
+                validate_baseline(response.baseline, response.snapshot_chunk,
+                                  effective);
+            }
+        }
+
+    private:
+        struct Cursor {
+            const std::uint8_t* data;
+            std::size_t size;
+            std::size_t pos;
+        };
+
+        static const CodecBounds& effective_bounds(const CodecBounds* bounds) {
+            static const CodecBounds defaults;
+            return bounds != nullptr ? *bounds : defaults;
+        }
+
+        static std::vector<std::uint8_t> make_header(MessageType type) {
+            std::vector<std::uint8_t> out;
+            append_bytes(out, magic(), magic_size());
+            append_u16(out, codec_version());
+            append_u8(out, static_cast<std::uint8_t>(type));
+            return out;
+        }
+
+        static Cursor make_cursor(const std::vector<std::uint8_t>& encoded,
+                                  const CodecBounds& bounds) {
+            if (encoded.size() > bounds.max_transport_message_bytes) {
+                throw std::length_error(
+                    "logical recovery message exceeds max_transport_message_bytes");
+            }
+            Cursor cur = { encoded.empty() ? nullptr : &encoded[0],
+                           encoded.size(), 0u };
+            return cur;
+        }
+
+        static void check_header(Cursor& cur, MessageType expected) {
+            check_magic_and_version(cur);
+            if (read_u8(cur) != static_cast<std::uint8_t>(expected)) {
+                throw std::runtime_error("Unexpected logical recovery message type");
+            }
+        }
+
+        static void check_magic_and_version(Cursor& cur) {
+            require(cur, magic_size());
+            if (std::memcmp(cur.data + cur.pos, magic(), magic_size()) != 0) {
+                throw std::runtime_error("Invalid logical recovery magic");
+            }
+            cur.pos += magic_size();
+            if (read_u16(cur) != codec_version()) {
+                throw std::runtime_error("Unsupported logical recovery codec version");
+            }
+        }
+
+        static void check_consumed(const Cursor& cur) {
+            if (cur.pos != cur.size) {
+                throw std::runtime_error("Trailing bytes after logical recovery message");
+            }
+        }
+
+        static void require(const Cursor& cur, std::size_t size) {
+            if (size > cur.size - cur.pos) {
+                throw std::runtime_error("Truncated logical recovery message");
+            }
+        }
+
+        static void append_bytes(std::vector<std::uint8_t>& out,
+                                 const std::uint8_t* data,
+                                 std::size_t size) {
+            if (size == 0u) return;
+            if (data == nullptr ||
+                size > (std::numeric_limits<std::size_t>::max)() - out.size()) {
+                throw std::length_error("logical recovery message size overflow");
+            }
+            const std::size_t old_size = out.size();
+            out.resize(old_size + size);
+            std::memcpy(&out[old_size], data, size);
+        }
+
+        static void append_u8(std::vector<std::uint8_t>& out, std::uint8_t value) {
+            out.push_back(value);
+        }
+
+        static void append_bool(std::vector<std::uint8_t>& out, bool value) {
+            append_u8(out, value ? 1u : 0u);
+        }
+
+        static void append_u16(std::vector<std::uint8_t>& out, std::uint16_t value) {
+            out.push_back(static_cast<std::uint8_t>(value & 0xffu));
+            out.push_back(static_cast<std::uint8_t>((value >> 8u) & 0xffu));
+        }
+
+        static void append_u32(std::vector<std::uint8_t>& out, std::uint32_t value) {
+            for (std::size_t i = 0u; i < 4u; ++i) {
+                out.push_back(static_cast<std::uint8_t>(value >> (8u * i)));
+            }
+        }
+
+        static void append_u64(std::vector<std::uint8_t>& out, std::uint64_t value) {
+            for (std::size_t i = 0u; i < 8u; ++i) {
+                out.push_back(static_cast<std::uint8_t>(value >> (8u * i)));
+            }
+        }
+
+        static std::uint8_t read_u8(Cursor& cur) {
+            require(cur, 1u);
+            return cur.data[cur.pos++];
+        }
+
+        static bool read_bool(Cursor& cur) {
+            const std::uint8_t value = read_u8(cur);
+            if (value > 1u) {
+                throw std::runtime_error("Invalid logical recovery bool value");
+            }
+            return value != 0u;
+        }
+
+        static std::uint16_t read_u16(Cursor& cur) {
+            require(cur, 2u);
+            const std::uint16_t out = static_cast<std::uint16_t>(cur.data[cur.pos]) |
+                static_cast<std::uint16_t>(cur.data[cur.pos + 1u] << 8u);
+            cur.pos += 2u;
+            return out;
+        }
+
+        static std::uint32_t read_u32(Cursor& cur) {
+            require(cur, 4u);
+            std::uint32_t out = 0u;
+            for (std::size_t i = 0u; i < 4u; ++i) {
+                out |= static_cast<std::uint32_t>(cur.data[cur.pos + i]) <<
+                    (8u * i);
+            }
+            cur.pos += 4u;
+            return out;
+        }
+
+        static std::uint64_t read_u64(Cursor& cur) {
+            require(cur, 8u);
+            std::uint64_t out = 0u;
+            for (std::size_t i = 0u; i < 8u; ++i) {
+                out |= static_cast<std::uint64_t>(cur.data[cur.pos + i]) <<
+                    (8u * i);
+            }
+            cur.pos += 8u;
+            return out;
+        }
+
+        static const std::uint8_t* read_bytes(Cursor& cur, std::size_t size) {
+            require(cur, size);
+            const std::uint8_t* out = size == 0u ? nullptr : cur.data + cur.pos;
+            cur.pos += size;
+            return out;
+        }
+
+        static void append_id(std::vector<std::uint8_t>& out, const NodeId& id) {
+            append_bytes(out, id.data(), id.size());
+        }
+
+        static void read_id(Cursor& cur, NodeId& out) {
+            const std::uint8_t* bytes = read_bytes(cur, out.size());
+            std::memcpy(out.data(), bytes, out.size());
+        }
+
+        static void append_u32_size(std::vector<std::uint8_t>& out,
+                                    std::size_t size,
+                                    const char* error) {
+            if (size > (std::numeric_limits<std::uint32_t>::max)()) {
+                throw std::length_error(error);
+            }
+            append_u32(out, static_cast<std::uint32_t>(size));
+        }
+
+        static void append_string(std::vector<std::uint8_t>& out,
+                                  const std::string& value,
+                                  std::uint32_t max_size,
+                                  const char* error) {
+            if (value.size() > max_size) {
+                throw std::length_error(error);
+            }
+            append_u32_size(out, value.size(), error);
+            append_bytes(out,
+                         value.empty() ? nullptr :
+                             reinterpret_cast<const std::uint8_t*>(value.data()),
+                         value.size());
+        }
+
+        static std::string read_string(Cursor& cur, std::uint32_t max_size,
+                                       const char* error) {
+            const std::uint32_t size = read_u32(cur);
+            if (size > max_size) {
+                throw std::length_error(error);
+            }
+            const std::uint8_t* bytes = read_bytes(cur, size);
+            return size == 0u ? std::string() :
+                std::string(reinterpret_cast<const char*>(bytes), size);
+        }
+
+        static void append_snapshot_token(std::vector<std::uint8_t>& out,
+                                          const std::string& value,
+                                          const CodecBounds& bounds) {
+            append_string(out, value, bounds.max_snapshot_id_len,
+                          "logical recovery token exceeds max_snapshot_id_len");
+        }
+
+        static std::string read_snapshot_token(Cursor& cur,
+                                               const CodecBounds& bounds) {
+            return read_string(cur, bounds.max_snapshot_id_len,
+                               "logical recovery token exceeds max_snapshot_id_len");
+        }
+
+        static void append_error(std::vector<std::uint8_t>& out,
+                                 const std::string& value,
+                                 const CodecBounds& bounds) {
+            append_string(out, value, bounds.max_error_len,
+                          "logical recovery error exceeds max_error_len");
+        }
+
+        static std::string read_error(Cursor& cur, const CodecBounds& bounds) {
+            return read_string(cur, bounds.max_error_len,
+                               "logical recovery error exceeds max_error_len");
+        }
+
+        static SyncResponseErrorCode read_error_code(Cursor& cur) {
+            const std::uint16_t value = read_u16(cur);
+            switch (value) {
+                case static_cast<std::uint16_t>(SyncResponseErrorCode::None):
+                    return SyncResponseErrorCode::None;
+                case static_cast<std::uint16_t>(SyncResponseErrorCode::DbIdMismatch):
+                    return SyncResponseErrorCode::DbIdMismatch;
+                case static_cast<std::uint16_t>(SyncResponseErrorCode::UnsupportedFullSnapshot):
+                    return SyncResponseErrorCode::UnsupportedFullSnapshot;
+                case static_cast<std::uint16_t>(SyncResponseErrorCode::ApplyConflict):
+                    return SyncResponseErrorCode::ApplyConflict;
+                case static_cast<std::uint16_t>(SyncResponseErrorCode::SnapshotRequired):
+                    return SyncResponseErrorCode::SnapshotRequired;
+                case static_cast<std::uint16_t>(SyncResponseErrorCode::BatchTooLarge):
+                    return SyncResponseErrorCode::BatchTooLarge;
+                case static_cast<std::uint16_t>(SyncResponseErrorCode::SnapshotNotConfigured):
+                    return SyncResponseErrorCode::SnapshotNotConfigured;
+                case static_cast<std::uint16_t>(SyncResponseErrorCode::SnapshotSessionInvalid):
+                    return SyncResponseErrorCode::SnapshotSessionInvalid;
+                case static_cast<std::uint16_t>(SyncResponseErrorCode::SnapshotSessionBusy):
+                    return SyncResponseErrorCode::SnapshotSessionBusy;
+                case static_cast<std::uint16_t>(SyncResponseErrorCode::SnapshotLogicalStateUnsupported):
+                    return SyncResponseErrorCode::SnapshotLogicalStateUnsupported;
+            }
+            throw std::runtime_error("Invalid logical recovery error code");
+        }
+
+        static void append_snapshot_chunk(std::vector<std::uint8_t>& out,
+                                          const FullSnapshotChunk& chunk,
+                                          const CodecBounds& bounds) {
+            const std::vector<std::uint8_t> nested =
+                FullSnapshotCodec::encode(chunk, &bounds);
+            if (nested.size() > bounds.max_snapshot_chunk_bytes) {
+                throw std::length_error(
+                    "logical recovery snapshot exceeds max_snapshot_chunk_bytes");
+            }
+            append_u32_size(out, nested.size(),
+                            "logical recovery snapshot length exceeds u32");
+            append_bytes(out, nested.empty() ? nullptr : &nested[0], nested.size());
+        }
+
+        static FullSnapshotChunk read_snapshot_chunk(Cursor& cur,
+                                                     const CodecBounds& bounds) {
+            const std::uint32_t size = read_u32(cur);
+            if (size > bounds.max_snapshot_chunk_bytes) {
+                throw std::length_error(
+                    "logical recovery snapshot exceeds max_snapshot_chunk_bytes");
+            }
+            const std::uint8_t* bytes = read_bytes(cur, size);
+            std::vector<std::uint8_t> nested(size);
+            if (size != 0u) std::memcpy(&nested[0], bytes, size);
+            return FullSnapshotCodec::decode(nested, &bounds);
+        }
+
+        static void append_baseline(std::vector<std::uint8_t>& out,
+                                    const LogicalRecoveryBaseline& baseline,
+                                    const CodecBounds& bounds) {
+            append_id(out, baseline.source_node_id);
+            append_id(out, baseline.source_db_uuid);
+            append_snapshot_token(out, baseline.snapshot_id, bounds);
+            append_u32_size(out, baseline.schemas.size(),
+                            "logical recovery schema count exceeds u32");
+            for (std::size_t i = 0u; i < baseline.schemas.size(); ++i) {
+                append_schema(out, baseline.schemas[i], bounds);
+            }
+            append_u32_size(out, baseline.delivery_markers.size(),
+                            "logical recovery marker count exceeds u32");
+            for (std::size_t i = 0u; i < baseline.delivery_markers.size(); ++i) {
+                append_marker(out, baseline.delivery_markers[i], bounds);
+            }
+            append_u32_size(out, baseline.delivery_watermarks.size(),
+                            "logical recovery watermark count exceeds u32");
+            for (std::size_t i = 0u; i < baseline.delivery_watermarks.size(); ++i) {
+                append_id(out, baseline.delivery_watermarks[i].origin_node_id);
+                append_u64(out, baseline.delivery_watermarks[i].sequence);
+            }
+            append_u32_size(out, baseline.delivery_order.size(),
+                            "logical recovery order count exceeds u32");
+            for (std::size_t i = 0u; i < baseline.delivery_order.size(); ++i) {
+                append_id(out, baseline.delivery_order[i].origin_node_id);
+                append_u64(out, baseline.delivery_order[i].acknowledged_through);
+            }
+            append_u32_size(out, baseline.source_outbox_pending.size(),
+                            "logical recovery pending count exceeds u32");
+            for (std::size_t i = 0u; i < baseline.source_outbox_pending.size(); ++i) {
+                const std::vector<std::uint8_t> envelope =
+                    LogicalDeliveryEnvelopeCodec::encode(
+                        baseline.source_outbox_pending[i], &bounds);
+                append_u32_size(out, envelope.size(),
+                                "logical recovery envelope length exceeds u32");
+                append_bytes(out, envelope.empty() ? nullptr : &envelope[0],
+                             envelope.size());
+            }
+            append_u64(out, baseline.source_outbox_known_tail);
+        }
+
+        static LogicalRecoveryBaseline read_baseline(Cursor& cur,
+                                                      const CodecBounds& bounds) {
+            LogicalRecoveryBaseline out;
+            read_id(cur, out.source_node_id);
+            read_id(cur, out.source_db_uuid);
+            out.snapshot_id = read_snapshot_token(cur, bounds);
+            out.schemas = read_schemas(cur, bounds);
+            out.delivery_markers = read_markers(cur, bounds);
+            const std::uint32_t watermark_count = read_collection_count(cur, bounds,
+                "logical recovery watermark count exceeds max_snapshot_manifest_entries");
+            out.delivery_watermarks.reserve(watermark_count);
+            for (std::uint32_t i = 0u; i < watermark_count; ++i) {
+                LogicalDeliveryWatermarkInfo item;
+                read_id(cur, item.origin_node_id);
+                item.sequence = read_u64(cur);
+                out.delivery_watermarks.push_back(item);
+            }
+            const std::uint32_t order_count = read_collection_count(cur, bounds,
+                "logical recovery order count exceeds max_snapshot_manifest_entries");
+            out.delivery_order.reserve(order_count);
+            for (std::uint32_t i = 0u; i < order_count; ++i) {
+                LogicalDeliveryOrderEntry item;
+                read_id(cur, item.origin_node_id);
+                item.acknowledged_through = read_u64(cur);
+                out.delivery_order.push_back(item);
+            }
+            const std::uint32_t pending_count = read_collection_count(cur, bounds,
+                "logical recovery pending count exceeds max_snapshot_manifest_entries");
+            out.source_outbox_pending.reserve(pending_count);
+            for (std::uint32_t i = 0u; i < pending_count; ++i) {
+                const std::uint32_t size = read_u32(cur);
+                if (size > bounds.max_batch_total_bytes) {
+                    throw std::length_error(
+                        "logical recovery envelope exceeds max_batch_total_bytes");
+                }
+                const std::uint8_t* bytes = read_bytes(cur, size);
+                std::vector<std::uint8_t> nested(size);
+                if (size != 0u) std::memcpy(&nested[0], bytes, size);
+                out.source_outbox_pending.push_back(
+                    LogicalDeliveryEnvelopeCodec::decode(nested, &bounds));
+            }
+            out.source_outbox_known_tail = read_u64(cur);
+            return out;
+        }
+
+        static void append_schema(std::vector<std::uint8_t>& out,
+                                  const LogicalSchemaRegistryEntry& entry,
+                                  const CodecBounds& bounds) {
+            append_string(out, entry.schema_id, bounds.max_logical_schema_id_len,
+                          "logical recovery schema id exceeds max_logical_schema_id_len");
+            append_string(out, entry.record.dbi_name, bounds.max_dbi_name_len,
+                          "logical recovery schema DBI exceeds max_dbi_name_len");
+            if (!is_known_logical_table_kind(entry.record.kind)) {
+                throw std::invalid_argument("logical recovery schema kind is unknown");
+            }
+            append_u16(out, static_cast<std::uint16_t>(entry.record.kind));
+            append_u32(out, entry.record.schema_version);
+            append_u32(out, entry.record.flags);
+            append_u32_size(out, entry.record.dbi_names.size(),
+                            "logical recovery schema DBI count exceeds u32");
+            for (std::size_t i = 0u; i < entry.record.dbi_names.size(); ++i) {
+                append_string(out, entry.record.dbi_names[i], bounds.max_dbi_name_len,
+                              "logical recovery schema DBI exceeds max_dbi_name_len");
+            }
+            append_id(out, entry.record.ordered_delivery_origin_node_id);
+        }
+
+        static std::vector<LogicalSchemaRegistryEntry> read_schemas(
+                Cursor& cur, const CodecBounds& bounds) {
+            const std::uint32_t count = read_collection_count(cur, bounds,
+                "logical recovery schema count exceeds max_snapshot_manifest_entries");
+            std::vector<LogicalSchemaRegistryEntry> out;
+            out.reserve(count);
+            for (std::uint32_t i = 0u; i < count; ++i) {
+                LogicalSchemaRegistryEntry entry;
+                entry.schema_id = read_string(cur, bounds.max_logical_schema_id_len,
+                    "logical recovery schema id exceeds max_logical_schema_id_len");
+                entry.record.dbi_name = read_string(cur, bounds.max_dbi_name_len,
+                    "logical recovery schema DBI exceeds max_dbi_name_len");
+                const std::uint16_t kind = read_u16(cur);
+                entry.record.kind = static_cast<LogicalTableKind>(kind);
+                if (!is_known_logical_table_kind(entry.record.kind)) {
+                    throw std::runtime_error("logical recovery schema kind is unknown");
+                }
+                entry.record.schema_version = read_u32(cur);
+                entry.record.flags = read_u32(cur);
+                const std::uint32_t dbi_count = read_collection_count(cur, bounds,
+                    "logical recovery schema DBI count exceeds max_snapshot_manifest_entries");
+                entry.record.dbi_names.reserve(dbi_count);
+                for (std::uint32_t j = 0u; j < dbi_count; ++j) {
+                    entry.record.dbi_names.push_back(read_string(
+                        cur, bounds.max_dbi_name_len,
+                        "logical recovery schema DBI exceeds max_dbi_name_len"));
+                }
+                read_id(cur, entry.record.ordered_delivery_origin_node_id);
+                out.push_back(entry);
+            }
+            return out;
+        }
+
+        static void append_marker(std::vector<std::uint8_t>& out,
+                                  const LogicalDeliveryMarkerInfo& marker,
+                                  const CodecBounds& bounds) {
+            if (marker.encoded_frame.size() != marker.frame_bytes_size) {
+                throw std::invalid_argument(
+                    "logical recovery marker frame size is inconsistent");
+            }
+            if (marker.encoded_frame.size() > bounds.max_batch_total_bytes) {
+                throw std::length_error(
+                    "logical recovery marker frame exceeds max_batch_total_bytes");
+            }
+            append_id(out, marker.destination_db_uuid);
+            append_id(out, marker.origin_node_id);
+            append_u64(out, marker.origin_sequence);
+            append_string(out, marker.frame_id,
+                          bounds.max_logical_delivery_frame_id_len,
+                          "logical recovery marker frame id exceeds max_logical_delivery_frame_id_len");
+            append_u16(out, marker.frame_codec_version);
+            append_u32(out, marker.frame_bytes_size);
+            append_u32_size(out, marker.encoded_frame.size(),
+                            "logical recovery marker frame length exceeds u32");
+            append_bytes(out, marker.encoded_frame.empty() ? nullptr :
+                         &marker.encoded_frame[0], marker.encoded_frame.size());
+        }
+
+        static std::vector<LogicalDeliveryMarkerInfo> read_markers(
+                Cursor& cur, const CodecBounds& bounds) {
+            const std::uint32_t count = read_collection_count(cur, bounds,
+                "logical recovery marker count exceeds max_snapshot_manifest_entries");
+            std::vector<LogicalDeliveryMarkerInfo> out;
+            out.reserve(count);
+            for (std::uint32_t i = 0u; i < count; ++i) {
+                LogicalDeliveryMarkerInfo marker;
+                read_id(cur, marker.destination_db_uuid);
+                read_id(cur, marker.origin_node_id);
+                marker.origin_sequence = read_u64(cur);
+                marker.frame_id = read_string(cur,
+                    bounds.max_logical_delivery_frame_id_len,
+                    "logical recovery marker frame id exceeds max_logical_delivery_frame_id_len");
+                marker.frame_codec_version = read_u16(cur);
+                marker.frame_bytes_size = read_u32(cur);
+                const std::uint32_t size = read_u32(cur);
+                if (size != marker.frame_bytes_size) {
+                    throw std::runtime_error(
+                        "logical recovery marker frame size is inconsistent");
+                }
+                if (size > bounds.max_batch_total_bytes) {
+                    throw std::length_error(
+                        "logical recovery marker frame exceeds max_batch_total_bytes");
+                }
+                const std::uint8_t* bytes = read_bytes(cur, size);
+                marker.encoded_frame.resize(size);
+                if (size != 0u) std::memcpy(&marker.encoded_frame[0], bytes, size);
+                out.push_back(marker);
+            }
+            return out;
+        }
+
+        static std::uint32_t read_collection_count(Cursor& cur,
+                                                   const CodecBounds& bounds,
+                                                   const char* error) {
+            const std::uint32_t count = read_u32(cur);
+            if (count > bounds.max_snapshot_manifest_entries) {
+                throw std::length_error(error);
+            }
+            return count;
+        }
+
+        static void validate_baseline(const LogicalRecoveryBaseline& baseline,
+                                      const FullSnapshotChunk& chunk,
+                                      const CodecBounds& bounds) {
+            if (is_zero_sync_id(baseline.source_node_id) ||
+                is_zero_sync_id(baseline.source_db_uuid) ||
+                baseline.snapshot_id.empty() ||
+                compare_node_id(baseline.source_node_id, chunk.source_node_id) != 0 ||
+                compare_node_id(baseline.source_db_uuid, chunk.source_db_uuid) != 0 ||
+                baseline.snapshot_id != chunk.snapshot_id) {
+                throw std::invalid_argument(
+                    "logical recovery baseline does not match snapshot identity");
+            }
+            if (baseline.schemas.size() > bounds.max_snapshot_manifest_entries ||
+                baseline.delivery_markers.size() > bounds.max_snapshot_manifest_entries ||
+                baseline.delivery_watermarks.size() > bounds.max_snapshot_manifest_entries ||
+                baseline.delivery_order.size() > bounds.max_snapshot_manifest_entries ||
+                baseline.source_outbox_pending.size() > bounds.max_snapshot_manifest_entries) {
+                throw std::length_error(
+                    "logical recovery baseline collection exceeds max_snapshot_manifest_entries");
+            }
+            for (std::size_t i = 0u; i < baseline.schemas.size(); ++i) {
+                const LogicalSchemaRegistryEntry& entry = baseline.schemas[i];
+                if (entry.schema_id.empty() || entry.record.dbi_name.empty() ||
+                    !is_known_logical_table_kind(entry.record.kind)) {
+                    throw std::invalid_argument(
+                        "logical recovery baseline schema is incomplete");
+                }
+            }
+            for (std::size_t i = 0u; i < baseline.delivery_markers.size(); ++i) {
+                const LogicalDeliveryMarkerInfo& marker = baseline.delivery_markers[i];
+                if (is_zero_sync_id(marker.destination_db_uuid) ||
+                    is_zero_sync_id(marker.origin_node_id) ||
+                    marker.origin_sequence == 0u || marker.frame_id.empty() ||
+                    marker.encoded_frame.size() != marker.frame_bytes_size) {
+                    throw std::invalid_argument(
+                        "logical recovery baseline marker is incomplete");
+                }
+            }
+            for (std::size_t i = 0u; i < baseline.source_outbox_pending.size(); ++i) {
+                validate_logical_delivery_envelope(
+                    baseline.source_outbox_pending[i], &bounds);
+            }
+        }
+
+        static void validate_size(const std::vector<std::uint8_t>& out,
+                                  const CodecBounds& bounds) {
+            if (out.size() > bounds.max_transport_message_bytes) {
+                throw std::length_error(
+                    "logical recovery message exceeds max_transport_message_bytes");
+            }
+        }
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_LOGICAL_RECOVERY_PROTOCOL_HPP_INCLUDED

--- a/include/mdbx_containers/sync/logical/LogicalRecoveryProtocol.hpp
+++ b/include/mdbx_containers/sync/logical/LogicalRecoveryProtocol.hpp
@@ -36,7 +36,7 @@ namespace sync {
         }
 
         static std::size_t magic_size() { return 8u; }
-        static std::uint16_t codec_version() { return 1u; }
+        static std::uint16_t codec_version() { return 2u; }
 
         static std::vector<std::uint8_t> encode_request(
                 const LogicalRecoveryRequest& request,
@@ -45,6 +45,7 @@ namespace sync {
             validate_request(request, &effective);
             std::vector<std::uint8_t> out = make_header(MessageType::Request);
             append_id(out, request.requester);
+            append_id(out, request.db_id);
             append_snapshot_token(out, request.snapshot_id, effective);
             append_snapshot_token(out, request.continuation, effective);
             append_u64(out, request.max_bytes);
@@ -61,6 +62,7 @@ namespace sync {
             check_header(cur, MessageType::Request);
             LogicalRecoveryRequest out;
             read_id(cur, out.requester);
+            read_id(cur, out.db_id);
             out.snapshot_id = read_snapshot_token(cur, effective);
             out.continuation = read_snapshot_token(cur, effective);
             out.max_bytes = read_u64(cur);
@@ -79,7 +81,7 @@ namespace sync {
             append_bool(out, response.ok);
             append_bool(out, response.has_more);
             append_bool(out, response.has_baseline);
-            append_u16(out, static_cast<std::uint16_t>(response.error_code));
+            append_response_error_code(out, response.error_code);
             append_bool(out, response.error_retryable);
             append_error(out, response.error, effective);
             if (response.ok) {
@@ -140,6 +142,10 @@ namespace sync {
             if (is_zero_sync_id(request.requester)) {
                 throw std::invalid_argument(
                     "Logical recovery requester identity is incomplete");
+            }
+            if (is_zero_sync_id(request.db_id)) {
+                throw std::invalid_argument(
+                    "Logical recovery db_id is incomplete");
             }
             if (request.snapshot_id.size() > effective.max_snapshot_id_len ||
                 request.continuation.size() > effective.max_snapshot_id_len) {
@@ -496,6 +502,10 @@ namespace sync {
                 const std::vector<std::uint8_t> envelope =
                     LogicalDeliveryEnvelopeCodec::encode(
                         baseline.source_outbox_pending[i], &bounds);
+                if (envelope.size() > bounds.max_batch_total_bytes) {
+                    throw std::length_error(
+                        "logical recovery envelope exceeds max_batch_total_bytes");
+                }
                 append_u32_size(out, envelope.size(),
                                 "logical recovery envelope length exceeds u32");
                 append_bytes(out, envelope.empty() ? nullptr : &envelope[0],
@@ -562,6 +572,11 @@ namespace sync {
             append_u16(out, static_cast<std::uint16_t>(entry.record.kind));
             append_u32(out, entry.record.schema_version);
             append_u32(out, entry.record.flags);
+            if (entry.record.dbi_names.size() >
+                bounds.max_snapshot_manifest_entries) {
+                throw std::length_error(
+                    "logical recovery schema DBI count exceeds max_snapshot_manifest_entries");
+            }
             append_u32_size(out, entry.record.dbi_names.size(),
                             "logical recovery schema DBI count exceeds u32");
             for (std::size_t i = 0u; i < entry.record.dbi_names.size(); ++i) {
@@ -670,6 +685,26 @@ namespace sync {
                 throw std::length_error(error);
             }
             return count;
+        }
+
+        static void append_response_error_code(
+                std::vector<std::uint8_t>& out,
+                SyncResponseErrorCode code) {
+            switch (code) {
+                case SyncResponseErrorCode::None:
+                case SyncResponseErrorCode::DbIdMismatch:
+                case SyncResponseErrorCode::UnsupportedFullSnapshot:
+                case SyncResponseErrorCode::ApplyConflict:
+                case SyncResponseErrorCode::SnapshotRequired:
+                case SyncResponseErrorCode::BatchTooLarge:
+                case SyncResponseErrorCode::SnapshotNotConfigured:
+                case SyncResponseErrorCode::SnapshotSessionInvalid:
+                case SyncResponseErrorCode::SnapshotSessionBusy:
+                case SyncResponseErrorCode::SnapshotLogicalStateUnsupported:
+                    append_u16(out, static_cast<std::uint16_t>(code));
+                    return;
+            }
+            throw std::logic_error("unknown SyncResponseErrorCode");
         }
 
         static void validate_baseline(const LogicalRecoveryBaseline& baseline,

--- a/include/mdbx_containers/sync/logical/logical_recovery.hpp
+++ b/include/mdbx_containers/sync/logical/logical_recovery.hpp
@@ -44,6 +44,8 @@ namespace sync {
     /// state guard.
     struct LogicalRecoveryRequest {
         NodeId requester{};
+        /// \brief Database identity authorized for recovery.
+        DbId db_id{};
         std::string snapshot_id;
         std::string continuation;
         std::uint64_t max_bytes = 4ULL * 1024ULL * 1024ULL;

--- a/include/mdbx_containers/sync/transport/HttpTransport.hpp
+++ b/include/mdbx_containers/sync/transport/HttpTransport.hpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "TransportMessageCodec.hpp"
+#include "../logical/LogicalRecoveryProtocol.hpp"
 
 namespace mdbxc {
 namespace sync {
@@ -275,6 +276,10 @@ namespace sync {
         static const char* logical_delivery_target() {
             return "/mdbxc/sync/v1/logical/delivery";
         }
+
+        static const char* logical_recovery_target() {
+            return "/mdbxc/sync/v1/logical/recovery";
+        }
     };
 
     /// \brief Server-side dispatcher from HTTP-shaped requests to SyncEngine.
@@ -304,6 +309,9 @@ namespace sync {
             } else if (request.target ==
                        HttpSyncRoutes::logical_delivery_target()) {
                 response = handle_logical_delivery(request.body);
+            } else if (request.target ==
+                       HttpSyncRoutes::logical_recovery_target()) {
+                response = handle_logical_recovery(request.body);
             } else {
                 response = make_error(404, "unknown sync route");
             }
@@ -404,6 +412,20 @@ namespace sync {
             }
         }
 
+        HttpSyncResponse handle_logical_recovery(
+                const std::vector<std::uint8_t>& body) const {
+            try {
+                const LogicalRecoveryRequest request =
+                    LogicalRecoveryProtocolCodec::decode_request(body, &m_bounds);
+                return make_binary(LogicalRecoveryProtocolCodec::encode_response(
+                    m_engine.handle_logical_recovery(request), &m_bounds));
+            } catch (const std::length_error& e) {
+                return make_error(413, e.what());
+            } catch (const std::exception& e) {
+                return make_error(400, e.what());
+            }
+        }
+
         static HttpSyncResponse make_binary(
                 const std::vector<std::uint8_t>& body) {
             HttpSyncResponse response;
@@ -466,6 +488,32 @@ namespace sync {
 
         bool supports_logical_delivery() const override {
             return true;
+        }
+
+        bool supports_logical_recovery() const override {
+            return true;
+        }
+
+        LogicalRecoveryResponse logical_recovery(
+                const LogicalRecoveryRequest& request) override {
+            return logical_recovery_with_cancel(request, nullptr);
+        }
+
+        LogicalRecoveryResponse logical_recovery_with_cancel(
+                const LogicalRecoveryRequest& request,
+                const CancellationToken* cancel_token = nullptr) override {
+            clear_last_retry_hint();
+            const CancellationToken token = cancel_token != nullptr
+                ? *cancel_token
+                : CancellationToken();
+            const HttpSyncResponse response = m_client.post(
+                HttpSyncRoutes::logical_recovery_target(),
+                HttpSyncRoutes::content_type(),
+                LogicalRecoveryProtocolCodec::encode_request(request, &m_bounds),
+                token);
+            require_ok_response(response, "logical recovery");
+            return LogicalRecoveryProtocolCodec::decode_response(
+                response.body, &m_bounds);
         }
 
         LogicalDeliveryHello logical_delivery_hello() override {

--- a/include/mdbx_containers/sync/transport/HttpTransport.hpp
+++ b/include/mdbx_containers/sync/transport/HttpTransport.hpp
@@ -414,15 +414,21 @@ namespace sync {
 
         HttpSyncResponse handle_logical_recovery(
                 const std::vector<std::uint8_t>& body) const {
+            LogicalRecoveryRequest decoded;
             try {
-                const LogicalRecoveryRequest request =
-                    LogicalRecoveryProtocolCodec::decode_request(body, &m_bounds);
-                return make_binary(LogicalRecoveryProtocolCodec::encode_response(
-                    m_engine.handle_logical_recovery(request), &m_bounds));
+                decoded = LogicalRecoveryProtocolCodec::decode_request(
+                    body, &m_bounds);
             } catch (const std::length_error& e) {
                 return make_error(413, e.what());
             } catch (const std::exception& e) {
                 return make_error(400, e.what());
+            }
+
+            try {
+                return make_binary(LogicalRecoveryProtocolCodec::encode_response(
+                    m_engine.handle_logical_recovery(decoded), &m_bounds));
+            } catch (const std::exception& e) {
+                return make_error(500, e.what());
             }
         }
 

--- a/include/mdbx_containers/sync/transport/TransportMiddleware.hpp
+++ b/include/mdbx_containers/sync/transport/TransportMiddleware.hpp
@@ -374,7 +374,8 @@ namespace sync {
     /// \brief Binds HTTP bearer tokens to sync \c NodeId values.
     /// \details This policy enforces the production-facing identity contract:
     /// the authenticated bearer principal must match
-    /// \c PullRequest::requester for pull and \c PushRequest::sender for push.
+    /// \c PullRequest::requester for pull, \c PushRequest::sender for push,
+    /// and \c LogicalRecoveryRequest::requester for logical recovery.
     /// Optional per-token DB access rules validate \c db_id before dispatch.
     /// Token bindings default to \c SyncDbAccess::any(); calling
     /// \c allow_db_id_for_token() switches that token to a restricted list.
@@ -460,6 +461,9 @@ namespace sync {
             if (request.target == HttpSyncRoutes::push_target()) {
                 return check_push_identity(request.body, binding);
             }
+            if (request.target == HttpSyncRoutes::logical_recovery_target()) {
+                return check_logical_recovery_identity(request.body, binding);
+            }
             return SyncTransportDecision::allow();
         }
 
@@ -522,6 +526,25 @@ namespace sync {
             }
         }
 
+        SyncTransportDecision check_logical_recovery_identity(
+                const std::vector<std::uint8_t>& body,
+                const Binding& binding) const {
+            try {
+                const LogicalRecoveryRequest request =
+                    LogicalRecoveryProtocolCodec::decode_request(body, &m_bounds);
+                if (request.requester != binding.node_id) {
+                    return SyncTransportDecision::reject(
+                        "logical recovery requester does not match authenticated node",
+                        403);
+                }
+                return SyncTransportDecision::allow();
+            } catch (const std::length_error& e) {
+                return SyncTransportDecision::reject(e.what(), 413);
+            } catch (const std::exception& e) {
+                return SyncTransportDecision::reject(e.what(), 400);
+            }
+        }
+
         static SyncTransportDecision check_db(const Binding& binding,
                                               const DbId& db_id) {
             if (!binding.db_access.allows_db_id(db_id)) {
@@ -561,6 +584,9 @@ namespace sync {
             }
 
             try {
+                if (is_logical_recovery_message(request.binary_message)) {
+                    return check_logical_recovery_identity(request);
+                }
                 const TransportMessageType type =
                     TransportMessageCodec::peek_message_type(
                         request.binary_message, &m_bounds);
@@ -585,6 +611,13 @@ namespace sync {
         }
 
     private:
+        static bool is_logical_recovery_message(
+                const std::vector<std::uint8_t>& message) {
+            return message.size() >= LogicalRecoveryProtocolCodec::magic_size() &&
+                std::memcmp(&message[0], LogicalRecoveryProtocolCodec::magic(),
+                            LogicalRecoveryProtocolCodec::magic_size()) == 0;
+        }
+
         SyncTransportDecision check_pull_identity(
                 const WebSocketSyncRequestContext& context) const {
             const PullRequest request =
@@ -609,6 +642,27 @@ namespace sync {
                     1008);
             }
             return check_db(context.db_access, request.db_id);
+        }
+
+        SyncTransportDecision check_logical_recovery_identity(
+                const WebSocketSyncRequestContext& context) const {
+            const LogicalRecoveryProtocolCodec::MessageType type =
+                LogicalRecoveryProtocolCodec::peek_message_type(
+                    context.binary_message, &m_bounds);
+            if (type != LogicalRecoveryProtocolCodec::MessageType::Request) {
+                return SyncTransportDecision::reject(
+                    "sync WebSocket server received logical recovery response message",
+                    1008);
+            }
+            const LogicalRecoveryRequest request =
+                LogicalRecoveryProtocolCodec::decode_request(
+                    context.binary_message, &m_bounds);
+            if (request.requester != context.authenticated_node) {
+                return SyncTransportDecision::reject(
+                    "logical recovery requester does not match authenticated WebSocket node",
+                    1008);
+            }
+            return SyncTransportDecision::allow();
         }
 
         static SyncTransportDecision check_db(
@@ -1326,6 +1380,64 @@ namespace sync {
         void request_cancel() override {
             detail::notify_transport_cancel_requested(m_observer);
             m_next.request_cancel();
+        }
+
+        bool supports_logical_delivery() const override {
+            return m_next.supports_logical_delivery();
+        }
+
+        LogicalDeliveryHello logical_delivery_hello() override {
+            return m_next.logical_delivery_hello();
+        }
+
+        LogicalDeliveryHello logical_delivery_hello_with_cancel(
+                const CancellationToken* cancel_token = nullptr) override {
+            return m_next.logical_delivery_hello_with_cancel(cancel_token);
+        }
+
+        LogicalDeliveryAcknowledgement deliver_ordered_logical_delivery(
+                const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds = nullptr) override {
+            return m_next.deliver_ordered_logical_delivery(envelope, bounds);
+        }
+
+        LogicalDeliveryAcknowledgement
+        deliver_ordered_logical_delivery_with_cancel(
+                const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds = nullptr,
+                const CancellationToken* cancel_token = nullptr) override {
+            return m_next.deliver_ordered_logical_delivery_with_cancel(
+                envelope, bounds, cancel_token);
+        }
+
+        LogicalDeliveryAcknowledgement deliver_ordered_logical_request(
+                const LogicalDeliveryRequest& request,
+                const CodecBounds* bounds = nullptr) override {
+            return m_next.deliver_ordered_logical_request(request, bounds);
+        }
+
+        LogicalDeliveryAcknowledgement
+        deliver_ordered_logical_request_with_cancel(
+                const LogicalDeliveryRequest& request,
+                const CodecBounds* bounds = nullptr,
+                const CancellationToken* cancel_token = nullptr) override {
+            return m_next.deliver_ordered_logical_request_with_cancel(
+                request, bounds, cancel_token);
+        }
+
+        bool supports_logical_recovery() const override {
+            return m_next.supports_logical_recovery();
+        }
+
+        LogicalRecoveryResponse logical_recovery(
+                const LogicalRecoveryRequest& request) override {
+            return m_next.logical_recovery(request);
+        }
+
+        LogicalRecoveryResponse logical_recovery_with_cancel(
+                const LogicalRecoveryRequest& request,
+                const CancellationToken* cancel_token = nullptr) override {
+            return m_next.logical_recovery_with_cancel(request, cancel_token);
         }
 
     private:

--- a/include/mdbx_containers/sync/transport/TransportMiddleware.hpp
+++ b/include/mdbx_containers/sync/transport/TransportMiddleware.hpp
@@ -537,7 +537,7 @@ namespace sync {
                         "logical recovery requester does not match authenticated node",
                         403);
                 }
-                return SyncTransportDecision::allow();
+                return check_db(binding, request.db_id);
             } catch (const std::length_error& e) {
                 return SyncTransportDecision::reject(e.what(), 413);
             } catch (const std::exception& e) {
@@ -662,7 +662,7 @@ namespace sync {
                     "logical recovery requester does not match authenticated WebSocket node",
                     1008);
             }
-            return SyncTransportDecision::allow();
+            return check_db(context.db_access, request.db_id);
         }
 
         static SyncTransportDecision check_db(

--- a/include/mdbx_containers/sync/transport/WebSocketTransport.hpp
+++ b/include/mdbx_containers/sync/transport/WebSocketTransport.hpp
@@ -7,7 +7,7 @@
 /// \details
 /// This header does not open sockets and does not depend on any WebSocket
 /// library. It defines a synchronous request/response message seam over
-/// complete binary WebSocket messages encoded by \c TransportMessageCodec.
+/// complete binary WebSocket messages encoded by a sync wire codec.
 /// Concrete bindings own connection setup, authentication headers, ping/pong,
 /// fragmentation/reassembly, backpressure, retries, and socket cancellation.
 
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "TransportMessageCodec.hpp"
+#include "../logical/LogicalRecoveryProtocol.hpp"
 
 namespace mdbxc {
 namespace sync {
@@ -72,17 +73,17 @@ namespace sync {
     }
 
     /// \brief Client-side bridge implemented by a concrete WebSocket library.
-    /// \details \p binary_message must contain exactly one
-    /// \c TransportMessageCodec request. Implementations return exactly one
-    /// encoded response message or throw on transport failure.
+    /// \details \p binary_message must contain exactly one raw, logical
+    /// delivery, or logical recovery request. Implementations return exactly
+    /// one encoded response message or throw on transport failure.
     class IWebSocketSyncChannel {
     public:
         virtual ~IWebSocketSyncChannel() {}
 
         /// \brief Sends one binary sync message and waits for its response.
-        /// \param binary_message Encoded pull or push request.
+        /// \param binary_message Encoded sync request.
         /// \param cancel_token Local call-control token; it is not serialized.
-        /// \return Encoded pull or push response.
+        /// \return Encoded sync response.
         /// \note The v0.1 wire DTOs have no request id. Implementations must
         /// serialize concurrent exchanges on one connection unless the
         /// concrete WebSocket binding adds its own correlation layer.
@@ -121,6 +122,9 @@ namespace sync {
             if (is_logical_delivery_message(binary_message)) {
                 return handle_logical_delivery(binary_message);
             }
+            if (is_logical_recovery_message(binary_message)) {
+                return handle_logical_recovery(binary_message);
+            }
             const TransportMessageType type =
                 TransportMessageCodec::peek_message_type(
                     binary_message, &m_bounds);
@@ -145,6 +149,15 @@ namespace sync {
                    std::memcmp(&binary_message[0],
                                LogicalDeliveryProtocolCodec::magic(),
                                LogicalDeliveryProtocolCodec::magic_size()) == 0;
+        }
+
+        static bool is_logical_recovery_message(
+                const std::vector<std::uint8_t>& binary_message) {
+            return binary_message.size() >=
+                       LogicalRecoveryProtocolCodec::magic_size() &&
+                   std::memcmp(&binary_message[0],
+                               LogicalRecoveryProtocolCodec::magic(),
+                               LogicalRecoveryProtocolCodec::magic_size()) == 0;
         }
 
         std::vector<std::uint8_t> handle_pull(
@@ -198,6 +211,21 @@ namespace sync {
             throw std::runtime_error("Unexpected logical delivery message type");
         }
 
+        std::vector<std::uint8_t> handle_logical_recovery(
+                const std::vector<std::uint8_t>& binary_message) const {
+            const LogicalRecoveryProtocolCodec::MessageType type =
+                LogicalRecoveryProtocolCodec::peek_message_type(
+                    binary_message, &m_bounds);
+            if (type != LogicalRecoveryProtocolCodec::MessageType::Request) {
+                throw std::runtime_error(
+                    "WebSocket sync server received logical recovery response message");
+            }
+            const LogicalRecoveryRequest request =
+                LogicalRecoveryProtocolCodec::decode_request(binary_message, &m_bounds);
+            return LogicalRecoveryProtocolCodec::encode_response(
+                m_engine.handle_logical_recovery(request), &m_bounds);
+        }
+
         SyncEngine& m_engine;
         CodecBounds m_bounds;
     };
@@ -234,6 +262,28 @@ namespace sync {
 
         bool supports_logical_delivery() const override {
             return true;
+        }
+
+        bool supports_logical_recovery() const override {
+            return true;
+        }
+
+        LogicalRecoveryResponse logical_recovery(
+                const LogicalRecoveryRequest& request) override {
+            return logical_recovery_with_cancel(request, nullptr);
+        }
+
+        LogicalRecoveryResponse logical_recovery_with_cancel(
+                const LogicalRecoveryRequest& request,
+                const CancellationToken* cancel_token = nullptr) override {
+            const CancellationToken token = cancel_token != nullptr
+                ? *cancel_token
+                : CancellationToken();
+            return LogicalRecoveryProtocolCodec::decode_response(
+                m_channel.exchange_binary(
+                    LogicalRecoveryProtocolCodec::encode_request(request, &m_bounds),
+                    token),
+                &m_bounds);
         }
 
         LogicalDeliveryHello logical_delivery_hello() override {

--- a/tests/test_http_transport.cpp
+++ b/tests/test_http_transport.cpp
@@ -365,14 +365,21 @@ void test_http_peer_logical_recovery_route() {
     cleanup(source_path);
 
     std::shared_ptr<mdbxc::Connection> source = open_db(source_path);
-    mdbxc::sync::SyncEngine engine(source);
+    mdbxc::sync::FullSnapshotExportOptions options;
+    options.replacement_scope =
+        mdbxc::sync::FullSnapshotScope::CompleteUserDatabase;
+    mdbxc::sync::SyncEngine engine(
+        source, mdbxc::sync::ConflictPolicy::Reject, options);
     engine.initialize_local_identity(make_node(0x81), make_node(0x91));
+    mdbxc::KeyValueTable<int, std::string> source_values(source, "values");
+    source_values.insert_or_assign(1, "recovery-value");
     mdbxc::sync::HttpSyncServer server(engine);
     LoopbackHttpClient client(server);
     mdbxc::sync::HttpSyncPeer peer(client);
 
     mdbxc::sync::LogicalRecoveryRequest request;
     request.requester = make_node(0xA1);
+    request.db_id = make_node(0x91);
     mdbxc::sync::CancellationSource cancellation;
     const mdbxc::sync::CancellationToken token = cancellation.token();
     const mdbxc::sync::LogicalRecoveryResponse response =
@@ -380,9 +387,9 @@ void test_http_peer_logical_recovery_route() {
 
     require_true(peer.supports_logical_recovery(),
                  "HTTP peer did not advertise logical recovery");
-    require_true(!response.ok && response.error_code ==
-                     mdbxc::sync::SyncResponseErrorCode::SnapshotNotConfigured,
-                 "HTTP logical recovery structured failure mismatch");
+    require_true(response.ok && response.has_baseline &&
+                     !response.snapshot_chunk.has_more,
+                 "HTTP logical recovery success response mismatch");
     require_true(client.last_target() ==
                      mdbxc::sync::HttpSyncRoutes::logical_recovery_target(),
                  "HTTP logical recovery target mismatch");
@@ -393,6 +400,36 @@ void test_http_peer_logical_recovery_route() {
     cleanup(source_path);
 }
 
+void test_http_logical_recovery_execution_error_is_server_error() {
+    const std::string source_path = "test_http_logical_recovery_error.mdbx";
+    cleanup(source_path);
+
+    std::shared_ptr<mdbxc::Connection> source = open_db(source_path);
+    const mdbxc::sync::DbId db_id = make_node(0x92);
+    mdbxc::sync::SyncEngine engine(source);
+    engine.initialize_local_identity(make_node(0x82), db_id);
+    mdbxc::sync::CodecBounds bounds;
+    bounds.max_error_len = 1u;
+    mdbxc::sync::HttpSyncServer server(engine, bounds);
+
+    mdbxc::sync::LogicalRecoveryRequest recovery;
+    recovery.requester = make_node(0xA2);
+    recovery.db_id = db_id;
+    mdbxc::sync::HttpSyncRequest request;
+    request.method = mdbxc::sync::HttpSyncRoutes::method_post();
+    request.target = mdbxc::sync::HttpSyncRoutes::logical_recovery_target();
+    request.content_type = mdbxc::sync::HttpSyncRoutes::content_type();
+    request.body = mdbxc::sync::LogicalRecoveryProtocolCodec::encode_request(
+        recovery);
+    const mdbxc::sync::HttpSyncResponse response = server.handle(request);
+
+    source->disconnect();
+    cleanup(source_path);
+
+    require_true(response.status_code == 500u,
+                 "logical recovery execution error was classified as HTTP 400");
+}
+
 } // namespace
 
 int main() {
@@ -401,5 +438,6 @@ int main() {
     test_http_peer_rejects_transport_error();
     test_http_peer_delivers_ordered_logical_outbox();
     test_http_peer_logical_recovery_route();
+    test_http_logical_recovery_execution_error_is_server_error();
     return 0;
 }

--- a/tests/test_http_transport.cpp
+++ b/tests/test_http_transport.cpp
@@ -268,6 +268,11 @@ void test_http_server_status_mapping() {
     require_true(response.status_code == 400,
                  "malformed logical delivery body must be rejected");
 
+    request.target = mdbxc::sync::HttpSyncRoutes::logical_recovery_target();
+    response = server.handle(request);
+    require_true(response.status_code == 400,
+                 "malformed logical recovery body must be rejected");
+
     mdbxc::sync::CodecBounds bounds;
     bounds.max_transport_message_bytes = 16;
     mdbxc::sync::HttpSyncServer bounded_server(engine, bounds);
@@ -355,6 +360,39 @@ void test_http_peer_rejects_transport_error() {
                  "HTTP peer Retry-After hint mismatch");
 }
 
+void test_http_peer_logical_recovery_route() {
+    const std::string source_path = "test_http_logical_recovery_source.mdbx";
+    cleanup(source_path);
+
+    std::shared_ptr<mdbxc::Connection> source = open_db(source_path);
+    mdbxc::sync::SyncEngine engine(source);
+    engine.initialize_local_identity(make_node(0x81), make_node(0x91));
+    mdbxc::sync::HttpSyncServer server(engine);
+    LoopbackHttpClient client(server);
+    mdbxc::sync::HttpSyncPeer peer(client);
+
+    mdbxc::sync::LogicalRecoveryRequest request;
+    request.requester = make_node(0xA1);
+    mdbxc::sync::CancellationSource cancellation;
+    const mdbxc::sync::CancellationToken token = cancellation.token();
+    const mdbxc::sync::LogicalRecoveryResponse response =
+        peer.logical_recovery_with_cancel(request, &token);
+
+    require_true(peer.supports_logical_recovery(),
+                 "HTTP peer did not advertise logical recovery");
+    require_true(!response.ok && response.error_code ==
+                     mdbxc::sync::SyncResponseErrorCode::SnapshotNotConfigured,
+                 "HTTP logical recovery structured failure mismatch");
+    require_true(client.last_target() ==
+                     mdbxc::sync::HttpSyncRoutes::logical_recovery_target(),
+                 "HTTP logical recovery target mismatch");
+    require_true(client.last_token_cancellable(),
+                 "HTTP logical recovery did not receive cancellation token");
+
+    source->disconnect();
+    cleanup(source_path);
+}
+
 } // namespace
 
 int main() {
@@ -362,5 +400,6 @@ int main() {
     test_http_server_status_mapping();
     test_http_peer_rejects_transport_error();
     test_http_peer_delivers_ordered_logical_outbox();
+    test_http_peer_logical_recovery_route();
     return 0;
 }

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -2863,8 +2863,18 @@ void test_engine_recovers_logical_baseline_atomically() {
 
     sync::LogicalRecoveryRequest request;
     request.requester = replica_node;
+    request.db_id = db_id;
     request.max_bytes = 8192u;
     request.max_single_batch_bytes = 8192u;
+    request.db_id = make_node(0xE1);
+    const sync::LogicalRecoveryResponse db_mismatch =
+        source.handle_logical_recovery(request);
+    if (db_mismatch.ok || db_mismatch.error_code !=
+            sync::SyncResponseErrorCode::DbIdMismatch) {
+        throw std::runtime_error(
+            "logical recovery did not reject a mismatched db_id");
+    }
+    request.db_id = db_id;
     const sync::LogicalRecoveryResponse response =
         source.handle_logical_recovery(request);
     if (!response.ok || response.has_more || !response.has_baseline) {
@@ -3033,6 +3043,7 @@ void test_engine_recovery_preserves_global_origin_sequence_across_receiver_cutov
 
     sync::LogicalRecoveryRequest request;
     request.requester = recovered_node;
+    request.db_id = db_id;
     request.max_bytes = 8192u;
     request.max_single_batch_bytes = 8192u;
     const sync::LogicalRecoveryResponse response =
@@ -3119,6 +3130,7 @@ void test_engine_recovery_counts_fixed_logical_baseline_records_in_byte_budget()
 
     sync::LogicalRecoveryRequest request;
     request.requester = requester_node;
+    request.db_id = db_id;
     request.max_bytes = 8192u;
     request.max_single_batch_bytes = 8192u;
     const sync::LogicalRecoveryResponse response =
@@ -3194,6 +3206,7 @@ void test_engine_recovery_counts_schema_dbi_name_storage_in_byte_budget() {
 
     sync::LogicalRecoveryRequest request;
     request.requester = requester_node;
+    request.db_id = db_id;
     request.max_bytes = 8192u;
     request.max_single_batch_bytes = 8192u;
     const sync::LogicalRecoveryResponse response =
@@ -3241,6 +3254,7 @@ void test_engine_recovery_counts_outbox_change_storage_in_byte_budget() {
 
     sync::LogicalRecoveryRequest request;
     request.requester = requester_node;
+    request.db_id = db_id;
     request.max_bytes = 8192u;
     request.max_single_batch_bytes = 8192u;
     const sync::LogicalRecoveryResponse response =
@@ -3284,6 +3298,7 @@ void test_engine_cancels_direct_logical_recovery_materialization() {
     sync::DirectSyncPeer peer(&source);
     sync::LogicalRecoveryRequest request;
     request.requester = replica_node;
+    request.db_id = db_id;
     request.max_bytes = 8192u;
     request.max_single_batch_bytes = 8192u;
     sync::CancellationSource cancellation;

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -300,6 +300,48 @@ private:
     mdbxc::sync::SyncEngine& m_remote;
 };
 
+class SnapshotRequiredLogicalRecoveryDelegatingPeer
+    : public mdbxc::sync::ISyncPeer {
+public:
+    explicit SnapshotRequiredLogicalRecoveryDelegatingPeer(
+            mdbxc::sync::ISyncPeer& recovery_peer)
+        : m_recovery_peer(recovery_peer) {}
+
+    mdbxc::sync::PullResponse pull(
+            const mdbxc::sync::PullRequest& request) override {
+        (void)request;
+        mdbxc::sync::PullResponse out;
+        out.ok = false;
+        out.error = "retained raw history is unavailable";
+        out.error_code = mdbxc::sync::SyncResponseErrorCode::SnapshotRequired;
+        return out;
+    }
+
+    mdbxc::sync::PushResponse push(
+            const mdbxc::sync::PushRequest& request) override {
+        (void)request;
+        return mdbxc::sync::PushResponse();
+    }
+
+    bool supports_logical_recovery() const override {
+        return m_recovery_peer.supports_logical_recovery();
+    }
+
+    mdbxc::sync::LogicalRecoveryResponse logical_recovery(
+            const mdbxc::sync::LogicalRecoveryRequest& request) override {
+        return m_recovery_peer.logical_recovery(request);
+    }
+
+    mdbxc::sync::LogicalRecoveryResponse logical_recovery_with_cancel(
+            const mdbxc::sync::LogicalRecoveryRequest& request,
+            const mdbxc::sync::CancellationToken* cancel_token = nullptr) override {
+        return m_recovery_peer.logical_recovery_with_cancel(request, cancel_token);
+    }
+
+private:
+    mdbxc::sync::ISyncPeer& m_recovery_peer;
+};
+
 class BlockingPeer : public mdbxc::sync::ISyncPeer {
 public:
     explicit BlockingPeer(const mdbxc::sync::PullResponse& response)
@@ -3135,6 +3177,95 @@ void test_worker_recovers_logical_fresh_replica() {
     cleanup(replica_path);
 }
 
+void test_worker_recovers_logical_fresh_replica_over_http_transport() {
+    using namespace mdbxc;
+    typedef sync::KeyValueLogicalStringCodec<std::string> StringCodec;
+    typedef sync::KeyValueTableLogicalAdapter<
+        std::string, std::string, StringCodec, StringCodec> LogicalAdapter;
+
+    const std::string source_path =
+        "test_worker_http_logical_recovery_source.mdbx";
+    const std::string replica_path =
+        "test_worker_http_logical_recovery_replica.mdbx";
+    const std::string schema_id = "app.worker.http_logical_recovery.v1";
+    cleanup(source_path);
+    cleanup(replica_path);
+
+    const sync::NodeId source_node = make_node(0xB0);
+    const sync::NodeId replica_node = make_node(0xC0);
+    const sync::DbId db_id = make_node(0xE0);
+    sync::FullSnapshotExportOptions snapshot_options;
+    snapshot_options.replacement_scope =
+        sync::FullSnapshotScope::CompleteUserDatabase;
+    snapshot_options.max_materialized_operations = 32u;
+    snapshot_options.max_materialized_bytes = 8192u;
+
+    std::shared_ptr<Connection> source_conn = open_env(source_path);
+    std::shared_ptr<Connection> replica_conn = open_env(replica_path);
+    sync::SyncEngine source(
+        source_conn, sync::ConflictPolicy::Reject, snapshot_options);
+    sync::SyncEngine replica(replica_conn);
+    source.initialize_local_identity(source_node, db_id);
+    replica.initialize_local_identity(replica_node, db_id);
+
+    KeyValueTable<std::string, std::string> source_documents(
+        source_conn, "documents");
+    KeyValueTable<std::string, std::string> replica_documents(
+        replica_conn, "documents");
+    LogicalAdapter source_adapter(source_documents, schema_id);
+    LogicalAdapter replica_adapter(replica_documents, schema_id);
+    sync::LogicalSchemaRecord record;
+    record.dbi_name = "documents";
+    record.kind = sync::LogicalTableKind::KeyValue;
+    record.schema_version = 1u;
+    record.dbi_names.push_back("documents");
+    source.initialize_logical_adapter_schema(source_adapter, record);
+    source.register_logical_adapter(source_adapter);
+    replica.register_logical_adapter(replica_adapter);
+    {
+        std::unique_ptr<LogicalAdapter::LogicalCaptureSession> session =
+            source_adapter.begin_capture_session();
+        session->insert_or_assign("recovered", "over-http");
+        (void)session->commit_to_outbox(source, db_id, replica_node);
+    }
+
+    sync::HttpBearerNodeIdentityPolicy identity;
+    identity.allow_token_for_node("replica-token", replica_node);
+    identity.allow_db_id_for_token("replica-token", db_id);
+    sync::HttpSyncServer source_server(source);
+    sync::HttpSyncServerMiddleware guarded_server(source_server, &identity);
+    ContextHttpClient client(guarded_server, "replica-token", "127.0.0.1");
+    sync::HttpSyncPeer network_recovery_peer(client);
+    SnapshotRequiredLogicalRecoveryDelegatingPeer peer(network_recovery_peer);
+    sync::SyncPeerMiddleware wrapped_peer(peer);
+    sync::SyncWorkerOptions options;
+    options.enable_logical_recovery_fallback = true;
+    options.max_bytes = 8192u;
+    options.max_single_batch_bytes = 8192u;
+    sync::SyncWorker worker(replica, wrapped_peer, options);
+    const sync::SyncWorkerRoundResult result = worker.run_once();
+
+    if (!result.ok || result.pages_pulled != 1u ||
+        kv_or_throw(replica_conn, replica_documents, std::string("recovered"),
+                    "worker HTTP logical recovery value") != "over-http") {
+        throw std::runtime_error(
+            "worker did not recover a logical fresh replica over HTTP");
+    }
+    {
+        auto txn = replica_conn->transaction(TransactionMode::READ_ONLY);
+        sync::LogicalDeliveryOrderStore order(replica_conn->env_handle());
+        if (order.last_applied(txn.handle(), source_node) != 1u) {
+            throw std::runtime_error(
+                "worker HTTP logical recovery did not restore sender frontier");
+        }
+    }
+
+    source_conn->disconnect();
+    replica_conn->disconnect();
+    cleanup(source_path);
+    cleanup(replica_path);
+}
+
 void test_worker_rejects_logical_complete_snapshot_fallback() {
     using namespace mdbxc;
     const std::string source_path = "test_worker_logical_snapshot_source.mdbx";
@@ -3233,6 +3364,8 @@ int main() {
           &test_worker_preserves_outbox_after_unavailable_or_retryable_logical_delivery },
         { "test_worker_recovers_logical_fresh_replica",
           &test_worker_recovers_logical_fresh_replica },
+        { "test_worker_recovers_logical_fresh_replica_over_http_transport",
+          &test_worker_recovers_logical_fresh_replica_over_http_transport },
         { "test_worker_rejects_logical_complete_snapshot_fallback",
           &test_worker_rejects_logical_complete_snapshot_fallback },
         { "test_worker_run_once_drains_paginated_pull",

--- a/tests/test_sync_worker.cpp
+++ b/tests/test_sync_worker.cpp
@@ -3107,11 +3107,12 @@ void test_worker_recovers_logical_fresh_replica() {
     }
 
     SnapshotRequiredLogicalRecoveryPeer peer(source);
+    sync::SyncPeerMiddleware wrapped_peer(peer);
     sync::SyncWorkerOptions options;
     options.enable_logical_recovery_fallback = true;
     options.max_bytes = 8192u;
     options.max_single_batch_bytes = 8192u;
-    sync::SyncWorker worker(replica, peer, options);
+    sync::SyncWorker worker(replica, wrapped_peer, options);
     const sync::SyncWorkerRoundResult result = worker.run_once();
     if (!result.ok || result.pages_pulled != 1u ||
         kv_or_throw(replica_conn, replica_documents, std::string("recovered"),

--- a/tests/test_transport_codec.cpp
+++ b/tests/test_transport_codec.cpp
@@ -436,6 +436,143 @@ void test_logical_snapshot_error_roundtrip() {
                  "logical snapshot error unexpectedly retryable");
 }
 
+void test_logical_recovery_protocol_roundtrip() {
+    using namespace mdbxc::sync;
+
+    LogicalRecoveryRequest request;
+    request.requester = make_node(0x31);
+    request.max_bytes = 8192u;
+    request.max_single_batch_bytes = 4096u;
+    const LogicalRecoveryRequest decoded_request =
+        LogicalRecoveryProtocolCodec::decode_request(
+            LogicalRecoveryProtocolCodec::encode_request(request));
+    require_true(decoded_request.requester == request.requester,
+                 "logical recovery requester mismatch");
+    require_true(decoded_request.max_bytes == request.max_bytes,
+                 "logical recovery max bytes mismatch");
+
+    LogicalRecoveryResponse intermediate;
+    intermediate.has_more = true;
+    intermediate.snapshot_chunk = make_snapshot_chunk();
+    const LogicalRecoveryResponse decoded_intermediate =
+        LogicalRecoveryProtocolCodec::decode_response(
+            LogicalRecoveryProtocolCodec::encode_response(intermediate));
+    require_true(decoded_intermediate.ok && decoded_intermediate.has_more &&
+                     !decoded_intermediate.has_baseline,
+                 "logical recovery intermediate response mismatch");
+
+    LogicalRecoveryResponse final_response;
+    final_response.snapshot_chunk = make_snapshot_chunk();
+    final_response.snapshot_chunk.has_more = false;
+    final_response.snapshot_chunk.continuation.clear();
+    final_response.snapshot_chunk.batch.batch_flags = BATCH_NONE;
+    final_response.has_baseline = true;
+    final_response.baseline.source_node_id =
+        final_response.snapshot_chunk.source_node_id;
+    final_response.baseline.source_db_uuid =
+        final_response.snapshot_chunk.source_db_uuid;
+    final_response.baseline.snapshot_id =
+        final_response.snapshot_chunk.snapshot_id;
+    LogicalSchemaRegistryEntry schema;
+    schema.schema_id = "app.recovery.v1";
+    schema.record.dbi_name = "documents";
+    schema.record.kind = LogicalTableKind::KeyValue;
+    schema.record.schema_version = 1u;
+    schema.record.dbi_names.push_back("documents");
+    final_response.baseline.schemas.push_back(schema);
+    LogicalSchemaRef frame_schema;
+    frame_schema.schema_id = schema.schema_id;
+    frame_schema.kind = schema.record.kind;
+    frame_schema.schema_version = schema.record.schema_version;
+    LogicalChangeFrame frame;
+    frame.changes.push_back(LogicalChange(
+        frame_schema, 1u, 0u, std::vector<std::uint8_t>(1u, 0x5Au)));
+    LogicalDeliveryMarkerInfo marker;
+    marker.destination_db_uuid = final_response.snapshot_chunk.source_db_uuid;
+    marker.origin_node_id = make_node(0x60);
+    marker.origin_sequence = 7u;
+    marker.frame_id = "marker-7";
+    marker.frame_codec_version = LogicalChangeFrameCodec::codec_version();
+    marker.encoded_frame = LogicalChangeFrameCodec::encode(frame);
+    marker.frame_bytes_size = static_cast<std::uint32_t>(
+        marker.encoded_frame.size());
+    final_response.baseline.delivery_markers.push_back(marker);
+    LogicalDeliveryWatermarkInfo watermark;
+    watermark.origin_node_id = make_node(0x61);
+    watermark.sequence = 3u;
+    final_response.baseline.delivery_watermarks.push_back(watermark);
+    LogicalDeliveryOrderEntry order;
+    order.origin_node_id = make_node(0x62);
+    order.acknowledged_through = 5u;
+    final_response.baseline.delivery_order.push_back(order);
+    LogicalDeliveryEnvelope pending;
+    pending.destination_db_uuid = final_response.snapshot_chunk.source_db_uuid;
+    pending.origin_node_id = final_response.snapshot_chunk.source_node_id;
+    pending.origin_sequence = 1u;
+    pending.frame_id = "pending-1";
+    pending.frame = frame;
+    final_response.baseline.source_outbox_pending.push_back(pending);
+    final_response.baseline.source_outbox_known_tail = 1u;
+    const LogicalRecoveryResponse decoded_final =
+        LogicalRecoveryProtocolCodec::decode_response(
+            LogicalRecoveryProtocolCodec::encode_response(final_response));
+    require_true(decoded_final.ok && !decoded_final.has_more &&
+                     decoded_final.has_baseline &&
+                     decoded_final.baseline.snapshot_id == "snapshot-session" &&
+                     decoded_final.baseline.schemas.size() == 1u &&
+                     decoded_final.baseline.delivery_markers.size() == 1u &&
+                     decoded_final.baseline.delivery_watermarks.size() == 1u &&
+                     decoded_final.baseline.delivery_order.size() == 1u &&
+                     decoded_final.baseline.source_outbox_pending.size() == 1u,
+                 "logical recovery final response mismatch");
+
+    LogicalRecoveryResponse failure;
+    failure.ok = false;
+    failure.error = "logical recovery unavailable";
+    failure.error_code = SyncResponseErrorCode::SnapshotSessionBusy;
+    failure.error_retryable = true;
+    const LogicalRecoveryResponse decoded_failure =
+        LogicalRecoveryProtocolCodec::decode_response(
+            LogicalRecoveryProtocolCodec::encode_response(failure));
+    require_true(!decoded_failure.ok && decoded_failure.error_retryable &&
+                     decoded_failure.error_code ==
+                         SyncResponseErrorCode::SnapshotSessionBusy,
+                 "logical recovery failure response mismatch");
+}
+
+void test_logical_recovery_protocol_rejections() {
+    using namespace mdbxc::sync;
+
+    LogicalRecoveryResponse response;
+    response.snapshot_chunk = make_snapshot_chunk();
+    response.snapshot_chunk.has_more = false;
+    response.snapshot_chunk.continuation.clear();
+    response.snapshot_chunk.batch.batch_flags = BATCH_NONE;
+
+    expect_throw("logical recovery missing baseline", [response] {
+        (void)LogicalRecoveryProtocolCodec::encode_response(response);
+    });
+
+    response.has_baseline = true;
+    response.baseline.source_node_id = response.snapshot_chunk.source_node_id;
+    response.baseline.source_db_uuid = response.snapshot_chunk.source_db_uuid;
+    response.baseline.snapshot_id = response.snapshot_chunk.snapshot_id;
+    std::vector<std::uint8_t> encoded =
+        LogicalRecoveryProtocolCodec::encode_response(response);
+    encoded.push_back(0xFFu);
+    expect_throw("logical recovery trailing bytes", [encoded] {
+        (void)LogicalRecoveryProtocolCodec::decode_response(encoded);
+    });
+
+    CodecBounds bounds;
+    bounds.max_transport_message_bytes = 16u;
+    expect_throw("logical recovery transport bound", [&bounds] {
+        LogicalRecoveryRequest request;
+        request.requester = make_node(0x44);
+        (void)LogicalRecoveryProtocolCodec::encode_request(request, &bounds);
+    });
+}
+
 void test_golden_header_shape() {
     using namespace mdbxc::sync;
     const std::vector<std::uint8_t> bytes =
@@ -468,6 +605,8 @@ int main() {
     test_bounds_rejections();
     test_response_error_code_rejections();
     test_logical_snapshot_error_roundtrip();
+    test_logical_recovery_protocol_roundtrip();
+    test_logical_recovery_protocol_rejections();
     test_golden_header_shape();
     return 0;
 }

--- a/tests/test_transport_codec.cpp
+++ b/tests/test_transport_codec.cpp
@@ -441,6 +441,7 @@ void test_logical_recovery_protocol_roundtrip() {
 
     LogicalRecoveryRequest request;
     request.requester = make_node(0x31);
+    request.db_id = make_node(0xD1);
     request.max_bytes = 8192u;
     request.max_single_batch_bytes = 4096u;
     const LogicalRecoveryRequest decoded_request =
@@ -448,6 +449,8 @@ void test_logical_recovery_protocol_roundtrip() {
             LogicalRecoveryProtocolCodec::encode_request(request));
     require_true(decoded_request.requester == request.requester,
                  "logical recovery requester mismatch");
+    require_true(decoded_request.db_id == request.db_id,
+                 "logical recovery db_id mismatch");
     require_true(decoded_request.max_bytes == request.max_bytes,
                  "logical recovery max bytes mismatch");
 
@@ -569,7 +572,44 @@ void test_logical_recovery_protocol_rejections() {
     expect_throw("logical recovery transport bound", [&bounds] {
         LogicalRecoveryRequest request;
         request.requester = make_node(0x44);
+        request.db_id = make_node(0xD4);
         (void)LogicalRecoveryProtocolCodec::encode_request(request, &bounds);
+    });
+
+    LogicalRecoveryResponse invalid_error_code;
+    invalid_error_code.ok = false;
+    invalid_error_code.error_code =
+        static_cast<SyncResponseErrorCode>(0xFFFFu);
+    expect_throw("logical recovery unknown error code", [invalid_error_code] {
+        (void)LogicalRecoveryProtocolCodec::encode_response(invalid_error_code);
+    });
+
+    LogicalRecoveryResponse oversized_pending = response;
+    LogicalDeliveryEnvelope pending;
+    pending.destination_db_uuid = response.snapshot_chunk.source_db_uuid;
+    pending.origin_node_id = make_node(0x55);
+    pending.origin_sequence = 1u;
+    pending.frame_id = "pending-bound";
+    oversized_pending.baseline.source_outbox_pending.push_back(pending);
+    CodecBounds envelope_bounds;
+    envelope_bounds.max_batch_total_bytes = 1u;
+    expect_throw("logical recovery pending envelope bound", [oversized_pending,
+                                                               &envelope_bounds] {
+        (void)LogicalRecoveryProtocolCodec::encode_response(
+            oversized_pending, &envelope_bounds);
+    });
+
+    response.baseline.schemas.push_back(LogicalSchemaRegistryEntry());
+    response.baseline.schemas.back().schema_id = "app.recovery.bound";
+    response.baseline.schemas.back().record.dbi_name = "documents";
+    response.baseline.schemas.back().record.kind = LogicalTableKind::KeyValue;
+    response.baseline.schemas.back().record.schema_version = 1u;
+    response.baseline.schemas.back().record.dbi_names.push_back("documents");
+    response.baseline.schemas.back().record.dbi_names.push_back("metadata");
+    CodecBounds schema_bounds;
+    schema_bounds.max_snapshot_manifest_entries = 1u;
+    expect_throw("logical recovery schema DBI count bound", [response, &schema_bounds] {
+        (void)LogicalRecoveryProtocolCodec::encode_response(response, &schema_bounds);
     });
 }
 

--- a/tests/test_transport_middleware.cpp
+++ b/tests/test_transport_middleware.cpp
@@ -291,6 +291,7 @@ void test_peer_middleware_forwards_logical_capabilities() {
 
     mdbxc::sync::LogicalRecoveryRequest request;
     request.requester = make_node(0x33);
+    request.db_id = make_node(0xD3);
     mdbxc::sync::CancellationSource cancellation;
     const mdbxc::sync::CancellationToken token = cancellation.token();
     const mdbxc::sync::LogicalRecoveryResponse response =
@@ -671,6 +672,7 @@ void test_http_bearer_node_identity_policy() {
 
     mdbxc::sync::LogicalRecoveryRequest recovery;
     recovery.requester = node_a;
+    recovery.db_id = db_a;
     request.target = mdbxc::sync::HttpSyncRoutes::logical_recovery_target();
     request.body = mdbxc::sync::LogicalRecoveryProtocolCodec::encode_request(
         recovery);
@@ -678,7 +680,15 @@ void test_http_bearer_node_identity_policy() {
     require_true(decision.allowed,
                  "matching logical recovery requester was rejected");
 
+    recovery.db_id = db_b;
+    request.body = mdbxc::sync::LogicalRecoveryProtocolCodec::encode_request(
+        recovery);
+    decision = policy.check_http_request(request);
+    require_true(!decision.allowed && decision.status_code == 403,
+                 "logical recovery db_id mismatch was not rejected");
+
     recovery.requester = node_b;
+    recovery.db_id = db_a;
     request.body = mdbxc::sync::LogicalRecoveryProtocolCodec::encode_request(
         recovery);
     decision = policy.check_http_request(request);

--- a/tests/test_transport_middleware.cpp
+++ b/tests/test_transport_middleware.cpp
@@ -52,7 +52,12 @@ std::shared_ptr<mdbxc::Connection> open_db(const std::string& path) {
 
 class RecordingPeer : public mdbxc::sync::ISyncPeer {
 public:
-    RecordingPeer() : m_pull_count(0), m_push_count(0), m_cancel_count(0) {}
+    RecordingPeer()
+        : m_pull_count(0),
+          m_push_count(0),
+          m_cancel_count(0),
+          m_logical_recovery_count(0),
+          m_logical_recovery_token_cancellable(false) {}
 
     mdbxc::sync::PullResponse pull(
             const mdbxc::sync::PullRequest& request) override {
@@ -77,16 +82,49 @@ public:
         ++m_cancel_count;
     }
 
+    bool supports_logical_delivery() const override { return true; }
+
+    bool supports_logical_recovery() const override { return true; }
+
+    mdbxc::sync::LogicalRecoveryResponse logical_recovery(
+            const mdbxc::sync::LogicalRecoveryRequest& request) override {
+        return logical_recovery_with_cancel(request, nullptr);
+    }
+
+    mdbxc::sync::LogicalRecoveryResponse logical_recovery_with_cancel(
+            const mdbxc::sync::LogicalRecoveryRequest& request,
+            const mdbxc::sync::CancellationToken* cancel_token = nullptr) override {
+        ++m_logical_recovery_count;
+        m_last_logical_recovery = request;
+        m_logical_recovery_token_cancellable =
+            cancel_token != nullptr && cancel_token->can_be_cancelled();
+        mdbxc::sync::LogicalRecoveryResponse response;
+        response.ok = false;
+        response.error = "recorded logical recovery";
+        response.error_code =
+            mdbxc::sync::SyncResponseErrorCode::SnapshotNotConfigured;
+        return response;
+    }
+
     std::size_t pull_count() const { return m_pull_count; }
     std::size_t push_count() const { return m_push_count; }
     std::size_t cancel_count() const { return m_cancel_count; }
+    std::size_t logical_recovery_count() const {
+        return m_logical_recovery_count;
+    }
+    bool logical_recovery_token_cancellable() const {
+        return m_logical_recovery_token_cancellable;
+    }
 
 private:
     std::size_t m_pull_count;
     std::size_t m_push_count;
     std::size_t m_cancel_count;
+    std::size_t m_logical_recovery_count;
+    bool m_logical_recovery_token_cancellable;
     mdbxc::sync::PullRequest m_last_pull;
     mdbxc::sync::PushRequest m_last_push;
+    mdbxc::sync::LogicalRecoveryRequest m_last_logical_recovery;
 };
 
 class RecordingHttpClient : public mdbxc::sync::IHttpSyncClient {
@@ -241,6 +279,28 @@ void test_peer_middleware_allows_limits_and_observes() {
                  "pulled batch metric mismatch");
     require_true(snapshot.pushed_batches == 1u,
                  "pushed batch metric mismatch");
+}
+
+void test_peer_middleware_forwards_logical_capabilities() {
+    RecordingPeer peer;
+    mdbxc::sync::SyncPeerMiddleware wrapped(peer);
+    require_true(wrapped.supports_logical_delivery(),
+                 "peer middleware lost logical delivery capability");
+    require_true(wrapped.supports_logical_recovery(),
+                 "peer middleware lost logical recovery capability");
+
+    mdbxc::sync::LogicalRecoveryRequest request;
+    request.requester = make_node(0x33);
+    mdbxc::sync::CancellationSource cancellation;
+    const mdbxc::sync::CancellationToken token = cancellation.token();
+    const mdbxc::sync::LogicalRecoveryResponse response =
+        wrapped.logical_recovery_with_cancel(request, &token);
+
+    require_true(!response.ok, "recording logical recovery unexpectedly succeeded");
+    require_true(peer.logical_recovery_count() == 1u,
+                 "peer middleware did not forward logical recovery");
+    require_true(peer.logical_recovery_token_cancellable(),
+                 "peer middleware did not preserve logical recovery cancellation");
 }
 
 void test_transport_trace_context_helpers() {
@@ -609,10 +669,23 @@ void test_http_bearer_node_identity_policy() {
     require_true(!decision.allowed && decision.status_code == 403,
                  "sender mismatch was not rejected");
 
+    mdbxc::sync::LogicalRecoveryRequest recovery;
+    recovery.requester = node_a;
+    request.target = mdbxc::sync::HttpSyncRoutes::logical_recovery_target();
+    request.body = mdbxc::sync::LogicalRecoveryProtocolCodec::encode_request(
+        recovery);
+    decision = policy.check_http_request(request);
+    require_true(decision.allowed,
+                 "matching logical recovery requester was rejected");
+
+    recovery.requester = node_b;
+    request.body = mdbxc::sync::LogicalRecoveryProtocolCodec::encode_request(
+        recovery);
+    decision = policy.check_http_request(request);
+    require_true(!decision.allowed && decision.status_code == 403,
+                 "logical recovery requester mismatch was not rejected");
+
     request.headers.clear();
-    push.sender = node_a;
-    request.body = mdbxc::sync::TransportMessageCodec::encode_push_request(
-        push);
     decision = policy.check_http_request(request);
     require_true(!decision.allowed && decision.status_code == 401,
                  "missing bearer identity was not rejected");
@@ -949,6 +1022,7 @@ void test_http_server_middleware_copies_rejection_headers() {
 
 int main() {
     test_peer_middleware_allows_limits_and_observes();
+    test_peer_middleware_forwards_logical_capabilities();
     test_transport_trace_context_helpers();
     test_transport_observer_receives_request_context();
     test_observer_exceptions_are_swallowed();

--- a/tests/test_websocket_transport.cpp
+++ b/tests/test_websocket_transport.cpp
@@ -74,6 +74,12 @@ public:
             std::memcmp(&binary_message[0],
                         mdbxc::sync::LogicalDeliveryProtocolCodec::magic(),
                         mdbxc::sync::LogicalDeliveryProtocolCodec::magic_size()) == 0;
+        m_last_was_logical = m_last_was_logical ||
+            (binary_message.size() >=
+                mdbxc::sync::LogicalRecoveryProtocolCodec::magic_size() &&
+             std::memcmp(&binary_message[0],
+                         mdbxc::sync::LogicalRecoveryProtocolCodec::magic(),
+                         mdbxc::sync::LogicalRecoveryProtocolCodec::magic_size()) == 0);
         if (!m_last_was_logical) {
             m_last_type =
                 mdbxc::sync::TransportMessageCodec::peek_message_type(
@@ -242,6 +248,22 @@ void test_websocket_server_rejects_response_messages() {
     require_true(caught,
                  "WebSocket server must reject response messages");
 
+    mdbxc::sync::LogicalRecoveryResponse recovery_response;
+    recovery_response.ok = false;
+    recovery_response.error = "client response";
+    const std::vector<std::uint8_t> logical_response =
+        mdbxc::sync::LogicalRecoveryProtocolCodec::encode_response(
+            recovery_response);
+    caught = false;
+    try {
+        (void)server.handle_binary_message(logical_response);
+    } catch (const std::runtime_error& e) {
+        caught = std::string(e.what()).find("response message") !=
+                 std::string::npos;
+    }
+    require_true(caught,
+                 "WebSocket server must reject logical recovery responses");
+
     db->disconnect();
     cleanup(path);
 }
@@ -378,6 +400,21 @@ void test_websocket_authenticated_node_policy() {
     require_true(!decision.allowed && decision.status_code == 1008,
                  "WebSocket sender mismatch was not rejected");
 
+    mdbxc::sync::LogicalRecoveryRequest recovery;
+    recovery.requester = node_a;
+    context.binary_message =
+        mdbxc::sync::LogicalRecoveryProtocolCodec::encode_request(recovery);
+    decision = policy.check_websocket_message(context);
+    require_true(decision.allowed,
+                 "matching WebSocket logical recovery requester was rejected");
+
+    recovery.requester = node_b;
+    context.binary_message =
+        mdbxc::sync::LogicalRecoveryProtocolCodec::encode_request(recovery);
+    decision = policy.check_websocket_message(context);
+    require_true(!decision.allowed && decision.status_code == 1008,
+                 "WebSocket logical recovery requester mismatch was not rejected");
+
     context.has_authenticated_node = false;
     push.sender = node_a;
     context.binary_message =
@@ -508,6 +545,38 @@ void test_websocket_server_middleware_preserves_close_code() {
                  "WebSocket policy rejection was counted as exception");
 }
 
+void test_websocket_peer_logical_recovery_route() {
+    const std::string source_path = "test_websocket_logical_recovery_source.mdbx";
+    cleanup(source_path);
+
+    std::shared_ptr<mdbxc::Connection> source = open_db(source_path);
+    mdbxc::sync::SyncEngine engine(source);
+    engine.initialize_local_identity(make_node(0x81), make_node(0x91));
+    mdbxc::sync::WebSocketSyncServer server(engine);
+    LoopbackWebSocketChannel channel(server);
+    mdbxc::sync::WebSocketSyncPeer peer(channel);
+
+    mdbxc::sync::LogicalRecoveryRequest request;
+    request.requester = make_node(0xA1);
+    mdbxc::sync::CancellationSource cancellation;
+    const mdbxc::sync::CancellationToken token = cancellation.token();
+    const mdbxc::sync::LogicalRecoveryResponse response =
+        peer.logical_recovery_with_cancel(request, &token);
+
+    require_true(peer.supports_logical_recovery(),
+                 "WebSocket peer did not advertise logical recovery");
+    require_true(!response.ok && response.error_code ==
+                     mdbxc::sync::SyncResponseErrorCode::SnapshotNotConfigured,
+                 "WebSocket logical recovery structured failure mismatch");
+    require_true(channel.last_was_logical(),
+                 "WebSocket logical recovery did not use logical wire family");
+    require_true(channel.last_token_cancellable(),
+                 "WebSocket logical recovery did not receive cancellation token");
+
+    source->disconnect();
+    cleanup(source_path);
+}
+
 } // namespace
 
 int main() {
@@ -519,5 +588,6 @@ int main() {
     test_websocket_authenticated_node_policy_rejects_invalid_body();
     test_websocket_server_middleware_rejects_spoofed_identity();
     test_websocket_server_middleware_preserves_close_code();
+    test_websocket_peer_logical_recovery_route();
     return 0;
 }

--- a/tests/test_websocket_transport.cpp
+++ b/tests/test_websocket_transport.cpp
@@ -402,13 +402,22 @@ void test_websocket_authenticated_node_policy() {
 
     mdbxc::sync::LogicalRecoveryRequest recovery;
     recovery.requester = node_a;
+    recovery.db_id = db_a;
     context.binary_message =
         mdbxc::sync::LogicalRecoveryProtocolCodec::encode_request(recovery);
     decision = policy.check_websocket_message(context);
     require_true(decision.allowed,
                  "matching WebSocket logical recovery requester was rejected");
 
+    recovery.db_id = db_b;
+    context.binary_message =
+        mdbxc::sync::LogicalRecoveryProtocolCodec::encode_request(recovery);
+    decision = policy.check_websocket_message(context);
+    require_true(!decision.allowed && decision.status_code == 1008,
+                 "WebSocket logical recovery db_id mismatch was not rejected");
+
     recovery.requester = node_b;
+    recovery.db_id = db_a;
     context.binary_message =
         mdbxc::sync::LogicalRecoveryProtocolCodec::encode_request(recovery);
     decision = policy.check_websocket_message(context);
@@ -550,14 +559,21 @@ void test_websocket_peer_logical_recovery_route() {
     cleanup(source_path);
 
     std::shared_ptr<mdbxc::Connection> source = open_db(source_path);
-    mdbxc::sync::SyncEngine engine(source);
+    mdbxc::sync::FullSnapshotExportOptions options;
+    options.replacement_scope =
+        mdbxc::sync::FullSnapshotScope::CompleteUserDatabase;
+    mdbxc::sync::SyncEngine engine(
+        source, mdbxc::sync::ConflictPolicy::Reject, options);
     engine.initialize_local_identity(make_node(0x81), make_node(0x91));
+    mdbxc::KeyValueTable<int, std::string> source_values(source, "values");
+    source_values.insert_or_assign(1, "recovery-value");
     mdbxc::sync::WebSocketSyncServer server(engine);
     LoopbackWebSocketChannel channel(server);
     mdbxc::sync::WebSocketSyncPeer peer(channel);
 
     mdbxc::sync::LogicalRecoveryRequest request;
     request.requester = make_node(0xA1);
+    request.db_id = make_node(0x91);
     mdbxc::sync::CancellationSource cancellation;
     const mdbxc::sync::CancellationToken token = cancellation.token();
     const mdbxc::sync::LogicalRecoveryResponse response =
@@ -565,9 +581,9 @@ void test_websocket_peer_logical_recovery_route() {
 
     require_true(peer.supports_logical_recovery(),
                  "WebSocket peer did not advertise logical recovery");
-    require_true(!response.ok && response.error_code ==
-                     mdbxc::sync::SyncResponseErrorCode::SnapshotNotConfigured,
-                 "WebSocket logical recovery structured failure mismatch");
+    require_true(response.ok && response.has_baseline &&
+                     !response.snapshot_chunk.has_more,
+                 "WebSocket logical recovery success response mismatch");
     require_true(channel.last_was_logical(),
                  "WebSocket logical recovery did not use logical wire family");
     require_true(channel.last_token_cancellable(),


### PR DESCRIPTION
## What changed
- Adds LogicalRecoveryProtocolCodec, a strict versioned MDBXCLRP request/response codec for bounded logical recovery pages and final baselines.
- Exposes logical recovery through HTTP and WebSocket routes, servers, and peers.
- Preserves logical delivery/recovery capabilities through SyncPeerMiddleware and extends authenticated request binding to recovery.

## Why
Logical-aware recovery already worked with DirectSyncPeer, but network peers could not participate after SnapshotRequired.

## Verification
- Focused codec, HTTP, WebSocket, middleware, and worker recovery tests passed on MinGW C++11 and C++17.
- header_sync_umbrella_test builds on C++11 and C++17.

## Scope
Client cancellation is forwarded to HTTP/WebSocket transport waits. Backend-specific source-side cancellation from remote disconnects remains deferred.