### PR TITLE
[codex] Add receiver-neutral logical journal

### DIFF
--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1261,6 +1261,12 @@ deployments therefore retain their existing DBI footprint; deployments that
 publish journal-backed logical frames need one additional named-DBI slot in
 `Config::max_dbs`.
 
+The first journal append atomically writes a persistent layout-v1 marker with
+its entry. Subsequent append-time migration guards use only that constant-size
+marker lookup; they do not scan or decode the accumulated journal. The deeper
+`has_persistent_state()` inspection remains reserved for snapshot, recovery,
+and diagnostics paths where validating every durable journal record is needed.
+
 This first journal layout deliberately has no migration of pre-journal outbox
 records. A process opening an existing non-empty outbox without journal state
 fails closed before it appends a new logical frame. Operators must drain or

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -24,8 +24,8 @@ Wire is transport-agnostic, codec is versioned, storage uses named DBIs.
   `MetaStore`, `ChangeLogStore`, `OriginIndexStore`, `AppliedStore`, and
   `IdentityIndexStore`. Durable logical state is separate under
   `include/mdbx_containers/sync/logical/stores/`: `SchemaRegistryStore`,
-  `LogicalDeliveryStore`, `LogicalDeliveryOrderStore`, and
-  `LogicalOutboxStore`.
+  `LogicalDeliveryStore`, `LogicalDeliveryOrderStore`, `LogicalJournalStore`,
+  and `LogicalOutboxStore`.
 - `ChangeBatchCodec` strict versioned wire format (magic, codec version,
   batch version, batch flags, then payload); rejects unknown mandatory
   flags and version mismatches at both encode and decode.
@@ -1226,25 +1226,45 @@ the numeric `origin_sequence`: it does not decide whether an envelope is an
 exact duplicate delivery identity, persist a watermark, buffer missing frames,
 or decide whether it is safe to advance one.
 
-`LogicalOutboxStore` is the sender-side durable foundation for ordered delivery.
-`SyncEngine::enqueue_logical_delivery()` persists an envelope
-in `_mdbxc_logical_outbox` and allocates a monotonic `origin_sequence` per
-destination database and origin, independent of the selected receiver. This is
-the stable logical-event identity carried by replay markers and ordered
-frontiers. Receiver routes retain only their own pending entries,
-`acknowledged_through`, and known tail. Its MDBX entry keys contain the
-destination, receiver node id, and a big-endian event-sequence suffix, so
-`pending_logical_deliveries()` reads one receiver route in numeric order. The
-generated frame id is stable for the origin event sequence, and allocating a
-frame, updating the global allocator, acknowledging a route prefix, and
-deleting acknowledged route entries are all transactional. A receiver hello
-must match the selected receiver node id before its queue can be dispatched; an
-acknowledgement can therefore advance only that receiver's durable frontier. A
-rollback neither consumes a sequence nor leaves a queue entry behind.
-`_mdbxc_logical_outbox` is created during the normal
-committed sync-system initialization lifecycle, so deployments need one
-additional named-DBI slot in `Config::max_dbs` compared with a layout that did
-not use the outbox.
+`LogicalJournalStore` is the receiver-neutral durable source for locally
+originated ordered logical frames. It stores the destination database id,
+origin node id, monotonic `origin_sequence`, stable frame id, and frame bytes
+in `_mdbxc_logical_journal`; it contains no receiver node id or acknowledgement
+state. `SyncEngine::append_logical_journal()` records one such frame atomically
+with an optional caller-owned table mutation, without selecting a peer.
+
+`LogicalOutboxStore` remains the sender-side receiver-specific delivery queue.
+`SyncEngine::materialize_logical_journal()` projects a contiguous prefix of one
+local journal stream into one selected receiver route. Projection preserves the
+journal-assigned envelope bytes and sequence, is transactional and retry-safe,
+and can be repeated independently for multiple receivers. The route owns only
+its pending entries, `acknowledged_through`, and known tail. Its MDBX entry
+keys contain the destination, receiver node id, and a big-endian event-sequence
+suffix, so `pending_logical_deliveries()` reads one route in numeric order. A
+receiver hello must match the selected receiver node id before its queue can be
+dispatched; an acknowledgement can therefore advance only that receiver's
+durable frontier. A rollback neither consumes a journal sequence nor leaves a
+projected queue entry behind.
+
+`SyncEngine::enqueue_logical_delivery()` remains source-compatible for existing
+typed capture sessions. It appends to the journal and projects the same
+envelope to its supplied receiver in one transaction. Its legacy behavior for
+a newly selected receiver is retained: that route begins at the current event
+sequence and does not automatically receive earlier frames. New fan-out code
+must instead append once and materialize the journal for every receiver from
+the desired retained prefix.
+
+`_mdbxc_logical_journal` and `_mdbxc_logical_outbox` are created during normal
+committed sync-system initialization. Deployments therefore need two additional
+named-DBI slots in `Config::max_dbs` compared with a layout that has neither
+logical journal nor outbox.
+
+This first journal layout deliberately has no migration of pre-journal outbox
+records. A process opening an existing non-empty outbox without journal state
+fails closed before it appends a new logical frame. Operators must drain or
+replace that legacy logical state with an explicit recovery plan before enabling
+journal-backed capture; silently creating a new sequence allocator could reuse
+an existing `(destination, origin, sequence)` identity.
 
 Persisted outbox entries always satisfy the library-default `CodecBounds`, so a
 later worker can decode them without carrying a caller-specific bounds object.

--- a/include/mdbx_containers/sync/DESIGN.md
+++ b/include/mdbx_containers/sync/DESIGN.md
@@ -1254,10 +1254,12 @@ sequence and does not automatically receive earlier frames. New fan-out code
 must instead append once and materialize the journal for every receiver from
 the desired retained prefix.
 
-`_mdbxc_logical_journal` and `_mdbxc_logical_outbox` are created during normal
-committed sync-system initialization. Deployments therefore need two additional
-named-DBI slots in `Config::max_dbs` compared with a layout that has neither
-logical journal nor outbox.
+`_mdbxc_logical_outbox` is created during normal committed sync-system
+initialization. `_mdbxc_logical_journal` is created lazily only by
+`append_logical_journal()` or legacy `enqueue_logical_delivery()`. Raw-only
+deployments therefore retain their existing DBI footprint; deployments that
+publish journal-backed logical frames need one additional named-DBI slot in
+`Config::max_dbs`.
 
 This first journal layout deliberately has no migration of pre-journal outbox
 records. A process opening an existing non-empty outbox without journal state

--- a/include/mdbx_containers/sync/engine/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/engine/SyncEngine.hpp
@@ -3053,7 +3053,6 @@ namespace sync {
             SchemaRegistryStore schemas(m_conn->env_handle());
             LogicalDeliveryStore logical_delivery(m_conn->env_handle());
             LogicalDeliveryOrderStore logical_delivery_order(m_conn->env_handle());
-            LogicalJournalStore logical_journal(m_conn->env_handle());
             LogicalOutboxStore logical_outbox(m_conn->env_handle());
             meta.open(txn);
             change_log.open(txn);
@@ -3061,7 +3060,6 @@ namespace sync {
             schemas.open(txn);
             logical_delivery.open(txn);
             logical_delivery_order.open(txn);
-            logical_journal.open(txn);
             logical_outbox.open(txn);
         }
 

--- a/include/mdbx_containers/sync/engine/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/engine/SyncEngine.hpp
@@ -1030,6 +1030,121 @@ namespace sync {
                                   bounds);
         }
 
+        /// \brief Appends one receiver-neutral local logical journal frame.
+        /// \details This records the change atomically without selecting a
+        /// delivery peer. Use materialize_logical_journal() to create one or
+        /// more receiver-specific outbox routes later.
+        LogicalDeliveryEnvelope append_logical_journal(
+                const DbId& destination,
+                const LogicalChangeFrame& frame,
+                const CodecBounds* bounds = nullptr) {
+            auto txn = m_conn->transaction(TransactionMode::WRITABLE);
+            const LogicalDeliveryEnvelope envelope = append_logical_journal(
+                txn.handle(), destination, frame, bounds);
+            txn.commit();
+            return envelope;
+        }
+
+        /// \brief Appends one receiver-neutral frame in a caller-owned transaction.
+        /// \details This does not commit or roll back \p txn, so callers can
+        /// atomically persist their table mutation and its logical journal frame.
+        LogicalDeliveryEnvelope append_logical_journal(
+                MDBX_txn* txn,
+                const DbId& destination,
+                const LogicalChangeFrame& frame,
+                const CodecBounds* bounds = nullptr) {
+            txn = checked_external_txn(txn, "SyncEngine::append_logical_journal");
+            initialize_system_stores(txn);
+            MetaStore meta(m_conn->env_handle());
+            LogicalJournalStore journal(m_conn->env_handle());
+            LogicalOutboxStore outbox(m_conn->env_handle());
+            meta.open(txn);
+            const NodeId origin = meta.get_node_id(txn);
+            if (is_zero_sync_id(origin)) {
+                throw std::logic_error(
+                    "SyncEngine local node identity is not initialised");
+            }
+            if (!journal.has_persistent_state(txn) &&
+                outbox.has_persistent_state(txn)) {
+                throw std::logic_error(
+                    "logical journal cannot start with legacy outbox state");
+            }
+            return journal.append(txn, destination, origin, frame, bounds);
+        }
+
+        /// \brief Projects pending local journal frames onto one receiver route.
+        /// \param destination Logical database represented by the local journal.
+        /// \param receiver Receiver node selected by routing configuration.
+        /// \param limit Maximum number of frames to project, or zero for all.
+        /// \param bounds Optional additional validation bounds.
+        /// \return Number of newly projected receiver-specific outbox entries.
+        std::size_t materialize_logical_journal(
+                const DbId& destination,
+                const NodeId& receiver,
+                std::size_t limit = 0u,
+                const CodecBounds* bounds = nullptr) {
+            auto txn = m_conn->transaction(TransactionMode::WRITABLE);
+            const std::size_t projected = materialize_logical_journal(
+                txn.handle(), destination, receiver, limit, bounds);
+            txn.commit();
+            return projected;
+        }
+
+        /// \brief Projects local journal frames in a caller-owned transaction.
+        /// \details Projection is contiguous and idempotent for a route whose
+        /// origin is the local node. It does not commit or roll back \p txn.
+        std::size_t materialize_logical_journal(
+                MDBX_txn* txn,
+                const DbId& destination,
+                const NodeId& receiver,
+                std::size_t limit = 0u,
+                const CodecBounds* bounds = nullptr) {
+            txn = checked_external_txn(
+                txn, "SyncEngine::materialize_logical_journal");
+            initialize_system_stores(txn);
+            MetaStore meta(m_conn->env_handle());
+            LogicalJournalStore journal(m_conn->env_handle());
+            LogicalOutboxStore outbox(m_conn->env_handle());
+            meta.open(txn);
+            const NodeId origin = meta.get_node_id(txn);
+            if (is_zero_sync_id(origin)) {
+                throw std::logic_error(
+                    "SyncEngine local node identity is not initialised");
+            }
+            const NodeId route_origin = outbox.route_origin(
+                txn, destination, receiver);
+            if (!is_zero_sync_id(route_origin) &&
+                compare_node_id(route_origin, origin) != 0) {
+                throw std::logic_error(
+                    "logical journal route belongs to a different origin");
+            }
+            const std::uint64_t projected_through = outbox.known_tail(
+                txn, destination, receiver);
+            std::size_t projected = 0u;
+            journal.for_each_after(txn, destination, origin, projected_through,
+                [&outbox, txn, &receiver, bounds, &projected](
+                        const LogicalDeliveryEnvelope& envelope) {
+                    outbox.project(txn, receiver, envelope, bounds);
+                    ++projected;
+                }, bounds, limit);
+            return projected;
+        }
+
+        /// \brief Returns the highest local logical journal sequence.
+        std::uint64_t logical_journal_known_tail(
+                const DbId& destination) const {
+            auto txn = m_conn->transaction(TransactionMode::READ_ONLY);
+            MetaStore meta(m_conn->env_handle());
+            LogicalJournalStore journal(m_conn->env_handle());
+            meta.open(txn.handle());
+            const NodeId origin = meta.get_node_id(txn.handle());
+            if (is_zero_sync_id(origin)) {
+                throw std::logic_error(
+                    "SyncEngine local node identity is not initialised");
+            }
+            return journal.known_tail(txn.handle(), destination, origin);
+        }
+
         /// \brief Lists locally queued ordered deliveries for one receiver.
         std::vector<LogicalDeliveryEnvelope> pending_logical_deliveries(
                 const DbId& destination,
@@ -1770,10 +1885,12 @@ namespace sync {
                 SchemaRegistryStore schemas(m_conn->env_handle());
                 LogicalDeliveryStore delivery(m_conn->env_handle());
                 LogicalDeliveryOrderStore order(m_conn->env_handle());
+                LogicalJournalStore journal(m_conn->env_handle());
                 LogicalOutboxStore outbox(m_conn->env_handle());
                 if (schemas.has_entries(txn) ||
                     delivery.has_persistent_state(txn) ||
                     order.has_entries(txn) ||
+                    journal.has_persistent_state(txn) ||
                     outbox.has_persistent_state(txn)) {
                     throw FullSnapshotLogicalStateUnsupported();
                 }
@@ -2158,9 +2275,11 @@ namespace sync {
             SchemaRegistryStore schemas(m_conn->env_handle());
             LogicalDeliveryStore delivery(m_conn->env_handle());
             LogicalDeliveryOrderStore order(m_conn->env_handle());
+            LogicalJournalStore journal(m_conn->env_handle());
             LogicalOutboxStore outbox(m_conn->env_handle());
             if (schemas.has_entries(txn) || delivery.has_persistent_state(txn) ||
-                order.has_entries(txn) || outbox.has_persistent_state(txn)) {
+                order.has_entries(txn) || journal.has_persistent_state(txn) ||
+                outbox.has_persistent_state(txn)) {
                 throw std::logic_error(
                     "logical recovery destination has persistent logical state");
             }
@@ -2934,6 +3053,7 @@ namespace sync {
             SchemaRegistryStore schemas(m_conn->env_handle());
             LogicalDeliveryStore logical_delivery(m_conn->env_handle());
             LogicalDeliveryOrderStore logical_delivery_order(m_conn->env_handle());
+            LogicalJournalStore logical_journal(m_conn->env_handle());
             LogicalOutboxStore logical_outbox(m_conn->env_handle());
             meta.open(txn);
             change_log.open(txn);
@@ -2941,6 +3061,7 @@ namespace sync {
             schemas.open(txn);
             logical_delivery.open(txn);
             logical_delivery_order.open(txn);
+            logical_journal.open(txn);
             logical_outbox.open(txn);
         }
 

--- a/include/mdbx_containers/sync/engine/SyncEngine.hpp
+++ b/include/mdbx_containers/sync/engine/SyncEngine.hpp
@@ -1064,10 +1064,12 @@ namespace sync {
                 throw std::logic_error(
                     "SyncEngine local node identity is not initialised");
             }
-            if (!journal.has_persistent_state(txn) &&
-                outbox.has_persistent_state(txn)) {
-                throw std::logic_error(
-                    "logical journal cannot start with legacy outbox state");
+            if (!journal.is_initialized(txn)) {
+                if (outbox.has_persistent_state(txn)) {
+                    throw std::logic_error(
+                        "logical journal cannot start with legacy outbox state");
+                }
+                journal.initialize(txn);
             }
             return journal.append(txn, destination, origin, frame, bounds);
         }

--- a/include/mdbx_containers/sync/logical.hpp
+++ b/include/mdbx_containers/sync/logical.hpp
@@ -22,6 +22,7 @@
 #include "logical/stores/SchemaRegistryStore.hpp"
 #include "logical/stores/LogicalDeliveryStore.hpp"
 #include "logical/stores/LogicalDeliveryOrderStore.hpp"
+#include "logical/stores/LogicalJournalStore.hpp"
 #include "logical/stores/LogicalOutboxStore.hpp"
 #include "logical/logical_schema_validation.hpp"
 #include "logical/logical_recovery.hpp"

--- a/include/mdbx_containers/sync/logical/stores/LogicalDeliveryStore.hpp
+++ b/include/mdbx_containers/sync/logical/stores/LogicalDeliveryStore.hpp
@@ -15,6 +15,7 @@
 
 #include <mdbx.h>
 
+#include "detail/NamedDbiLookup.hpp"
 
 namespace mdbxc {
 namespace sync {
@@ -507,27 +508,7 @@ namespace sync {
 
         static bool named_dbi_exists(MDBX_txn* txn,
                                      const std::string& name) {
-            // Check the main DB first so a missing named DBI is not opened.
-            MDBX_dbi main_dbi = 0;
-            check_mdbx(
-                mdbx_dbi_open(
-                    txn,
-                    static_cast<const char*>(MDBX_CHK_MAIN),
-                    static_cast<MDBX_db_flags_t>(0),
-                    &main_dbi),
-                "Failed to open main DBI while checking LogicalDeliveryStore DBI");
-            MDBX_val key = {
-                const_cast<char*>(name.data()),
-                name.size()
-            };
-            MDBX_val value;
-            const int rc = mdbx_get(txn, main_dbi, &key, &value);
-            if (rc == MDBX_NOTFOUND) {
-                return false;
-            }
-            check_mdbx(rc,
-                       "Failed to inspect LogicalDeliveryStore DBI");
-            return true;
+            return detail::named_dbi_exists(txn, name);
         }
 
         std::uint64_t read_watermark(MDBX_txn* txn,

--- a/include/mdbx_containers/sync/logical/stores/LogicalJournalStore.hpp
+++ b/include/mdbx_containers/sync/logical/stores/LogicalJournalStore.hpp
@@ -86,7 +86,7 @@ namespace sync {
                             std::size_t limit = 0u) const {
             txn = checked_txn(txn, "LogicalJournalStore::for_each_after");
             validate_identity(destination, origin);
-            open_existing(txn);
+            if (!try_open_existing(txn)) return;
             const OriginMetadata metadata = read_origin_metadata(txn,
                                                                   destination,
                                                                   origin);
@@ -136,7 +136,7 @@ namespace sync {
                                  const NodeId& origin) const {
             txn = checked_txn(txn, "LogicalJournalStore::known_tail");
             validate_identity(destination, origin);
-            open_existing(txn);
+            if (!try_open_existing(txn)) return 0u;
             return read_origin_metadata(txn, destination, origin).
                 next_sequence - 1u;
         }
@@ -156,7 +156,10 @@ namespace sync {
             if (bounds != nullptr) {
                 (void)LogicalDeliveryEnvelopeCodec::encode(envelope, bounds);
             }
-            open_existing(txn);
+            if (!try_open_existing(txn)) {
+                throw std::invalid_argument(
+                    "LogicalJournalStore envelope is not a journal entry");
+            }
             const std::vector<std::uint8_t> key = make_entry_key(
                 envelope.destination_db_uuid, envelope.origin_node_id,
                 envelope.origin_sequence);
@@ -182,7 +185,7 @@ namespace sync {
         bool has_persistent_state(MDBX_txn* txn,
                                   const CodecBounds* bounds = nullptr) const {
             txn = checked_txn(txn, "LogicalJournalStore::has_persistent_state");
-            open_existing(txn);
+            if (!try_open_existing(txn)) return false;
             MDBX_cursor* cursor = nullptr;
             check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
                        "LogicalJournalStore state cursor open failed");
@@ -233,14 +236,57 @@ namespace sync {
             std::uint64_t sequence;
         };
 
+        struct TableLookup {
+            TableLookup(const std::string& expected_name)
+                : expected(&expected_name),
+                  found(false) {}
+
+            const std::string* expected;
+            bool found;
+        };
+
         MDBX_txn* checked_txn(MDBX_txn* txn, const char* context) const {
             return checked_txn_env(txn, m_env, context);
         }
 
-        void open_existing(MDBX_txn* txn) const {
-            check_mdbx(mdbx_dbi_open(txn, m_dbi_name.c_str(),
-                                     static_cast<MDBX_db_flags_t>(0), &m_dbi),
-                       "Failed to open LogicalJournalStore DBI");
+        bool try_open_existing(MDBX_txn* txn) const {
+            if (!table_exists(txn)) return false;
+            const int rc = mdbx_dbi_open(txn, m_dbi_name.c_str(),
+                                         static_cast<MDBX_db_flags_t>(0),
+                                         &m_dbi);
+            check_mdbx(rc, "Failed to open LogicalJournalStore DBI");
+            return true;
+        }
+
+        bool table_exists(MDBX_txn* txn) const {
+            TableLookup lookup(m_dbi_name);
+            const int rc = mdbx_enumerate_tables(
+                txn, &LogicalJournalStore::find_named_table, &lookup);
+            if (lookup.found && rc == MDBX_RESULT_TRUE) return true;
+            check_mdbx(rc, "Failed to inspect LogicalJournalStore DBI");
+            return false;
+        }
+
+        static int find_named_table(
+                void* context,
+                const MDBX_txn*,
+                const MDBX_val* name,
+                MDBX_db_flags_t,
+                const MDBX_stat*,
+                MDBX_dbi)
+#if __cplusplus >= 201703L
+                noexcept
+#endif
+                {
+            TableLookup* lookup = static_cast<TableLookup*>(context);
+            if (name != nullptr && name->iov_base != nullptr &&
+                name->iov_len == lookup->expected->size() &&
+                std::memcmp(name->iov_base, lookup->expected->data(),
+                            name->iov_len) == 0) {
+                lookup->found = true;
+                return MDBX_RESULT_TRUE;
+            }
+            return MDBX_SUCCESS;
         }
 
         void open_for_write(MDBX_txn* txn) const {

--- a/include/mdbx_containers/sync/logical/stores/LogicalJournalStore.hpp
+++ b/include/mdbx_containers/sync/logical/stores/LogicalJournalStore.hpp
@@ -14,6 +14,7 @@
 
 #include <mdbx.h>
 
+#include "detail/NamedDbiLookup.hpp"
 #include "../LogicalDeliveryEnvelopeCodec.hpp"
 
 namespace mdbxc {
@@ -37,6 +38,37 @@ namespace sync {
             open_for_write(txn);
         }
 
+        /// \brief Returns whether the journal has its persistent v1 layout marker.
+        /// \details This is a constant-size lookup intended for append-time
+        /// migration guards. It deliberately does not validate journal entries;
+        /// use has_persistent_state() for that deep integrity inspection.
+        bool is_initialized(MDBX_txn* txn) const {
+            txn = checked_txn(txn, "LogicalJournalStore::is_initialized");
+            if (!try_open_existing(txn)) return false;
+            return has_layout_marker(txn);
+        }
+
+        /// \brief Writes the persistent v1 layout marker if it is absent.
+        /// \details Callers must perform any migration guard before this call.
+        /// The marker and the first journal entry are committed atomically when
+        /// both operations use the same transaction.
+        void initialize(MDBX_txn* txn) {
+            txn = checked_txn(txn, "LogicalJournalStore::initialize");
+            open_for_write(txn);
+            const std::vector<std::uint8_t> key = make_layout_marker_key();
+            const std::vector<std::uint8_t> value = make_layout_marker_value();
+            MDBX_val raw_key = make_val(key);
+            MDBX_val raw_value = make_val(value);
+            const int rc = mdbx_put(txn, m_dbi, &raw_key, &raw_value,
+                                    MDBX_NOOVERWRITE);
+            if (rc == MDBX_SUCCESS) return;
+            if (rc == MDBX_KEYEXIST) {
+                (void)has_layout_marker(txn);
+                return;
+            }
+            check_mdbx(rc, "LogicalJournalStore layout marker write failed");
+        }
+
         LogicalDeliveryEnvelope append(
                 MDBX_txn* txn,
                 const DbId& destination,
@@ -46,6 +78,10 @@ namespace sync {
             txn = checked_txn(txn, "LogicalJournalStore::append");
             validate_identity(destination, origin);
             open_for_write(txn);
+            if (!has_layout_marker(txn)) {
+                throw std::logic_error(
+                    "LogicalJournalStore layout is not initialized");
+            }
             OriginMetadata metadata = read_origin_metadata(txn, destination,
                                                             origin);
             if (metadata.next_sequence ==
@@ -195,7 +231,9 @@ namespace sync {
                 MDBX_val value;
                 int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
                 while (rc == MDBX_SUCCESS) {
-                    if (is_origin_metadata_key(key)) {
+                    if (is_layout_marker_key(key)) {
+                        decode_layout_marker(value);
+                    } else if (is_origin_metadata_key(key)) {
                         (void)decode_origin_metadata(value);
                     } else {
                         const Entry entry = decode_entry(key);
@@ -236,57 +274,17 @@ namespace sync {
             std::uint64_t sequence;
         };
 
-        struct TableLookup {
-            TableLookup(const std::string& expected_name)
-                : expected(&expected_name),
-                  found(false) {}
-
-            const std::string* expected;
-            bool found;
-        };
-
         MDBX_txn* checked_txn(MDBX_txn* txn, const char* context) const {
             return checked_txn_env(txn, m_env, context);
         }
 
         bool try_open_existing(MDBX_txn* txn) const {
-            if (!table_exists(txn)) return false;
+            if (!detail::named_dbi_exists(txn, m_dbi_name)) return false;
             const int rc = mdbx_dbi_open(txn, m_dbi_name.c_str(),
                                          static_cast<MDBX_db_flags_t>(0),
                                          &m_dbi);
             check_mdbx(rc, "Failed to open LogicalJournalStore DBI");
             return true;
-        }
-
-        bool table_exists(MDBX_txn* txn) const {
-            TableLookup lookup(m_dbi_name);
-            const int rc = mdbx_enumerate_tables(
-                txn, &LogicalJournalStore::find_named_table, &lookup);
-            if (lookup.found && rc == MDBX_RESULT_TRUE) return true;
-            check_mdbx(rc, "Failed to inspect LogicalJournalStore DBI");
-            return false;
-        }
-
-        static int find_named_table(
-                void* context,
-                const MDBX_txn*,
-                const MDBX_val* name,
-                MDBX_db_flags_t,
-                const MDBX_stat*,
-                MDBX_dbi)
-#if __cplusplus >= 201703L
-                noexcept
-#endif
-                {
-            TableLookup* lookup = static_cast<TableLookup*>(context);
-            if (name != nullptr && name->iov_base != nullptr &&
-                name->iov_len == lookup->expected->size() &&
-                std::memcmp(name->iov_base, lookup->expected->data(),
-                            name->iov_len) == 0) {
-                lookup->found = true;
-                return MDBX_RESULT_TRUE;
-            }
-            return MDBX_SUCCESS;
         }
 
         void open_for_write(MDBX_txn* txn) const {
@@ -318,6 +316,20 @@ namespace sync {
             out.push_back(origin_metadata_key_kind());
             out.insert(out.end(), destination.begin(), destination.end());
             out.insert(out.end(), origin.begin(), origin.end());
+            return out;
+        }
+
+        static std::vector<std::uint8_t> make_layout_marker_key() {
+            std::vector<std::uint8_t> out;
+            out.reserve(layout_marker_key_size());
+            out.push_back(key_version());
+            out.push_back(layout_marker_key_kind());
+            return out;
+        }
+
+        static std::vector<std::uint8_t> make_layout_marker_value() {
+            std::vector<std::uint8_t> out;
+            out.push_back(layout_value_version());
             return out;
         }
 
@@ -362,6 +374,17 @@ namespace sync {
                 static_cast<const std::uint8_t*>(key.iov_base);
             return bytes[0] == key_version() &&
                    bytes[1] == origin_metadata_key_kind();
+        }
+
+        static bool is_layout_marker_key(const MDBX_val& key) {
+            if (key.iov_len != layout_marker_key_size() ||
+                key.iov_base == nullptr) {
+                return false;
+            }
+            const std::uint8_t* bytes =
+                static_cast<const std::uint8_t*>(key.iov_base);
+            return bytes[0] == key_version() &&
+                   bytes[1] == layout_marker_key_kind();
         }
 
         static Entry decode_entry(const MDBX_val& key) {
@@ -442,6 +465,31 @@ namespace sync {
             return out;
         }
 
+        bool has_layout_marker(MDBX_txn* txn) const {
+            const std::vector<std::uint8_t> key = make_layout_marker_key();
+            MDBX_val raw_key = make_val(key);
+            MDBX_val raw_value;
+            const int rc = mdbx_get(txn, m_dbi, &raw_key, &raw_value);
+            if (rc == MDBX_NOTFOUND) return false;
+            check_mdbx(rc, "LogicalJournalStore layout marker read failed");
+            decode_layout_marker(raw_value);
+            return true;
+        }
+
+        static void decode_layout_marker(const MDBX_val& value) {
+            if (value.iov_len != layout_marker_value_size() ||
+                value.iov_base == nullptr) {
+                throw std::runtime_error(
+                    "LogicalJournalStore layout marker is invalid");
+            }
+            const std::uint8_t* bytes =
+                static_cast<const std::uint8_t*>(value.iov_base);
+            if (bytes[0] != layout_value_version()) {
+                throw std::runtime_error(
+                    "Unsupported LogicalJournalStore layout version");
+            }
+        }
+
         static LogicalDeliveryEnvelope decode_value(const MDBX_val& value,
                                                     const CodecBounds* bounds) {
             if (value.iov_base == nullptr && value.iov_len != 0u) {
@@ -454,9 +502,13 @@ namespace sync {
         }
 
         static constexpr std::uint8_t key_version() { return 1u; }
+        static constexpr std::uint8_t layout_marker_key_kind() { return 0u; }
         static constexpr std::uint8_t origin_metadata_key_kind() { return 1u; }
         static constexpr std::uint8_t entry_key_kind() { return 2u; }
+        static constexpr std::uint8_t layout_value_version() { return 1u; }
         static constexpr std::uint16_t metadata_value_version() { return 1u; }
+        static constexpr std::size_t layout_marker_key_size() { return 2u; }
+        static constexpr std::size_t layout_marker_value_size() { return 1u; }
         static constexpr std::size_t metadata_key_size() {
             return 2u + DbId().size() + NodeId().size();
         }

--- a/include/mdbx_containers/sync/logical/stores/LogicalJournalStore.hpp
+++ b/include/mdbx_containers/sync/logical/stores/LogicalJournalStore.hpp
@@ -1,0 +1,430 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_STORES_LOGICAL_JOURNAL_STORE_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_STORES_LOGICAL_JOURNAL_STORE_HPP_INCLUDED
+
+/// \file logical/stores/LogicalJournalStore.hpp
+/// \brief Persistent receiver-neutral journal for logical changes.
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <mdbx.h>
+
+#include "../LogicalDeliveryEnvelopeCodec.hpp"
+
+namespace mdbxc {
+namespace sync {
+
+    /// \brief Persists locally originated logical frames independently of peers.
+    /// \details One journal stream is ordered by destination database and
+    /// origin. Receiver-specific outbox entries are projected later without
+    /// changing the durable journal record or its sequence.
+    class LogicalJournalStore {
+    public:
+        explicit LogicalJournalStore(
+                MDBX_env* env,
+                const std::string& dbi_name = "_mdbxc_logical_journal")
+            : m_env(env),
+              m_dbi_name(dbi_name),
+              m_dbi(0) {}
+
+        void open(MDBX_txn* txn) {
+            txn = checked_txn(txn, "LogicalJournalStore::open");
+            open_for_write(txn);
+        }
+
+        LogicalDeliveryEnvelope append(
+                MDBX_txn* txn,
+                const DbId& destination,
+                const NodeId& origin,
+                const LogicalChangeFrame& frame,
+                const CodecBounds* bounds = nullptr) {
+            txn = checked_txn(txn, "LogicalJournalStore::append");
+            validate_identity(destination, origin);
+            open_for_write(txn);
+            OriginMetadata metadata = read_origin_metadata(txn, destination,
+                                                            origin);
+            if (metadata.next_sequence ==
+                (std::numeric_limits<std::uint64_t>::max)()) {
+                throw std::overflow_error("LogicalJournalStore sequence exhausted");
+            }
+
+            LogicalDeliveryEnvelope envelope;
+            envelope.destination_db_uuid = destination;
+            envelope.origin_node_id = origin;
+            envelope.origin_sequence = metadata.next_sequence;
+            envelope.frame_id = make_frame_id(metadata.next_sequence);
+            envelope.frame = frame;
+            if (bounds != nullptr) {
+                (void)LogicalDeliveryEnvelopeCodec::encode(envelope, bounds);
+            }
+            const std::vector<std::uint8_t> key = make_entry_key(
+                destination, origin, envelope.origin_sequence);
+            const std::vector<std::uint8_t> value =
+                LogicalDeliveryEnvelopeCodec::encode(envelope);
+            MDBX_val raw_key = make_val(key);
+            MDBX_val raw_value = make_val(value);
+            check_mdbx(mdbx_put(txn, m_dbi, &raw_key, &raw_value,
+                                MDBX_NOOVERWRITE),
+                       "LogicalJournalStore append failed");
+            ++metadata.next_sequence;
+            write_origin_metadata(txn, destination, origin, metadata);
+            return envelope;
+        }
+
+        template<typename Visitor>
+        void for_each_after(MDBX_txn* txn,
+                            const DbId& destination,
+                            const NodeId& origin,
+                            std::uint64_t sequence,
+                            Visitor visitor,
+                            const CodecBounds* bounds = nullptr,
+                            std::size_t limit = 0u) const {
+            txn = checked_txn(txn, "LogicalJournalStore::for_each_after");
+            validate_identity(destination, origin);
+            open_existing(txn);
+            const OriginMetadata metadata = read_origin_metadata(txn,
+                                                                  destination,
+                                                                  origin);
+            if (sequence >= metadata.next_sequence - 1u) return;
+
+            const std::vector<std::uint8_t> prefix = make_entry_prefix(
+                destination, origin);
+            std::vector<std::uint8_t> first_key = prefix;
+            detail::append_u64_be(first_key, sequence + 1u);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "LogicalJournalStore cursor open failed");
+            std::size_t visited = 0u;
+            try {
+                MDBX_val key = make_val(first_key);
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_SET_RANGE);
+                while (rc == MDBX_SUCCESS && has_entry_prefix(key, prefix)) {
+                    const std::uint64_t current = decode_entry_sequence(key);
+                    if (current >= metadata.next_sequence) break;
+                    const LogicalDeliveryEnvelope envelope = decode_value(value,
+                                                                          bounds);
+                    if (compare_node_id(envelope.destination_db_uuid,
+                                        destination) != 0 ||
+                        compare_node_id(envelope.origin_node_id, origin) != 0 ||
+                        envelope.origin_sequence != current) {
+                        throw std::runtime_error(
+                            "LogicalJournalStore entry key/value mismatch");
+                    }
+                    visitor(envelope);
+                    ++visited;
+                    if (limit != 0u && visited >= limit) break;
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_SUCCESS && rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "LogicalJournalStore cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+        }
+
+        std::uint64_t known_tail(MDBX_txn* txn,
+                                 const DbId& destination,
+                                 const NodeId& origin) const {
+            txn = checked_txn(txn, "LogicalJournalStore::known_tail");
+            validate_identity(destination, origin);
+            open_existing(txn);
+            return read_origin_metadata(txn, destination, origin).
+                next_sequence - 1u;
+        }
+
+        /// \brief Verifies that \p envelope is the immutable stored journal entry.
+        /// \throws std::invalid_argument if no byte-identical journal entry exists.
+        void verify_envelope(MDBX_txn* txn,
+                             const LogicalDeliveryEnvelope& envelope,
+                             const CodecBounds* bounds = nullptr) const {
+            txn = checked_txn(txn, "LogicalJournalStore::verify_envelope");
+            validate_identity(envelope.destination_db_uuid,
+                              envelope.origin_node_id);
+            if (envelope.origin_sequence == 0u) {
+                throw std::invalid_argument(
+                    "LogicalJournalStore envelope sequence is zero");
+            }
+            if (bounds != nullptr) {
+                (void)LogicalDeliveryEnvelopeCodec::encode(envelope, bounds);
+            }
+            open_existing(txn);
+            const std::vector<std::uint8_t> key = make_entry_key(
+                envelope.destination_db_uuid, envelope.origin_node_id,
+                envelope.origin_sequence);
+            const std::vector<std::uint8_t> encoded =
+                LogicalDeliveryEnvelopeCodec::encode(envelope);
+            MDBX_val raw_key = make_val(key);
+            MDBX_val raw_value;
+            const int rc = mdbx_get(txn, m_dbi, &raw_key, &raw_value);
+            if (rc == MDBX_NOTFOUND) {
+                throw std::invalid_argument(
+                    "LogicalJournalStore envelope is not a journal entry");
+            }
+            check_mdbx(rc, "LogicalJournalStore envelope read failed");
+            if (raw_value.iov_len != encoded.size() ||
+                raw_value.iov_base == nullptr ||
+                std::memcmp(raw_value.iov_base, &encoded[0],
+                            encoded.size()) != 0) {
+                throw std::invalid_argument(
+                    "LogicalJournalStore envelope is not a journal entry");
+            }
+        }
+
+        bool has_persistent_state(MDBX_txn* txn,
+                                  const CodecBounds* bounds = nullptr) const {
+            txn = checked_txn(txn, "LogicalJournalStore::has_persistent_state");
+            open_existing(txn);
+            MDBX_cursor* cursor = nullptr;
+            check_mdbx(mdbx_cursor_open(txn, m_dbi, &cursor),
+                       "LogicalJournalStore state cursor open failed");
+            bool found = false;
+            try {
+                MDBX_val key;
+                MDBX_val value;
+                int rc = mdbx_cursor_get(cursor, &key, &value, MDBX_FIRST);
+                while (rc == MDBX_SUCCESS) {
+                    if (is_origin_metadata_key(key)) {
+                        (void)decode_origin_metadata(value);
+                    } else {
+                        const Entry entry = decode_entry(key);
+                        const LogicalDeliveryEnvelope envelope = decode_value(
+                            value, bounds);
+                        if (compare_node_id(envelope.destination_db_uuid,
+                                            entry.destination) != 0 ||
+                            compare_node_id(envelope.origin_node_id,
+                                            entry.origin) != 0 ||
+                            envelope.origin_sequence != entry.sequence) {
+                            throw std::runtime_error(
+                                "LogicalJournalStore entry key/value mismatch");
+                        }
+                    }
+                    found = true;
+                    rc = mdbx_cursor_get(cursor, &key, &value, MDBX_NEXT);
+                }
+                if (rc != MDBX_NOTFOUND) {
+                    check_mdbx(rc, "LogicalJournalStore state cursor read failed");
+                }
+            } catch (...) {
+                mdbx_cursor_close(cursor);
+                throw;
+            }
+            mdbx_cursor_close(cursor);
+            return found;
+        }
+
+    private:
+        struct OriginMetadata {
+            OriginMetadata() : next_sequence(1u) {}
+            std::uint64_t next_sequence;
+        };
+
+        struct Entry {
+            DbId destination;
+            NodeId origin;
+            std::uint64_t sequence;
+        };
+
+        MDBX_txn* checked_txn(MDBX_txn* txn, const char* context) const {
+            return checked_txn_env(txn, m_env, context);
+        }
+
+        void open_existing(MDBX_txn* txn) const {
+            check_mdbx(mdbx_dbi_open(txn, m_dbi_name.c_str(),
+                                     static_cast<MDBX_db_flags_t>(0), &m_dbi),
+                       "Failed to open LogicalJournalStore DBI");
+        }
+
+        void open_for_write(MDBX_txn* txn) const {
+            int rc = mdbx_dbi_open(txn, m_dbi_name.c_str(), MDBX_CREATE,
+                                   &m_dbi);
+            if (rc == MDBX_EACCESS) {
+                rc = mdbx_dbi_open(txn, m_dbi_name.c_str(),
+                                   static_cast<MDBX_db_flags_t>(0), &m_dbi);
+            }
+            check_mdbx(rc, "Failed to open LogicalJournalStore DBI");
+        }
+
+        static void validate_identity(const DbId& destination,
+                                      const NodeId& origin) {
+            if (is_zero_sync_id(destination) || is_zero_sync_id(origin)) {
+                throw std::invalid_argument("LogicalJournalStore identity is zero");
+            }
+        }
+
+        static std::string make_frame_id(std::uint64_t sequence) {
+            return std::string("mdbxc-ordered-") + std::to_string(sequence);
+        }
+
+        static std::vector<std::uint8_t> make_origin_metadata_key(
+                const DbId& destination, const NodeId& origin) {
+            std::vector<std::uint8_t> out;
+            out.reserve(2u + destination.size() + origin.size());
+            out.push_back(key_version());
+            out.push_back(origin_metadata_key_kind());
+            out.insert(out.end(), destination.begin(), destination.end());
+            out.insert(out.end(), origin.begin(), origin.end());
+            return out;
+        }
+
+        static std::vector<std::uint8_t> make_entry_prefix(
+                const DbId& destination, const NodeId& origin) {
+            std::vector<std::uint8_t> out;
+            out.reserve(2u + destination.size() + origin.size());
+            out.push_back(key_version());
+            out.push_back(entry_key_kind());
+            out.insert(out.end(), destination.begin(), destination.end());
+            out.insert(out.end(), origin.begin(), origin.end());
+            return out;
+        }
+
+        static std::vector<std::uint8_t> make_entry_key(
+                const DbId& destination, const NodeId& origin,
+                std::uint64_t sequence) {
+            std::vector<std::uint8_t> out = make_entry_prefix(destination, origin);
+            detail::append_u64_be(out, sequence);
+            return out;
+        }
+
+        static MDBX_val make_val(const std::vector<std::uint8_t>& bytes) {
+            MDBX_val out = {
+                const_cast<std::uint8_t*>(bytes.empty() ? nullptr : &bytes[0]),
+                bytes.size()
+            };
+            return out;
+        }
+
+        static bool has_entry_prefix(const MDBX_val& key,
+                                     const std::vector<std::uint8_t>& prefix) {
+            return key.iov_len == prefix.size() + 8u && key.iov_base != nullptr &&
+                   std::memcmp(key.iov_base, &prefix[0], prefix.size()) == 0;
+        }
+
+        static bool is_origin_metadata_key(const MDBX_val& key) {
+            if (key.iov_len != metadata_key_size() || key.iov_base == nullptr) {
+                return false;
+            }
+            const std::uint8_t* bytes =
+                static_cast<const std::uint8_t*>(key.iov_base);
+            return bytes[0] == key_version() &&
+                   bytes[1] == origin_metadata_key_kind();
+        }
+
+        static Entry decode_entry(const MDBX_val& key) {
+            if (key.iov_len != entry_key_size() || key.iov_base == nullptr) {
+                throw std::runtime_error("LogicalJournalStore entry key is invalid");
+            }
+            const std::uint8_t* bytes =
+                static_cast<const std::uint8_t*>(key.iov_base);
+            if (bytes[0] != key_version() || bytes[1] != entry_key_kind()) {
+                throw std::runtime_error("LogicalJournalStore entry key has invalid prefix");
+            }
+            Entry out;
+            std::memcpy(out.destination.data(), bytes + 2u,
+                        out.destination.size());
+            std::memcpy(out.origin.data(), bytes + 2u + out.destination.size(),
+                        out.origin.size());
+            out.sequence = detail::read_u64_be(bytes + metadata_key_size());
+            validate_identity(out.destination, out.origin);
+            return out;
+        }
+
+        static std::uint64_t decode_entry_sequence(const MDBX_val& key) {
+            return decode_entry(key).sequence;
+        }
+
+        OriginMetadata read_origin_metadata(MDBX_txn* txn,
+                                            const DbId& destination,
+                                            const NodeId& origin) const {
+            const std::vector<std::uint8_t> key = make_origin_metadata_key(
+                destination, origin);
+            MDBX_val raw_key = make_val(key);
+            MDBX_val raw_value;
+            const int rc = mdbx_get(txn, m_dbi, &raw_key, &raw_value);
+            if (rc == MDBX_NOTFOUND) return OriginMetadata();
+            check_mdbx(rc, "LogicalJournalStore origin metadata read failed");
+            return decode_origin_metadata(raw_value);
+        }
+
+        void write_origin_metadata(MDBX_txn* txn,
+                                   const DbId& destination,
+                                   const NodeId& origin,
+                                   const OriginMetadata& metadata) const {
+            const std::vector<std::uint8_t> key = make_origin_metadata_key(
+                destination, origin);
+            const std::vector<std::uint8_t> value = encode_origin_metadata(metadata);
+            MDBX_val raw_key = make_val(key);
+            MDBX_val raw_value = make_val(value);
+            check_mdbx(mdbx_put(txn, m_dbi, &raw_key, &raw_value, MDBX_UPSERT),
+                       "LogicalJournalStore origin metadata write failed");
+        }
+
+        static std::vector<std::uint8_t> encode_origin_metadata(
+                const OriginMetadata& metadata) {
+            if (metadata.next_sequence == 0u) {
+                throw std::logic_error("LogicalJournalStore metadata is invalid");
+            }
+            std::vector<std::uint8_t> out;
+            out.reserve(10u);
+            detail::append_u16_le(out, metadata_value_version());
+            detail::append_u64_le(out, metadata.next_sequence);
+            return out;
+        }
+
+        static OriginMetadata decode_origin_metadata(const MDBX_val& value) {
+            if (value.iov_len != metadata_value_size() || value.iov_base == nullptr) {
+                throw std::runtime_error("LogicalJournalStore metadata is invalid");
+            }
+            const std::uint8_t* bytes =
+                static_cast<const std::uint8_t*>(value.iov_base);
+            if (detail::read_u16_le(bytes) != metadata_value_version()) {
+                throw std::runtime_error("Unsupported LogicalJournalStore metadata version");
+            }
+            OriginMetadata out;
+            out.next_sequence = detail::read_u64_le(bytes + 2u);
+            if (out.next_sequence == 0u) {
+                throw std::runtime_error("LogicalJournalStore metadata is invalid");
+            }
+            return out;
+        }
+
+        static LogicalDeliveryEnvelope decode_value(const MDBX_val& value,
+                                                    const CodecBounds* bounds) {
+            if (value.iov_base == nullptr && value.iov_len != 0u) {
+                throw std::runtime_error("LogicalJournalStore value is null");
+            }
+            const std::uint8_t* bytes =
+                static_cast<const std::uint8_t*>(value.iov_base);
+            return LogicalDeliveryEnvelopeCodec::decode(
+                std::vector<std::uint8_t>(bytes, bytes + value.iov_len), bounds);
+        }
+
+        static constexpr std::uint8_t key_version() { return 1u; }
+        static constexpr std::uint8_t origin_metadata_key_kind() { return 1u; }
+        static constexpr std::uint8_t entry_key_kind() { return 2u; }
+        static constexpr std::uint16_t metadata_value_version() { return 1u; }
+        static constexpr std::size_t metadata_key_size() {
+            return 2u + DbId().size() + NodeId().size();
+        }
+        static constexpr std::size_t entry_key_size() {
+            return metadata_key_size() + 8u;
+        }
+        static constexpr std::size_t metadata_value_size() { return 10u; }
+
+        MDBX_env* m_env;
+        std::string m_dbi_name;
+        mutable MDBX_dbi m_dbi;
+    };
+
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_STORES_LOGICAL_JOURNAL_STORE_HPP_INCLUDED

--- a/include/mdbx_containers/sync/logical/stores/LogicalOutboxStore.hpp
+++ b/include/mdbx_containers/sync/logical/stores/LogicalOutboxStore.hpp
@@ -70,10 +70,12 @@ namespace sync {
                     "LogicalOutboxStore receiver already belongs to a different origin");
             }
             LogicalJournalStore journal(m_env);
-            if (!journal.has_persistent_state(txn) &&
-                has_persistent_state(txn)) {
-                throw std::logic_error(
-                    "LogicalOutboxStore legacy state cannot allocate journal entries");
+            if (!journal.is_initialized(txn)) {
+                if (has_persistent_state(txn)) {
+                    throw std::logic_error(
+                        "LogicalOutboxStore legacy state cannot allocate journal entries");
+                }
+                journal.initialize(txn);
             }
             const LogicalDeliveryEnvelope envelope = journal.append(
                 txn, destination, origin, frame, bounds);

--- a/include/mdbx_containers/sync/logical/stores/LogicalOutboxStore.hpp
+++ b/include/mdbx_containers/sync/logical/stores/LogicalOutboxStore.hpp
@@ -14,6 +14,7 @@
 
 #include <mdbx.h>
 
+#include "LogicalJournalStore.hpp"
 
 namespace mdbxc {
 namespace sync {
@@ -48,9 +49,9 @@ namespace sync {
         }
 
         /// \brief Appends one globally ordered event to one receiver route.
-        /// \details The generated frame id is stable for the origin event
-        /// sequence. A rollback also rolls back sequence allocation and route
-        /// state.
+        /// \details The event is first persisted in the receiver-neutral
+        /// journal, then projected onto \p receiver in the same transaction.
+        /// A rollback also rolls back sequence allocation and route state.
         LogicalDeliveryEnvelope enqueue(
                 MDBX_txn* txn,
                 const DbId& destination,
@@ -61,54 +62,99 @@ namespace sync {
             txn = checked_txn(txn, "LogicalOutboxStore::enqueue");
             validate_identity(destination, receiver, origin);
             open_for_write(txn);
-
-            OriginMetadata origin_metadata = read_origin_metadata(
-                txn, destination, origin);
-            if (origin_metadata.next_sequence ==
-                (std::numeric_limits<std::uint64_t>::max)()) {
-                throw std::overflow_error(
-                    "LogicalOutboxStore sequence exhausted");
-            }
-
-            RouteMetadata route_metadata = read_route_metadata(
+            const RouteMetadata existing_route = read_route_metadata(
                 txn, destination, receiver);
-            if (is_zero_sync_id(route_metadata.origin_node_id)) {
-                route_metadata.origin_node_id = origin;
-                route_metadata.acknowledged_through =
-                    origin_metadata.next_sequence - 1u;
-                route_metadata.known_tail =
-                    origin_metadata.next_sequence - 1u;
-            } else if (compare_node_id(route_metadata.origin_node_id, origin) != 0) {
+            if (!is_zero_sync_id(existing_route.origin_node_id) &&
+                compare_node_id(existing_route.origin_node_id, origin) != 0) {
+                throw std::invalid_argument(
+                    "LogicalOutboxStore receiver already belongs to a different origin");
+            }
+            LogicalJournalStore journal(m_env);
+            journal.open(txn);
+            if (!journal.has_persistent_state(txn) &&
+                has_persistent_state(txn)) {
+                throw std::logic_error(
+                    "LogicalOutboxStore legacy state cannot allocate journal entries");
+            }
+            const LogicalDeliveryEnvelope envelope = journal.append(
+                txn, destination, origin, frame, bounds);
+            return project(txn, receiver, envelope, bounds);
+        }
+
+        /// \brief Adds an existing journal envelope to one receiver route.
+        /// \details Projection accepts only an immutable journal entry and
+        /// preserves its assigned event identity. Repeating an already
+        /// projected envelope is a no-op only when its durable bytes are
+        /// identical. A newly created direct route may start at its first
+        /// projected sequence; journal materialization starts at sequence one.
+        LogicalDeliveryEnvelope project(
+                MDBX_txn* txn,
+                const NodeId& receiver,
+                const LogicalDeliveryEnvelope& envelope,
+                const CodecBounds* bounds = nullptr) {
+            txn = checked_txn(txn, "LogicalOutboxStore::project");
+            validate_identity(envelope.destination_db_uuid, receiver,
+                              envelope.origin_node_id);
+            if (envelope.origin_sequence == 0u) {
+                throw std::invalid_argument(
+                    "LogicalOutboxStore projected sequence is zero");
+            }
+            if (bounds != nullptr) {
+                (void)LogicalDeliveryEnvelopeCodec::encode(envelope, bounds);
+            }
+            LogicalJournalStore journal(m_env);
+            journal.verify_envelope(txn, envelope, bounds);
+            const std::vector<std::uint8_t> encoded =
+                LogicalDeliveryEnvelopeCodec::encode(envelope);
+            open_for_write(txn);
+
+            RouteMetadata metadata = read_route_metadata(
+                txn, envelope.destination_db_uuid, receiver);
+            if (is_zero_sync_id(metadata.origin_node_id)) {
+                metadata.origin_node_id = envelope.origin_node_id;
+                metadata.acknowledged_through = envelope.origin_sequence - 1u;
+                metadata.known_tail = envelope.origin_sequence - 1u;
+            } else if (compare_node_id(metadata.origin_node_id,
+                                       envelope.origin_node_id) != 0) {
                 throw std::invalid_argument(
                     "LogicalOutboxStore receiver already belongs to a different origin");
             }
 
-            LogicalDeliveryEnvelope envelope;
-            envelope.destination_db_uuid = destination;
-            envelope.origin_node_id = origin;
-            envelope.origin_sequence = origin_metadata.next_sequence;
-            envelope.frame_id = make_frame_id(origin_metadata.next_sequence);
-            envelope.frame = frame;
-            if (bounds != nullptr) {
-                (void)LogicalDeliveryEnvelopeCodec::encode(envelope, bounds);
+            if (envelope.origin_sequence <= metadata.acknowledged_through) {
+                return envelope;
             }
-            // Pending entries can be decoded by a later worker invocation
-            // without carrying a caller-specific bounds object.
-            const std::vector<std::uint8_t> encoded =
-                LogicalDeliveryEnvelopeCodec::encode(envelope);
-            const std::vector<std::uint8_t> key =
-                make_entry_key(destination, receiver,
-                               origin_metadata.next_sequence);
+            const std::vector<std::uint8_t> key = make_entry_key(
+                envelope.destination_db_uuid, receiver,
+                envelope.origin_sequence);
             MDBX_val raw_key = make_val(key);
-            MDBX_val raw_value = make_val(encoded);
+            MDBX_val raw_value;
+            if (envelope.origin_sequence <= metadata.known_tail) {
+                const int rc = mdbx_get(txn, m_dbi, &raw_key, &raw_value);
+                if (rc == MDBX_NOTFOUND) {
+                    throw std::runtime_error(
+                        "LogicalOutboxStore projected entry is missing");
+                }
+                check_mdbx(rc, "LogicalOutboxStore projected entry read failed");
+                if (raw_value.iov_len != encoded.size() ||
+                    raw_value.iov_base == nullptr ||
+                    std::memcmp(raw_value.iov_base, &encoded[0],
+                                encoded.size()) != 0) {
+                    throw std::runtime_error(
+                        "LogicalOutboxStore projected entry conflicts");
+                }
+                return envelope;
+            }
+            if (envelope.origin_sequence != metadata.known_tail + 1u) {
+                throw std::invalid_argument(
+                    "LogicalOutboxStore projected sequence has a gap");
+            }
+            raw_value = make_val(encoded);
             check_mdbx(mdbx_put(txn, m_dbi, &raw_key, &raw_value,
                                 MDBX_NOOVERWRITE),
-                       "LogicalOutboxStore enqueue failed");
-
-            ++origin_metadata.next_sequence;
-            route_metadata.known_tail = envelope.origin_sequence;
-            write_origin_metadata(txn, destination, origin, origin_metadata);
-            write_route_metadata(txn, destination, receiver, route_metadata);
+                       "LogicalOutboxStore projection failed");
+            metadata.known_tail = envelope.origin_sequence;
+            write_route_metadata(txn, envelope.destination_db_uuid, receiver,
+                                 metadata);
             return envelope;
         }
 
@@ -218,6 +264,18 @@ namespace sync {
             validate_route(destination, receiver);
             open_existing(txn);
             return read_route_metadata(txn, destination, receiver).known_tail;
+        }
+
+        /// \brief Returns the origin assigned to one receiver route.
+        /// \return Zero id when the route does not exist.
+        NodeId route_origin(MDBX_txn* txn,
+                            const DbId& destination,
+                            const NodeId& receiver) const {
+            txn = checked_txn(txn, "LogicalOutboxStore::route_origin");
+            validate_route(destination, receiver);
+            open_existing(txn);
+            return read_route_metadata(txn, destination, receiver).
+                origin_node_id;
         }
 
         /// \brief Returns whether any receiver route has pending work.

--- a/include/mdbx_containers/sync/logical/stores/LogicalOutboxStore.hpp
+++ b/include/mdbx_containers/sync/logical/stores/LogicalOutboxStore.hpp
@@ -70,7 +70,6 @@ namespace sync {
                     "LogicalOutboxStore receiver already belongs to a different origin");
             }
             LogicalJournalStore journal(m_env);
-            journal.open(txn);
             if (!journal.has_persistent_state(txn) &&
                 has_persistent_state(txn)) {
                 throw std::logic_error(

--- a/include/mdbx_containers/sync/logical/stores/detail/NamedDbiLookup.hpp
+++ b/include/mdbx_containers/sync/logical/stores/detail/NamedDbiLookup.hpp
@@ -1,0 +1,40 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_STORES_DETAIL_NAMED_DBI_LOOKUP_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_STORES_DETAIL_NAMED_DBI_LOOKUP_HPP_INCLUDED
+
+/// \file logical/stores/detail/NamedDbiLookup.hpp
+/// \brief Constant-size named-DBI existence lookup.
+
+#include <string>
+
+#include <mdbx.h>
+
+namespace mdbxc {
+namespace sync {
+namespace detail {
+
+    inline bool named_dbi_exists(MDBX_txn* txn, const std::string& name) {
+        MDBX_dbi main_dbi = 0;
+        check_mdbx(
+            mdbx_dbi_open(
+                txn,
+                static_cast<const char*>(MDBX_CHK_MAIN),
+                static_cast<MDBX_db_flags_t>(0),
+                &main_dbi),
+            "Failed to open main DBI while checking named DBI");
+        MDBX_val key = {
+            const_cast<char*>(name.data()),
+            name.size()
+        };
+        MDBX_val value;
+        const int rc = mdbx_get(txn, main_dbi, &key, &value);
+        if (rc == MDBX_NOTFOUND) return false;
+        check_mdbx(rc, "Failed to inspect named DBI");
+        return true;
+    }
+
+} // namespace detail
+} // namespace sync
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_SYNC_LOGICAL_STORES_DETAIL_NAMED_DBI_LOOKUP_HPP_INCLUDED

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -5763,6 +5763,59 @@ void test_logical_journal_rejects_legacy_outbox_state() {
     cleanup(path);
 }
 
+void test_logical_journal_hot_append_uses_layout_marker() {
+    const std::string path = "test_logical_journal_layout_marker.mdbx";
+    cleanup(path);
+
+    const mdbxc::sync::NodeId local_node = make_node(0x96);
+    const mdbxc::sync::DbId local_db = make_node(0xA6);
+    const mdbxc::sync::DbId destination = make_node(0xB6);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 12;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(local_node, local_db);
+
+    const mdbxc::sync::LogicalDeliveryEnvelope first =
+        engine.append_logical_journal(
+            destination, make_outbox_test_frame("app.journal.marker", 1u));
+    MDBXC_TEST_ASSERT(first.origin_sequence == 1u);
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        MDBX_dbi journal_dbi = 0;
+        mdbxc::check_mdbx(mdbx_dbi_open(
+            txn.handle(), "_mdbxc_logical_journal",
+            static_cast<MDBX_db_flags_t>(0), &journal_dbi),
+            "LogicalJournalStore marker test DBI open failed");
+        std::uint8_t invalid_key_byte = 0xFFu;
+        std::uint8_t invalid_value_byte = 0u;
+        MDBX_val invalid_key = {
+            &invalid_key_byte, 1u
+        };
+        MDBX_val invalid_value = {
+            &invalid_value_byte, 1u
+        };
+        MDBXC_TEST_ASSERT(mdbx_put(
+            txn.handle(), journal_dbi, &invalid_key, &invalid_value,
+            MDBX_NOOVERWRITE) == MDBX_SUCCESS);
+        txn.commit();
+    }
+
+    const mdbxc::sync::LogicalDeliveryEnvelope second =
+        engine.append_logical_journal(
+            destination, make_outbox_test_frame("app.journal.marker", 2u));
+    MDBXC_TEST_ASSERT(second.origin_sequence == 2u);
+    MDBXC_TEST_ASSERT(engine.logical_journal_known_tail(destination) == 2u);
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 void test_logical_outbox_acknowledgement_accepts_recovered_sparse_route() {
     const std::string path = "test_logical_outbox_acknowledgement_gap.mdbx";
     cleanup(path);
@@ -6550,6 +6603,7 @@ int main() {
     test_logical_journal_separates_capture_from_routing();
     test_logical_journal_is_lazy_for_raw_sync_capacity();
     test_logical_journal_rejects_legacy_outbox_state();
+    test_logical_journal_hot_append_uses_layout_marker();
     test_logical_outbox_rejects_entries_above_default_codec_bounds();
     test_logical_outbox_acknowledgement_accepts_recovered_sparse_route();
     test_logical_outbox_acknowledgement_missing_tail_preserves_caller_transaction();

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -5629,6 +5629,140 @@ void test_logical_journal_separates_capture_from_routing() {
     cleanup(path);
 }
 
+void test_logical_journal_is_lazy_for_raw_sync_capacity() {
+    const std::string raw_path = "test_logical_journal_raw_capacity.mdbx";
+    const std::string journal_path = "test_logical_journal_lazy_create.mdbx";
+    cleanup(raw_path);
+    cleanup(journal_path);
+
+    const mdbxc::sync::NodeId local_node = make_node(0x94);
+    const mdbxc::sync::DbId local_db = make_node(0xA4);
+    const mdbxc::sync::DbId destination = make_node(0xB4);
+
+    {
+        mdbxc::Config cfg;
+        cfg.pathname = raw_path;
+        cfg.max_dbs = 9;
+        cfg.no_subdir = true;
+        std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+        mdbxc::sync::SyncEngine engine(conn);
+        engine.initialize_local_identity(local_node, local_db);
+
+        mdbxc::KeyValueTable<int, int> records(conn, "raw_records");
+        mdbxc::sync::ThreadLocalChangeAccumulator capture(conn);
+        conn->attach_sync_capture(&capture);
+        records.insert_or_assign(1, 10);
+        conn->detach_sync_capture();
+
+        mdbxc::sync::PullRequest request;
+        request.requester = make_node(0xC4);
+        request.db_id = local_db;
+        const mdbxc::sync::PullResponse response = engine.handle_pull(request);
+        MDBXC_TEST_ASSERT(response.ok);
+        MDBXC_TEST_ASSERT(response.batches.size() == 1u);
+        MDBXC_TEST_ASSERT(engine.logical_journal_known_tail(destination) == 0u);
+
+        conn->disconnect();
+    }
+
+    {
+        mdbxc::Config cfg;
+        cfg.pathname = journal_path;
+        cfg.max_dbs = 12;
+        cfg.no_subdir = true;
+        std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+        mdbxc::sync::SyncEngine engine(conn);
+        engine.initialize_local_identity(local_node, local_db);
+        MDBXC_TEST_ASSERT(engine.logical_journal_known_tail(destination) == 0u);
+
+        const mdbxc::sync::LogicalDeliveryEnvelope envelope =
+            engine.append_logical_journal(
+                destination, make_outbox_test_frame("app.journal.lazy", 1u));
+        MDBXC_TEST_ASSERT(envelope.origin_sequence == 1u);
+        MDBXC_TEST_ASSERT(engine.logical_journal_known_tail(destination) == 1u);
+
+        conn->disconnect();
+    }
+
+    cleanup(raw_path);
+    cleanup(journal_path);
+}
+
+void test_logical_journal_rejects_legacy_outbox_state() {
+    const std::string path = "test_logical_journal_legacy_outbox.mdbx";
+    cleanup(path);
+
+    const mdbxc::sync::NodeId local_node = make_node(0x95);
+    const mdbxc::sync::DbId local_db = make_node(0xA5);
+    const mdbxc::sync::DbId destination = make_node(0xB5);
+    const mdbxc::sync::NodeId receiver = make_node(0xC5);
+
+    mdbxc::Config cfg;
+    cfg.pathname = path;
+    cfg.max_dbs = 12;
+    cfg.no_subdir = true;
+    std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+    mdbxc::sync::SyncEngine engine(conn);
+    engine.initialize_local_identity(local_node, local_db);
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::WRITABLE);
+        mdbxc::sync::LogicalOutboxStore outbox(conn->env_handle());
+        const MDBX_dbi dbi = outbox.handle(txn.handle());
+        std::vector<std::uint8_t> key;
+        key.reserve(2u + destination.size() + receiver.size());
+        key.push_back(3u);
+        key.push_back(1u);
+        key.insert(key.end(), destination.begin(), destination.end());
+        key.insert(key.end(), receiver.begin(), receiver.end());
+        std::vector<std::uint8_t> value;
+        mdbxc::sync::detail::append_u16_le(value, 1u);
+        mdbxc::sync::detail::append_u64_le(value, 0u);
+        mdbxc::sync::detail::append_u64_le(value, 0u);
+        value.insert(value.end(), local_node.begin(), local_node.end());
+        MDBX_val raw_key = { key.empty() ? nullptr : &key[0], key.size() };
+        MDBX_val raw_value = {
+            value.empty() ? nullptr : &value[0], value.size()
+        };
+        MDBXC_TEST_ASSERT(mdbx_put(txn.handle(), dbi, &raw_key, &raw_value,
+                                   MDBX_UPSERT) == MDBX_SUCCESS);
+        txn.commit();
+    }
+
+    bool append_rejected = false;
+    try {
+        (void)engine.append_logical_journal(
+            destination, make_outbox_test_frame("app.journal.legacy", 1u));
+    } catch (const std::logic_error&) {
+        append_rejected = true;
+    }
+    MDBXC_TEST_ASSERT(append_rejected);
+
+    bool enqueue_rejected = false;
+    try {
+        (void)engine.enqueue_logical_delivery(
+            destination, receiver,
+            make_outbox_test_frame("app.journal.legacy", 2u));
+    } catch (const std::logic_error&) {
+        enqueue_rejected = true;
+    }
+    MDBXC_TEST_ASSERT(enqueue_rejected);
+    MDBXC_TEST_ASSERT(engine.logical_journal_known_tail(destination) == 0u);
+
+    {
+        mdbxc::Transaction txn =
+            conn->transaction(mdbxc::TransactionMode::READ_ONLY);
+        mdbxc::sync::LogicalOutboxStore outbox(conn->env_handle());
+        MDBXC_TEST_ASSERT(outbox.has_persistent_state(txn.handle()));
+        MDBXC_TEST_ASSERT(outbox.known_tail(
+            txn.handle(), destination, receiver) == 0u);
+    }
+
+    conn->disconnect();
+    cleanup(path);
+}
+
 void test_logical_outbox_acknowledgement_accepts_recovered_sparse_route() {
     const std::string path = "test_logical_outbox_acknowledgement_gap.mdbx";
     cleanup(path);
@@ -6414,6 +6548,8 @@ int main() {
     test_key_value_logical_apply_does_not_recapture_incoming_change();
     test_logical_outbox_persists_ordered_destination_streams();
     test_logical_journal_separates_capture_from_routing();
+    test_logical_journal_is_lazy_for_raw_sync_capacity();
+    test_logical_journal_rejects_legacy_outbox_state();
     test_logical_outbox_rejects_entries_above_default_codec_bounds();
     test_logical_outbox_acknowledgement_accepts_recovered_sparse_route();
     test_logical_outbox_acknowledgement_missing_tail_preserves_caller_transaction();

--- a/tests/test_key_value_logical_adapter.cpp
+++ b/tests/test_key_value_logical_adapter.cpp
@@ -5529,6 +5529,106 @@ void test_logical_outbox_persists_ordered_destination_streams() {
     cleanup(path);
 }
 
+void test_logical_journal_separates_capture_from_routing() {
+    const std::string path = "test_logical_journal_routing.mdbx";
+    cleanup(path);
+
+    const mdbxc::sync::NodeId local_node = make_node(0x93);
+    const mdbxc::sync::DbId local_db = make_node(0xA3);
+    const mdbxc::sync::DbId destination = make_node(0xB3);
+    const mdbxc::sync::NodeId receiver_b = make_node(0xC3);
+    const mdbxc::sync::NodeId receiver_c = make_node(0xD3);
+
+    {
+        mdbxc::Config cfg;
+        cfg.pathname = path;
+        cfg.max_dbs = 20;
+        cfg.no_subdir = true;
+        std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+        mdbxc::sync::SyncEngine engine(conn);
+        engine.initialize_local_identity(local_node, local_db);
+
+        const mdbxc::sync::LogicalDeliveryEnvelope first =
+            engine.append_logical_journal(
+                destination, make_outbox_test_frame("app.journal", 1u));
+        const mdbxc::sync::LogicalDeliveryEnvelope second =
+            engine.append_logical_journal(
+                destination, make_outbox_test_frame("app.journal", 2u));
+        MDBXC_TEST_ASSERT(first.origin_sequence == 1u);
+        MDBXC_TEST_ASSERT(second.origin_sequence == 2u);
+        MDBXC_TEST_ASSERT(first.frame_id == "mdbxc-ordered-1");
+        MDBXC_TEST_ASSERT(engine.logical_journal_known_tail(destination) == 2u);
+        MDBXC_TEST_ASSERT(
+            engine.pending_logical_deliveries(destination, receiver_b).empty());
+        MDBXC_TEST_ASSERT(
+            engine.pending_logical_deliveries(destination, receiver_c).empty());
+
+        {
+            mdbxc::Transaction txn =
+                conn->transaction(mdbxc::TransactionMode::WRITABLE);
+            MDBXC_TEST_ASSERT(engine.materialize_logical_journal(
+                txn.handle(), destination, receiver_b, 1u) == 1u);
+            txn.rollback();
+        }
+        MDBXC_TEST_ASSERT(
+            engine.pending_logical_deliveries(destination, receiver_b).empty());
+
+        MDBXC_TEST_ASSERT(engine.materialize_logical_journal(
+            destination, receiver_b, 1u) == 1u);
+        MDBXC_TEST_ASSERT(engine.materialize_logical_journal(
+            destination, receiver_b) == 1u);
+        MDBXC_TEST_ASSERT(engine.materialize_logical_journal(
+            destination, receiver_b) == 0u);
+        MDBXC_TEST_ASSERT(engine.materialize_logical_journal(
+            destination, receiver_c) == 2u);
+
+        const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending_b =
+            engine.pending_logical_deliveries(destination, receiver_b);
+        const std::vector<mdbxc::sync::LogicalDeliveryEnvelope> pending_c =
+            engine.pending_logical_deliveries(destination, receiver_c);
+        MDBXC_TEST_ASSERT(pending_b.size() == 2u);
+        MDBXC_TEST_ASSERT(pending_c.size() == 2u);
+        MDBXC_TEST_ASSERT(pending_b[0].origin_sequence == 1u);
+        MDBXC_TEST_ASSERT(pending_b[1].origin_sequence == 2u);
+        MDBXC_TEST_ASSERT(pending_c[0].origin_sequence == 1u);
+        MDBXC_TEST_ASSERT(pending_c[1].origin_sequence == 2u);
+        MDBXC_TEST_ASSERT(mdbxc::sync::LogicalDeliveryEnvelopeCodec::encode(
+            pending_b[0]) == mdbxc::sync::LogicalDeliveryEnvelopeCodec::encode(first));
+        MDBXC_TEST_ASSERT(mdbxc::sync::LogicalDeliveryEnvelopeCodec::encode(
+            pending_c[1]) == mdbxc::sync::LogicalDeliveryEnvelopeCodec::encode(second));
+        MDBXC_TEST_ASSERT(engine.acknowledge_logical_deliveries(
+            destination, receiver_b, 1u) == 1u);
+        MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(
+            destination, receiver_b).size() == 1u);
+
+        conn->disconnect();
+    }
+
+    {
+        mdbxc::Config cfg;
+        cfg.pathname = path;
+        cfg.max_dbs = 20;
+        cfg.no_subdir = true;
+        std::shared_ptr<mdbxc::Connection> conn = mdbxc::Connection::create(cfg);
+        mdbxc::sync::SyncEngine engine(conn);
+        engine.initialize_local_identity(local_node, local_db);
+
+        MDBXC_TEST_ASSERT(engine.logical_journal_known_tail(destination) == 2u);
+        MDBXC_TEST_ASSERT(engine.materialize_logical_journal(
+            destination, receiver_b) == 0u);
+        MDBXC_TEST_ASSERT(engine.materialize_logical_journal(
+            destination, receiver_c) == 0u);
+        MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(
+            destination, receiver_b).size() == 1u);
+        MDBXC_TEST_ASSERT(engine.pending_logical_deliveries(
+            destination, receiver_c).size() == 2u);
+
+        conn->disconnect();
+    }
+
+    cleanup(path);
+}
+
 void test_logical_outbox_acknowledgement_accepts_recovered_sparse_route() {
     const std::string path = "test_logical_outbox_acknowledgement_gap.mdbx";
     cleanup(path);
@@ -6313,6 +6413,7 @@ int main() {
     test_key_value_logical_adapter_decodes_literal_little_endian_payload();
     test_key_value_logical_apply_does_not_recapture_incoming_change();
     test_logical_outbox_persists_ordered_destination_streams();
+    test_logical_journal_separates_capture_from_routing();
     test_logical_outbox_rejects_entries_above_default_codec_bounds();
     test_logical_outbox_acknowledgement_accepts_recovered_sparse_route();
     test_logical_outbox_acknowledgement_missing_tail_preserves_caller_transaction();


### PR DESCRIPTION
Receiver-neutral durable logical journal with explicit projection into receiver-specific outbox routes. Validated with C++11 and C++17 adapter, engine, and sync umbrella tests.