### PR TITLE
[codex] Add versioned KeyValue LWW sync

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -122,10 +122,13 @@
 - `ConflictPolicy::LastWriterWins` имеет узкий путь source-version-wins для
   mutable-регистров `KeyValueTable`. Используйте `VersionedKeyValueTable` для
   точечных `insert_or_assign` и `erase`, передавая непустимую каноническую
-  source version в каждую операцию. Version остаётся sync-метаданными, а
-  durable sidecar хранит versioned tombstones. Обычные raw-операции,
-  bulk/range/clear, другие типы таблиц и восстановление через full snapshot
-  намеренно не входят в этот режим. См. [deployment patterns](docs/sync-deployment-patterns-RU.md).
+  source version в каждую операцию. Конструктор durable-регистрирует этот DBI;
+  каждый replica должен зарегистрировать ту же таблицу до приёма её batches.
+  Registered DBI отклоняет прямые raw writes, clear, bulk и range mutations.
+  Обычные raw DBI могут сосуществовать на том же engine. Version остаётся
+  sync-метаданными, а durable sidecars хранят versioned tombstones и
+  registrations. Full snapshots могут охватывать только raw-only manifest,
+  но не registered DBI. См. [deployment patterns](docs/sync-deployment-patterns-RU.md).
 - При активном sync capture мутирующие вызовы поддерживаемых таблиц должны
   использовать транзакции, созданные через `mdbx_containers::Transaction` или
   `Connection::begin()` / `commit()`. Caller-created raw writable `MDBX_txn*`

--- a/README-RU.md
+++ b/README-RU.md
@@ -119,6 +119,13 @@
   поддерживаемых таблиц, становится одним атомарным локальным batch.
   Read/search-вызовы не захватываются. Отдельный `SyncWorker` плюс транспорт
   `ISyncPeer` переносят закоммиченные batches между узлами.
+- `ConflictPolicy::LastWriterWins` имеет узкий путь source-version-wins для
+  mutable-регистров `KeyValueTable`. Используйте `VersionedKeyValueTable` для
+  точечных `insert_or_assign` и `erase`, передавая непустимую каноническую
+  source version в каждую операцию. Version остаётся sync-метаданными, а
+  durable sidecar хранит versioned tombstones. Обычные raw-операции,
+  bulk/range/clear, другие типы таблиц и восстановление через full snapshot
+  намеренно не входят в этот режим. См. [deployment patterns](docs/sync-deployment-patterns-RU.md).
 - При активном sync capture мутирующие вызовы поддерживаемых таблиц должны
   использовать транзакции, созданные через `mdbx_containers::Transaction` или
   `Connection::begin()` / `commit()`. Caller-created raw writable `MDBX_txn*`

--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@
   atomic local batch. Read/search calls are not captured. A separate
   `SyncWorker` plus an `ISyncPeer` transport moves committed batches between
   nodes.
+- `ConflictPolicy::LastWriterWins` has a narrow source-version-wins path for
+  mutable `KeyValueTable` registers. Use `VersionedKeyValueTable` for point
+  `insert_or_assign` and `erase`, providing a non-empty canonical source
+  version for each operation. The version is sync metadata; a durable sidecar
+  retains versioned tombstones. Ordinary raw operations, bulk/range/clear,
+  other table types, and full snapshot recovery are intentionally outside this
+  mode. See [deployment patterns](docs/sync-deployment-patterns.md).
 - When sync capture is attached, mutating supported table calls must use
   connection-managed transactions (`mdbx_containers::Transaction` or
   `Connection::begin()` / `commit()`). Caller-created raw writable

--- a/README.md
+++ b/README.md
@@ -93,10 +93,12 @@
 - `ConflictPolicy::LastWriterWins` has a narrow source-version-wins path for
   mutable `KeyValueTable` registers. Use `VersionedKeyValueTable` for point
   `insert_or_assign` and `erase`, providing a non-empty canonical source
-  version for each operation. The version is sync metadata; a durable sidecar
-  retains versioned tombstones. Ordinary raw operations, bulk/range/clear,
-  other table types, and full snapshot recovery are intentionally outside this
-  mode. See [deployment patterns](docs/sync-deployment-patterns.md).
+  version for each operation. Construction durably registers that DBI; every
+  replica must register the same table before receiving its batches. Registered
+  DBIs reject direct raw writes, clear, bulk, and range mutations. Normal raw
+  DBIs can coexist on the same engine. The version is sync metadata; durable
+  sidecars retain versioned tombstones and registrations. Full snapshots may
+  cover raw-only manifests, never a registered DBI. See [deployment patterns](docs/sync-deployment-patterns.md).
 - When sync capture is attached, mutating supported table calls must use
   connection-managed transactions (`mdbx_containers::Transaction` or
   `Connection::begin()` / `commit()`). Caller-created raw writable

--- a/docs/sync-RU.md
+++ b/docs/sync-RU.md
@@ -17,6 +17,7 @@ English version: [sync.md](sync.md).
 | Задача | Режим | Точки входа |
 | --- | --- | --- |
 | Реплицировать обычные записи таблиц между копиями БД | Raw-репликация | `ThreadLocalChangeAccumulator`, `SyncCaptureScope`, `SyncWorker`, `ISyncPeer` |
+| Разрешать один mutable key по upstream source version | Узкий LWW register | `ConflictPolicy::LastWriterWins`, `VersionedKeyValueTable` |
 | Реплицировать таблицу через явную типизированную схему приложения | Logical frames | Logical adapter таблицы, `LogicalChangeFrameCodec`, `SyncEngine::apply_logical_frame_bytes()` |
 | Сохранить одну авторитетную упорядоченную историю и безопасно повторять её доставку | Ordered logical delivery | Durable outbox, logical-capable `ISyncPeer`, `SyncWorkerOptions::enable_logical_delivery` |
 | Восстановить свежую raw-реплику после удаления нужной истории из changelog | Full snapshot recovery | `SyncWorkerOptions::enable_full_snapshot_fallback`, `CompleteUserDatabase` |
@@ -110,15 +111,26 @@ pre-commit hook. Read-only handles вызывающего кода остают�
 | Семейство таблиц | Raw-статус | Важная граница |
 | --- | --- | --- |
 | `KeyValueTable`, `KeyTable`, `ValueTable`, `SequenceTable` | Поддерживается | Операции захватываются как физические изменения DBI. |
+| `VersionedKeyValueTable` | Узкий LWW v1 adapter | Только точечные versioned put/delete для source-version-wins register. |
 | `VectorStore` | Поддерживается через owned tables | Raw-репликация обновляет четыре underlying DBI; уже открытые экземпляры лениво пересобирают in-memory index после remote apply. |
 | `KeyMultiValueTable` | Не реплицируется как raw | Используйте явный logical adapter, если подходит его documented typed contract. |
 | `KeyOrderedMultiValueTable` | Не реплицируется как raw | Для поддерживаемых схем используйте ordered logical delivery. |
 | `AnyValueTable`, `HashedKeyValueStore` | Отложено | Контракта raw capture пока нет. |
 
-Raw-репликация сохраняет contract операций на уровне storage. Это не общая
-система conflict resolution. Текущий engine отклоняет sequence gaps и не даёт
-last-writer-wins policy для конкурентных изменений приложения одних и тех же
-логических данных.
+Raw-репликация сохраняет contract операций на уровне storage и отклоняет
+sequence gaps. Узкое исключение для concurrent writes — register
+`VersionedKeyValueTable`: с `ConflictPolicy::LastWriterWins` каждая точечная
+put/delete-операция несёт непустимую application-owned version, которая
+сравнивается лексикографически, затем по `NodeId` origin-а. Version остаётся
+вне user value, а durable sidecar tombstone не позволяет старому put воскресить
+delete.
+
+Это не generic raw replication: для LWW connection используйте только
+versioned adapter. Обычные raw-операции, clear/bulk/range changes, logical
+identity remapping, другие table types и full-snapshot recovery отклоняются или
+не поддерживаются. Выберите upstream sequence либо другую canonical authority;
+wall-clock узла authority не является. Operational model приведён в
+[deployment patterns](sync-deployment-patterns-RU.md).
 
 ## Транспорт и эксплуатация
 

--- a/docs/sync-RU.md
+++ b/docs/sync-RU.md
@@ -125,11 +125,14 @@ put/delete-операция несёт непустимую application-owned ve
 вне user value, а durable sidecar tombstone не позволяет старому put воскресить
 delete.
 
-Это не generic raw replication: для LWW connection используйте только
-versioned adapter. Обычные raw-операции, clear/bulk/range changes, logical
-identity remapping, другие table types и full-snapshot recovery отклоняются или
-не поддерживаются. Выберите upstream sequence либо другую canonical authority;
-wall-clock узла authority не является. Operational model приведён в
+Это не generic conflict resolution. `VersionedKeyValueTable` durable-регистрирует
+только свой DBI; каждый replica должен сконструировать adapter до приёма
+revisioned operations. Registered DBI принимает только adapter-emitted point
+put/delete changes и отклоняет direct raw, clear, bulk и range writes. Обычные
+raw DBI могут сосуществовать на том же LWW engine и принимать unversioned raw
+operations. Full snapshots могут использовать manifest обычных DBI, но не могут
+включать registered DBI. Выберите upstream sequence либо другую canonical
+authority; wall-clock узла authority не является. Operational model приведён в
 [deployment patterns](sync-deployment-patterns-RU.md).
 
 ## Транспорт и эксплуатация

--- a/docs/sync-deployment-patterns-RU.md
+++ b/docs/sync-deployment-patterns-RU.md
@@ -5,11 +5,12 @@ Sync в `mdbx-containers` поддерживает multi-origin transport: ре�
 `NodeId`. Это делает несколько пишущих узлов практичными, когда их записи не
 конкурируют за одну logical record.
 
-При этом система пока не задаёт concurrent conflict resolution для двух
-writers, меняющих один logical key. В v0.1 по умолчанию используется
-`ConflictPolicy::Reject`; `LastWriterWins` зарезервирован для будущего дизайна
-и отклоняется `SyncEngine`. Поэтому поддержка нескольких origins не является
-контрактом last-writer-wins или CRDT.
+По умолчанию в v0.1 остаётся `ConflictPolicy::Reject`. Для одного узкого случая
+mutable register доступен `ConflictPolicy::LastWriterWins` вместе с
+`VersionedKeyValueTable`: он сравнивает application-provided source-version
+bytes, а не wall-clock узла. У всех остальных raw-путей concurrent
+conflict-resolution semantics по-прежнему нет. Multi-origin transport не
+является generic CRDT-контрактом.
 
 English version: [sync-deployment-patterns.md](sync-deployment-patterns.md).
 
@@ -48,6 +49,7 @@ updates одной mutable record.
 | Несколько nodes создают uniquely identified immutable records | Практичная multi-writer topology |
 | Два nodes одновременно меняют один logical key | Нет определённой conflict-resolution semantics |
 | Один node удаляет, а другой пишет тот же logical key | Нет гарантированной convergence semantics |
+| Versioned `KeyValueTable` put/erase с source authority | Узкий source-version-wins register |
 | Независимые вызовы `SequenceTable::append()` | Только single-writer; appenders надо сериализовать внешне |
 | Destructive multi-writer операции `KeyMultiValueTable` | Нужен один writer или application-level causal serialization |
 
@@ -102,17 +104,26 @@ coverage, collector lag или source divergence.
 ### Mutable bars и snapshots
 
 Open bar, latest quote или upstream snapshot не являются immutable event. Два
-collectors могут законно увидеть разные состояния одного key. У текущего raw
-sync нет source-version-wins поведения для этого случая: используйте одного
-authoritative projector-а или application-level serialization, пока не появится
-versioned conflict policy.
+collectors могут законно увидеть разные состояния одного key. Для этого узкого
+случая настройте у всех участников `ConflictPolicy::LastWriterWins` и пишите
+только через `VersionedKeyValueTable<K, V>`. Его `insert_or_assign` и `erase`
+принимают непустимую canonical source-version byte sequence. Version является
+sync-метаданными, а не частью `V`; получатель durable хранит победителя и
+delete tombstone в `_mdbxc_identity_index` в той же транзакции, что и user data.
 
-Нужный будущий primitive — versioned register: put или delete несёт
-application-provided source-authoritative version, отдельную от user value, а
-получатель атомарно оставляет наибольшую version и deletion tombstones. Broker
-timestamp может быть одним из компонентов, но при равных timestamps нужен source
-sequence либо другой deterministic tie-breaker. Wall-clock time writer-а и время
-приёма пакета не подходят как authority.
+Побеждает лексикографически наибольшая source version; при равных versions
+детерминированный tie-break выполняется по `NodeId` origin-а. Одна version должна
+описывать одно состояние одного source: её повторное использование для другого
+local state отклоняется. Broker timestamp может быть компонентом, но при равных
+timestamps необходим upstream sequence или deterministic tuple. Wall-clock
+writer-а и packet-receipt time не являются authority.
+
+Этот register v1 намеренно исключает обычные raw `KeyValueTable` writes,
+`clear`, bulk/range operations, logical identity remapping, другие table types
+и full-snapshot bootstrap. Не смешивайте обычный raw capture с LWW engine: он
+отклоняет unversioned incoming operations. Tombstones сохраняются; для их
+compaction требуется отдельно определённый replica horizon. Зарезервируйте ещё
+один MDBX DBI slot для `_mdbxc_identity_index` в `Config::max_dbs`.
 
 ## Поддерживаемые пути таблиц
 

--- a/docs/sync-deployment-patterns-RU.md
+++ b/docs/sync-deployment-patterns-RU.md
@@ -118,12 +118,16 @@ local state отклоняется. Broker timestamp может быть ком�
 timestamps необходим upstream sequence или deterministic tuple. Wall-clock
 writer-а и packet-receipt time не являются authority.
 
-Этот register v1 намеренно исключает обычные raw `KeyValueTable` writes,
-`clear`, bulk/range operations, logical identity remapping, другие table types
-и full-snapshot bootstrap. Не смешивайте обычный raw capture с LWW engine: он
-отклоняет unversioned incoming operations. Tombstones сохраняются; для их
-compaction требуется отдельно определённый replica horizon. Зарезервируйте ещё
-один MDBX DBI slot для `_mdbxc_identity_index` в `Config::max_dbs`.
+Этот register v1 durable-помечает свой DBI в `_mdbxc_versioned_dbis`. Каждый
+replica должен сконструировать adapter до приёма revisioned batches. Прямые raw
+`KeyValueTable` writes, `clear` и bulk/range mutations для этого DBI fail closed;
+используйте вместо них point operations adapter-а. Другие, unregistered DBI
+могут использовать ordinary raw capture на том же LWW engine. Unversioned
+incoming operations для registered DBI и revisioned operations для normal DBI
+отклоняются. Full snapshots могут включать только unregistered DBI. Tombstones
+сохраняются; для их compaction требуется отдельно определённый replica horizon.
+Зарезервируйте два дополнительных MDBX DBI slots для `_mdbxc_identity_index` и
+`_mdbxc_versioned_dbis` в `Config::max_dbs`.
 
 ## Поддерживаемые пути таблиц
 

--- a/docs/sync-deployment-patterns.md
+++ b/docs/sync-deployment-patterns.md
@@ -119,12 +119,16 @@ reusing it for different local state is rejected. A broker timestamp may be one
 component, but an upstream sequence or deterministic tuple must resolve timestamp
 ties. Writer wall-clock and packet-receipt time are not suitable authorities.
 
-This v1 register intentionally excludes normal raw `KeyValueTable` writes,
-`clear`, bulk/range operations, logical identity remapping, other table types,
-and full-snapshot bootstrap. Do not mix ordinary raw capture with an LWW engine:
-it rejects unversioned incoming operations. Tombstones are retained; compaction
-needs a separately specified replica horizon. Reserve one additional MDBX DBI
-slot for `_mdbxc_identity_index` in `Config::max_dbs`.
+This v1 register durably marks its DBI in `_mdbxc_versioned_dbis`. Every replica
+must construct the adapter before it receives revisioned batches. Direct raw
+`KeyValueTable` writes, `clear`, and bulk/range mutations against that DBI fail
+closed; use the adapter's point operations instead. Other, unregistered DBIs
+may use ordinary raw capture on the same LWW engine. Unversioned incoming
+operations targeting a registered DBI and revisioned operations targeting a
+normal DBI are rejected. Full snapshots can include only unregistered DBIs.
+Tombstones are retained; compaction needs a separately specified replica
+horizon. Reserve two additional MDBX DBI slots for `_mdbxc_identity_index` and
+`_mdbxc_versioned_dbis` in `Config::max_dbs`.
 
 ## Supported Table Paths
 

--- a/docs/sync-deployment-patterns.md
+++ b/docs/sync-deployment-patterns.md
@@ -5,11 +5,12 @@ committed change histories from multiple durable `NodeId` origins. This makes
 several writer nodes practical when their writes do not compete for the same
 logical record.
 
-It does **not** currently define concurrent conflict resolution for two writers
-that mutate the same logical key. `ConflictPolicy::Reject` is the v0.1 default;
-`LastWriterWins` is reserved for a future design and is rejected by
-`SyncEngine`. Transport support for multiple origins is therefore not a
-last-writer-wins or CRDT contract.
+`ConflictPolicy::Reject` remains the default. For one narrow mutable-register
+case, `ConflictPolicy::LastWriterWins` is available with
+`VersionedKeyValueTable`: it compares application-provided source-version bytes,
+not node wall-clock time. Every other raw table path still has no concurrent
+conflict-resolution semantics. Multi-origin transport is not a generic CRDT
+contract.
 
 Russian version: [sync-deployment-patterns-RU.md](sync-deployment-patterns-RU.md).
 
@@ -48,6 +49,7 @@ record wins.
 | Multiple nodes create uniquely identified immutable records | Practical multi-writer topology |
 | Two nodes concurrently mutate one logical key | No defined conflict-resolution semantics |
 | One node erases while another writes the same logical key | No guaranteed convergence semantics |
+| Versioned `KeyValueTable` put/erase with source authority | Narrow source-version-wins register |
 | Independent `SequenceTable::append()` calls | Single-writer only; serialize appenders externally |
 | Destructive multi-writer `KeyMultiValueTable` operations | Require one writer or application-level causal serialization |
 
@@ -103,17 +105,26 @@ coverage, collector lag, or source divergence.
 ### Mutable Bars And Snapshots
 
 An open bar, latest quote, or upstream snapshot is not an immutable event. Two
-collectors may legitimately observe different states for one key. Current raw
-sync has no source-version-wins behavior for this case; use one authoritative
-projector or application-level serialization until a versioned conflict policy
-is implemented.
+collectors may legitimately observe different states for one key. For this
+narrow case, configure every participant with
+`ConflictPolicy::LastWriterWins` and write only through
+`VersionedKeyValueTable<K, V>`. Its `insert_or_assign` and `erase` each take a
+non-empty, canonical source-version byte sequence. The version is sync metadata,
+not part of `V`; the receiver durably keeps the winner and a delete tombstone in
+`_mdbxc_identity_index` in the same transaction as user data.
 
-The required future primitive is a versioned register: a put or delete carries
-an application-provided, source-authoritative version separate from the user
-value, and a receiver atomically retains the greatest version plus deletion
-tombstones. A broker timestamp can be one component, but a source sequence or
-another deterministic tie-breaker is needed when timestamps are equal. Writer
-wall-clock time and packet-receipt time are not suitable authorities.
+The winner is the lexicographically greatest source version; equal versions are
+resolved by origin `NodeId`. A version must describe one state for one source:
+reusing it for different local state is rejected. A broker timestamp may be one
+component, but an upstream sequence or deterministic tuple must resolve timestamp
+ties. Writer wall-clock and packet-receipt time are not suitable authorities.
+
+This v1 register intentionally excludes normal raw `KeyValueTable` writes,
+`clear`, bulk/range operations, logical identity remapping, other table types,
+and full-snapshot bootstrap. Do not mix ordinary raw capture with an LWW engine:
+it rejects unversioned incoming operations. Tombstones are retained; compaction
+needs a separately specified replica horizon. Reserve one additional MDBX DBI
+slot for `_mdbxc_identity_index` in `Config::max_dbs`.
 
 ## Supported Table Paths
 
@@ -147,10 +158,10 @@ one of two explicit models:
 - deduplicate by `(exchange, symbol, exchange_event_id)` when the exchange
   provides a stable event identity.
 
-Do not make collectors concurrently overwrite mutable records such as
-`latest_quote["BTCUSDT"]` or an in-progress OHLCV candle. Treat latest quotes,
-candles, and similar aggregates as derived state: rebuild them from immutable
-ticks and trades, or assign one authoritative projector for each derived key.
+Do not use ordinary raw capture for concurrent mutable records such as
+`latest_quote["BTCUSDT"]` or an in-progress OHLCV candle. Either rebuild them
+from immutable ticks and trades, assign one authoritative projector, or use the
+narrow versioned register with an exchange-authoritative source version.
 
 ```text
 collector A ── immutable events ──┐
@@ -199,6 +210,8 @@ Before enabling sync for a dataset, define:
 - the logical identity of every replicated record and which writer owns it;
 - whether a record is immutable, or which application authority serializes its
   mutations and deletions;
+- for a versioned register, the canonical source-version encoding and its
+  upstream authority, including timestamp tie-breaking;
 - the rebuild or ownership strategy for derived state;
 - the table-specific sync path from the
   [coverage matrix](../guides/sync-table-coverage.md).

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -16,6 +16,7 @@ Russian version: [sync-RU.md](sync-RU.md).
 | Need | Mode | Entry points |
 | --- | --- | --- |
 | Replicate ordinary table writes between database copies | Raw replication | `ThreadLocalChangeAccumulator`, `SyncCaptureScope`, `SyncWorker`, `ISyncPeer` |
+| Resolve one mutable key by an upstream source version | Narrow LWW register | `ConflictPolicy::LastWriterWins`, `VersionedKeyValueTable` |
 | Replicate a table through an explicit typed application schema | Logical frames | A table logical adapter, `LogicalChangeFrameCodec`, `SyncEngine::apply_logical_frame_bytes()` |
 | Preserve one authoritative ordered history and retry its delivery safely | Ordered logical delivery | Durable outbox, logical-capable `ISyncPeer`, `SyncWorkerOptions::enable_logical_delivery` |
 | Rebuild a fresh raw replica after changelog retention removed needed history | Full snapshot recovery | `SyncWorkerOptions::enable_full_snapshot_fallback`, `CompleteUserDatabase` |
@@ -111,9 +112,19 @@ and snapshots.
 | `AnyValueTable`, `HashedKeyValueStore` | Deferred | No raw capture contract exists. |
 
 Raw replication preserves the storage-level operation contract. It is not a
-general conflict-resolution system. The current engine rejects sequence gaps
-and does not provide a last-writer-wins policy for concurrent application
-writes to the same logical data.
+general conflict-resolution system. It rejects sequence gaps. The only
+concurrent-write exception is the narrow `VersionedKeyValueTable` register:
+with `ConflictPolicy::LastWriterWins`, each point put/delete carries a
+non-empty application-owned version that is compared lexicographically, then
+by origin `NodeId`. The version remains outside the user value and a durable
+sidecar tombstone prevents an older put from resurrecting a delete.
+
+This mode is not generic raw replication: use only the versioned adapter on an
+LWW connection. Ordinary raw operations, clear/bulk/range changes, logical
+identity remapping, other table types, and full snapshot recovery are rejected
+or unsupported. Choose an upstream sequence or other canonical authority;
+node wall-clock time is not an authority. See
+[deployment patterns](sync-deployment-patterns.md) for the operational model.
 
 ## Transport And Operations
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -119,11 +119,14 @@ non-empty application-owned version that is compared lexicographically, then
 by origin `NodeId`. The version remains outside the user value and a durable
 sidecar tombstone prevents an older put from resurrecting a delete.
 
-This mode is not generic raw replication: use only the versioned adapter on an
-LWW connection. Ordinary raw operations, clear/bulk/range changes, logical
-identity remapping, other table types, and full snapshot recovery are rejected
-or unsupported. Choose an upstream sequence or other canonical authority;
-node wall-clock time is not an authority. See
+This mode is not generic conflict resolution. `VersionedKeyValueTable` durably
+registers only its DBI; every replica must construct the adapter before it
+receives revisioned operations. A registered DBI accepts only adapter-emitted
+point put/delete changes and rejects direct raw, clear, bulk, and range writes.
+Ordinary raw DBIs can coexist on the same LWW engine and continue to accept
+unversioned raw operations. Full snapshots may use a manifest of ordinary DBIs,
+but cannot include a registered DBI. Choose an upstream sequence or other
+canonical authority; node wall-clock time is not an authority. See
 [deployment patterns](sync-deployment-patterns.md) for the operational model.
 
 ## Transport And Operations

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -209,15 +209,14 @@ Operational rules:
   method. Calling a method before `open()` throws `std::logic_error` rather
   than silently writing to DBI 0. Do not weaken this guard.
 - `ConflictPolicy::Reject` is the v0.1 default. Narrow
-  `ConflictPolicy::LastWriterWins` v1 accepts only revisioned `Put`/`Delete`
-  operations emitted by `VersionedKeyValueTable`; it compares non-empty,
-  application-owned source-version bytes lexicographically and then `NodeId`.
-  The durable `_mdbxc_identity_index` sidecar keeps source version and delete
-  tombstones in the same transaction as user data. Do not mix ordinary raw
-  capture with an LWW engine: unversioned operations, clear, bulk/range paths,
-  identity remapping, other table types, and full snapshots are unsupported.
-  `time_unix_ns` remains metadata, not a reliable conflict authority. `Custom`
-  is deferred to v0.2.
+  `ConflictPolicy::LastWriterWins` v1 applies only to DBIs durably registered
+  by `VersionedKeyValueTable`. Registered DBIs accept only revisioned
+  `Put`/`Delete` operations; direct raw writes, clear, and bulk/range paths
+  fail closed. Other DBIs retain ordinary raw capture on the same engine. The
+  `_mdbxc_identity_index` sidecar keeps source version and delete tombstones,
+  while `_mdbxc_versioned_dbis` records the contract. Full snapshots may not
+  include a registered DBI. `time_unix_ns` remains metadata, not a reliable
+  conflict authority. `Custom` is deferred to v0.2.
 - `PullRequest::request_full_snapshot=true` starts an explicit source session
   when snapshot export is configured. `ManifestOnly` requires a non-empty
   explicit `FullSnapshotExportOptions::manifest`; without one the source

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -212,7 +212,9 @@ Operational rules:
   `ConflictPolicy::LastWriterWins` v1 applies only to DBIs durably registered
   by `VersionedKeyValueTable`. Registered DBIs accept only revisioned
   `Put`/`Delete` operations; direct raw writes, clear, and bulk/range paths
-  fail closed. Other DBIs retain ordinary raw capture on the same engine. The
+  fail closed through a durable registry lookup in `Connection`, independent
+  of `SyncEngine` lifetime and capture suppression. Other DBIs retain ordinary
+  raw capture on the same engine. The
   `_mdbxc_identity_index` sidecar keeps source version and delete tombstones,
   while `_mdbxc_versioned_dbis` records the contract. Full snapshots may not
   include a registered DBI. `time_unix_ns` remains metadata, not a reliable

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -208,10 +208,16 @@ Operational rules:
 - The four stores each have an `ensure_open()` guard on every public
   method. Calling a method before `open()` throws `std::logic_error` rather
   than silently writing to DBI 0. Do not weaken this guard.
-- `ConflictPolicy::Reject` is the v0.1 default. `LastWriterWins` is declared
-  for future logical-key conflict resolution, but `SyncEngine` rejects it until
-  timestamp/version-based apply semantics exist. `time_unix_ns` is metadata,
-  not a reliable conflict authority. `Custom` is deferred to v0.2.
+- `ConflictPolicy::Reject` is the v0.1 default. Narrow
+  `ConflictPolicy::LastWriterWins` v1 accepts only revisioned `Put`/`Delete`
+  operations emitted by `VersionedKeyValueTable`; it compares non-empty,
+  application-owned source-version bytes lexicographically and then `NodeId`.
+  The durable `_mdbxc_identity_index` sidecar keeps source version and delete
+  tombstones in the same transaction as user data. Do not mix ordinary raw
+  capture with an LWW engine: unversioned operations, clear, bulk/range paths,
+  identity remapping, other table types, and full snapshots are unsupported.
+  `time_unix_ns` remains metadata, not a reliable conflict authority. `Custom`
+  is deferred to v0.2.
 - `PullRequest::request_full_snapshot=true` starts an explicit source session
   when snapshot export is configured. `ManifestOnly` requires a non-empty
   explicit `FullSnapshotExportOptions::manifest`; without one the source

--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -18,6 +18,9 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
   `PullRequest::request_full_snapshot=true` is rejected, and
   `ConflictPolicy::LastWriterWins` cannot be selected until the apply semantics
   exist.
+- Current status: narrow LWW v1 is now available through
+  `VersionedKeyValueTable` with application-provided source versions. The
+  historical PR #155 statement remains applicable to ordinary raw operations.
 - PR #156 renamed the changelog pull internals enough to clarify that empty
   cursors replay retained changelog history rather than exporting a database
   snapshot.

--- a/guides/sync-audit-followups.md
+++ b/guides/sync-audit-followups.md
@@ -19,8 +19,10 @@ into small PRs so behavior, storage format, and build hygiene remain reviewable.
   `ConflictPolicy::LastWriterWins` cannot be selected until the apply semantics
   exist.
 - Current status: narrow LWW v1 is now available through
-  `VersionedKeyValueTable` with application-provided source versions. The
-  historical PR #155 statement remains applicable to ordinary raw operations.
+  `VersionedKeyValueTable` with application-provided source versions. Its DBI
+  is durably registered and fail-closed for direct raw writes; ordinary raw
+  DBIs remain supported on the same engine. The historical PR #155 statement
+  remains applicable to ordinary raw operations without a versioned contract.
 - PR #156 renamed the changelog pull internals enough to clarify that empty
   cursors replay retained changelog history rather than exporting a database
   snapshot.

--- a/guides/sync-table-coverage.md
+++ b/guides/sync-table-coverage.md
@@ -18,6 +18,7 @@ can dispatch that outbox through a logical-capable peer after a raw round drains
 | Table wrapper | v0.1 status | Captured operations | Apply semantics | Main tests |
 | --- | --- | --- | --- | --- |
 | `KeyValueTable<K, V>` | Supported | `Put`, `Delete`, `ClearTable`; point writes, bulk writes, range erase, and clear paths are implemented. | Raw key/value bytes are replayed into a destination DBI opened with captured DBI flags. | `test_sync_capture`, `test_sync_replication`, `test_sync_engine` |
+| `VersionedKeyValueTable<K, V>` | Narrow LWW v1 adapter | Only point `insert_or_assign` and `erase`, each with a non-empty application source version. | With `ConflictPolicy::LastWriterWins`, source-version bytes order competing operations; equal versions use origin `NodeId`; durable sidecar tombstones prevent stale puts from resurrecting deletes. | `test_sync_engine` |
 | `KeyTable<K>` | Supported | `Put`, `Delete`, `ClearTable`; insert, erase, range erase, and clear paths are implemented. | Raw key bytes are replayed with empty values. | `test_sync_capture`, `test_sync_engine`, `test_sync_replication` |
 | `ValueTable<V>` | Supported | `Put`, `Delete`, `ClearTable`; set, insert, update, erase, and clear paths are implemented. | The singleton physical key and serialized value bytes are replayed. | `test_sync_capture`, `test_sync_replication` |
 | `SequenceTable<V>` | Supported | `Put`, `Delete`, `ClearTable`; append, `insert_or_assign`, erase, and clear paths are implemented. | Stable `uint64_t` sequence keys and value bytes are replayed. | `test_sync_capture`, `test_sync_replication` |
@@ -42,6 +43,16 @@ calls. Attach capture to the writing connection, preferably through
 The captured DBI name, DBI flags, physical key bytes, and value bytes must
 remain sufficient to open or validate the destination DBI and replay the
 operation without table-specific decoding.
+
+`VersionedKeyValueTable` is deliberately outside that general raw contract. It
+owns one automatic write transaction per point operation, suppresses ordinary
+capture for the table mutation, and emits one revisioned raw `ChangeOp`. It
+requires initialized sync identity and an attached `ThreadLocalChangeAccumulator`.
+All peers using `ConflictPolicy::LastWriterWins` accept only these revisioned
+`Put`/`Delete` operations; `ClearTable`, ranges, bulk operations, identity
+remapping, other table families, and full snapshots are excluded. Its durable
+`_mdbxc_identity_index` sidecar consumes one additional named DBI and retains
+delete tombstones.
 
 Logical table sync is still a reserved extension. The scaffolding added for it
 has three separate pieces that must not be treated as support by themselves:

--- a/guides/sync-table-coverage.md
+++ b/guides/sync-table-coverage.md
@@ -50,7 +50,9 @@ capture for the table mutation, and emits one revisioned raw `ChangeOp`. It
 requires initialized sync identity and an attached `ThreadLocalChangeAccumulator`.
 The adapter durably registers its DBI in `_mdbxc_versioned_dbis`. Registered
 DBIs accept only these revisioned `Put`/`Delete` operations; `ClearTable`,
-ranges, bulk operations, and direct raw writes fail closed. Other table DBIs
+ranges, bulk operations, direct raw writes, and generic logical-table writes
+fail closed. The durable `Connection` lookup remains active without a live
+`SyncEngine` and is not bypassed by capture suppression. Other table DBIs
 continue under their ordinary raw contracts on the same LWW engine. Full
 snapshots may not include a registered DBI. The registry and
 `_mdbxc_identity_index` consume two additional named DBIs; the index retains

--- a/guides/sync-table-coverage.md
+++ b/guides/sync-table-coverage.md
@@ -18,7 +18,7 @@ can dispatch that outbox through a logical-capable peer after a raw round drains
 | Table wrapper | v0.1 status | Captured operations | Apply semantics | Main tests |
 | --- | --- | --- | --- | --- |
 | `KeyValueTable<K, V>` | Supported | `Put`, `Delete`, `ClearTable`; point writes, bulk writes, range erase, and clear paths are implemented. | Raw key/value bytes are replayed into a destination DBI opened with captured DBI flags. | `test_sync_capture`, `test_sync_replication`, `test_sync_engine` |
-| `VersionedKeyValueTable<K, V>` | Narrow LWW v1 adapter | Only point `insert_or_assign` and `erase`, each with a non-empty application source version. | With `ConflictPolicy::LastWriterWins`, source-version bytes order competing operations; equal versions use origin `NodeId`; durable sidecar tombstones prevent stale puts from resurrecting deletes. | `test_sync_engine` |
+| `VersionedKeyValueTable<K, V>` | Narrow LWW v1 adapter | Only point `insert_or_assign` and `erase`, each with a non-empty application source version. | Durably registers its DBI; with `ConflictPolicy::LastWriterWins`, source-version bytes order competing operations and equal versions use origin `NodeId`. Tombstones prevent stale puts from resurrecting deletes. | `test_sync_engine` |
 | `KeyTable<K>` | Supported | `Put`, `Delete`, `ClearTable`; insert, erase, range erase, and clear paths are implemented. | Raw key bytes are replayed with empty values. | `test_sync_capture`, `test_sync_engine`, `test_sync_replication` |
 | `ValueTable<V>` | Supported | `Put`, `Delete`, `ClearTable`; set, insert, update, erase, and clear paths are implemented. | The singleton physical key and serialized value bytes are replayed. | `test_sync_capture`, `test_sync_replication` |
 | `SequenceTable<V>` | Supported | `Put`, `Delete`, `ClearTable`; append, `insert_or_assign`, erase, and clear paths are implemented. | Stable `uint64_t` sequence keys and value bytes are replayed. | `test_sync_capture`, `test_sync_replication` |
@@ -48,10 +48,12 @@ operation without table-specific decoding.
 owns one automatic write transaction per point operation, suppresses ordinary
 capture for the table mutation, and emits one revisioned raw `ChangeOp`. It
 requires initialized sync identity and an attached `ThreadLocalChangeAccumulator`.
-All peers using `ConflictPolicy::LastWriterWins` accept only these revisioned
-`Put`/`Delete` operations; `ClearTable`, ranges, bulk operations, identity
-remapping, other table families, and full snapshots are excluded. Its durable
-`_mdbxc_identity_index` sidecar consumes one additional named DBI and retains
+The adapter durably registers its DBI in `_mdbxc_versioned_dbis`. Registered
+DBIs accept only these revisioned `Put`/`Delete` operations; `ClearTable`,
+ranges, bulk operations, and direct raw writes fail closed. Other table DBIs
+continue under their ordinary raw contracts on the same LWW engine. Full
+snapshots may not include a registered DBI. The registry and
+`_mdbxc_identity_index` consume two additional named DBIs; the index retains
 delete tombstones.
 
 Logical table sync is still a reserved extension. The scaffolding added for it

--- a/include/mdbx_containers/common/Connection.hpp
+++ b/include/mdbx_containers/common/Connection.hpp
@@ -332,6 +332,12 @@ namespace mdbxc {
         bool sync_capture_suppressed(MDBX_txn* txn) const;
         void ensure_sync_capture_txn_supported(MDBX_txn* txn,
                                                const char* context) const;
+        void ensure_sync_dbi_external_txn_supported(
+            MDBX_txn* txn,
+            const std::string& dbi_name,
+            const char* context) const;
+        bool is_sync_versioned_dbi(MDBX_txn* txn,
+                                   const std::string& dbi_name) const;
         void validate_sync_dbi_write(MDBX_txn* txn,
                                      const std::string& dbi_name,
                                      sync::ChangeOpType op_type);

--- a/include/mdbx_containers/common/Connection.hpp
+++ b/include/mdbx_containers/common/Connection.hpp
@@ -34,6 +34,7 @@ namespace mdbxc {
 
     namespace sync {
         class ISyncCaptureSink;
+        class ISyncDbiWritePolicy;
         class ISyncApplyObserver;
         class SyncCaptureScope;
         class SyncEngine;
@@ -71,6 +72,7 @@ namespace mdbxc {
         friend class TableSequence;
 #   if MDBXC_SYNC_ENABLED
         friend class sync::SyncCaptureScope;
+        friend class sync::SyncEngine;
 #   endif
     public:
 
@@ -332,6 +334,11 @@ namespace mdbxc {
         bool sync_capture_suppressed(MDBX_txn* txn) const;
         void ensure_sync_capture_txn_supported(MDBX_txn* txn,
                                                const char* context) const;
+        void attach_sync_dbi_write_policy(sync::ISyncDbiWritePolicy* policy);
+        void detach_sync_dbi_write_policy(sync::ISyncDbiWritePolicy* policy);
+        void validate_sync_dbi_write(MDBX_txn* txn,
+                                     const std::string& dbi_name,
+                                     sync::ChangeOpType op_type);
         struct SyncApplyObserverState;
 
         struct SyncApplyObserverCallback {
@@ -382,6 +389,7 @@ namespace mdbxc {
         };
 
         sync::ISyncCaptureSink* m_sync_capture = nullptr;
+        sync::ISyncDbiWritePolicy* m_sync_dbi_write_policy = nullptr;
         std::uint64_t m_sync_capture_token = 0;
         std::uint64_t m_next_sync_capture_token = 0;
         MDBX_txn* m_sync_capture_failed_txn = nullptr;

--- a/include/mdbx_containers/common/Connection.hpp
+++ b/include/mdbx_containers/common/Connection.hpp
@@ -34,7 +34,6 @@ namespace mdbxc {
 
     namespace sync {
         class ISyncCaptureSink;
-        class ISyncDbiWritePolicy;
         class ISyncApplyObserver;
         class SyncCaptureScope;
         class SyncEngine;
@@ -72,7 +71,6 @@ namespace mdbxc {
         friend class TableSequence;
 #   if MDBXC_SYNC_ENABLED
         friend class sync::SyncCaptureScope;
-        friend class sync::SyncEngine;
 #   endif
     public:
 
@@ -334,8 +332,6 @@ namespace mdbxc {
         bool sync_capture_suppressed(MDBX_txn* txn) const;
         void ensure_sync_capture_txn_supported(MDBX_txn* txn,
                                                const char* context) const;
-        void attach_sync_dbi_write_policy(sync::ISyncDbiWritePolicy* policy);
-        void detach_sync_dbi_write_policy(sync::ISyncDbiWritePolicy* policy);
         void validate_sync_dbi_write(MDBX_txn* txn,
                                      const std::string& dbi_name,
                                      sync::ChangeOpType op_type);
@@ -389,7 +385,6 @@ namespace mdbxc {
         };
 
         sync::ISyncCaptureSink* m_sync_capture = nullptr;
-        sync::ISyncDbiWritePolicy* m_sync_dbi_write_policy = nullptr;
         std::uint64_t m_sync_capture_token = 0;
         std::uint64_t m_next_sync_capture_token = 0;
         MDBX_txn* m_sync_capture_failed_txn = nullptr;

--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -187,38 +187,36 @@ namespace mdbxc {
         return m_sync_capture;
     }
 
-    inline void Connection::attach_sync_dbi_write_policy(
-            sync::ISyncDbiWritePolicy* policy) {
-        if (policy == nullptr) {
-            throw std::invalid_argument(
-                "Connection::attach_sync_dbi_write_policy policy cannot be null");
-        }
-        std::lock_guard<std::mutex> locker(m_mdbx_mutex);
-        m_sync_dbi_write_policy = policy;
-    }
-
-    inline void Connection::detach_sync_dbi_write_policy(
-            sync::ISyncDbiWritePolicy* policy) {
-        std::lock_guard<std::mutex> locker(m_mdbx_mutex);
-        if (m_sync_dbi_write_policy == policy) {
-            m_sync_dbi_write_policy = nullptr;
-        }
-    }
-
     inline void Connection::validate_sync_dbi_write(
             MDBX_txn* txn,
             const std::string& dbi_name,
             sync::ChangeOpType op_type) {
-        sync::ISyncDbiWritePolicy* policy = nullptr;
-        {
-            std::lock_guard<std::mutex> locker(m_mdbx_mutex);
-            policy = m_sync_dbi_write_policy;
-        }
-        if (policy == nullptr) {
-            return;
-        }
         try {
-            policy->validate_sync_dbi_write(txn, dbi_name, op_type);
+            (void)op_type;
+            checked_txn_env(txn, m_env, "Connection::validate_sync_dbi_write");
+            MDBX_dbi registry_dbi = 0;
+            const int open_rc = mdbx_dbi_open(
+                txn, "_mdbxc_versioned_dbis", static_cast<MDBX_db_flags_t>(0),
+                &registry_dbi);
+            if (open_rc == MDBX_NOTFOUND) {
+                return;
+            }
+            check_mdbx(open_rc,
+                       "Connection failed to open versioned DBI registry");
+            MDBX_val key = {
+                dbi_name.empty() ? nullptr : const_cast<char*>(dbi_name.data()),
+                dbi_name.size()
+            };
+            MDBX_val value;
+            const int get_rc = mdbx_get(txn, registry_dbi, &key, &value);
+            if (get_rc == MDBX_NOTFOUND) {
+                return;
+            }
+            check_mdbx(get_rc,
+                       "Connection failed to query versioned DBI registry");
+            throw std::logic_error(
+                "registered source-version-wins DBI must be mutated through "
+                "VersionedKeyValueTable");
         } catch (...) {
             mark_sync_capture_failed(txn);
             throw;

--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -193,27 +193,9 @@ namespace mdbxc {
             sync::ChangeOpType op_type) {
         try {
             (void)op_type;
-            checked_txn_env(txn, m_env, "Connection::validate_sync_dbi_write");
-            MDBX_dbi registry_dbi = 0;
-            const int open_rc = mdbx_dbi_open(
-                txn, "_mdbxc_versioned_dbis", static_cast<MDBX_db_flags_t>(0),
-                &registry_dbi);
-            if (open_rc == MDBX_NOTFOUND) {
+            if (!is_sync_versioned_dbi(txn, dbi_name)) {
                 return;
             }
-            check_mdbx(open_rc,
-                       "Connection failed to open versioned DBI registry");
-            MDBX_val key = {
-                dbi_name.empty() ? nullptr : const_cast<char*>(dbi_name.data()),
-                dbi_name.size()
-            };
-            MDBX_val value;
-            const int get_rc = mdbx_get(txn, registry_dbi, &key, &value);
-            if (get_rc == MDBX_NOTFOUND) {
-                return;
-            }
-            check_mdbx(get_rc,
-                       "Connection failed to query versioned DBI registry");
             throw std::logic_error(
                 "registered source-version-wins DBI must be mutated through "
                 "VersionedKeyValueTable");
@@ -418,6 +400,54 @@ namespace mdbxc {
             std::string(context) +
             " cannot use caller-created raw writable MDBX_txn* while sync capture is attached; "
             "use mdbx_containers::Transaction or Connection::begin()/commit()");
+    }
+
+    inline void Connection::ensure_sync_dbi_external_txn_supported(
+            MDBX_txn* txn,
+            const std::string& dbi_name,
+            const char* context) const {
+        if (thread_txn() == txn) {
+            return;
+        }
+        const MDBX_txn_flags_t flags = mdbx_txn_flags(txn);
+        if ((static_cast<int>(flags) &
+             static_cast<int>(MDBX_TXN_RDONLY)) != 0) {
+            return;
+        }
+        if (!is_sync_versioned_dbi(txn, dbi_name)) {
+            return;
+        }
+        throw std::logic_error(
+            std::string(context) +
+            " cannot use caller-created raw writable MDBX_txn* with a "
+            "registered source-version-wins DBI; use VersionedKeyValueTable");
+    }
+
+    inline bool Connection::is_sync_versioned_dbi(
+            MDBX_txn* txn,
+            const std::string& dbi_name) const {
+        checked_txn_env(txn, m_env, "Connection::is_sync_versioned_dbi");
+        MDBX_dbi registry_dbi = 0;
+        const int open_rc = mdbx_dbi_open(
+            txn, "_mdbxc_versioned_dbis", static_cast<MDBX_db_flags_t>(0),
+            &registry_dbi);
+        if (open_rc == MDBX_NOTFOUND) {
+            return false;
+        }
+        check_mdbx(open_rc,
+                   "Connection failed to open versioned DBI registry");
+        MDBX_val key = {
+            dbi_name.empty() ? nullptr : const_cast<char*>(dbi_name.data()),
+            dbi_name.size()
+        };
+        MDBX_val value;
+        const int get_rc = mdbx_get(txn, registry_dbi, &key, &value);
+        if (get_rc == MDBX_NOTFOUND) {
+            return false;
+        }
+        check_mdbx(get_rc,
+                   "Connection failed to query versioned DBI registry");
+        return true;
     }
 
     inline Connection::SyncApplyNotification Connection::mark_sync_apply_committed(

--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -187,6 +187,44 @@ namespace mdbxc {
         return m_sync_capture;
     }
 
+    inline void Connection::attach_sync_dbi_write_policy(
+            sync::ISyncDbiWritePolicy* policy) {
+        if (policy == nullptr) {
+            throw std::invalid_argument(
+                "Connection::attach_sync_dbi_write_policy policy cannot be null");
+        }
+        std::lock_guard<std::mutex> locker(m_mdbx_mutex);
+        m_sync_dbi_write_policy = policy;
+    }
+
+    inline void Connection::detach_sync_dbi_write_policy(
+            sync::ISyncDbiWritePolicy* policy) {
+        std::lock_guard<std::mutex> locker(m_mdbx_mutex);
+        if (m_sync_dbi_write_policy == policy) {
+            m_sync_dbi_write_policy = nullptr;
+        }
+    }
+
+    inline void Connection::validate_sync_dbi_write(
+            MDBX_txn* txn,
+            const std::string& dbi_name,
+            sync::ChangeOpType op_type) {
+        sync::ISyncDbiWritePolicy* policy = nullptr;
+        {
+            std::lock_guard<std::mutex> locker(m_mdbx_mutex);
+            policy = m_sync_dbi_write_policy;
+        }
+        if (policy == nullptr) {
+            return;
+        }
+        try {
+            policy->validate_sync_dbi_write(txn, dbi_name, op_type);
+        } catch (...) {
+            mark_sync_capture_failed(txn);
+            throw;
+        }
+    }
+
     inline Connection::SyncCaptureSuppressionScope::
     SyncCaptureSuppressionScope(Connection& connection, MDBX_txn* txn)
         : m_connection(&connection),

--- a/include/mdbx_containers/common/Connection.ipp
+++ b/include/mdbx_containers/common/Connection.ipp
@@ -427,9 +427,29 @@ namespace mdbxc {
             MDBX_txn* txn,
             const std::string& dbi_name) const {
         checked_txn_env(txn, m_env, "Connection::is_sync_versioned_dbi");
+        static const char versioned_dbi_registry_name[] =
+            "_mdbxc_versioned_dbis";
+        MDBX_val registry_name = {
+            const_cast<char*>(versioned_dbi_registry_name),
+            sizeof(versioned_dbi_registry_name) - 1u
+        };
+        MDBX_dbi main_dbi = 0;
+        check_mdbx(mdbx_dbi_open(
+                       txn, nullptr, static_cast<MDBX_db_flags_t>(0),
+                       &main_dbi),
+                   "Connection failed to open main DBI");
+        MDBX_val registry_value;
+        const int registry_lookup_rc = mdbx_get(
+            txn, main_dbi, &registry_name, &registry_value);
+        if (registry_lookup_rc == MDBX_NOTFOUND) {
+            return false;
+        }
+        check_mdbx(registry_lookup_rc,
+                   "Connection failed to find versioned DBI registry");
         MDBX_dbi registry_dbi = 0;
         const int open_rc = mdbx_dbi_open(
-            txn, "_mdbxc_versioned_dbis", static_cast<MDBX_db_flags_t>(0),
+            txn, versioned_dbi_registry_name,
+            static_cast<MDBX_db_flags_t>(0),
             &registry_dbi);
         if (open_rc == MDBX_NOTFOUND) {
             return false;

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -223,8 +223,8 @@ namespace mdbxc {
                        const std::vector<std::uint8_t>& storage_key,
                        const std::vector<std::uint8_t>& value) const {
             if (m_connection->is_read_only()) return;
-            if (m_connection->sync_capture_suppressed(txn)) return;
             m_connection->validate_sync_dbi_write(txn, m_name, op_type);
+            if (m_connection->sync_capture_suppressed(txn)) return;
             sync::ISyncCaptureSink* sink = m_connection->sync_capture();
             if (sink == nullptr) return;
             sync::ChangeOp op;

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -224,6 +224,7 @@ namespace mdbxc {
                        const std::vector<std::uint8_t>& value) const {
             if (m_connection->is_read_only()) return;
             if (m_connection->sync_capture_suppressed(txn)) return;
+            m_connection->validate_sync_dbi_write(txn, m_name, op_type);
             sync::ISyncCaptureSink* sink = m_connection->sync_capture();
             if (sink == nullptr) return;
             sync::ChangeOp op;

--- a/include/mdbx_containers/detail/BaseTable.hpp
+++ b/include/mdbx_containers/detail/BaseTable.hpp
@@ -184,6 +184,8 @@ namespace mdbxc {
 #       if MDBXC_SYNC_ENABLED
             m_connection->ensure_sync_capture_txn_supported(
                 checked, "BaseTable external transaction");
+            m_connection->ensure_sync_dbi_external_txn_supported(
+                checked, m_name, "BaseTable external transaction");
 #       endif
             return checked;
         }

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1124,10 +1124,14 @@ Each key is one non-reserved user DBI name with an empty value. Constructing a
 `VersionedKeyValueTable` registers an empty user DBI in the same environment;
 every replica must make the same registration before it receives revisioned
 operations. The registration makes direct raw writes, clear, and bulk/range
-mutations fail closed through `Connection`'s write policy. It also determines
-apply semantics per operation: a registered DBI requires `LastWriterWins` and
-revisioned point put/delete; an unregistered DBI rejects revision metadata and
-uses ordinary raw apply. Full snapshot manifests cannot include registered DBIs.
+mutations fail closed through a `Connection` lookup of the durable registry;
+the result does not depend on `SyncEngine` lifetime or capture attachment.
+Capture suppression prevents raw re-publication only and does not bypass this
+check, so generic logical adapters cannot mutate a registered DBI. It also
+determines apply semantics per operation: a registered DBI requires
+`LastWriterWins` and revisioned point put/delete; an unregistered DBI rejects
+revision metadata and uses ordinary raw apply. Full snapshot manifests cannot
+include registered DBIs.
 
 ### `_mdbxc_sync_schema` (SchemaRegistryStore) — logical adapter marker
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -87,8 +87,9 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
   round-trip and fail-closed duplicate, schema, malformed-payload, and
   capture-rollback cases.
 - `ConflictPolicy::Reject` is the default. Narrow `ConflictPolicy::LastWriterWins`
-  v1 accepts only revisioned raw `Put`/`Delete` operations emitted by
-  `VersionedKeyValueTable`. It orders non-empty application source-version
+  v1 applies to DBIs durably registered by `VersionedKeyValueTable`. Registered
+  DBIs accept only revisioned raw `Put`/`Delete` operations; ordinary DBIs keep
+  raw sync on the same engine. It orders non-empty application source-version
   bytes lexicographically, then origin `NodeId`, and persists winner/tombstone
   markers in `_mdbxc_identity_index` with the user mutation.
 - `SyncWorker` background pull/apply lifecycle, cooperative cancellation
@@ -1116,6 +1117,17 @@ and `SyncEngine` atomically write the source version, origin, and tombstone with
 the user mutation. Incoming LWW batches may not carry a different
 `identity_key`. Tombstones are not compacted by v1; real removal requires a
 separately specified replica horizon.
+
+### `_mdbxc_versioned_dbis` (VersionedDbiStore) — LWW v1 contract registry
+
+Each key is one non-reserved user DBI name with an empty value. Constructing a
+`VersionedKeyValueTable` registers an empty user DBI in the same environment;
+every replica must make the same registration before it receives revisioned
+operations. The registration makes direct raw writes, clear, and bulk/range
+mutations fail closed through `Connection`'s write policy. It also determines
+apply semantics per operation: a registered DBI requires `LastWriterWins` and
+revisioned point put/delete; an unregistered DBI rejects revision metadata and
+uses ordinary raw apply. Full snapshot manifests cannot include registered DBIs.
 
 ### `_mdbxc_sync_schema` (SchemaRegistryStore) — logical adapter marker
 

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -86,9 +86,11 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
   separate logical-adapter regression covers VectorStore add/erase/clear
   round-trip and fail-closed duplicate, schema, malformed-payload, and
   capture-rollback cases.
-- `ConflictPolicy::Reject` is the default. `ConflictPolicy::LastWriterWins`
-  is declared for future logical-key conflict resolution; `SyncEngine`
-  rejects it until a reliable conflict authority exists.
+- `ConflictPolicy::Reject` is the default. Narrow `ConflictPolicy::LastWriterWins`
+  v1 accepts only revisioned raw `Put`/`Delete` operations emitted by
+  `VersionedKeyValueTable`. It orders non-empty application source-version
+  bytes lexicographically, then origin `NodeId`, and persists winner/tombstone
+  markers in `_mdbxc_identity_index` with the user mutation.
 - `SyncWorker` background pull/apply lifecycle, cooperative cancellation
   tokens, best-effort peer cancellation hook, and focused worker tests.
 - Manual hub-style benchmark (`sync_tick_hub_benchmark`) plus opt-in and
@@ -981,10 +983,10 @@ anchors, see the
 - Specialized table types not listed in the implemented scope are not treated
   as sync-covered without explicit wire-format design and round-trip tests.
 - Automatic remap of physical `storage_key` from logical `identity_key`.
-- HLC or other production authority for logical-key `LastWriterWins`.
-  `time_unix_ns` is metadata only, not a reliable conflict authority. The
-  current apply path does not maintain enough identity-index conflict state to
-  use `LastWriterWins`, so `SyncEngine` rejects that policy.
+- HLC or another general production authority for logical-key conflict
+  resolution. `time_unix_ns` remains metadata only. The narrow LWW v1 uses an
+  application-owned source version for `VersionedKeyValueTable` point writes;
+  it is not a generic resolver for raw tables or logical identities.
 - `Custom` conflict resolver — schema-level callback; deferred until the
   first real consumer needs it.
 - Production-grade deployment wrappers for concrete socket-bound HTTP and
@@ -1095,7 +1097,7 @@ normal background-sync loop or per-pull hot path.
 missing batches arrive. If `incoming.seq <= last`, the batch is a redundant
 replay and is skipped.
 
-### `_mdbxc_identity_index` (IdentityIndexStore) — declared in v0.1, write path deferred
+### `_mdbxc_identity_index` (IdentityIndexStore) — LWW v1 sidecar
 
 | | |
 |---|---|
@@ -1109,7 +1111,11 @@ back to a physical `storage_key` without re-reading the user table.
 
 `IDENTITY_TOMBSTONE` flag bit marks deleted logical records while keeping
 the row readable for older incoming batches that still reference the key.
-Real removal is explicit via `erase()`.
+For LWW v1 the index key is the physical `storage_key`: `VersionedKeyValueTable`
+and `SyncEngine` atomically write the source version, origin, and tombstone with
+the user mutation. Incoming LWW batches may not carry a different
+`identity_key`. Tombstones are not compacted by v1; real removal requires a
+separately specified replica horizon.
 
 ### `_mdbxc_sync_schema` (SchemaRegistryStore) — logical adapter marker
 

--- a/include/mdbx_containers/sync/adapters.hpp
+++ b/include/mdbx_containers/sync/adapters.hpp
@@ -14,10 +14,13 @@
 #if MDBXC_SYNC_ENABLED
 #include <mdbx_containers/tables.hpp>
 #include <mdbx_containers/vector.hpp>
+#include "capture.hpp"
+#include "storage.hpp"
 #include "logical.hpp"
 #include "logical/adapters/detail/blob_payload.hpp"
 #include "logical/adapters/detail/captured_logical_transaction.hpp"
 #include "logical/adapters/KeyValueTableLogicalAdapter.hpp"
+#include "logical/adapters/VersionedKeyValueTable.hpp"
 #include "logical/adapters/KeyTableLogicalAdapter.hpp"
 #include "logical/adapters/KeyMultiValueTableLogicalAdapter.hpp"
 #include "logical/adapters/KeyOrderedMultiValueTableLogicalAdapter.hpp"

--- a/include/mdbx_containers/sync/capture/ISyncCaptureSink.hpp
+++ b/include/mdbx_containers/sync/capture/ISyncCaptureSink.hpp
@@ -23,24 +23,6 @@
 namespace mdbxc {
 namespace sync {
 
-    /// \brief Validates writes to DBIs with special sync semantics.
-    /// \details Connection invokes this narrow hook before forwarding a table
-    /// write to capture. Implementations may throw to make the surrounding
-    /// connection-managed transaction rollback-only.
-    class ISyncDbiWritePolicy {
-    public:
-        virtual ~ISyncDbiWritePolicy() = default;
-
-        /// \brief Validates one user-table write.
-        /// \param txn Active writable MDBX transaction.
-        /// \param dbi_name User DBI name.
-        /// \param op_type Physical operation about to be captured.
-        virtual void validate_sync_dbi_write(
-                MDBX_txn* txn,
-                const std::string& dbi_name,
-                ChangeOpType op_type) = 0;
-    };
-
     /// \brief Interface between mdbxc-core write paths and the sync recorder.
     /// \details The implementation owns thread-local pending state, decides
     /// when to assemble a batch, and writes it to \c _mdbxc_changelog inside

--- a/include/mdbx_containers/sync/capture/ISyncCaptureSink.hpp
+++ b/include/mdbx_containers/sync/capture/ISyncCaptureSink.hpp
@@ -23,6 +23,24 @@
 namespace mdbxc {
 namespace sync {
 
+    /// \brief Validates writes to DBIs with special sync semantics.
+    /// \details Connection invokes this narrow hook before forwarding a table
+    /// write to capture. Implementations may throw to make the surrounding
+    /// connection-managed transaction rollback-only.
+    class ISyncDbiWritePolicy {
+    public:
+        virtual ~ISyncDbiWritePolicy() = default;
+
+        /// \brief Validates one user-table write.
+        /// \param txn Active writable MDBX transaction.
+        /// \param dbi_name User DBI name.
+        /// \param op_type Physical operation about to be captured.
+        virtual void validate_sync_dbi_write(
+                MDBX_txn* txn,
+                const std::string& dbi_name,
+                ChangeOpType op_type) = 0;
+    };
+
     /// \brief Interface between mdbxc-core write paths and the sync recorder.
     /// \details The implementation owns thread-local pending state, decides
     /// when to assemble a batch, and writes it to \c _mdbxc_changelog inside

--- a/include/mdbx_containers/sync/core/ConflictPolicy.hpp
+++ b/include/mdbx_containers/sync/core/ConflictPolicy.hpp
@@ -12,9 +12,11 @@ namespace sync {
     enum class ConflictPolicy {
         /// \brief Reject the incoming change; surface an error to the caller.
         Reject,
-        /// \brief Reserved for future timestamp/version based resolution.
-        /// \details v0.1 \c SyncEngine rejects this policy because raw batch
-        /// apply does not yet have a reliable logical-key conflict authority.
+        /// \brief Applies the greatest application-provided source version.
+        /// \details Narrow v1 support accepts only revisioned raw \c Put and
+        /// \c Delete operations emitted by \c VersionedKeyValueTable. Source
+        /// version bytes are compared lexicographically, then \c NodeId breaks
+        /// an equal-version tie deterministically. It is not wall-clock LWW.
         LastWriterWins,
     };
 

--- a/include/mdbx_containers/sync/core/ConflictPolicy.hpp
+++ b/include/mdbx_containers/sync/core/ConflictPolicy.hpp
@@ -13,10 +13,12 @@ namespace sync {
         /// \brief Reject the incoming change; surface an error to the caller.
         Reject,
         /// \brief Applies the greatest application-provided source version.
-        /// \details Narrow v1 support accepts only revisioned raw \c Put and
-        /// \c Delete operations emitted by \c VersionedKeyValueTable. Source
-        /// version bytes are compared lexicographically, then \c NodeId breaks
-        /// an equal-version tie deterministically. It is not wall-clock LWW.
+        /// \details Narrow v1 support applies to DBIs registered by
+        /// \c VersionedKeyValueTable. Those DBIs accept only revisioned raw
+        /// \c Put and \c Delete operations. Ordinary DBIs keep raw sync on
+        /// the same engine. Source version bytes are compared lexicographically,
+        /// then \c NodeId breaks an equal-version tie deterministically.
+        /// It is not wall-clock LWW.
         LastWriterWins,
     };
 

--- a/include/mdbx_containers/sync/engine/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/engine/SyncEngine.hpp
@@ -59,6 +59,8 @@ namespace sync {
         InconsistentBatchDbiFlags,///< One batch carries contradictory flags for one DBI.
         ExistingDbiFlagsMismatch, ///< Existing destination DBI rejects captured flags.
         ReservedDbiName,          ///< Incoming ChangeOp targets an internal DBI name.
+        MissingLwwRevision,       ///< LWW operation lacks a non-empty source revision.
+        UnsupportedLwwOperation,  ///< LWW accepts only raw put/delete without identity remapping.
     };
 
     /// \brief Detailed result for callers that need conflict diagnostics.
@@ -209,11 +211,12 @@ namespace sync {
             : m_conn(std::move(conn)),
               m_policy(policy),
               m_full_snapshot_options(full_snapshot_options) {
-            if (m_policy == ConflictPolicy::LastWriterWins) {
-                throw std::invalid_argument(
-                    "ConflictPolicy::LastWriterWins is not implemented");
-            }
             validate_full_snapshot_export_options(m_full_snapshot_options);
+            if (m_policy == ConflictPolicy::LastWriterWins &&
+                full_snapshot_export_is_configured(m_full_snapshot_options)) {
+                throw std::invalid_argument(
+                    "LastWriterWins does not support full snapshot export");
+            }
         }
 
         /// \brief Initialises the local \c node_id and \c db_uuid.
@@ -271,6 +274,11 @@ namespace sync {
         void set_full_snapshot_export_options(
                 const FullSnapshotExportOptions& options) {
             validate_full_snapshot_export_options(options);
+            if (m_policy == ConflictPolicy::LastWriterWins &&
+                full_snapshot_export_is_configured(options)) {
+                throw std::invalid_argument(
+                    "LastWriterWins does not support full snapshot export");
+            }
             std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
             m_full_snapshot_options = options;
             m_full_snapshot_sessions.clear();
@@ -306,6 +314,7 @@ namespace sync {
         /// inventory and bootstraps the applied cursor from its source tail.
         FullSnapshotImportResult apply_full_snapshot_chunk(
                 const FullSnapshotChunk& chunk) {
+            reject_lww_full_snapshot_import();
             FullSnapshotCodec::validate(chunk);
             FullSnapshotImportResult result;
             Connection::SyncApplyNotification notification;
@@ -335,6 +344,7 @@ namespace sync {
         FullSnapshotImportResult apply_logical_recovery_chunk(
                 const FullSnapshotChunk& chunk,
                 const LogicalRecoveryBaseline* baseline = nullptr) {
+            reject_lww_full_snapshot_import();
             FullSnapshotCodec::validate(chunk);
             if (chunk.has_more ? baseline != nullptr : baseline == nullptr) {
                 throw std::invalid_argument(
@@ -1244,6 +1254,10 @@ namespace sync {
                 outcome.conflict_reason = ApplyConflictReason::SequenceGap;
                 return outcome;
             }
+            if (m_policy == ConflictPolicy::LastWriterWins &&
+                !validate_lww_batch(batch, &outcome)) {
+                return outcome;
+            }
             std::vector<BatchDbiFlags> batch_dbis;
             if (!collect_batch_dbi_flags(batch, batch_dbis, &outcome)) return outcome;
 
@@ -1251,8 +1265,17 @@ namespace sync {
             if (!preflight_batch_user_dbis(txn, batch_dbis, dbi_cache, &outcome)) {
                 return outcome;
             }
+            IdentityIndexStore identity_index(m_conn->env_handle());
+            if (m_policy == ConflictPolicy::LastWriterWins) {
+                identity_index.open(txn);
+            }
             for (const ChangeOp& op : batch.ops) {
-                apply_one_op(txn, op, dbi_cache);
+                if (m_policy == ConflictPolicy::LastWriterWins) {
+                    apply_lww_one_op(txn, op, batch.origin_node_id,
+                                     batch.seq, dbi_cache, identity_index);
+                } else {
+                    apply_one_op(txn, op, dbi_cache);
+                }
             }
             applied.set_last_applied_seq(txn, batch.origin_node_id, batch.seq);
             outcome.result = ApplyResult::Applied;
@@ -1274,6 +1297,10 @@ namespace sync {
                     return "existing_dbi_flags_mismatch";
                 case ApplyConflictReason::ReservedDbiName:
                     return "reserved_dbi_name";
+                case ApplyConflictReason::MissingLwwRevision:
+                    return "missing_lww_revision";
+                case ApplyConflictReason::UnsupportedLwwOperation:
+                    return "unsupported_lww_operation";
             }
             return "unknown";
         }
@@ -2377,6 +2404,12 @@ namespace sync {
                 LogicalRecoveryBaseline* final_baseline = nullptr,
                 const CancellationToken* cancel_token = nullptr) {
             PullResponse out;
+            if (m_policy == ConflictPolicy::LastWriterWins) {
+                out.ok = false;
+                out.error = "LastWriterWins does not support full snapshots";
+                out.error_code = SyncResponseErrorCode::UnsupportedFullSnapshot;
+                return out;
+            }
             if (cancel_token != nullptr &&
                 cancel_token->is_cancellation_requested()) {
                 out.ok = false;
@@ -3600,6 +3633,70 @@ namespace sync {
             check_mdbx(rc, "SyncEngine: failed to open user DBI '" + name + "'");
             cache[name] = dbi;
             return dbi;
+        }
+
+        static void apply_lww_one_op(
+                MDBX_txn* txn,
+                const ChangeOp& op,
+                const NodeId& origin,
+                std::uint64_t sequence,
+                std::unordered_map<std::string, MDBX_dbi>& cache,
+                IdentityIndexStore& identity_index) {
+            IdentityIndexValue current;
+            if (identity_index.get(txn, op.dbi_name, op.storage_key, current)) {
+                if (op.revision_key < current.revision_key) return;
+                if (op.revision_key == current.revision_key &&
+                    compare_node_id(origin, current.origin_node_id) <= 0) {
+                    return;
+                }
+            }
+            apply_one_op(txn, op, cache);
+            IdentityIndexValue marker;
+            marker.storage_key = op.storage_key;
+            marker.origin_node_id = origin;
+            marker.seq = sequence;
+            marker.revision_key = op.revision_key;
+            if (op.op_type == ChangeOpType::Delete) {
+                identity_index.tombstone(txn, op.dbi_name, op.storage_key, marker);
+            } else {
+                identity_index.put(txn, op.dbi_name, op.storage_key, marker);
+            }
+        }
+
+        static bool validate_lww_batch(const ChangeBatch& batch,
+                                       ApplyOutcome* outcome) {
+            for (std::size_t i = 0u; i < batch.ops.size(); ++i) {
+                const ChangeOp& op = batch.ops[i];
+                if ((op.op_flags & OP_HAS_REVISION_KEY) == 0 ||
+                    op.revision_key.empty()) {
+                    if (outcome != nullptr) {
+                        outcome->result = ApplyResult::Conflict;
+                        outcome->conflict_reason =
+                            ApplyConflictReason::MissingLwwRevision;
+                        outcome->dbi_name = op.dbi_name;
+                    }
+                    return false;
+                }
+                if ((op.op_flags & OP_HAS_IDENTITY_KEY) != 0 ||
+                    (op.op_type != ChangeOpType::Put &&
+                     op.op_type != ChangeOpType::Delete)) {
+                    if (outcome != nullptr) {
+                        outcome->result = ApplyResult::Conflict;
+                        outcome->conflict_reason =
+                            ApplyConflictReason::UnsupportedLwwOperation;
+                        outcome->dbi_name = op.dbi_name;
+                    }
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        void reject_lww_full_snapshot_import() const {
+            if (m_policy == ConflictPolicy::LastWriterWins) {
+                throw std::logic_error(
+                    "LastWriterWins does not support full snapshot import");
+            }
         }
 
         static void apply_one_op(MDBX_txn* txn,

--- a/include/mdbx_containers/sync/engine/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/engine/SyncEngine.hpp
@@ -117,8 +117,7 @@ namespace sync {
     };
 
     /// \brief Pull/push/apply coordinator bound to a single \c Connection.
-    class SyncEngine : public ILogicalDeliveryOutbox,
-                       private ISyncDbiWritePolicy {
+    class SyncEngine : public ILogicalDeliveryOutbox {
         struct PullOrigin {
             NodeId origin;
             std::uint64_t last_seq;
@@ -224,11 +223,6 @@ namespace sync {
               m_policy(policy),
               m_full_snapshot_options(full_snapshot_options) {
             validate_full_snapshot_export_options(m_full_snapshot_options);
-            m_conn->attach_sync_dbi_write_policy(this);
-        }
-
-        ~SyncEngine() {
-            m_conn->detach_sync_dbi_write_policy(this);
         }
 
         /// \brief Initialises the local \c node_id and \c db_uuid.
@@ -3757,18 +3751,6 @@ namespace sync {
                 }
             }
             return true;
-        }
-
-        void validate_sync_dbi_write(
-                MDBX_txn* txn,
-                const std::string& dbi_name,
-                ChangeOpType) override {
-            VersionedDbiStore registry(m_conn->env_handle());
-            if (registry.contains(txn, dbi_name)) {
-                throw std::logic_error(
-                    "registered source-version-wins DBI must be mutated through "
-                    "VersionedKeyValueTable");
-            }
         }
 
         static void apply_one_op(MDBX_txn* txn,

--- a/include/mdbx_containers/sync/engine/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/engine/SyncEngine.hpp
@@ -61,6 +61,8 @@ namespace sync {
         ReservedDbiName,          ///< Incoming ChangeOp targets an internal DBI name.
         MissingLwwRevision,       ///< LWW operation lacks a non-empty source revision.
         UnsupportedLwwOperation,  ///< LWW accepts only raw put/delete without identity remapping.
+        LwwPolicyDisabled,        ///< A registered LWW DBI requires LastWriterWins policy.
+        UnexpectedLwwRevision,    ///< A normal DBI received source-version metadata.
     };
 
     /// \brief Detailed result for callers that need conflict diagnostics.
@@ -115,7 +117,8 @@ namespace sync {
     };
 
     /// \brief Pull/push/apply coordinator bound to a single \c Connection.
-    class SyncEngine : public ILogicalDeliveryOutbox {
+    class SyncEngine : public ILogicalDeliveryOutbox,
+                       private ISyncDbiWritePolicy {
         struct PullOrigin {
             NodeId origin;
             std::uint64_t last_seq;
@@ -177,6 +180,15 @@ namespace sync {
                 : std::runtime_error(message) {}
         };
 
+        class FullSnapshotVersionedDbiUnsupported : public std::runtime_error {
+        public:
+            explicit FullSnapshotVersionedDbiUnsupported(
+                    const std::string& dbi_name)
+                : std::runtime_error(
+                    "full snapshot does not support registered versioned DBI: " +
+                    dbi_name) {}
+        };
+
         struct FullSnapshotImportSession {
             enum class ReplacementState {
                 NotSeen,
@@ -212,11 +224,11 @@ namespace sync {
               m_policy(policy),
               m_full_snapshot_options(full_snapshot_options) {
             validate_full_snapshot_export_options(m_full_snapshot_options);
-            if (m_policy == ConflictPolicy::LastWriterWins &&
-                full_snapshot_export_is_configured(m_full_snapshot_options)) {
-                throw std::invalid_argument(
-                    "LastWriterWins does not support full snapshot export");
-            }
+            m_conn->attach_sync_dbi_write_policy(this);
+        }
+
+        ~SyncEngine() {
+            m_conn->detach_sync_dbi_write_policy(this);
         }
 
         /// \brief Initialises the local \c node_id and \c db_uuid.
@@ -274,11 +286,6 @@ namespace sync {
         void set_full_snapshot_export_options(
                 const FullSnapshotExportOptions& options) {
             validate_full_snapshot_export_options(options);
-            if (m_policy == ConflictPolicy::LastWriterWins &&
-                full_snapshot_export_is_configured(options)) {
-                throw std::invalid_argument(
-                    "LastWriterWins does not support full snapshot export");
-            }
             std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
             m_full_snapshot_options = options;
             m_full_snapshot_sessions.clear();
@@ -314,8 +321,8 @@ namespace sync {
         /// inventory and bootstraps the applied cursor from its source tail.
         FullSnapshotImportResult apply_full_snapshot_chunk(
                 const FullSnapshotChunk& chunk) {
-            reject_lww_full_snapshot_import();
             FullSnapshotCodec::validate(chunk);
+            reject_versioned_full_snapshot_manifest(chunk.manifest);
             FullSnapshotImportResult result;
             Connection::SyncApplyNotification notification;
             bool notification_ready = false;
@@ -344,8 +351,8 @@ namespace sync {
         FullSnapshotImportResult apply_logical_recovery_chunk(
                 const FullSnapshotChunk& chunk,
                 const LogicalRecoveryBaseline* baseline = nullptr) {
-            reject_lww_full_snapshot_import();
             FullSnapshotCodec::validate(chunk);
+            reject_versioned_full_snapshot_manifest(chunk.manifest);
             if (chunk.has_more ? baseline != nullptr : baseline == nullptr) {
                 throw std::invalid_argument(
                     "logical recovery baseline must accompany only the final page");
@@ -1254,8 +1261,10 @@ namespace sync {
                 outcome.conflict_reason = ApplyConflictReason::SequenceGap;
                 return outcome;
             }
-            if (m_policy == ConflictPolicy::LastWriterWins &&
-                !validate_lww_batch(batch, &outcome)) {
+            VersionedDbiStore versioned_dbis(m_conn->env_handle());
+            std::vector<bool> versioned_ops;
+            if (!validate_versioned_dbi_batch(
+                    txn, batch, versioned_dbis, versioned_ops, &outcome)) {
                 return outcome;
             }
             std::vector<BatchDbiFlags> batch_dbis;
@@ -1266,11 +1275,13 @@ namespace sync {
                 return outcome;
             }
             IdentityIndexStore identity_index(m_conn->env_handle());
-            if (m_policy == ConflictPolicy::LastWriterWins) {
+            if (std::find(versioned_ops.begin(), versioned_ops.end(), true) !=
+                versioned_ops.end()) {
                 identity_index.open(txn);
             }
-            for (const ChangeOp& op : batch.ops) {
-                if (m_policy == ConflictPolicy::LastWriterWins) {
+            for (std::size_t i = 0u; i < batch.ops.size(); ++i) {
+                const ChangeOp& op = batch.ops[i];
+                if (versioned_ops[i]) {
                     apply_lww_one_op(txn, op, batch.origin_node_id,
                                      batch.seq, dbi_cache, identity_index);
                 } else {
@@ -1301,6 +1312,10 @@ namespace sync {
                     return "missing_lww_revision";
                 case ApplyConflictReason::UnsupportedLwwOperation:
                     return "unsupported_lww_operation";
+                case ApplyConflictReason::LwwPolicyDisabled:
+                    return "lww_policy_disabled";
+                case ApplyConflictReason::UnexpectedLwwRevision:
+                    return "unexpected_lww_revision";
             }
             return "unknown";
         }
@@ -1778,6 +1793,24 @@ namespace sync {
             }
         }
 
+        void reject_versioned_full_snapshot_manifest(
+                MDBX_txn* txn,
+                const std::vector<FullSnapshotManifestEntry>& manifest) const {
+            VersionedDbiStore registry(m_conn->env_handle());
+            for (std::size_t i = 0u; i < manifest.size(); ++i) {
+                if (registry.contains(txn, manifest[i].dbi_name)) {
+                    throw FullSnapshotVersionedDbiUnsupported(
+                        manifest[i].dbi_name);
+                }
+            }
+        }
+
+        void reject_versioned_full_snapshot_manifest(
+                const std::vector<FullSnapshotManifestEntry>& manifest) const {
+            auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
+            reject_versioned_full_snapshot_manifest(txn.handle(), manifest);
+        }
+
         void collect_logical_recovery_baseline(
                 MDBX_txn* txn,
                 FullSnapshotSession& session,
@@ -2219,6 +2252,8 @@ namespace sync {
                     FullSnapshotScope::CompleteUserDatabase
                 ? enumerate_user_snapshot_manifest(txn.handle())
                 : options.manifest;
+            reject_versioned_full_snapshot_manifest(
+                txn.handle(), session->manifest);
             if (session->replacement_scope ==
                     FullSnapshotScope::CompleteUserDatabase &&
                 session->manifest.empty()) {
@@ -2404,12 +2439,6 @@ namespace sync {
                 LogicalRecoveryBaseline* final_baseline = nullptr,
                 const CancellationToken* cancel_token = nullptr) {
             PullResponse out;
-            if (m_policy == ConflictPolicy::LastWriterWins) {
-                out.ok = false;
-                out.error = "LastWriterWins does not support full snapshots";
-                out.error_code = SyncResponseErrorCode::UnsupportedFullSnapshot;
-                return out;
-            }
             if (cancel_token != nullptr &&
                 cancel_token->is_cancellation_requested()) {
                 out.ok = false;
@@ -2488,6 +2517,13 @@ namespace sync {
                     out.error = e.what();
                     out.error_code =
                         SyncResponseErrorCode::SnapshotLogicalStateUnsupported;
+                    return out;
+                } catch (const FullSnapshotVersionedDbiUnsupported& e) {
+                    std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
+                    --m_full_snapshot_creating;
+                    out.ok = false;
+                    out.error = e.what();
+                    out.error_code = SyncResponseErrorCode::UnsupportedFullSnapshot;
                     return out;
                 } catch (const std::length_error& e) {
                     std::lock_guard<std::mutex> lock(m_full_snapshot_mutex);
@@ -3663,12 +3699,43 @@ namespace sync {
             }
         }
 
-        static bool validate_lww_batch(const ChangeBatch& batch,
-                                       ApplyOutcome* outcome) {
+        bool validate_versioned_dbi_batch(
+                MDBX_txn* txn,
+                const ChangeBatch& batch,
+                VersionedDbiStore& registry,
+                std::vector<bool>& versioned_ops,
+                ApplyOutcome* outcome) const {
+            versioned_ops.clear();
+            versioned_ops.reserve(batch.ops.size());
             for (std::size_t i = 0u; i < batch.ops.size(); ++i) {
                 const ChangeOp& op = batch.ops[i];
-                if ((op.op_flags & OP_HAS_REVISION_KEY) == 0 ||
-                    op.revision_key.empty()) {
+                const bool is_versioned = registry.contains(txn, op.dbi_name);
+                versioned_ops.push_back(is_versioned);
+                const bool has_revision =
+                    (op.op_flags & OP_HAS_REVISION_KEY) != 0 ||
+                    !op.revision_key.empty();
+                if (!is_versioned) {
+                    if (!has_revision) {
+                        continue;
+                    }
+                    if (outcome != nullptr) {
+                        outcome->result = ApplyResult::Conflict;
+                        outcome->conflict_reason =
+                            ApplyConflictReason::UnexpectedLwwRevision;
+                        outcome->dbi_name = op.dbi_name;
+                    }
+                    return false;
+                }
+                if (m_policy != ConflictPolicy::LastWriterWins) {
+                    if (outcome != nullptr) {
+                        outcome->result = ApplyResult::Conflict;
+                        outcome->conflict_reason =
+                            ApplyConflictReason::LwwPolicyDisabled;
+                        outcome->dbi_name = op.dbi_name;
+                    }
+                    return false;
+                }
+                if (!has_revision || op.revision_key.empty()) {
                     if (outcome != nullptr) {
                         outcome->result = ApplyResult::Conflict;
                         outcome->conflict_reason =
@@ -3692,10 +3759,15 @@ namespace sync {
             return true;
         }
 
-        void reject_lww_full_snapshot_import() const {
-            if (m_policy == ConflictPolicy::LastWriterWins) {
+        void validate_sync_dbi_write(
+                MDBX_txn* txn,
+                const std::string& dbi_name,
+                ChangeOpType) override {
+            VersionedDbiStore registry(m_conn->env_handle());
+            if (registry.contains(txn, dbi_name)) {
                 throw std::logic_error(
-                    "LastWriterWins does not support full snapshot import");
+                    "registered source-version-wins DBI must be mutated through "
+                    "VersionedKeyValueTable");
             }
         }
 

--- a/include/mdbx_containers/sync/logical/adapters/VersionedKeyValueTable.hpp
+++ b/include/mdbx_containers/sync/logical/adapters/VersionedKeyValueTable.hpp
@@ -60,6 +60,7 @@ namespace sync {
             std::shared_ptr<Connection> connection = m_table.connection();
             auto txn = connection->transaction(TransactionMode::WRITABLE);
             const std::vector<std::uint8_t> storage_key = encode_key(key);
+            const std::vector<std::uint8_t> storage_value = encode_value(value);
             const NodeId local_node = require_local_node(txn.handle());
             IdentityIndexStore index(connection->env_handle());
             index.open(txn.handle());
@@ -67,16 +68,13 @@ namespace sync {
                       source_version, local_node)) {
                 validate_repeated_write(index, txn.handle(), storage_key,
                                         source_version, local_node,
-                                        ChangeOpType::Put, encode_value(value));
+                                        ChangeOpType::Put, storage_value);
                 txn.commit();
                 return VersionedWriteResult::Ignored;
             }
-            {
-                Connection::SyncCaptureSuppressionScope suppress(*connection, txn.handle());
-                m_table.insert_or_assign(key, value, txn.handle());
-            }
+            write_value(txn.handle(), storage_key, storage_value);
             record(txn.handle(), ChangeOpType::Put, storage_key,
-                   encode_value(value), source_version);
+                   storage_value, source_version);
             put_marker(index, txn.handle(), storage_key, local_node,
                        source_version, false);
             txn.commit();
@@ -112,10 +110,7 @@ namespace sync {
                 txn.commit();
                 return VersionedWriteResult::Ignored;
             }
-            {
-                Connection::SyncCaptureSuppressionScope suppress(*connection, txn.handle());
-                (void)m_table.erase(key, txn.handle());
-            }
+            erase_value(txn.handle(), storage_key);
             record(txn.handle(), ChangeOpType::Delete, storage_key,
                    std::vector<std::uint8_t>(), source_version);
             put_marker(index, txn.handle(), storage_key, local_node,
@@ -264,6 +259,29 @@ namespace sync {
                                      MDBX_DB_ACCEDE, &dbi),
                        "VersionedKeyValueTable failed to open table DBI");
             return dbi;
+        }
+
+        void write_value(MDBX_txn* txn,
+                         const std::vector<std::uint8_t>& key,
+                         const std::vector<std::uint8_t>& value) const {
+            const MDBX_dbi dbi = open_table_dbi(txn);
+            MDBX_val db_key = { key.empty() ? nullptr :
+                                const_cast<std::uint8_t*>(key.data()), key.size() };
+            MDBX_val db_value = { value.empty() ? nullptr :
+                                  const_cast<std::uint8_t*>(value.data()), value.size() };
+            check_mdbx(mdbx_put(txn, dbi, &db_key, &db_value, MDBX_UPSERT),
+                       "VersionedKeyValueTable failed to write table value");
+        }
+
+        void erase_value(MDBX_txn* txn,
+                         const std::vector<std::uint8_t>& key) const {
+            const MDBX_dbi dbi = open_table_dbi(txn);
+            MDBX_val db_key = { key.empty() ? nullptr :
+                                const_cast<std::uint8_t*>(key.data()), key.size() };
+            const int rc = mdbx_del(txn, dbi, &db_key, nullptr);
+            if (rc != MDBX_NOTFOUND) {
+                check_mdbx(rc, "VersionedKeyValueTable failed to erase table value");
+            }
         }
 
         void ensure_capture_attached() const {

--- a/include/mdbx_containers/sync/logical/adapters/VersionedKeyValueTable.hpp
+++ b/include/mdbx_containers/sync/logical/adapters/VersionedKeyValueTable.hpp
@@ -1,0 +1,266 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_ADAPTERS_VERSIONED_KEY_VALUE_TABLE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_ADAPTERS_VERSIONED_KEY_VALUE_TABLE_HPP_INCLUDED
+
+/// \file logical/adapters/VersionedKeyValueTable.hpp
+/// \brief Opt-in source-version writes for a \c KeyValueTable.
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Outcome of an attempted source-version write.
+    enum class VersionedWriteResult {
+        Applied, ///< Incoming source version won and was committed.
+        Ignored  ///< A greater version or equal-version origin already won.
+    };
+
+    /// \brief Writes versioned raw changes for one \c KeyValueTable.
+    /// \details A source version is compared lexicographically, then by the
+    /// durable local \c NodeId. The table value stays unchanged when a newer
+    /// version has already been accepted. Callers must use a canonical,
+    /// non-empty byte encoding whose lexicographic order is the desired source
+    /// order. Reusing one source version for different state from the same
+    /// node throws \c std::invalid_argument.
+    template<class KeyT, class ValueT, class Options = DefaultTableOptions>
+    class VersionedKeyValueTable {
+    public:
+        /// \brief Binds versioned writes to one captured key-value table.
+        /// \param table User table receiving versioned point mutations.
+        /// \param capture Attached accumulator for the same connection.
+        VersionedKeyValueTable(
+                KeyValueTable<KeyT, ValueT, Options>& table,
+                ThreadLocalChangeAccumulator& capture)
+            : m_table(table), m_capture(capture) {}
+
+        /// \brief Upserts a value when its source version wins.
+        /// \param key User key to update.
+        /// \param value User value stored outside sync version metadata.
+        /// \param source_version Canonical non-empty source-version bytes.
+        /// \return Whether the write was committed or superseded locally.
+        /// \throws std::invalid_argument When the version is empty or reused
+        ///         by this node for different state.
+        /// \throws std::logic_error When sync identity or capture is absent.
+        VersionedWriteResult insert_or_assign(
+                const KeyT& key,
+                const ValueT& value,
+                const std::vector<std::uint8_t>& source_version) {
+            if (source_version.empty()) {
+                throw std::invalid_argument("VersionedKeyValueTable source_version is empty");
+            }
+            ensure_capture_attached();
+            std::shared_ptr<Connection> connection = m_table.connection();
+            auto txn = connection->transaction(TransactionMode::WRITABLE);
+            const std::vector<std::uint8_t> storage_key = encode_key(key);
+            const NodeId local_node = require_local_node(txn.handle());
+            IdentityIndexStore index(connection->env_handle());
+            index.open(txn.handle());
+            if (!wins(index, txn.handle(), m_table.dbi_name(), storage_key,
+                      source_version, local_node)) {
+                validate_repeated_write(index, txn.handle(), storage_key,
+                                        source_version, local_node,
+                                        ChangeOpType::Put, encode_value(value));
+                txn.commit();
+                return VersionedWriteResult::Ignored;
+            }
+            {
+                Connection::SyncCaptureSuppressionScope suppress(*connection, txn.handle());
+                m_table.insert_or_assign(key, value, txn.handle());
+            }
+            record(txn.handle(), ChangeOpType::Put, storage_key,
+                   encode_value(value), source_version);
+            put_marker(index, txn.handle(), storage_key, local_node,
+                       source_version, false);
+            txn.commit();
+            return VersionedWriteResult::Applied;
+        }
+
+        /// \brief Deletes a key when its source version wins.
+        /// \param key User key to delete.
+        /// \param source_version Canonical non-empty source-version bytes.
+        /// \return Whether the delete was committed or superseded locally.
+        /// \throws std::invalid_argument When the version is empty or reused
+        ///         by this node for different state.
+        /// \throws std::logic_error When sync identity or capture is absent.
+        VersionedWriteResult erase(
+                const KeyT& key,
+                const std::vector<std::uint8_t>& source_version) {
+            if (source_version.empty()) {
+                throw std::invalid_argument("VersionedKeyValueTable source_version is empty");
+            }
+            ensure_capture_attached();
+            std::shared_ptr<Connection> connection = m_table.connection();
+            auto txn = connection->transaction(TransactionMode::WRITABLE);
+            const std::vector<std::uint8_t> storage_key = encode_key(key);
+            const NodeId local_node = require_local_node(txn.handle());
+            IdentityIndexStore index(connection->env_handle());
+            index.open(txn.handle());
+            if (!wins(index, txn.handle(), m_table.dbi_name(), storage_key,
+                      source_version, local_node)) {
+                validate_repeated_write(index, txn.handle(), storage_key,
+                                        source_version, local_node,
+                                        ChangeOpType::Delete,
+                                        std::vector<std::uint8_t>());
+                txn.commit();
+                return VersionedWriteResult::Ignored;
+            }
+            {
+                Connection::SyncCaptureSuppressionScope suppress(*connection, txn.handle());
+                (void)m_table.erase(key, txn.handle());
+            }
+            record(txn.handle(), ChangeOpType::Delete, storage_key,
+                   std::vector<std::uint8_t>(), source_version);
+            put_marker(index, txn.handle(), storage_key, local_node,
+                       source_version, true);
+            txn.commit();
+            return VersionedWriteResult::Applied;
+        }
+
+    private:
+        std::vector<std::uint8_t> encode_key(const KeyT& key) const {
+            SerializeScratch scratch;
+            const MDBX_val value = serialize_key<Options::safe_integer_key>(key, scratch);
+            return bytes(value);
+        }
+
+        std::vector<std::uint8_t> encode_value(const ValueT& value) const {
+            SerializeScratch scratch;
+            const MDBX_val encoded = serialize_value(value, scratch);
+            return bytes(encoded);
+        }
+
+        static std::vector<std::uint8_t> bytes(const MDBX_val& value) {
+            if (value.iov_len == 0u) return std::vector<std::uint8_t>();
+            const std::uint8_t* begin = static_cast<const std::uint8_t*>(value.iov_base);
+            return std::vector<std::uint8_t>(begin, begin + value.iov_len);
+        }
+
+        NodeId require_local_node(MDBX_txn* txn) const {
+            MetaStore meta(m_table.connection()->env_handle());
+            meta.open(txn);
+            const NodeId node = meta.get_node_id(txn);
+            if (compare_node_id(node, make_zero_node()) == 0) {
+                throw std::logic_error("VersionedKeyValueTable requires initialized SyncEngine identity");
+            }
+            return node;
+        }
+
+        static bool wins(IdentityIndexStore& index, MDBX_txn* txn,
+                         const std::string& dbi_name,
+                         const std::vector<std::uint8_t>& key,
+                         const std::vector<std::uint8_t>& revision,
+                         const NodeId& origin) {
+            IdentityIndexValue current;
+            if (!index.get(txn, dbi_name, key, current)) return true;
+            if (revision != current.revision_key) return revision > current.revision_key;
+            return compare_node_id(origin, current.origin_node_id) > 0;
+        }
+
+        void put_marker(IdentityIndexStore& index, MDBX_txn* txn,
+                        const std::vector<std::uint8_t>& key,
+                        const NodeId& origin,
+                        const std::vector<std::uint8_t>& revision,
+                        bool tombstone) const {
+            IdentityIndexValue marker;
+            marker.storage_key = key;
+            marker.origin_node_id = origin;
+            marker.revision_key = revision;
+            if (tombstone) {
+                index.tombstone(txn, m_table.dbi_name(), key, marker);
+            } else {
+                index.put(txn, m_table.dbi_name(), key, marker);
+            }
+        }
+
+        void record(MDBX_txn* txn, ChangeOpType type,
+                    const std::vector<std::uint8_t>& key,
+                    const std::vector<std::uint8_t>& value,
+                    const std::vector<std::uint8_t>& revision) const {
+            ChangeOp op;
+            op.op_type = type;
+            op.dbi_flags = table_dbi_flags(txn);
+            op.dbi_name = m_table.dbi_name();
+            op.storage_key = key;
+            op.value = value;
+            op.op_flags = OP_HAS_REVISION_KEY;
+            op.revision_key = revision;
+            m_capture.record_change_op(txn, op);
+        }
+
+        void validate_repeated_write(
+                IdentityIndexStore& index,
+                MDBX_txn* txn,
+                const std::vector<std::uint8_t>& key,
+                const std::vector<std::uint8_t>& revision,
+                const NodeId& origin,
+                ChangeOpType type,
+                const std::vector<std::uint8_t>& value) const {
+            IdentityIndexValue current;
+            if (!index.get(txn, m_table.dbi_name(), key, current) ||
+                current.revision_key != revision ||
+                compare_node_id(origin, current.origin_node_id) != 0) {
+                return;
+            }
+            const bool is_tombstone =
+                (current.flags & static_cast<std::uint32_t>(IDENTITY_TOMBSTONE)) != 0;
+            if ((type == ChangeOpType::Delete && is_tombstone) ||
+                (type == ChangeOpType::Put && !is_tombstone &&
+                 stored_value_equals(txn, key, value))) {
+                return;
+            }
+            throw std::invalid_argument(
+                "VersionedKeyValueTable source_version was reused for different state");
+        }
+
+        bool stored_value_equals(
+                MDBX_txn* txn,
+                const std::vector<std::uint8_t>& key,
+                const std::vector<std::uint8_t>& value) const {
+            MDBX_dbi dbi = open_table_dbi(txn);
+            MDBX_val db_key = { key.empty() ? nullptr :
+                                const_cast<std::uint8_t*>(key.data()), key.size() };
+            MDBX_val stored;
+            const int rc = mdbx_get(txn, dbi, &db_key, &stored);
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "VersionedKeyValueTable failed to read stored value");
+            if (stored.iov_len != value.size()) return false;
+            if (stored.iov_len == 0u) return true;
+            return std::memcmp(stored.iov_base, value.data(), stored.iov_len) == 0;
+        }
+
+        std::uint32_t table_dbi_flags(MDBX_txn* txn) const {
+            const MDBX_dbi dbi = open_table_dbi(txn);
+            unsigned flags = 0u;
+            check_mdbx(mdbx_dbi_flags(txn, dbi, &flags),
+                       "VersionedKeyValueTable failed to read table flags");
+            return static_cast<std::uint32_t>(flags);
+        }
+
+        MDBX_dbi open_table_dbi(MDBX_txn* txn) const {
+            MDBX_dbi dbi = 0;
+            check_mdbx(mdbx_dbi_open(txn, m_table.dbi_name().c_str(),
+                                     MDBX_DB_ACCEDE, &dbi),
+                       "VersionedKeyValueTable failed to open table DBI");
+            return dbi;
+        }
+
+        void ensure_capture_attached() const {
+            if (m_table.connection()->sync_capture() != &m_capture) {
+                throw std::logic_error("VersionedKeyValueTable capture is not attached to the table connection");
+            }
+        }
+
+        KeyValueTable<KeyT, ValueT, Options>& m_table;
+        ThreadLocalChangeAccumulator&          m_capture;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_ADAPTERS_VERSIONED_KEY_VALUE_TABLE_HPP_INCLUDED

--- a/include/mdbx_containers/sync/logical/adapters/VersionedKeyValueTable.hpp
+++ b/include/mdbx_containers/sync/logical/adapters/VersionedKeyValueTable.hpp
@@ -37,7 +37,9 @@ namespace sync {
         VersionedKeyValueTable(
                 KeyValueTable<KeyT, ValueT, Options>& table,
                 ThreadLocalChangeAccumulator& capture)
-            : m_table(table), m_capture(capture) {}
+            : m_table(table), m_capture(capture) {
+            register_table();
+        }
 
         /// \brief Upserts a value when its source version wins.
         /// \param key User key to update.
@@ -123,6 +125,20 @@ namespace sync {
         }
 
     private:
+        void register_table() {
+            std::shared_ptr<Connection> connection = m_table.connection();
+            auto txn = connection->transaction(TransactionMode::WRITABLE);
+            VersionedDbiStore registry(connection->env_handle());
+            if (!registry.contains(txn.handle(), m_table.dbi_name())) {
+                if (!m_table.empty(txn.handle())) {
+                    throw std::invalid_argument(
+                        "VersionedKeyValueTable can register only an empty table");
+                }
+                (void)registry.register_dbi(txn.handle(), m_table.dbi_name());
+            }
+            txn.commit();
+        }
+
         std::vector<std::uint8_t> encode_key(const KeyT& key) const {
             SerializeScratch scratch;
             const MDBX_val value = serialize_key<Options::safe_integer_key>(key, scratch);

--- a/include/mdbx_containers/sync/storage.hpp
+++ b/include/mdbx_containers/sync/storage.hpp
@@ -15,6 +15,7 @@
 #include "stores/OriginIndexStore.hpp"
 #include "stores/ChangeLogStore.hpp"
 #include "stores/IdentityIndexStore.hpp"
+#include "stores/VersionedDbiStore.hpp"
 #endif
 
 #endif // MDBX_CONTAINERS_HEADER_SYNC_STORAGE_HPP_INCLUDED

--- a/include/mdbx_containers/sync/stores/VersionedDbiStore.hpp
+++ b/include/mdbx_containers/sync/stores/VersionedDbiStore.hpp
@@ -1,0 +1,95 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_STORES_VERSIONED_DBI_STORE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_STORES_VERSIONED_DBI_STORE_HPP_INCLUDED
+
+/// \file VersionedDbiStore.hpp
+/// \brief Durable registry of DBIs using source-version-wins replication.
+
+#include <stdexcept>
+#include <string>
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Thin wrapper around \c _mdbxc_versioned_dbis.
+    /// \details Each key is one user DBI name and has an empty value. A key
+    /// selects the narrow \c VersionedKeyValueTable replication contract.
+    class VersionedDbiStore {
+    public:
+        /// \brief Binds the store to an MDBX environment.
+        /// \param env Live MDBX environment.
+        explicit VersionedDbiStore(MDBX_env* env)
+            : m_env(env), m_dbi(0), m_open(false) {}
+
+        /// \brief Registers a user DBI.
+        /// \param txn Active writable MDBX transaction.
+        /// \param dbi_name User DBI name.
+        /// \return True when this call added the marker, false when present.
+        bool register_dbi(MDBX_txn* txn, const std::string& dbi_name) {
+            txn = checked_txn(txn, "VersionedDbiStore::register_dbi");
+            validate_name(dbi_name);
+            open_for_write(txn);
+            MDBX_val key = { const_cast<char*>(dbi_name.data()), dbi_name.size() };
+            MDBX_val value = { nullptr, 0u };
+            const int rc = mdbx_put(txn, m_dbi, &key, &value, MDBX_NOOVERWRITE);
+            if (rc == MDBX_SUCCESS) return true;
+            if (rc == MDBX_KEYEXIST) return false;
+            check_mdbx(rc, "VersionedDbiStore register failed");
+            return false;
+        }
+
+        /// \brief Tests whether a user DBI is registered.
+        /// \param txn Active MDBX transaction.
+        /// \param dbi_name User DBI name.
+        /// \return True only for a registered source-version-wins DBI.
+        bool contains(MDBX_txn* txn, const std::string& dbi_name) {
+            txn = checked_txn(txn, "VersionedDbiStore::contains");
+            if (dbi_name.empty() || !open_existing(txn)) return false;
+            MDBX_val key = { const_cast<char*>(dbi_name.data()), dbi_name.size() };
+            MDBX_val value;
+            const int rc = mdbx_get(txn, m_dbi, &key, &value);
+            if (rc == MDBX_SUCCESS) return true;
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "VersionedDbiStore lookup failed");
+            return false;
+        }
+
+    private:
+        MDBX_txn* checked_txn(MDBX_txn* txn, const char* context) const {
+            return checked_txn_env(txn, m_env, context);
+        }
+
+        static void validate_name(const std::string& dbi_name) {
+            if (dbi_name.empty() || is_reserved_dbi_name(dbi_name)) {
+                throw std::invalid_argument(
+                    "VersionedDbiStore requires a non-reserved user DBI name");
+            }
+        }
+
+        void open_for_write(MDBX_txn* txn) {
+            if (m_open) return;
+            check_mdbx(mdbx_dbi_open(txn, "_mdbxc_versioned_dbis", MDBX_CREATE,
+                                     &m_dbi),
+                       "Failed to open VersionedDbiStore DBI");
+            m_open = true;
+        }
+
+        bool open_existing(MDBX_txn* txn) {
+            if (m_open) return true;
+            const int rc = mdbx_dbi_open(txn, "_mdbxc_versioned_dbis",
+                                         static_cast<MDBX_db_flags_t>(0), &m_dbi);
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "Failed to open VersionedDbiStore DBI");
+            m_open = true;
+            return true;
+        }
+
+        MDBX_env* m_env;
+        MDBX_dbi  m_dbi;
+        bool      m_open;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_STORES_VERSIONED_DBI_STORE_HPP_INCLUDED

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -3972,6 +3972,37 @@ void test_versioned_dbi_guard_survives_engine_lifetime() {
             throw std::runtime_error(
                 "registered DBI was mutable after SyncEngine destruction");
         }
+
+        KeyValueTable<int, int> trades(conn, "trades");
+        MDBX_txn* raw_trades_txn = nullptr;
+        check_mdbx(mdbx_txn_begin(conn->env_handle(), nullptr,
+                                  MDBX_TXN_READWRITE, &raw_trades_txn),
+                   "failed to begin raw trades transaction");
+        trades.insert_or_assign(1, 20, raw_trades_txn);
+        check_mdbx(mdbx_txn_commit(raw_trades_txn),
+                   "failed to commit raw trades transaction");
+        if (kv_or_throw(conn, trades, 1, "raw transaction value") != 20u) {
+            throw std::runtime_error(
+                "raw transaction write to ordinary DBI was rejected");
+        }
+
+        MDBX_txn* raw_bars_txn = nullptr;
+        check_mdbx(mdbx_txn_begin(conn->env_handle(), nullptr,
+                                  MDBX_TXN_READWRITE, &raw_bars_txn),
+                   "failed to begin raw versioned transaction");
+        bool rejected_raw_versioned_write = false;
+        try {
+            bars.insert_or_assign(1, 11, raw_bars_txn);
+        } catch (const std::logic_error&) {
+            rejected_raw_versioned_write = true;
+        }
+        check_mdbx(mdbx_txn_commit(raw_bars_txn),
+                   "failed to commit rejected raw versioned transaction");
+        if (!rejected_raw_versioned_write ||
+            kv_or_throw(conn, bars, 1, "raw versioned value") != 10u) {
+            throw std::runtime_error(
+                "raw transaction write bypassed versioned DBI guard");
+        }
     }
     conn->disconnect();
     conn.reset();

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -3615,6 +3615,8 @@ void test_engine_last_writer_wins_versioned_key_value() {
 
     KeyValueTable<int, int> source_table(
         source_conn, "bars");
+    KeyValueTable<int, int> source_trades(
+        source_conn, "trades");
     sync::VersionedKeyValueTable<int, int> source(
         source_table, source_capture);
     if (source.insert_or_assign(1, 10, version_10) !=
@@ -3625,6 +3627,53 @@ void test_engine_last_writer_wins_versioned_key_value() {
         sync::VersionedWriteResult::Ignored) {
         throw std::runtime_error("older local versioned write was not ignored");
     }
+    source_conn->detach_sync_capture();
+    bool rejected_direct_write = false;
+    try {
+        source_table.insert_or_assign(4, 40);
+    } catch (const std::logic_error&) {
+        rejected_direct_write = true;
+    }
+    if (!rejected_direct_write || kv_has(source_conn, source_table, 4)) {
+        throw std::runtime_error("direct versioned-table write was not rolled back");
+    }
+    auto direct_write_txn = source_conn->transaction(TransactionMode::WRITABLE);
+    bool rejected_manual_write = false;
+    try {
+        source_table.insert_or_assign(4, 40, direct_write_txn.handle());
+    } catch (const std::logic_error&) {
+        rejected_manual_write = true;
+    }
+    bool rejected_manual_commit = false;
+    try {
+        direct_write_txn.commit();
+    } catch (const std::logic_error&) {
+        rejected_manual_commit = true;
+    }
+    direct_write_txn.rollback();
+    if (!rejected_manual_write || !rejected_manual_commit ||
+        kv_has(source_conn, source_table, 4)) {
+        throw std::runtime_error("manual direct versioned-table write reached commit");
+    }
+    bool rejected_clear = false;
+    try {
+        source_table.clear();
+    } catch (const std::logic_error&) {
+        rejected_clear = true;
+    }
+    if (!rejected_clear || !kv_has(source_conn, source_table, 1)) {
+        throw std::runtime_error("direct versioned-table clear was not rolled back");
+    }
+    bool rejected_range_erase = false;
+    try {
+        (void)source_table.erase_range(1, 1);
+    } catch (const std::logic_error&) {
+        rejected_range_erase = true;
+    }
+    if (!rejected_range_erase || !kv_has(source_conn, source_table, 1)) {
+        throw std::runtime_error("direct versioned-table range erase was not rolled back");
+    }
+    source_conn->attach_sync_capture(&source_capture);
     expect_invalid_argument("VersionedKeyValueTable duplicate source version",
                             [&source, &version_10]() {
                                 source.insert_or_assign(1, 11, version_10);
@@ -3636,13 +3685,14 @@ void test_engine_last_writer_wins_versioned_key_value() {
     if (source.erase(1, version_30) != sync::VersionedWriteResult::Applied) {
         throw std::runtime_error("versioned delete was not applied");
     }
+    source_trades.insert_or_assign(5, 50);
     source_conn->detach_sync_capture();
 
     sync::PullRequest pull;
     pull.requester = receiver_node;
     pull.db_id = db_id;
     const sync::PullResponse changes = source_engine.handle_pull(pull);
-    if (!changes.ok || changes.batches.size() != 2u ||
+    if (!changes.ok || changes.batches.size() != 3u ||
         changes.batches[0].ops.size() != 1u ||
         (changes.batches[0].ops[0].op_flags & sync::OP_HAS_REVISION_KEY) == 0 ||
         changes.batches[0].ops[0].revision_key != version_10 ||
@@ -3650,19 +3700,68 @@ void test_engine_last_writer_wins_versioned_key_value() {
             static_cast<std::uint32_t>(MDBX_INTEGERKEY)) {
         throw std::runtime_error("versioned source changelog did not preserve LWW metadata");
     }
+    if (changes.batches[2].ops.size() != 1u ||
+        changes.batches[2].ops[0].dbi_name != "trades" ||
+        (changes.batches[2].ops[0].op_flags & sync::OP_HAS_REVISION_KEY) != 0) {
+        throw std::runtime_error("normal DBI operation was not captured as raw sync");
+    }
+    sync::FullSnapshotExportOptions raw_snapshot_options;
+    sync::FullSnapshotManifestEntry raw_snapshot_entry;
+    raw_snapshot_entry.dbi_name = "trades";
+    raw_snapshot_entry.dbi_flags = changes.batches[2].ops[0].dbi_flags;
+    raw_snapshot_options.manifest.push_back(raw_snapshot_entry);
+    source_engine.set_full_snapshot_export_options(raw_snapshot_options);
     sync::PullRequest snapshot_pull = pull;
     snapshot_pull.request_full_snapshot = true;
-    const sync::PullResponse snapshot = source_engine.handle_pull(snapshot_pull);
-    if (snapshot.ok ||
-        snapshot.error_code != sync::SyncResponseErrorCode::UnsupportedFullSnapshot ||
-        snapshot.error_retryable) {
-        throw std::runtime_error("LWW full snapshot request was not rejected");
+    const sync::PullResponse raw_snapshot = source_engine.handle_pull(snapshot_pull);
+    if (!raw_snapshot.ok || !raw_snapshot.is_full_snapshot ||
+        raw_snapshot.snapshot_chunk.manifest.size() != 1u ||
+        raw_snapshot.snapshot_chunk.manifest[0].dbi_name != "trades") {
+        throw std::runtime_error("raw-only snapshot was rejected by an LWW engine");
+    }
+    sync::FullSnapshotExportOptions versioned_snapshot_options;
+    sync::FullSnapshotManifestEntry versioned_snapshot_entry;
+    versioned_snapshot_entry.dbi_name = "bars";
+    versioned_snapshot_entry.dbi_flags = changes.batches[0].ops[0].dbi_flags;
+    versioned_snapshot_options.manifest.push_back(versioned_snapshot_entry);
+    source_engine.set_full_snapshot_export_options(versioned_snapshot_options);
+    const sync::PullResponse versioned_snapshot =
+        source_engine.handle_pull(snapshot_pull);
+    if (versioned_snapshot.ok ||
+        versioned_snapshot.error_code !=
+            sync::SyncResponseErrorCode::UnsupportedFullSnapshot ||
+        versioned_snapshot.error_retryable) {
+        throw std::runtime_error("snapshot of registered versioned DBI was accepted");
     }
 
     auto receiver_conn = open_env(receiver_path);
     sync::SyncEngine receiver_engine(
         receiver_conn, sync::ConflictPolicy::LastWriterWins);
     receiver_engine.initialize_local_identity(receiver_node, db_id);
+    sync::ThreadLocalChangeAccumulator receiver_capture(receiver_conn);
+    KeyValueTable<int, int> receiver_table(
+        receiver_conn, "bars");
+    KeyValueTable<int, int> receiver_trades(
+        receiver_conn, "trades");
+    sync::VersionedKeyValueTable<int, int> receiver(
+        receiver_table, receiver_capture);
+    sync::FullSnapshotChunk versioned_import = raw_snapshot.snapshot_chunk;
+    versioned_import.manifest[0].dbi_name = "bars";
+    versioned_import.manifest[0].dbi_flags = changes.batches[0].ops[0].dbi_flags;
+    for (std::size_t i = 0u; i < versioned_import.batch.ops.size(); ++i) {
+        versioned_import.batch.ops[i].dbi_name = "bars";
+        versioned_import.batch.ops[i].dbi_flags =
+            changes.batches[0].ops[0].dbi_flags;
+    }
+    bool rejected_versioned_import = false;
+    try {
+        (void)receiver_engine.apply_full_snapshot_chunk(versioned_import);
+    } catch (const std::runtime_error&) {
+        rejected_versioned_import = true;
+    }
+    if (!rejected_versioned_import) {
+        throw std::runtime_error("snapshot import accepted registered versioned DBI");
+    }
     sync::PushRequest push;
     push.sender = source_node;
     push.db_id = db_id;
@@ -3672,10 +3771,12 @@ void test_engine_last_writer_wins_versioned_key_value() {
         throw std::runtime_error("versioned LWW push failed: " + pushed.error);
     }
 
-    KeyValueTable<int, int> receiver_table(
-        receiver_conn, "bars");
     if (kv_has(receiver_conn, receiver_table, 1)) {
         throw std::runtime_error("LWW tombstone did not remove receiver value");
+    }
+    if (kv_or_throw(receiver_conn, receiver_trades, 5,
+                    "mixed raw trade value") != 50u) {
+        throw std::runtime_error("normal DBI did not replicate with versioned DBI");
     }
 
     sync::ChangeBatch stale_put;
@@ -3757,6 +3858,34 @@ void test_engine_last_writer_wins_versioned_key_value() {
     }
     if (kv_has(receiver_conn, receiver_table, 3)) {
         throw std::runtime_error("rejected unversioned LWW batch changed receiver value");
+    }
+
+    sync::ChangeBatch revisioned_normal;
+    revisioned_normal.origin_node_id = make_node(0x61);
+    revisioned_normal.seq = 1u;
+    sync::ChangeOp revisioned_normal_op;
+    revisioned_normal_op.op_type = sync::ChangeOpType::Put;
+    revisioned_normal_op.dbi_name = "trades";
+    revisioned_normal_op.dbi_flags = changes.batches[2].ops[0].dbi_flags;
+    assign_int_key(revisioned_normal_op.storage_key, 6);
+    assign_int_value(revisioned_normal_op.value, 60);
+    revisioned_normal_op.op_flags = sync::OP_HAS_REVISION_KEY;
+    revisioned_normal_op.revision_key = version_20;
+    revisioned_normal.ops.push_back(revisioned_normal_op);
+    {
+        auto txn = receiver_conn->transaction(TransactionMode::WRITABLE);
+        const sync::ApplyOutcome outcome = receiver_engine.apply_batch_ex(
+            txn.handle(), revisioned_normal);
+        if (outcome.result != sync::ApplyResult::Conflict ||
+            outcome.conflict_reason !=
+                sync::ApplyConflictReason::UnexpectedLwwRevision ||
+            outcome.dbi_name != "trades") {
+            throw std::runtime_error("revisioned normal DBI batch returned wrong conflict");
+        }
+        txn.rollback();
+    }
+    if (kv_has(receiver_conn, receiver_trades, 6)) {
+        throw std::runtime_error("rejected revisioned normal batch changed receiver value");
     }
 
     source_conn->disconnect();

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -3592,22 +3592,177 @@ void test_engine_handle_push_wrong_db_id() {
     cleanup(p);
 }
 
-void test_engine_rejects_last_writer_wins_policy() {
+void test_engine_last_writer_wins_versioned_key_value() {
     using namespace mdbxc;
-    const std::string p = "test_engine_lww_policy.mdbx";
-    cleanup(p);
+    const std::string source_path = "test_engine_lww_source.mdbx";
+    const std::string receiver_path = "test_engine_lww_receiver.mdbx";
+    cleanup(source_path);
+    cleanup(receiver_path);
 
-    auto conn = open_env(p);
-    expect_invalid_argument("SyncEngine LastWriterWins policy",
-                            [&conn]() {
-                                sync::SyncEngine engine(
-                                    conn,
-                                    sync::ConflictPolicy::LastWriterWins);
-                                (void)engine;
+    const sync::NodeId source_node = make_node(0x20);
+    const sync::NodeId receiver_node = make_node(0x70);
+    const sync::DbId db_id = make_node(0xB0);
+    const std::vector<std::uint8_t> version_10 = { 0u, 10u };
+    const std::vector<std::uint8_t> version_20 = { 0u, 20u };
+    const std::vector<std::uint8_t> version_30 = { 0u, 30u };
+
+    auto source_conn = open_env(source_path);
+    sync::SyncEngine source_engine(
+        source_conn, sync::ConflictPolicy::LastWriterWins);
+    source_engine.initialize_local_identity(source_node, db_id);
+    sync::ThreadLocalChangeAccumulator source_capture(source_conn);
+    source_conn->attach_sync_capture(&source_capture);
+
+    KeyValueTable<int, int> source_table(
+        source_conn, "bars");
+    sync::VersionedKeyValueTable<int, int> source(
+        source_table, source_capture);
+    if (source.insert_or_assign(1, 10, version_10) !=
+        sync::VersionedWriteResult::Applied) {
+        throw std::runtime_error("initial versioned write was not applied");
+    }
+    if (source.insert_or_assign(1, 9, std::vector<std::uint8_t>{ 0u, 9u }) !=
+        sync::VersionedWriteResult::Ignored) {
+        throw std::runtime_error("older local versioned write was not ignored");
+    }
+    expect_invalid_argument("VersionedKeyValueTable duplicate source version",
+                            [&source, &version_10]() {
+                                source.insert_or_assign(1, 11, version_10);
                             });
+    if (kv_or_throw(source_conn, source_table, 1,
+                    "source LWW value") != 10u) {
+        throw std::runtime_error("ignored local version changed source value");
+    }
+    if (source.erase(1, version_30) != sync::VersionedWriteResult::Applied) {
+        throw std::runtime_error("versioned delete was not applied");
+    }
+    source_conn->detach_sync_capture();
 
-    conn->disconnect();
-    cleanup(p);
+    sync::PullRequest pull;
+    pull.requester = receiver_node;
+    pull.db_id = db_id;
+    const sync::PullResponse changes = source_engine.handle_pull(pull);
+    if (!changes.ok || changes.batches.size() != 2u ||
+        changes.batches[0].ops.size() != 1u ||
+        (changes.batches[0].ops[0].op_flags & sync::OP_HAS_REVISION_KEY) == 0 ||
+        changes.batches[0].ops[0].revision_key != version_10 ||
+        changes.batches[0].ops[0].dbi_flags !=
+            static_cast<std::uint32_t>(MDBX_INTEGERKEY)) {
+        throw std::runtime_error("versioned source changelog did not preserve LWW metadata");
+    }
+    sync::PullRequest snapshot_pull = pull;
+    snapshot_pull.request_full_snapshot = true;
+    const sync::PullResponse snapshot = source_engine.handle_pull(snapshot_pull);
+    if (snapshot.ok ||
+        snapshot.error_code != sync::SyncResponseErrorCode::UnsupportedFullSnapshot ||
+        snapshot.error_retryable) {
+        throw std::runtime_error("LWW full snapshot request was not rejected");
+    }
+
+    auto receiver_conn = open_env(receiver_path);
+    sync::SyncEngine receiver_engine(
+        receiver_conn, sync::ConflictPolicy::LastWriterWins);
+    receiver_engine.initialize_local_identity(receiver_node, db_id);
+    sync::PushRequest push;
+    push.sender = source_node;
+    push.db_id = db_id;
+    push.batches = changes.batches;
+    const sync::PushResponse pushed = receiver_engine.handle_push(push);
+    if (!pushed.ok) {
+        throw std::runtime_error("versioned LWW push failed: " + pushed.error);
+    }
+
+    KeyValueTable<int, int> receiver_table(
+        receiver_conn, "bars");
+    if (kv_has(receiver_conn, receiver_table, 1)) {
+        throw std::runtime_error("LWW tombstone did not remove receiver value");
+    }
+
+    sync::ChangeBatch stale_put;
+    stale_put.origin_node_id = make_node(0x30);
+    stale_put.seq = 1u;
+    sync::ChangeOp stale_op;
+    stale_op.op_type = sync::ChangeOpType::Put;
+    stale_op.dbi_name = "bars";
+    stale_op.dbi_flags = changes.batches[0].ops[0].dbi_flags;
+    assign_int_key(stale_op.storage_key, 1);
+    assign_int_value(stale_op.value, 10);
+    stale_op.op_flags = sync::OP_HAS_REVISION_KEY;
+    stale_op.revision_key = version_10;
+    stale_put.ops.push_back(stale_op);
+    {
+        auto txn = receiver_conn->transaction(TransactionMode::WRITABLE);
+        if (receiver_engine.apply_batch(txn.handle(), stale_put) !=
+            sync::ApplyResult::Applied) {
+            throw std::runtime_error("stale versioned put was not accepted as a no-op");
+        }
+        txn.commit();
+    }
+    if (kv_has(receiver_conn, receiver_table, 1)) {
+        throw std::runtime_error("stale put resurrected a tombstoned receiver value");
+    }
+
+    const sync::NodeId lower_origin = make_node(0x40);
+    const sync::NodeId higher_origin = make_node(0x50);
+    sync::ChangeBatch lower;
+    lower.origin_node_id = lower_origin;
+    lower.seq = 1u;
+    sync::ChangeOp lower_op;
+    lower_op.op_type = sync::ChangeOpType::Put;
+    lower_op.dbi_name = "bars";
+    lower_op.dbi_flags = changes.batches[0].ops[0].dbi_flags;
+    assign_int_key(lower_op.storage_key, 2);
+    assign_int_value(lower_op.value, 1);
+    lower_op.op_flags = sync::OP_HAS_REVISION_KEY;
+    lower_op.revision_key = version_20;
+    lower.ops.push_back(lower_op);
+    sync::ChangeBatch higher = lower;
+    higher.origin_node_id = higher_origin;
+    assign_int_value(higher.ops[0].value, 2);
+    {
+        auto txn = receiver_conn->transaction(TransactionMode::WRITABLE);
+        if (receiver_engine.apply_batch(txn.handle(), lower) !=
+                sync::ApplyResult::Applied ||
+            receiver_engine.apply_batch(txn.handle(), higher) !=
+                sync::ApplyResult::Applied) {
+            throw std::runtime_error("equal-version LWW operations did not apply");
+        }
+        txn.commit();
+    }
+    if (kv_or_throw(receiver_conn, receiver_table, 2,
+                    "LWW origin tie-break value") != 2u) {
+        throw std::runtime_error("LWW did not use NodeId as equal-version tie-breaker");
+    }
+
+    sync::ChangeBatch unversioned;
+    unversioned.origin_node_id = make_node(0x60);
+    unversioned.seq = 1u;
+    sync::ChangeOp unversioned_op;
+    unversioned_op.op_type = sync::ChangeOpType::Put;
+    unversioned_op.dbi_name = "bars";
+    unversioned_op.dbi_flags = changes.batches[0].ops[0].dbi_flags;
+    assign_int_key(unversioned_op.storage_key, 3);
+    assign_int_value(unversioned_op.value, 3);
+    unversioned.ops.push_back(unversioned_op);
+    {
+        auto txn = receiver_conn->transaction(TransactionMode::WRITABLE);
+        const sync::ApplyOutcome outcome =
+            receiver_engine.apply_batch_ex(txn.handle(), unversioned);
+        if (outcome.result != sync::ApplyResult::Conflict ||
+            outcome.conflict_reason != sync::ApplyConflictReason::MissingLwwRevision ||
+            outcome.dbi_name != "bars") {
+            throw std::runtime_error("unversioned LWW batch returned wrong conflict");
+        }
+        txn.rollback();
+    }
+    if (kv_has(receiver_conn, receiver_table, 3)) {
+        throw std::runtime_error("rejected unversioned LWW batch changed receiver value");
+    }
+
+    source_conn->disconnect();
+    receiver_conn->disconnect();
+    cleanup(source_path);
+    cleanup(receiver_path);
 }
 
 void test_engine_handle_pull_pagination_has_more() {
@@ -4019,8 +4174,8 @@ int main() {
         { "test_engine_pull_rejects_oversized_single_batch",
           &test_engine_pull_rejects_oversized_single_batch },
         { "test_engine_handle_push_wrong_db_id",&test_engine_handle_push_wrong_db_id },
-        { "test_engine_rejects_last_writer_wins_policy",
-          &test_engine_rejects_last_writer_wins_policy },
+        { "test_engine_last_writer_wins_versioned_key_value",
+          &test_engine_last_writer_wins_versioned_key_value },
         { "test_engine_handle_pull_pagination", &test_engine_handle_pull_pagination_has_more },
         { "test_engine_handle_pull_multi_origin",&test_engine_handle_pull_multi_origin_pagination },
         { "test_engine_handle_pull_legacy_origin_index",&test_engine_handle_pull_legacy_changelog_without_origin_index },

--- a/tests/test_sync_engine.cpp
+++ b/tests/test_sync_engine.cpp
@@ -3627,6 +3627,47 @@ void test_engine_last_writer_wins_versioned_key_value() {
         sync::VersionedWriteResult::Ignored) {
         throw std::runtime_error("older local versioned write was not ignored");
     }
+    typedef sync::KeyValueTableLogicalAdapter<
+        int,
+        int,
+        sync::KeyValueLogicalInt32Codec<int>,
+        sync::KeyValueLogicalInt32Codec<int> > IntLogicalAdapter;
+    sync::LogicalSchemaRecord logical_record;
+    logical_record.dbi_name = source_table.dbi_name();
+    logical_record.kind = sync::LogicalTableKind::KeyValue;
+    logical_record.schema_version = 1u;
+    logical_record.dbi_names.push_back(source_table.dbi_name());
+    source_engine.register_logical_schema(
+        "test.versioned_bars.v1", logical_record);
+    IntLogicalAdapter logical_adapter(source_table, "test.versioned_bars.v1");
+    const sync::LogicalChange logical_change =
+        logical_adapter.make_upsert(1, 11);
+    {
+        auto txn = source_conn->transaction(TransactionMode::WRITABLE);
+        const sync::LogicalApplyResult logical_result =
+            logical_adapter.apply(txn.handle(), logical_change);
+        if (logical_result.ok) {
+            throw std::runtime_error("logical apply accepted registered versioned DBI");
+        }
+        txn.rollback();
+    }
+    if (kv_or_throw(source_conn, source_table, 1,
+                    "logical LWW guard source value") != 10u) {
+        throw std::runtime_error("logical apply changed registered versioned DBI");
+    }
+    std::unique_ptr<IntLogicalAdapter::LogicalCaptureSession> logical_session =
+        logical_adapter.begin_capture_session();
+    bool rejected_logical_capture = false;
+    try {
+        logical_session->insert_or_assign(1, 12);
+    } catch (const std::logic_error&) {
+        rejected_logical_capture = true;
+    }
+    if (!rejected_logical_capture ||
+        kv_or_throw(source_conn, source_table, 1,
+                    "logical capture LWW guard source value") != 10u) {
+        throw std::runtime_error("logical capture changed registered versioned DBI");
+    }
     source_conn->detach_sync_capture();
     bool rejected_direct_write = false;
     try {
@@ -3892,6 +3933,66 @@ void test_engine_last_writer_wins_versioned_key_value() {
     receiver_conn->disconnect();
     cleanup(source_path);
     cleanup(receiver_path);
+}
+
+void test_versioned_dbi_guard_survives_engine_lifetime() {
+    using namespace mdbxc;
+    const std::string path = "test_versioned_dbi_guard_lifetime.mdbx";
+    cleanup(path);
+    const sync::NodeId node = make_node(0x71);
+    const sync::DbId db_id = make_node(0xC1);
+    const std::vector<std::uint8_t> version = { 0u, 1u };
+
+    std::shared_ptr<Connection> conn = open_env(path);
+    {
+        KeyValueTable<int, int> bars(conn, "bars");
+        sync::ThreadLocalChangeAccumulator capture(conn);
+        {
+            sync::SyncEngine first_engine(
+                conn, sync::ConflictPolicy::LastWriterWins);
+            first_engine.initialize_local_identity(node, db_id);
+            sync::SyncEngine second_engine(
+                conn, sync::ConflictPolicy::LastWriterWins);
+            conn->attach_sync_capture(&capture);
+            sync::VersionedKeyValueTable<int, int> versioned(bars, capture);
+            if (versioned.insert_or_assign(1, 10, version) !=
+                sync::VersionedWriteResult::Applied) {
+                throw std::runtime_error("initial lifetime-guard write was not applied");
+            }
+            conn->detach_sync_capture();
+        }
+        bool rejected_after_engine_destruction = false;
+        try {
+            bars.insert_or_assign(1, 11);
+        } catch (const std::logic_error&) {
+            rejected_after_engine_destruction = true;
+        }
+        if (!rejected_after_engine_destruction ||
+            kv_or_throw(conn, bars, 1, "post-engine versioned value") != 10u) {
+            throw std::runtime_error(
+                "registered DBI was mutable after SyncEngine destruction");
+        }
+    }
+    conn->disconnect();
+    conn.reset();
+
+    std::shared_ptr<Connection> reopened = open_env(path);
+    {
+        KeyValueTable<int, int> bars(reopened, "bars");
+        bool rejected_before_engine_creation = false;
+        try {
+            bars.insert_or_assign(1, 12);
+        } catch (const std::logic_error&) {
+            rejected_before_engine_creation = true;
+        }
+        if (!rejected_before_engine_creation ||
+            kv_or_throw(reopened, bars, 1, "reopened versioned value") != 10u) {
+            throw std::runtime_error(
+                "durable versioned DBI guard did not survive reopen");
+        }
+    }
+    reopened->disconnect();
+    cleanup(path);
 }
 
 void test_engine_handle_pull_pagination_has_more() {
@@ -4305,6 +4406,8 @@ int main() {
         { "test_engine_handle_push_wrong_db_id",&test_engine_handle_push_wrong_db_id },
         { "test_engine_last_writer_wins_versioned_key_value",
           &test_engine_last_writer_wins_versioned_key_value },
+        { "test_versioned_dbi_guard_survives_engine_lifetime",
+          &test_versioned_dbi_guard_survives_engine_lifetime },
         { "test_engine_handle_pull_pagination", &test_engine_handle_pull_pagination_has_more },
         { "test_engine_handle_pull_multi_origin",&test_engine_handle_pull_multi_origin_pagination },
         { "test_engine_handle_pull_legacy_origin_index",&test_engine_handle_pull_legacy_changelog_without_origin_index },


### PR DESCRIPTION
## What changed

Adds a narrow, opt-in source-version-wins register for one `KeyValueTable` DBI while retaining ordinary raw sync for other DBIs in the same database and engine.

- `VersionedKeyValueTable` durably registers its DBI, emits revisioned point `insert_or_assign` / `erase` operations, and keeps winner/tombstone state in `_mdbxc_identity_index`.
- `ConflictPolicy::LastWriterWins` is selected per registered DBI: registered DBIs require revisioned point Put/Delete, while normal DBIs continue to accept unversioned raw operations. Revision metadata on a normal DBI is rejected.
- `Connection` consults the durable registration before every public table mutation. Direct raw, clear, bulk/range, and generic logical-table mutations of a registered DBI fail closed before commit, independently of `SyncEngine` lifetime, capture attachment, or database reopen.
- Raw-only full snapshot manifests remain supported; a snapshot cannot include a registered DBI.

## Why

Mutable market bars and snapshots need source-authoritative ordering without placing sync metadata inside user values. The table value and its durable winner/tombstone sidecar must not diverge through direct, lifecycle, or logical-adapter paths.

## Validation

- `test_sync_engine` passed in C++17.
- `test_sync_engine` passed in C++11.

This draft is stacked on #304 (`codex/sync-deployment-guidance`), which supplies deployment guidance updated for the implemented contract.