### PR TITLE
fix(sync): enforce logical delivery middleware policy

### DIFF
--- a/include/mdbx_containers/sync/transport/TransportMiddleware.hpp
+++ b/include/mdbx_containers/sync/transport/TransportMiddleware.hpp
@@ -242,7 +242,9 @@ namespace sync {
 
     /// \brief Allows only configured node ids and database ids.
     /// \details Node allow-list defaults to "allow any". DB access defaults to
-    /// "allow any" for compatibility with simple peer-level policies.
+    /// "allow any" for compatibility with simple peer-level policies. Logical
+    /// delivery checks the envelope origin for the envelope-only API and the
+    /// receiver route for receiver-bound delivery requests.
     class NodeDbAllowListPolicy : public ISyncTransportPolicy {
     public:
         NodeDbAllowListPolicy()
@@ -1561,9 +1563,8 @@ namespace sync {
                     detail::notify_transport_rejected(
                         m_observer, SyncTransportOperation::LogicalDelivery,
                         decision.error);
-                    return rejected_logical_delivery_acknowledgement(
-                        envelope, NodeId(), decision,
-                        "logical delivery rejected");
+                    throw std::runtime_error(reject_message(
+                        decision, "logical delivery rejected"));
                 }
             }
 

--- a/include/mdbx_containers/sync/transport/TransportMiddleware.hpp
+++ b/include/mdbx_containers/sync/transport/TransportMiddleware.hpp
@@ -32,6 +32,7 @@ namespace sync {
         Pull,
         Push,
         LogicalRecovery,
+        LogicalDelivery,
         HttpPost,
         WebSocketMessage
     };
@@ -184,6 +185,18 @@ namespace sync {
             return SyncTransportDecision::allow();
         }
 
+        virtual SyncTransportDecision check_logical_delivery(
+                const LogicalDeliveryEnvelope& envelope) {
+            (void)envelope;
+            return SyncTransportDecision::allow();
+        }
+
+        virtual SyncTransportDecision check_logical_delivery_request(
+                const LogicalDeliveryRequest& request) {
+            (void)request;
+            return SyncTransportDecision::allow();
+        }
+
         virtual SyncTransportDecision check_http_post(
                 const std::string& target,
                 const std::string& content_type,
@@ -280,6 +293,21 @@ namespace sync {
             return check_node_and_db(request.requester,
                                      request.db_id,
                                      "sync requester is not allowed");
+        }
+
+        SyncTransportDecision check_logical_delivery(
+                const LogicalDeliveryEnvelope& envelope) override {
+            return check_node_and_db(envelope.origin_node_id,
+                                     envelope.destination_db_uuid,
+                                     "logical delivery origin is not allowed");
+        }
+
+        SyncTransportDecision check_logical_delivery_request(
+                const LogicalDeliveryRequest& request) override {
+            return check_node_and_db(
+                request.receiver_node_id,
+                request.envelope.destination_db_uuid,
+                "logical delivery receiver is not allowed");
         }
 
     private:
@@ -943,21 +971,25 @@ namespace sync {
                 std::uint64_t pull_budget,
                 std::uint64_t push_budget,
                 std::uint64_t http_post_budget = unlimited_budget(),
-                std::uint64_t logical_recovery_budget = unlimited_budget())
+                std::uint64_t logical_recovery_budget = unlimited_budget(),
+                std::uint64_t logical_delivery_budget = unlimited_budget())
             : m_pull_remaining(pull_budget),
               m_push_remaining(push_budget),
               m_http_post_remaining(http_post_budget),
-              m_logical_recovery_remaining(logical_recovery_budget) {}
+              m_logical_recovery_remaining(logical_recovery_budget),
+              m_logical_delivery_remaining(logical_delivery_budget) {}
 
         void reset(std::uint64_t pull_budget,
                    std::uint64_t push_budget,
                    std::uint64_t http_post_budget = unlimited_budget(),
-                   std::uint64_t logical_recovery_budget = unlimited_budget()) {
+                   std::uint64_t logical_recovery_budget = unlimited_budget(),
+                   std::uint64_t logical_delivery_budget = unlimited_budget()) {
             std::lock_guard<std::mutex> lock(m_mutex);
             m_pull_remaining = pull_budget;
             m_push_remaining = push_budget;
             m_http_post_remaining = http_post_budget;
             m_logical_recovery_remaining = logical_recovery_budget;
+            m_logical_delivery_remaining = logical_delivery_budget;
         }
 
         SyncTransportDecision check_pull(
@@ -977,6 +1009,20 @@ namespace sync {
             (void)request;
             return consume(m_logical_recovery_remaining,
                            "sync logical recovery rate limit exceeded");
+        }
+
+        SyncTransportDecision check_logical_delivery(
+                const LogicalDeliveryEnvelope& envelope) override {
+            (void)envelope;
+            return consume(m_logical_delivery_remaining,
+                           "sync logical delivery rate limit exceeded");
+        }
+
+        SyncTransportDecision check_logical_delivery_request(
+                const LogicalDeliveryRequest& request) override {
+            (void)request;
+            return consume(m_logical_delivery_remaining,
+                           "sync logical delivery rate limit exceeded");
         }
 
         SyncTransportDecision check_http_post(
@@ -1009,6 +1055,7 @@ namespace sync {
         std::uint64_t m_push_remaining;
         std::uint64_t m_http_post_remaining;
         std::uint64_t m_logical_recovery_remaining;
+        std::uint64_t m_logical_delivery_remaining;
     };
 
     /// \brief Runs several policies in insertion order.
@@ -1051,6 +1098,30 @@ namespace sync {
             for (std::size_t i = 0; i < m_policies.size(); ++i) {
                 const SyncTransportDecision decision =
                     m_policies[i]->check_logical_recovery(request);
+                if (!decision.allowed) {
+                    return decision;
+                }
+            }
+            return SyncTransportDecision::allow();
+        }
+
+        SyncTransportDecision check_logical_delivery(
+                const LogicalDeliveryEnvelope& envelope) override {
+            for (std::size_t i = 0; i < m_policies.size(); ++i) {
+                const SyncTransportDecision decision =
+                    m_policies[i]->check_logical_delivery(envelope);
+                if (!decision.allowed) {
+                    return decision;
+                }
+            }
+            return SyncTransportDecision::allow();
+        }
+
+        SyncTransportDecision check_logical_delivery_request(
+                const LogicalDeliveryRequest& request) override {
+            for (std::size_t i = 0; i < m_policies.size(); ++i) {
+                const SyncTransportDecision decision =
+                    m_policies[i]->check_logical_delivery_request(request);
                 if (!decision.allowed) {
                     return decision;
                 }
@@ -1108,6 +1179,7 @@ namespace sync {
         std::uint64_t pull_calls = 0;
         std::uint64_t push_calls = 0;
         std::uint64_t logical_recovery_calls = 0;
+        std::uint64_t logical_delivery_calls = 0;
         std::uint64_t http_post_calls = 0;
         std::uint64_t rejected_calls = 0;
         std::uint64_t failed_calls = 0;
@@ -1151,6 +1223,13 @@ namespace sync {
                 const LogicalRecoveryResponse& response) {
             (void)request;
             (void)response;
+        }
+
+        virtual void on_sync_transport_logical_delivery_result(
+                const LogicalDeliveryEnvelope& envelope,
+                const LogicalDeliveryAcknowledgement& acknowledgement) {
+            (void)envelope;
+            (void)acknowledgement;
         }
 
         virtual void on_sync_transport_http_request(
@@ -1235,6 +1314,17 @@ namespace sync {
             std::lock_guard<std::mutex> lock(m_mutex);
             ++m_snapshot.logical_recovery_calls;
             if (!response.ok) {
+                ++m_snapshot.failed_calls;
+            }
+        }
+
+        void on_sync_transport_logical_delivery_result(
+                const LogicalDeliveryEnvelope& envelope,
+                const LogicalDeliveryAcknowledgement& acknowledgement) override {
+            (void)envelope;
+            std::lock_guard<std::mutex> lock(m_mutex);
+            ++m_snapshot.logical_delivery_calls;
+            if (!acknowledgement.ok) {
                 ++m_snapshot.failed_calls;
             }
         }
@@ -1455,7 +1545,8 @@ namespace sync {
         LogicalDeliveryAcknowledgement deliver_ordered_logical_delivery(
                 const LogicalDeliveryEnvelope& envelope,
                 const CodecBounds* bounds = nullptr) override {
-            return m_next.deliver_ordered_logical_delivery(envelope, bounds);
+            return deliver_ordered_logical_delivery_with_cancel(
+                envelope, bounds, nullptr);
         }
 
         LogicalDeliveryAcknowledgement
@@ -1463,14 +1554,43 @@ namespace sync {
                 const LogicalDeliveryEnvelope& envelope,
                 const CodecBounds* bounds = nullptr,
                 const CancellationToken* cancel_token = nullptr) override {
-            return m_next.deliver_ordered_logical_delivery_with_cancel(
-                envelope, bounds, cancel_token);
+            if (m_policy != nullptr) {
+                const SyncTransportDecision decision =
+                    m_policy->check_logical_delivery(envelope);
+                if (!decision.allowed) {
+                    detail::notify_transport_rejected(
+                        m_observer, SyncTransportOperation::LogicalDelivery,
+                        decision.error);
+                    return rejected_logical_delivery_acknowledgement(
+                        envelope, NodeId(), decision,
+                        "logical delivery rejected");
+                }
+            }
+
+            try {
+                const LogicalDeliveryAcknowledgement acknowledgement =
+                    m_next.deliver_ordered_logical_delivery_with_cancel(
+                        envelope, bounds, cancel_token);
+                notify_logical_delivery_result(envelope, acknowledgement);
+                return acknowledgement;
+            } catch (const std::exception& e) {
+                detail::notify_transport_exception(
+                    m_observer, SyncTransportOperation::LogicalDelivery,
+                    e.what());
+                throw;
+            } catch (...) {
+                detail::notify_transport_exception(
+                    m_observer, SyncTransportOperation::LogicalDelivery,
+                    "unknown logical delivery exception");
+                throw;
+            }
         }
 
         LogicalDeliveryAcknowledgement deliver_ordered_logical_request(
                 const LogicalDeliveryRequest& request,
                 const CodecBounds* bounds = nullptr) override {
-            return m_next.deliver_ordered_logical_request(request, bounds);
+            return deliver_ordered_logical_request_with_cancel(
+                request, bounds, nullptr);
         }
 
         LogicalDeliveryAcknowledgement
@@ -1478,8 +1598,36 @@ namespace sync {
                 const LogicalDeliveryRequest& request,
                 const CodecBounds* bounds = nullptr,
                 const CancellationToken* cancel_token = nullptr) override {
-            return m_next.deliver_ordered_logical_request_with_cancel(
-                request, bounds, cancel_token);
+            if (m_policy != nullptr) {
+                const SyncTransportDecision decision =
+                    m_policy->check_logical_delivery_request(request);
+                if (!decision.allowed) {
+                    detail::notify_transport_rejected(
+                        m_observer, SyncTransportOperation::LogicalDelivery,
+                        decision.error);
+                    return rejected_logical_delivery_acknowledgement(
+                        request.envelope, request.receiver_node_id, decision,
+                        "logical delivery request rejected");
+                }
+            }
+
+            try {
+                const LogicalDeliveryAcknowledgement acknowledgement =
+                    m_next.deliver_ordered_logical_request_with_cancel(
+                        request, bounds, cancel_token);
+                notify_logical_delivery_result(request.envelope, acknowledgement);
+                return acknowledgement;
+            } catch (const std::exception& e) {
+                detail::notify_transport_exception(
+                    m_observer, SyncTransportOperation::LogicalDelivery,
+                    e.what());
+                throw;
+            } catch (...) {
+                detail::notify_transport_exception(
+                    m_observer, SyncTransportOperation::LogicalDelivery,
+                    "unknown logical delivery request exception");
+                throw;
+            }
         }
 
         bool supports_logical_recovery() const override {
@@ -1535,6 +1683,21 @@ namespace sync {
                                           : decision.error;
         }
 
+        static LogicalDeliveryAcknowledgement
+        rejected_logical_delivery_acknowledgement(
+                const LogicalDeliveryEnvelope& envelope,
+                const NodeId& receiver_node_id,
+                const SyncTransportDecision& decision,
+                const char* fallback) {
+            LogicalDeliveryAcknowledgement acknowledgement;
+            acknowledgement.destination_db_uuid = envelope.destination_db_uuid;
+            acknowledgement.receiver_node_id = receiver_node_id;
+            acknowledgement.origin_node_id = envelope.origin_node_id;
+            acknowledgement.ok = false;
+            acknowledgement.error = reject_message(decision, fallback);
+            return acknowledgement;
+        }
+
         void notify_pull_result(const PullRequest& request,
                                 const PullResponse& response) const {
             if (m_observer == nullptr) {
@@ -1564,6 +1727,18 @@ namespace sync {
             try {
                 m_observer->on_sync_transport_logical_recovery_result(
                     request, response);
+            } catch (...) {}
+        }
+
+        void notify_logical_delivery_result(
+                const LogicalDeliveryEnvelope& envelope,
+                const LogicalDeliveryAcknowledgement& acknowledgement) const {
+            if (m_observer == nullptr) {
+                return;
+            }
+            try {
+                m_observer->on_sync_transport_logical_delivery_result(
+                    envelope, acknowledgement);
             } catch (...) {}
         }
 

--- a/tests/test_transport_middleware.cpp
+++ b/tests/test_transport_middleware.cpp
@@ -57,7 +57,11 @@ public:
           m_push_count(0),
           m_cancel_count(0),
           m_logical_recovery_count(0),
-          m_logical_recovery_token_cancellable(false) {}
+          m_logical_recovery_token_cancellable(false),
+          m_logical_delivery_count(0),
+          m_logical_request_count(0),
+          m_logical_delivery_token_cancellable(false),
+          m_logical_request_token_cancellable(false) {}
 
     mdbxc::sync::PullResponse pull(
             const mdbxc::sync::PullRequest& request) override {
@@ -85,6 +89,46 @@ public:
     bool supports_logical_delivery() const override { return true; }
 
     bool supports_logical_recovery() const override { return true; }
+
+    mdbxc::sync::LogicalDeliveryAcknowledgement
+    deliver_ordered_logical_delivery(
+            const mdbxc::sync::LogicalDeliveryEnvelope& envelope,
+            const mdbxc::sync::CodecBounds* bounds = nullptr) override {
+        return deliver_ordered_logical_delivery_with_cancel(
+            envelope, bounds, nullptr);
+    }
+
+    mdbxc::sync::LogicalDeliveryAcknowledgement
+    deliver_ordered_logical_delivery_with_cancel(
+            const mdbxc::sync::LogicalDeliveryEnvelope& envelope,
+            const mdbxc::sync::CodecBounds* bounds = nullptr,
+            const mdbxc::sync::CancellationToken* cancel_token = nullptr) override {
+        (void)bounds;
+        ++m_logical_delivery_count;
+        m_logical_delivery_token_cancellable =
+            cancel_token != nullptr && cancel_token->can_be_cancelled();
+        return acknowledgement_for(envelope, mdbxc::sync::NodeId());
+    }
+
+    mdbxc::sync::LogicalDeliveryAcknowledgement
+    deliver_ordered_logical_request(
+            const mdbxc::sync::LogicalDeliveryRequest& request,
+            const mdbxc::sync::CodecBounds* bounds = nullptr) override {
+        return deliver_ordered_logical_request_with_cancel(
+            request, bounds, nullptr);
+    }
+
+    mdbxc::sync::LogicalDeliveryAcknowledgement
+    deliver_ordered_logical_request_with_cancel(
+            const mdbxc::sync::LogicalDeliveryRequest& request,
+            const mdbxc::sync::CodecBounds* bounds = nullptr,
+            const mdbxc::sync::CancellationToken* cancel_token = nullptr) override {
+        (void)bounds;
+        ++m_logical_request_count;
+        m_logical_request_token_cancellable =
+            cancel_token != nullptr && cancel_token->can_be_cancelled();
+        return acknowledgement_for(request.envelope, request.receiver_node_id);
+    }
 
     mdbxc::sync::LogicalRecoveryResponse logical_recovery(
             const mdbxc::sync::LogicalRecoveryRequest& request) override {
@@ -115,13 +159,40 @@ public:
     bool logical_recovery_token_cancellable() const {
         return m_logical_recovery_token_cancellable;
     }
+    std::size_t logical_delivery_count() const {
+        return m_logical_delivery_count;
+    }
+    std::size_t logical_request_count() const {
+        return m_logical_request_count;
+    }
+    bool logical_delivery_token_cancellable() const {
+        return m_logical_delivery_token_cancellable;
+    }
+    bool logical_request_token_cancellable() const {
+        return m_logical_request_token_cancellable;
+    }
 
 private:
+    static mdbxc::sync::LogicalDeliveryAcknowledgement acknowledgement_for(
+            const mdbxc::sync::LogicalDeliveryEnvelope& envelope,
+            const mdbxc::sync::NodeId& receiver_node_id) {
+        mdbxc::sync::LogicalDeliveryAcknowledgement acknowledgement;
+        acknowledgement.destination_db_uuid = envelope.destination_db_uuid;
+        acknowledgement.receiver_node_id = receiver_node_id;
+        acknowledgement.origin_node_id = envelope.origin_node_id;
+        acknowledgement.acknowledged_through = envelope.origin_sequence;
+        return acknowledgement;
+    }
+
     std::size_t m_pull_count;
     std::size_t m_push_count;
     std::size_t m_cancel_count;
     std::size_t m_logical_recovery_count;
     bool m_logical_recovery_token_cancellable;
+    std::size_t m_logical_delivery_count;
+    std::size_t m_logical_request_count;
+    bool m_logical_delivery_token_cancellable;
+    bool m_logical_request_token_cancellable;
     mdbxc::sync::PullRequest m_last_pull;
     mdbxc::sync::PushRequest m_last_push;
     mdbxc::sync::LogicalRecoveryRequest m_last_logical_recovery;
@@ -174,6 +245,14 @@ public:
         (void)request;
         (void)response;
         throw std::runtime_error("observer failure");
+    }
+
+    void on_sync_transport_logical_delivery_result(
+            const mdbxc::sync::LogicalDeliveryEnvelope& envelope,
+            const mdbxc::sync::LogicalDeliveryAcknowledgement& acknowledgement) override {
+        (void)envelope;
+        (void)acknowledgement;
+        throw std::runtime_error("observer logical delivery failure");
     }
 
     void on_sync_transport_rejected(
@@ -351,6 +430,86 @@ void test_peer_middleware_enforces_logical_recovery_policy() {
                  "allowed logical recovery was not observed");
 }
 
+void test_peer_middleware_enforces_logical_delivery_policy() {
+    const mdbxc::sync::NodeId origin = make_node(0x35);
+    const mdbxc::sync::NodeId receiver = make_node(0x36);
+    const mdbxc::sync::DbId allowed_db_id = make_node(0xD6);
+
+    mdbxc::sync::NodeDbAllowListPolicy allow_list;
+    allow_list.allow_node_id(origin);
+    allow_list.allow_node_id(receiver);
+    allow_list.allow_db_id(allowed_db_id);
+    mdbxc::sync::CompositeSyncTransportPolicy policy;
+    policy.add(allow_list);
+
+    RecordingPeer peer;
+    mdbxc::sync::SyncTransportMetricsObserver metrics;
+    mdbxc::sync::SyncPeerMiddleware wrapped(peer, &policy, &metrics);
+
+    mdbxc::sync::LogicalDeliveryEnvelope envelope;
+    envelope.destination_db_uuid = make_node(0xD7);
+    envelope.origin_node_id = origin;
+    envelope.origin_sequence = 1u;
+    envelope.frame_id = "denied-envelope";
+    const mdbxc::sync::LogicalDeliveryAcknowledgement denied_envelope =
+        wrapped.deliver_ordered_logical_delivery(envelope);
+    require_true(!denied_envelope.ok,
+                 "db-denied logical delivery was allowed");
+    require_true(denied_envelope.destination_db_uuid ==
+                     envelope.destination_db_uuid &&
+                     denied_envelope.origin_node_id == envelope.origin_node_id,
+                 "logical delivery rejection lost envelope identity");
+    require_true(peer.logical_delivery_count() == 0u,
+                 "db-denied logical delivery reached downstream peer");
+
+    envelope.destination_db_uuid = allowed_db_id;
+    mdbxc::sync::CancellationSource envelope_cancellation;
+    const mdbxc::sync::CancellationToken envelope_token =
+        envelope_cancellation.token();
+    const mdbxc::sync::LogicalDeliveryAcknowledgement allowed_envelope =
+        wrapped.deliver_ordered_logical_delivery_with_cancel(
+            envelope, nullptr, &envelope_token);
+    require_true(allowed_envelope.ok,
+                 "allowed logical delivery unexpectedly failed");
+    require_true(peer.logical_delivery_count() == 1u,
+                 "allowed logical delivery was not forwarded");
+    require_true(peer.logical_delivery_token_cancellable(),
+                 "logical delivery cancellation was not preserved");
+
+    mdbxc::sync::LogicalDeliveryRequest request;
+    request.receiver_node_id = make_node(0x37);
+    request.envelope = envelope;
+    const mdbxc::sync::LogicalDeliveryAcknowledgement denied_request =
+        wrapped.deliver_ordered_logical_request(request);
+    require_true(!denied_request.ok,
+                 "node-denied logical delivery request was allowed");
+    require_true(denied_request.receiver_node_id == request.receiver_node_id,
+                 "logical delivery request rejection lost receiver identity");
+    require_true(peer.logical_request_count() == 0u,
+                 "node-denied logical delivery request reached downstream peer");
+
+    request.receiver_node_id = receiver;
+    mdbxc::sync::CancellationSource request_cancellation;
+    const mdbxc::sync::CancellationToken request_token =
+        request_cancellation.token();
+    const mdbxc::sync::LogicalDeliveryAcknowledgement allowed_request =
+        wrapped.deliver_ordered_logical_request_with_cancel(
+            request, nullptr, &request_token);
+    require_true(allowed_request.ok,
+                 "allowed logical delivery request unexpectedly failed");
+    require_true(peer.logical_request_count() == 1u,
+                 "allowed logical delivery request was not forwarded");
+    require_true(peer.logical_request_token_cancellable(),
+                 "logical delivery request cancellation was not preserved");
+
+    const mdbxc::sync::SyncTransportMetricsSnapshot snapshot =
+        metrics.snapshot();
+    require_true(snapshot.logical_delivery_calls == 2u,
+                 "logical delivery metric mismatch");
+    require_true(snapshot.rejected_calls == 2u,
+                 "logical delivery rejection metric mismatch");
+}
+
 void test_transport_trace_context_helpers() {
     mdbxc::sync::HttpSyncRequest request;
     mdbxc::sync::http_add_header(
@@ -467,6 +626,18 @@ void test_observer_exceptions_are_swallowed() {
     require_true(response.ok, "observer exception changed pull result");
     require_true(peer.pull_count() == 1u,
                  "observer exception prevented downstream pull");
+
+    mdbxc::sync::LogicalDeliveryEnvelope delivery;
+    delivery.destination_db_uuid = make_node(0x52);
+    delivery.origin_node_id = make_node(0x53);
+    delivery.origin_sequence = 1u;
+    delivery.frame_id = "observer-exception";
+    const mdbxc::sync::LogicalDeliveryAcknowledgement acknowledgement =
+        wrapped.deliver_ordered_logical_delivery(delivery);
+    require_true(acknowledgement.ok,
+                 "observer exception changed logical delivery result");
+    require_true(peer.logical_delivery_count() == 1u,
+                 "observer exception prevented logical delivery forwarding");
 
     mdbxc::sync::NodeDbAllowListPolicy deny_db;
     deny_db.allow_db_id(make_node(0x99));
@@ -957,7 +1128,8 @@ void test_transport_zero_limit_policies() {
                      std::string(),
                  "zero HTTP request limit must include Retry-After");
 
-    mdbxc::sync::FixedBudgetSyncTransportPolicy budget(0u, 0u, 0u, 0u);
+    mdbxc::sync::FixedBudgetSyncTransportPolicy budget(
+        0u, 0u, 0u, 0u, 0u);
     mdbxc::sync::PullRequest pull;
     decision = budget.check_pull(pull);
     require_true(!decision.allowed && decision.status_code == 429,
@@ -972,6 +1144,26 @@ void test_transport_zero_limit_policies() {
     decision = budget.check_logical_recovery(recovery);
     require_true(!decision.allowed && decision.status_code == 429,
                  "zero logical recovery budget must reject");
+
+    mdbxc::sync::LogicalDeliveryEnvelope delivery;
+    decision = budget.check_logical_delivery(delivery);
+    require_true(!decision.allowed && decision.status_code == 429,
+                 "zero logical delivery budget must reject");
+
+    mdbxc::sync::FixedBudgetSyncTransportPolicy shared_delivery_budget(
+        mdbxc::sync::FixedBudgetSyncTransportPolicy::unlimited_budget(),
+        mdbxc::sync::FixedBudgetSyncTransportPolicy::unlimited_budget(),
+        mdbxc::sync::FixedBudgetSyncTransportPolicy::unlimited_budget(),
+        mdbxc::sync::FixedBudgetSyncTransportPolicy::unlimited_budget(),
+        1u);
+    decision = shared_delivery_budget.check_logical_delivery(delivery);
+    require_true(decision.allowed,
+                 "first shared logical delivery budget use was rejected");
+    mdbxc::sync::LogicalDeliveryRequest delivery_request;
+    decision = shared_delivery_budget.check_logical_delivery_request(
+        delivery_request);
+    require_true(!decision.allowed && decision.status_code == 429,
+                 "logical delivery request did not share delivery budget");
 
     decision = budget.check_http_post(
         mdbxc::sync::HttpSyncRoutes::pull_target(),
@@ -1086,6 +1278,7 @@ int main() {
     test_peer_middleware_allows_limits_and_observes();
     test_peer_middleware_forwards_logical_capabilities();
     test_peer_middleware_enforces_logical_recovery_policy();
+    test_peer_middleware_enforces_logical_delivery_policy();
     test_transport_trace_context_helpers();
     test_transport_observer_receives_request_context();
     test_observer_exceptions_are_swallowed();

--- a/tests/test_transport_middleware.cpp
+++ b/tests/test_transport_middleware.cpp
@@ -451,14 +451,14 @@ void test_peer_middleware_enforces_logical_delivery_policy() {
     envelope.origin_node_id = origin;
     envelope.origin_sequence = 1u;
     envelope.frame_id = "denied-envelope";
-    const mdbxc::sync::LogicalDeliveryAcknowledgement denied_envelope =
-        wrapped.deliver_ordered_logical_delivery(envelope);
-    require_true(!denied_envelope.ok,
-                 "db-denied logical delivery was allowed");
-    require_true(denied_envelope.destination_db_uuid ==
-                     envelope.destination_db_uuid &&
-                     denied_envelope.origin_node_id == envelope.origin_node_id,
-                 "logical delivery rejection lost envelope identity");
+    bool envelope_rejected = false;
+    try {
+        (void)wrapped.deliver_ordered_logical_delivery(envelope);
+    } catch (const std::runtime_error&) {
+        envelope_rejected = true;
+    }
+    require_true(envelope_rejected,
+                 "db-denied logical delivery did not fail locally");
     require_true(peer.logical_delivery_count() == 0u,
                  "db-denied logical delivery reached downstream peer");
 
@@ -485,6 +485,7 @@ void test_peer_middleware_enforces_logical_delivery_policy() {
                  "node-denied logical delivery request was allowed");
     require_true(denied_request.receiver_node_id == request.receiver_node_id,
                  "logical delivery request rejection lost receiver identity");
+    mdbxc::sync::validate_logical_delivery_acknowledgement(denied_request);
     require_true(peer.logical_request_count() == 0u,
                  "node-denied logical delivery request reached downstream peer");
 


### PR DESCRIPTION
Adds peer-level policy enforcement for logical delivery envelope and receiver-bound request operations. Envelope-only policy rejection fails locally with std::runtime_error because that legacy API has no receiver identity for a protocol-valid acknowledgement. Receiver-bound rejection returns a failed, protocol-valid acknowledgement. Allowed calls retain cancellation propagation and emit a dedicated observer/metrics category. The fixed budget policy has one shared logical-delivery budget. Verified with test_transport_middleware under C++11 and C++17.