### PR TITLE
[codex] Document sync deployment patterns

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -169,8 +169,10 @@
   Установленный package также экспортирует CMake provider functions для этих
   готовых transport targets.
   Начните с [обзора sync](docs/sync-RU.md), затем используйте [руководство по
-  logical и ordered sync](docs/sync-logical-RU.md) либо [руководство по
-  восстановлению и full snapshots](docs/sync-recovery-RU.md) для этих путей.
+  deployment patterns](docs/sync-deployment-patterns-RU.md) для выбора
+  multi-origin data model, [руководство по logical и ordered sync](docs/sync-logical-RU.md)
+  либо [руководство по восстановлению и full snapshots](docs/sync-recovery-RU.md)
+  для этих путей.
   См. [sync transport production notes](guides/sync-transport-production.md)
   про TLS/WSS, ротацию токенов, graceful shutdown, structured logging и
   offline dependency builds. См.

--- a/README.md
+++ b/README.md
@@ -141,8 +141,9 @@
   Installed packages also export CMake provider functions for these ready-made
   transport targets.
   Start with the human-facing [sync overview](docs/sync.md), then use the
-  [logical and ordered sync guide](docs/sync-logical.md) or the
-  [recovery and full snapshot guide](docs/sync-recovery.md) for those paths.
+  [deployment-pattern guide](docs/sync-deployment-patterns.md) to select a
+  multi-origin data model, the [logical and ordered sync guide](docs/sync-logical.md),
+  or the [recovery and full snapshot guide](docs/sync-recovery.md) for those paths.
   See [sync transport production notes](guides/sync-transport-production.md)
   for TLS/WSS, token rotation, graceful shutdown, structured logging, and
   offline dependency guidance. See the

--- a/docs/sync-RU.md
+++ b/docs/sync-RU.md
@@ -157,6 +157,8 @@ id и HTTP/WebSocket status mapping остаются на стороне adapter
 
 ## Дальнейшее чтение
 
+- [Практические схемы развёртывания](sync-deployment-patterns-RU.md): модели
+  данных и ownership writers для multi-origin datasets.
 - [Logical и ordered delivery](sync-logical-RU.md): typed schemas, adapter
   capture, ordered outbox delivery и границы concurrency.
 - [Восстановление и full snapshots](sync-recovery-RU.md): recovery retained

--- a/docs/sync-deployment-patterns-RU.md
+++ b/docs/sync-deployment-patterns-RU.md
@@ -1,0 +1,209 @@
+# Практические схемы развёртывания sync
+
+Sync в `mdbx-containers` поддерживает multi-origin transport: реплика может
+принимать закоммиченные истории изменений от нескольких устойчивых origin с
+`NodeId`. Это делает несколько пишущих узлов практичными, когда их записи не
+конкурируют за одну logical record.
+
+При этом система пока не задаёт concurrent conflict resolution для двух
+writers, меняющих один logical key. В v0.1 по умолчанию используется
+`ConflictPolicy::Reject`; `LastWriterWins` зарезервирован для будущего дизайна
+и отклоняется `SyncEngine`. Поэтому поддержка нескольких origins не является
+контрактом last-writer-wins или CRDT.
+
+English version: [sync-deployment-patterns.md](sync-deployment-patterns.md).
+
+## Одна БД получателя, несколько origins
+
+Несколько origins не требуют нескольких пользовательских БД у получателя. Их
+истории, progress и replay state ведёт sync subsystem; входящие operations
+применяются к одним и тем же пользовательским MDBX tables, выбранным по DBI
+name. Поэтому storage node может принимать данные redundant collectors в одну
+canonical database.
+
+```text
+collector A ──┐
+              ├── одна MDBX database
+collector B ──┘       user table: trades
+```
+
+Модель данных приложения, а не origin id, определяет, являются ли records одним
+logical event. Identity origin-а сохраняет значение для delivery и diagnostics,
+а при необходимости может быть отдельно записана как provenance data.
+
+## Сначала выберите модель данных, затем топологию
+
+Для реплицируемого набора данных используйте одну из двух схем:
+
+1. Назначьте каждому writer непересекающийся диапазон logical keys.
+2. Храните immutable records с глобально однозначными identities.
+
+Вторая схема часто лучше подходит для event data. Она позволяет нескольким
+writers работать без необходимости определять победителя среди concurrent
+updates одной mutable record.
+
+| Сценарий | Текущий контракт sync |
+| --- | --- |
+| Разные nodes пишут разные logical keys | Поддерживаемая multi-origin topology |
+| Несколько nodes создают uniquely identified immutable records | Практичная multi-writer topology |
+| Два nodes одновременно меняют один logical key | Нет определённой conflict-resolution semantics |
+| Один node удаляет, а другой пишет тот же logical key | Нет гарантированной convergence semantics |
+| Независимые вызовы `SequenceTable::append()` | Только single-writer; appenders надо сериализовать внешне |
+| Destructive multi-writer операции `KeyMultiValueTable` | Нужен один writer или application-level causal serialization |
+
+Не используйте только wall-clock time как authority порядка: часы разных nodes
+могут расходиться. Если приложению нужно выбрать победителя, до обработки
+данных как mutable replicated state определите и сохраните authority уровня
+приложения, например upstream sequence number или deterministic version tuple.
+
+## Отказоустойчивые рыночные данные
+
+### Primary и hot standby
+
+Один active collector публикует dataset, а standby следит за upstream feed и
+может стать active после application-coordinated failover. Это простейшая
+topology, потому что для каждого key range одновременно работает один writer.
+Приложению всё ещё нужна failover procedure, которая продолжает upstream feed
+без неучтённого gap.
+
+### Active-active collectors для immutable events
+
+Для trades и других immutable upstream events используйте canonical identity
+биржи как ключ user table, например:
+
+```text
+(exchange, symbol, trade_id) -> Trade
+```
+
+Два collectors, получившие один trade, должны дать один logical key и одинаковый
+serialized payload. Тогда любой из collectors может заполнить event gap другого
+в одной БД получателя.
+
+Текущий raw sync ещё не реализует canonical-event deduplication и integrity
+error для одинаковых keys с разными payloads. Поэтому active-active deployment
+должен проверять такую divergence в application code и не должен считать raw
+upsert ordering integrity- или conflict-resolution guarantee. Одинаковый event
+identity с разными payloads — это data-integrity anomaly, а не случай для
+молчаливого выбора writer-а.
+
+### Сохраняйте provenance observations, когда она нужна
+
+Храните canonical events и observations collectors отдельно, когда нужно
+измерять coverage или latency feed-а:
+
+```text
+trades:       trade_id -> Trade
+observations: (trade_id, collector_id) -> Observation
+```
+
+Так сохраняется одна история рынка и достаточно данных для расчёта missing
+coverage, collector lag или source divergence.
+
+### Mutable bars и snapshots
+
+Open bar, latest quote или upstream snapshot не являются immutable event. Два
+collectors могут законно увидеть разные состояния одного key. У текущего raw
+sync нет source-version-wins поведения для этого случая: используйте одного
+authoritative projector-а или application-level serialization, пока не появится
+versioned conflict policy.
+
+Нужный будущий primitive — versioned register: put или delete несёт
+application-provided source-authoritative version, отдельную от user value, а
+получатель атомарно оставляет наибольшую version и deletion tombstones. Broker
+timestamp может быть одним из компонентов, но при равных timestamps нужен source
+sequence либо другой deterministic tie-breaker. Wall-clock time writer-а и время
+приёма пакета не подходят как authority.
+
+## Поддерживаемые пути таблиц
+
+Raw capture v0.1 записывает обычные writes `KeyValueTable`, `KeyTable`,
+`ValueTable` и `SequenceTable`, когда к пишущему `Connection` прикреплён
+`ThreadLocalChangeAccumulator`.
+
+`KeyMultiValueTable` использует explicit logical adapter вместо raw capture.
+Его destructive operations требуют одного writer или application-level causal
+serialization. Для raw replication `VectorStore` и его logical adapter также
+нужен один authoritative либо externally serialized writer на collection.
+Полный контракт для каждой таблицы приведён в
+[sync table coverage matrix](../guides/sync-table-coverage.md).
+
+## Коллекторы рыночных данных
+
+Моделируйте raw market-data layer как immutable events. Каждый collector может
+писать свои records и синхронизировать их с aggregation или storage nodes.
+
+Для фидов с authoritative upstream sequence identity записи может быть такой:
+
+```text
+(exchange, symbol, stream, exchange_timestamp, exchange_sequence)
+```
+
+Если два collectors намеренно наблюдают один feed для redundancy, выберите одну
+из двух явных моделей:
+
+- сохранять оба observations с `(source_node, exchange, symbol,
+  exchange_event_id)`;
+- дедуплицировать по `(exchange, symbol, exchange_event_id)`, если биржа даёт
+  стабильную event identity.
+
+Не позволяйте collectors конкурентно перезаписывать mutable records наподобие
+`latest_quote["BTCUSDT"]` или формирующейся OHLCV candle. Рассматривайте latest
+quotes, candles и похожие aggregates как derived state: пересчитывайте их из
+immutable ticks и trades либо назначайте одного authoritative projector для
+каждого derived key.
+
+```text
+collector A ── immutable events ──┐
+                                  ├── aggregation or storage node
+collector B ── immutable events ──┘
+```
+
+Эта схема также поддерживает ownership или sharding, например по exchange,
+symbol range, market type или identity collector-а.
+
+## Records трейдеров и платформы
+
+Представляйте trades, fills, ledger events и audit records как immutable events
+с globally unique identities. Identity может включать выданный платформой trade
+или execution id либо сгенерированный приложением id, scoped by origin.
+Явно назначайте ownership, когда одна business record может появиться более чем
+на одном node.
+
+Реплицируйте event history, а balances, positions и reporting views выводите из
+этой истории либо обновляйте через одного authoritative writer. Не полагайтесь
+на raw sync для координации concurrent mutations одного account balance, order
+state или risk limit: такое решение требует application-level ownership,
+serialization или отдельно спроектированного conflict protocol.
+
+## Базы знаний и RAG chunks
+
+Храните source material и chunk revisions как immutable, versioned records.
+Identity chunk-а может объединять stable document id, source revision и chunk
+ordinal либо использовать content hash вместе с версиями codec и embedding.
+Так разные ingestion nodes смогут добавлять отдельные document revisions без
+конкуренции за один mutable key.
+
+Считайте mutable projections derived state. К ним относятся current-document
+pointer, search index, cached retrieval scores и vector collection, построенная
+из chunks. Перестраивайте такие projections из immutable corpus либо назначайте
+одного authoritative writer. В частности, текущие пути sync `VectorStore` не
+дают independent multi-writer id allocation или conflict resolution для одной
+collection.
+
+## Чек-лист развёртывания
+
+Перед включением sync для набора данных определите:
+
+- durable `NodeId` каждого writer-а и общий `DbId` replication set-а;
+- logical identity каждой реплицируемой record и writer-а, которому она
+  принадлежит;
+- является ли record immutable либо какая application authority сериализует её
+  mutations и deletions;
+- стратегию rebuild или ownership для derived state;
+- table-specific sync path из
+  [coverage matrix](../guides/sync-table-coverage.md).
+
+Настройка capture, transport deployment и recovery описаны в
+[sync overview](sync-RU.md),
+[transport production notes](../guides/sync-transport-production.md) и
+[recovery guide](sync-recovery-RU.md).

--- a/docs/sync-deployment-patterns.md
+++ b/docs/sync-deployment-patterns.md
@@ -1,0 +1,209 @@
+# Sync Deployment Patterns
+
+`mdbx-containers` sync supports multi-origin transport: a replica can receive
+committed change histories from multiple durable `NodeId` origins. This makes
+several writer nodes practical when their writes do not compete for the same
+logical record.
+
+It does **not** currently define concurrent conflict resolution for two writers
+that mutate the same logical key. `ConflictPolicy::Reject` is the v0.1 default;
+`LastWriterWins` is reserved for a future design and is rejected by
+`SyncEngine`. Transport support for multiple origins is therefore not a
+last-writer-wins or CRDT contract.
+
+Russian version: [sync-deployment-patterns-RU.md](sync-deployment-patterns-RU.md).
+
+## One Receiver Database, Multiple Origins
+
+Multiple origins do not require multiple user databases at a receiver. Their
+histories, progress, and replay state are maintained by the sync subsystem;
+incoming operations are applied to the same user MDBX tables selected by their
+DBI names. A storage node can therefore receive from redundant collectors into
+one canonical database.
+
+```text
+collector A ──┐
+              ├── one MDBX database
+collector B ──┘       user table: trades
+```
+
+The application data model, not the origin id, determines whether records are
+the same logical event. Origin identity remains relevant for delivery and
+diagnostics, and can also be retained explicitly as provenance data.
+
+## Select A Data Model Before Selecting A Topology
+
+Use one of these two patterns for a replicated dataset:
+
+1. Assign each writer a disjoint logical-key range.
+2. Store immutable records with globally unambiguous identities.
+
+The second pattern is often the better fit for event data. It permits several
+writers without requiring them to decide which concurrent update to one mutable
+record wins.
+
+| Scenario | Current sync contract |
+| --- | --- |
+| Different nodes write different logical keys | Supported multi-origin topology |
+| Multiple nodes create uniquely identified immutable records | Practical multi-writer topology |
+| Two nodes concurrently mutate one logical key | No defined conflict-resolution semantics |
+| One node erases while another writes the same logical key | No guaranteed convergence semantics |
+| Independent `SequenceTable::append()` calls | Single-writer only; serialize appenders externally |
+| Destructive multi-writer `KeyMultiValueTable` operations | Require one writer or application-level causal serialization |
+
+Do not use wall-clock time alone as an ordering authority. Clocks can differ
+between nodes. When an application must select a winner, define and persist an
+application-owned authority, such as an upstream sequence number or a
+deterministic version tuple, before it treats the data as mutable replicated
+state.
+
+## Fault-Tolerant Market Data
+
+### Primary And Hot Standby
+
+One active collector publishes a dataset while a standby follows the upstream
+feed and can take over after application-coordinated failover. This is the
+simplest topology because only one writer is active for each key range. The
+application still needs a failover procedure that resumes the upstream feed
+without an unaccounted gap.
+
+### Active-Active Collectors For Immutable Events
+
+For trades and other immutable upstream events, use the exchange's canonical
+identity as the user-table key, for example:
+
+```text
+(exchange, symbol, trade_id) -> Trade
+```
+
+Two collectors that receive the same trade should produce the same logical key
+and the same serialized payload. This allows either collector to fill an event
+gap observed by another collector in one receiver database.
+
+Current raw sync does not yet implement canonical-event deduplication or an
+integrity error for equal keys with different payloads. An active-active
+deployment must therefore validate such divergence in application code and
+must not describe raw upsert ordering as an integrity or conflict-resolution
+guarantee. A same event identity with different payload is a data-integrity
+anomaly, not a case for silently selecting a writer.
+
+### Preserve Observation Provenance When Needed
+
+Keep canonical events and collector observations separate when operations need
+to measure feed coverage or latency:
+
+```text
+trades:       trade_id -> Trade
+observations: (trade_id, collector_id) -> Observation
+```
+
+This keeps one market history while preserving enough data to calculate missing
+coverage, collector lag, or source divergence.
+
+### Mutable Bars And Snapshots
+
+An open bar, latest quote, or upstream snapshot is not an immutable event. Two
+collectors may legitimately observe different states for one key. Current raw
+sync has no source-version-wins behavior for this case; use one authoritative
+projector or application-level serialization until a versioned conflict policy
+is implemented.
+
+The required future primitive is a versioned register: a put or delete carries
+an application-provided, source-authoritative version separate from the user
+value, and a receiver atomically retains the greatest version plus deletion
+tombstones. A broker timestamp can be one component, but a source sequence or
+another deterministic tie-breaker is needed when timestamps are equal. Writer
+wall-clock time and packet-receipt time are not suitable authorities.
+
+## Supported Table Paths
+
+Raw v0.1 capture records normal writes for `KeyValueTable`, `KeyTable`,
+`ValueTable`, and `SequenceTable` when a
+`ThreadLocalChangeAccumulator` is attached to the writing `Connection`.
+
+`KeyMultiValueTable` uses an explicit logical adapter rather than raw capture.
+Its destructive operations require one writer or application-level causal
+serialization. `VectorStore` raw replication and its logical adapter likewise
+require one authoritative or externally serialized writer per collection.
+See the [sync table coverage matrix](../guides/sync-table-coverage.md) for the
+complete table-by-table contract.
+
+## Market Data Collectors
+
+Model the raw market-data layer as immutable events. Each collector can write
+its own records and synchronize them with aggregation or storage nodes.
+
+For feeds with an authoritative upstream sequence, a record identity can be:
+
+```text
+(exchange, symbol, stream, exchange_timestamp, exchange_sequence)
+```
+
+If two collectors intentionally observe the same feed for redundancy, choose
+one of two explicit models:
+
+- retain both observations with `(source_node, exchange, symbol,
+  exchange_event_id)`;
+- deduplicate by `(exchange, symbol, exchange_event_id)` when the exchange
+  provides a stable event identity.
+
+Do not make collectors concurrently overwrite mutable records such as
+`latest_quote["BTCUSDT"]` or an in-progress OHLCV candle. Treat latest quotes,
+candles, and similar aggregates as derived state: rebuild them from immutable
+ticks and trades, or assign one authoritative projector for each derived key.
+
+```text
+collector A ── immutable events ──┐
+                                  ├── aggregation or storage node
+collector B ── immutable events ──┘
+```
+
+This pattern also supports ownership or sharding, for example by exchange,
+symbol range, market type, or collector identity.
+
+## Trader And Platform Records
+
+Represent trades, fills, ledger events, and audit records as immutable events
+with globally unique identities. An identity can include a platform-issued
+trade or execution id, or an application-generated id scoped by its origin.
+Assign ownership explicitly when a platform can originate the same business
+record from more than one node.
+
+Replicate event history, then derive balances, positions, and reporting views
+from that history or update those views through one authoritative writer. Do
+not rely on raw sync to coordinate concurrent mutations of the same account
+balance, order state, or risk limit; such a decision needs application-level
+ownership, serialization, or a separately designed conflict protocol.
+
+## Knowledge Bases And RAG Chunks
+
+Store source material and chunk revisions as immutable, versioned records. A
+chunk identity can combine a stable document id, source revision, and chunk
+ordinal, or use a content hash together with the codec and embedding versions.
+This lets different ingestion nodes add distinct document revisions without
+competing for one mutable key.
+
+Treat mutable projections as derived state. Examples include a current-document
+pointer, a search index, cached retrieval scores, and a vector collection built
+from chunks. Rebuild such projections from the immutable corpus or assign a
+single authoritative writer. In particular, the current `VectorStore` sync
+paths do not provide independent multi-writer id allocation or conflict
+resolution for one collection.
+
+## Deployment Checklist
+
+Before enabling sync for a dataset, define:
+
+- the durable `NodeId` for every writer and the shared `DbId` for the
+  replication set;
+- the logical identity of every replicated record and which writer owns it;
+- whether a record is immutable, or which application authority serializes its
+  mutations and deletions;
+- the rebuild or ownership strategy for derived state;
+- the table-specific sync path from the
+  [coverage matrix](../guides/sync-table-coverage.md).
+
+For capture setup, transport deployment, and recovery behavior, start with the
+[sync overview](sync.md),
+[transport production notes](../guides/sync-transport-production.md), and
+[recovery guide](sync-recovery.md).

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -153,6 +153,8 @@ Useful runnable starting points:
 
 ## Next Reading
 
+- [Deployment patterns](sync-deployment-patterns.md): data models and writer
+  ownership for multi-origin datasets.
 - [Logical and ordered delivery](sync-logical.md): typed schemas, adapter
   capture, ordered outbox delivery, and concurrency boundaries.
 - [Recovery and full snapshots](sync-recovery.md): retained-history recovery,


### PR DESCRIPTION
## What changed

- Add English and Russian deployment-pattern guides for sync.
- Link the new guidance from the sync overview and both READMEs.

## Why

Multi-origin transport is available today, but same-key concurrent conflict resolution is not. The guides show data models that fit the implemented contract for market-data collectors, trader/platform events, and RAG chunks.

## Impact

Applications can choose immutable identities or writer-owned key ranges and keep mutable projections under a defined rebuild or authoritative-writer strategy. The guides do not introduce runtime or wire-format changes.

## Checks

- `git diff --check`
- Markdown code-fence and local relative-link validation