### PR TITLE
[codex] enforce peer policy for logical recovery

### DIFF
--- a/include/mdbx_containers/sync/transport/TransportMiddleware.hpp
+++ b/include/mdbx_containers/sync/transport/TransportMiddleware.hpp
@@ -29,11 +29,11 @@ namespace sync {
 
     /// \brief Transport operation observed by middleware.
     enum class SyncTransportOperation : std::uint8_t {
-        Pull,
-        Push,
-        LogicalRecovery,
-        HttpPost,
-        WebSocketMessage
+        Pull = 0,
+        Push = 1,
+        HttpPost = 2,
+        WebSocketMessage = 3,
+        LogicalRecovery = 4
     };
 
     /// \brief Result returned by a transport policy.

--- a/include/mdbx_containers/sync/transport/TransportMiddleware.hpp
+++ b/include/mdbx_containers/sync/transport/TransportMiddleware.hpp
@@ -31,6 +31,7 @@ namespace sync {
     enum class SyncTransportOperation : std::uint8_t {
         Pull,
         Push,
+        LogicalRecovery,
         HttpPost,
         WebSocketMessage
     };
@@ -177,6 +178,12 @@ namespace sync {
             return SyncTransportDecision::allow();
         }
 
+        virtual SyncTransportDecision check_logical_recovery(
+                const LogicalRecoveryRequest& request) {
+            (void)request;
+            return SyncTransportDecision::allow();
+        }
+
         virtual SyncTransportDecision check_http_post(
                 const std::string& target,
                 const std::string& content_type,
@@ -266,6 +273,13 @@ namespace sync {
             return check_node_and_db(request.sender,
                                      request.db_id,
                                      "sync sender is not allowed");
+        }
+
+        SyncTransportDecision check_logical_recovery(
+                const LogicalRecoveryRequest& request) override {
+            return check_node_and_db(request.requester,
+                                     request.db_id,
+                                     "sync requester is not allowed");
         }
 
     private:
@@ -928,18 +942,22 @@ namespace sync {
         FixedBudgetSyncTransportPolicy(
                 std::uint64_t pull_budget,
                 std::uint64_t push_budget,
-                std::uint64_t http_post_budget = unlimited_budget())
+                std::uint64_t http_post_budget = unlimited_budget(),
+                std::uint64_t logical_recovery_budget = unlimited_budget())
             : m_pull_remaining(pull_budget),
               m_push_remaining(push_budget),
-              m_http_post_remaining(http_post_budget) {}
+              m_http_post_remaining(http_post_budget),
+              m_logical_recovery_remaining(logical_recovery_budget) {}
 
         void reset(std::uint64_t pull_budget,
                    std::uint64_t push_budget,
-                   std::uint64_t http_post_budget = unlimited_budget()) {
+                   std::uint64_t http_post_budget = unlimited_budget(),
+                   std::uint64_t logical_recovery_budget = unlimited_budget()) {
             std::lock_guard<std::mutex> lock(m_mutex);
             m_pull_remaining = pull_budget;
             m_push_remaining = push_budget;
             m_http_post_remaining = http_post_budget;
+            m_logical_recovery_remaining = logical_recovery_budget;
         }
 
         SyncTransportDecision check_pull(
@@ -952,6 +970,13 @@ namespace sync {
                 const PushRequest& request) override {
             (void)request;
             return consume(m_push_remaining, "sync push rate limit exceeded");
+        }
+
+        SyncTransportDecision check_logical_recovery(
+                const LogicalRecoveryRequest& request) override {
+            (void)request;
+            return consume(m_logical_recovery_remaining,
+                           "sync logical recovery rate limit exceeded");
         }
 
         SyncTransportDecision check_http_post(
@@ -983,6 +1008,7 @@ namespace sync {
         std::uint64_t m_pull_remaining;
         std::uint64_t m_push_remaining;
         std::uint64_t m_http_post_remaining;
+        std::uint64_t m_logical_recovery_remaining;
     };
 
     /// \brief Runs several policies in insertion order.
@@ -1013,6 +1039,18 @@ namespace sync {
             for (std::size_t i = 0; i < m_policies.size(); ++i) {
                 const SyncTransportDecision decision =
                     m_policies[i]->check_push(request);
+                if (!decision.allowed) {
+                    return decision;
+                }
+            }
+            return SyncTransportDecision::allow();
+        }
+
+        SyncTransportDecision check_logical_recovery(
+                const LogicalRecoveryRequest& request) override {
+            for (std::size_t i = 0; i < m_policies.size(); ++i) {
+                const SyncTransportDecision decision =
+                    m_policies[i]->check_logical_recovery(request);
                 if (!decision.allowed) {
                     return decision;
                 }
@@ -1069,6 +1107,7 @@ namespace sync {
     struct SyncTransportMetricsSnapshot {
         std::uint64_t pull_calls = 0;
         std::uint64_t push_calls = 0;
+        std::uint64_t logical_recovery_calls = 0;
         std::uint64_t http_post_calls = 0;
         std::uint64_t rejected_calls = 0;
         std::uint64_t failed_calls = 0;
@@ -1103,6 +1142,13 @@ namespace sync {
         virtual void on_sync_transport_push_result(
                 const PushRequest& request,
                 const PushResponse& response) {
+            (void)request;
+            (void)response;
+        }
+
+        virtual void on_sync_transport_logical_recovery_result(
+                const LogicalRecoveryRequest& request,
+                const LogicalRecoveryResponse& response) {
             (void)request;
             (void)response;
         }
@@ -1180,6 +1226,17 @@ namespace sync {
                 ++m_snapshot.failed_calls;
             }
             m_snapshot.pushed_batches += request.batches.size();
+        }
+
+        void on_sync_transport_logical_recovery_result(
+                const LogicalRecoveryRequest& request,
+                const LogicalRecoveryResponse& response) override {
+            (void)request;
+            std::lock_guard<std::mutex> lock(m_mutex);
+            ++m_snapshot.logical_recovery_calls;
+            if (!response.ok) {
+                ++m_snapshot.failed_calls;
+            }
         }
 
         void on_sync_transport_http_request(
@@ -1431,13 +1488,43 @@ namespace sync {
 
         LogicalRecoveryResponse logical_recovery(
                 const LogicalRecoveryRequest& request) override {
-            return m_next.logical_recovery(request);
+            return logical_recovery_with_cancel(request, nullptr);
         }
 
         LogicalRecoveryResponse logical_recovery_with_cancel(
                 const LogicalRecoveryRequest& request,
                 const CancellationToken* cancel_token = nullptr) override {
-            return m_next.logical_recovery_with_cancel(request, cancel_token);
+            if (m_policy != nullptr) {
+                const SyncTransportDecision decision =
+                    m_policy->check_logical_recovery(request);
+                if (!decision.allowed) {
+                    detail::notify_transport_rejected(
+                        m_observer, SyncTransportOperation::LogicalRecovery,
+                        decision.error);
+                    LogicalRecoveryResponse response;
+                    response.ok = false;
+                    response.error = reject_message(
+                        decision, "logical recovery rejected");
+                    return response;
+                }
+            }
+
+            try {
+                const LogicalRecoveryResponse response =
+                    m_next.logical_recovery_with_cancel(request, cancel_token);
+                notify_logical_recovery_result(request, response);
+                return response;
+            } catch (const std::exception& e) {
+                detail::notify_transport_exception(
+                    m_observer, SyncTransportOperation::LogicalRecovery,
+                    e.what());
+                throw;
+            } catch (...) {
+                detail::notify_transport_exception(
+                    m_observer, SyncTransportOperation::LogicalRecovery,
+                    "unknown logical recovery exception");
+                throw;
+            }
         }
 
     private:
@@ -1465,6 +1552,18 @@ namespace sync {
             }
             try {
                 m_observer->on_sync_transport_push_result(request, response);
+            } catch (...) {}
+        }
+
+        void notify_logical_recovery_result(
+                const LogicalRecoveryRequest& request,
+                const LogicalRecoveryResponse& response) const {
+            if (m_observer == nullptr) {
+                return;
+            }
+            try {
+                m_observer->on_sync_transport_logical_recovery_result(
+                    request, response);
             } catch (...) {}
         }
 

--- a/tests/test_transport_middleware.cpp
+++ b/tests/test_transport_middleware.cpp
@@ -283,7 +283,8 @@ void test_peer_middleware_allows_limits_and_observes() {
 
 void test_peer_middleware_forwards_logical_capabilities() {
     RecordingPeer peer;
-    mdbxc::sync::SyncPeerMiddleware wrapped(peer);
+    mdbxc::sync::SyncTransportMetricsObserver metrics;
+    mdbxc::sync::SyncPeerMiddleware wrapped(peer, nullptr, &metrics);
     require_true(wrapped.supports_logical_delivery(),
                  "peer middleware lost logical delivery capability");
     require_true(wrapped.supports_logical_recovery(),
@@ -302,6 +303,52 @@ void test_peer_middleware_forwards_logical_capabilities() {
                  "peer middleware did not forward logical recovery");
     require_true(peer.logical_recovery_token_cancellable(),
                  "peer middleware did not preserve logical recovery cancellation");
+
+    const mdbxc::sync::SyncTransportMetricsSnapshot snapshot =
+        metrics.snapshot();
+    require_true(snapshot.logical_recovery_calls == 1u,
+                 "logical recovery metric mismatch");
+    require_true(snapshot.failed_calls == 1u,
+                 "logical recovery failure metric mismatch");
+}
+
+void test_peer_middleware_enforces_logical_recovery_policy() {
+    const mdbxc::sync::NodeId requester = make_node(0x34);
+    const mdbxc::sync::DbId allowed_db_id = make_node(0xD4);
+
+    mdbxc::sync::NodeDbAllowListPolicy allow_list;
+    allow_list.allow_node_id(requester);
+    allow_list.allow_db_id(allowed_db_id);
+    mdbxc::sync::CompositeSyncTransportPolicy policy;
+    policy.add(allow_list);
+
+    RecordingPeer peer;
+    mdbxc::sync::SyncTransportMetricsObserver metrics;
+    mdbxc::sync::SyncPeerMiddleware wrapped(peer, &policy, &metrics);
+
+    mdbxc::sync::LogicalRecoveryRequest request;
+    request.requester = requester;
+    request.db_id = make_node(0xD5);
+    const mdbxc::sync::LogicalRecoveryResponse rejected =
+        wrapped.logical_recovery(request);
+    require_true(!rejected.ok, "db-denied logical recovery was allowed");
+    require_true(peer.logical_recovery_count() == 0u,
+                 "db-denied logical recovery reached downstream peer");
+
+    request.db_id = allowed_db_id;
+    const mdbxc::sync::LogicalRecoveryResponse allowed =
+        wrapped.logical_recovery(request);
+    require_true(!allowed.ok,
+                 "recording logical recovery unexpectedly succeeded");
+    require_true(peer.logical_recovery_count() == 1u,
+                 "allowed logical recovery was not forwarded");
+
+    const mdbxc::sync::SyncTransportMetricsSnapshot snapshot =
+        metrics.snapshot();
+    require_true(snapshot.rejected_calls == 1u,
+                 "logical recovery rejection metric mismatch");
+    require_true(snapshot.logical_recovery_calls == 1u,
+                 "allowed logical recovery was not observed");
 }
 
 void test_transport_trace_context_helpers() {
@@ -910,7 +957,7 @@ void test_transport_zero_limit_policies() {
                      std::string(),
                  "zero HTTP request limit must include Retry-After");
 
-    mdbxc::sync::FixedBudgetSyncTransportPolicy budget(0u, 0u, 0u);
+    mdbxc::sync::FixedBudgetSyncTransportPolicy budget(0u, 0u, 0u, 0u);
     mdbxc::sync::PullRequest pull;
     decision = budget.check_pull(pull);
     require_true(!decision.allowed && decision.status_code == 429,
@@ -920,6 +967,11 @@ void test_transport_zero_limit_policies() {
     decision = budget.check_push(push);
     require_true(!decision.allowed && decision.status_code == 429,
                  "zero push budget must reject");
+
+    mdbxc::sync::LogicalRecoveryRequest recovery;
+    decision = budget.check_logical_recovery(recovery);
+    require_true(!decision.allowed && decision.status_code == 429,
+                 "zero logical recovery budget must reject");
 
     decision = budget.check_http_post(
         mdbxc::sync::HttpSyncRoutes::pull_target(),
@@ -1033,6 +1085,7 @@ void test_http_server_middleware_copies_rejection_headers() {
 int main() {
     test_peer_middleware_allows_limits_and_observes();
     test_peer_middleware_forwards_logical_capabilities();
+    test_peer_middleware_enforces_logical_recovery_policy();
     test_transport_trace_context_helpers();
     test_transport_observer_receives_request_context();
     test_observer_exceptions_are_swallowed();

--- a/tests/test_transport_middleware.cpp
+++ b/tests/test_transport_middleware.cpp
@@ -10,6 +10,15 @@
 #include <thread>
 #include <vector>
 
+static_assert(static_cast<std::uint8_t>(mdbxc::sync::SyncTransportOperation::Pull) == 0u,
+              "pull transport operation value changed");
+static_assert(static_cast<std::uint8_t>(mdbxc::sync::SyncTransportOperation::Push) == 1u,
+              "push transport operation value changed");
+static_assert(static_cast<std::uint8_t>(mdbxc::sync::SyncTransportOperation::HttpPost) == 2u,
+              "HTTP transport operation value changed");
+static_assert(static_cast<std::uint8_t>(mdbxc::sync::SyncTransportOperation::WebSocketMessage) == 3u,
+              "WebSocket transport operation value changed");
+
 namespace {
 
 mdbxc::sync::NodeId make_node(std::uint8_t seed) {


### PR DESCRIPTION
Logical recovery now follows the same peer policy and observer contract as pull and push. Node/database ACLs and composite policies reject requests before downstream dispatch; fixed budgets have a dedicated recovery limit. Tests cover policy rejection, cancellation forwarding, metrics, composite dispatch, and budget exhaustion.