### PR TITLE
[codex] add canonical composite keys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,6 +463,7 @@ if(MDBXC_BUILD_TESTS)
     set(MDBXC_STANDALONE_PUBLIC_HEADERS
         mdbx_containers/common.hpp
         mdbx_containers/common/backup.hpp
+        mdbx_containers/CompositeKey.hpp
         mdbx_containers/AnyValueTable.hpp
         mdbx_containers/HashedKeyValueStore.hpp
         mdbx_containers/KeyMultiValueTable.hpp

--- a/guides/project-overview.md
+++ b/guides/project-overview.md
@@ -38,6 +38,8 @@ Core support classes:
 
 - `Config` - MDBX environment configuration. Use `Config::pathname` for the
   database path.
+- `CompositeKey<P1, ..., PN>` - canonical bytewise-sortable key composed from
+  two to five supported parts.
 - `Connection` - owns one MDBX environment and the transaction registries.
 - `Transaction` - RAII wrapper for an MDBX transaction owned by one thread.
 - `BaseTable` - common DBI opening and transaction helpers.

--- a/guides/table-api-guide.md
+++ b/guides/table-api-guide.md
@@ -96,7 +96,9 @@ All public table classes follow the same broad shape:
 
 `CompositeKey<P1, ..., PN>` is a typed key for an MDBX table whose ordering
 depends on two to five components. It supports integral types up to 64 bits,
-`bool`, `float`, `double`, `std::string`, and `std::vector<uint8_t>`.
+`bool`, `float`, `double`, `std::string`, and `std::vector<uint8_t>`. Integral
+components use the same canonical 32-/64-bit storage widths as ordinary table
+keys, independent of LP64 versus LLP64 platform data models.
 
 - Its serialized form preserves lexicographic component ordering under MDBX's
   normal bytewise comparator, so it is suitable for prefix-oriented key layouts

--- a/guides/table-api-guide.md
+++ b/guides/table-api-guide.md
@@ -92,6 +92,20 @@ All public table classes follow the same broad shape:
 - Keep C++11 support. Guard `std::optional`, `std::filesystem`, structured
   bindings, and other C++17 features.
 
+### Composite Keys
+
+`CompositeKey<P1, ..., PN>` is a typed key for an MDBX table whose ordering
+depends on two to five components. It supports integral types up to 64 bits,
+`bool`, `float`, `double`, `std::string`, and `std::vector<uint8_t>`.
+
+- Its serialized form preserves lexicographic component ordering under MDBX's
+  normal bytewise comparator, so it is suitable for prefix-oriented key layouts
+  and table range reads.
+- Strings and byte vectors are binary-safe; embedded zero bytes are preserved.
+- `float` and `double` reject NaN keys, matching the ordinary table-key rule.
+- Do not use an arbitrary application's `to_bytes()` format as a component
+  unless a separate order-preserving component codec is defined.
+
 ## Bulk Semantics
 
 Bulk methods are similar across tables, but they do not all mean the same thing:

--- a/include/mdbx_containers/CompositeKey.hpp
+++ b/include/mdbx_containers/CompositeKey.hpp
@@ -1,0 +1,351 @@
+#pragma once
+#ifndef MDBX_CONTAINERS_HEADER_COMPOSITE_KEY_HPP_INCLUDED
+#define MDBX_CONTAINERS_HEADER_COMPOSITE_KEY_HPP_INCLUDED
+
+/// \file CompositeKey.hpp
+/// \brief Order-preserving typed composite keys for MDBX tables.
+
+#include "common.hpp"
+
+#include <climits>
+#include <tuple>
+
+namespace mdbxc {
+namespace detail {
+
+    template<typename T>
+    struct composite_key_dependent_false : std::false_type {};
+
+    inline void composite_key_require_bytes(const std::uint8_t* current,
+                                            const std::uint8_t* end,
+                                            std::size_t count) {
+        if (current == nullptr ||
+            static_cast<std::size_t>(end - current) < count) {
+            throw std::runtime_error(
+                "CompositeKey::from_bytes: truncated component");
+        }
+    }
+
+    template<typename UnsignedT>
+    inline void composite_key_append_big_endian(UnsignedT value,
+                                                 std::vector<std::uint8_t>& out) {
+        static_assert(CHAR_BIT == 8, "CompositeKey requires 8-bit bytes");
+        for (std::size_t i = sizeof(UnsignedT); i > 0u; --i) {
+            const std::size_t shift = (i - 1u) * CHAR_BIT;
+            out.push_back(static_cast<std::uint8_t>(value >> shift));
+        }
+    }
+
+    template<typename UnsignedT>
+    inline UnsignedT composite_key_read_big_endian(
+            const std::uint8_t*& current, const std::uint8_t* end) {
+        composite_key_require_bytes(current, end, sizeof(UnsignedT));
+        UnsignedT value = 0;
+        for (std::size_t i = 0; i < sizeof(UnsignedT); ++i) {
+            value = static_cast<UnsignedT>(
+                (value << CHAR_BIT) | static_cast<UnsignedT>(*current));
+            ++current;
+        }
+        return value;
+    }
+
+    inline void composite_key_append_terminated_bytes(
+            const std::uint8_t* data, std::size_t size,
+            std::vector<std::uint8_t>& out) {
+        for (std::size_t i = 0; i < size; ++i) {
+            if (data[i] == 0u) {
+                out.push_back(0u);
+                out.push_back(0xffu);
+            } else {
+                out.push_back(data[i]);
+            }
+        }
+        out.push_back(0u);
+        out.push_back(0u);
+    }
+
+    inline std::vector<std::uint8_t> composite_key_read_terminated_bytes(
+            const std::uint8_t*& current, const std::uint8_t* end) {
+        std::vector<std::uint8_t> out;
+        while (current != end) {
+            const std::uint8_t byte = *current;
+            ++current;
+            if (byte != 0u) {
+                out.push_back(byte);
+                continue;
+            }
+            if (current == end) {
+                throw std::runtime_error(
+                    "CompositeKey::from_bytes: truncated byte component");
+            }
+            const std::uint8_t escaped = *current;
+            ++current;
+            if (escaped == 0u) {
+                return out;
+            }
+            if (escaped == 0xffu) {
+                out.push_back(0u);
+                continue;
+            }
+            throw std::runtime_error(
+                "CompositeKey::from_bytes: invalid byte component escape");
+        }
+        throw std::runtime_error(
+            "CompositeKey::from_bytes: missing byte component terminator");
+    }
+
+    template<typename T, typename Enable = void>
+    struct CompositeKeyPartCodec {
+        static void append(const T&, std::vector<std::uint8_t>&) {
+            static_assert(composite_key_dependent_false<T>::value,
+                          "CompositeKey supports integral, float, double, bool, "
+                          "string, and uint8_t vector components only");
+        }
+
+        static T read(const std::uint8_t*&, const std::uint8_t*) {
+            static_assert(composite_key_dependent_false<T>::value,
+                          "CompositeKey supports integral, float, double, bool, "
+                          "string, and uint8_t vector components only");
+            return T();
+        }
+    };
+
+    template<typename T>
+    struct CompositeKeyPartCodec<T, typename std::enable_if<
+            std::is_integral<T>::value && !std::is_same<T, bool>::value>::type> {
+        typedef typename std::make_unsigned<T>::type UnsignedT;
+
+        static void append(T value, std::vector<std::uint8_t>& out) {
+            static_assert(sizeof(T) <= sizeof(std::uint64_t),
+                          "CompositeKey integral components must be at most 64 bits");
+            UnsignedT sortable = static_cast<UnsignedT>(value);
+            if (std::is_signed<T>::value) {
+                sortable = static_cast<UnsignedT>(
+                    sortable ^ (UnsignedT(1) << (sizeof(T) * CHAR_BIT - 1u)));
+            }
+            composite_key_append_big_endian(sortable, out);
+        }
+
+        static T read(const std::uint8_t*& current, const std::uint8_t* end) {
+            static_assert(sizeof(T) <= sizeof(std::uint64_t),
+                          "CompositeKey integral components must be at most 64 bits");
+            UnsignedT raw = composite_key_read_big_endian<UnsignedT>(current, end);
+            if (std::is_signed<T>::value) {
+                raw = static_cast<UnsignedT>(
+                    raw ^ (UnsignedT(1) << (sizeof(T) * CHAR_BIT - 1u)));
+                T value;
+                std::memcpy(&value, &raw, sizeof(value));
+                return value;
+            }
+            return static_cast<T>(raw);
+        }
+    };
+
+    template<>
+    struct CompositeKeyPartCodec<bool, void> {
+        static void append(bool value, std::vector<std::uint8_t>& out) {
+            out.push_back(value ? 1u : 0u);
+        }
+
+        static bool read(const std::uint8_t*& current, const std::uint8_t* end) {
+            composite_key_require_bytes(current, end, 1u);
+            const std::uint8_t value = *current;
+            ++current;
+            if (value > 1u) {
+                throw std::runtime_error(
+                    "CompositeKey::from_bytes: invalid bool component");
+            }
+            return value != 0u;
+        }
+    };
+
+    template<>
+    struct CompositeKeyPartCodec<float, void> {
+        static void append(float value, std::vector<std::uint8_t>& out) {
+            composite_key_append_big_endian(sortable_key_from_float(value), out);
+        }
+
+        static float read(const std::uint8_t*& current, const std::uint8_t* end) {
+            const std::uint32_t raw =
+                composite_key_read_big_endian<std::uint32_t>(current, end);
+            const float value = float_from_sortable_key(raw);
+            try {
+                if (sortable_key_from_float(value) != raw) {
+                    throw std::invalid_argument("non-canonical float");
+                }
+            } catch (const std::invalid_argument&) {
+                throw std::runtime_error(
+                    "CompositeKey::from_bytes: invalid or non-canonical float component");
+            }
+            return value;
+        }
+    };
+
+    template<>
+    struct CompositeKeyPartCodec<double, void> {
+        static void append(double value, std::vector<std::uint8_t>& out) {
+            composite_key_append_big_endian(sortable_key_from_double(value), out);
+        }
+
+        static double read(const std::uint8_t*& current, const std::uint8_t* end) {
+            const std::uint64_t raw =
+                composite_key_read_big_endian<std::uint64_t>(current, end);
+            const double value = double_from_sortable_key(raw);
+            try {
+                if (sortable_key_from_double(value) != raw) {
+                    throw std::invalid_argument("non-canonical double");
+                }
+            } catch (const std::invalid_argument&) {
+                throw std::runtime_error(
+                    "CompositeKey::from_bytes: invalid or non-canonical double component");
+            }
+            return value;
+        }
+    };
+
+    template<>
+    struct CompositeKeyPartCodec<std::string, void> {
+        static void append(const std::string& value,
+                           std::vector<std::uint8_t>& out) {
+            composite_key_append_terminated_bytes(
+                reinterpret_cast<const std::uint8_t*>(value.data()), value.size(), out);
+        }
+
+        static std::string read(const std::uint8_t*& current,
+                                const std::uint8_t* end) {
+            const std::vector<std::uint8_t> bytes =
+                composite_key_read_terminated_bytes(current, end);
+            return std::string(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+        }
+    };
+
+    template<>
+    struct CompositeKeyPartCodec<std::vector<std::uint8_t>, void> {
+        static void append(const std::vector<std::uint8_t>& value,
+                           std::vector<std::uint8_t>& out) {
+            composite_key_append_terminated_bytes(
+                value.empty() ? nullptr : value.data(), value.size(), out);
+        }
+
+        static std::vector<std::uint8_t> read(const std::uint8_t*& current,
+                                               const std::uint8_t* end) {
+            return composite_key_read_terminated_bytes(current, end);
+        }
+    };
+
+    template<std::size_t Index, std::size_t Count>
+    struct CompositeKeyCodec {
+        template<typename TupleT>
+        static void append(const TupleT& parts, std::vector<std::uint8_t>& out) {
+            typedef typename std::tuple_element<Index, TupleT>::type PartT;
+            CompositeKeyPartCodec<PartT>::append(std::get<Index>(parts), out);
+            CompositeKeyCodec<Index + 1u, Count>::append(parts, out);
+        }
+
+        template<typename TupleT>
+        static void read(TupleT& parts, const std::uint8_t*& current,
+                         const std::uint8_t* end) {
+            typedef typename std::tuple_element<Index, TupleT>::type PartT;
+            std::get<Index>(parts) = CompositeKeyPartCodec<PartT>::read(current, end);
+            CompositeKeyCodec<Index + 1u, Count>::read(parts, current, end);
+        }
+    };
+
+    template<std::size_t Count>
+    struct CompositeKeyCodec<Count, Count> {
+        template<typename TupleT>
+        static void append(const TupleT&, std::vector<std::uint8_t>&) {}
+
+        template<typename TupleT>
+        static void read(TupleT&, const std::uint8_t*&, const std::uint8_t*) {}
+    };
+
+} // namespace detail
+
+/// \brief Typed composite key with a canonical bytewise-sortable encoding.
+/// \tparam Parts Two to five supported component types.
+/// \details Integral components use big-endian sortable encodings; strings and
+///          byte vectors use a prefix-safe escaped terminator. The resulting
+///          bytes preserve lexicographic component ordering under MDBX's normal
+///          bytewise key comparator.
+template<typename... Parts>
+struct CompositeKey {
+    static_assert(sizeof...(Parts) >= 2u && sizeof...(Parts) <= 5u,
+                  "CompositeKey requires from two to five components");
+
+    typedef std::tuple<Parts...> parts_type;
+    parts_type parts;
+
+    CompositeKey() : parts() {}
+
+    explicit CompositeKey(const Parts&... values) : parts(values...) {}
+
+    /// \brief Serializes this key into canonical bytewise-sortable bytes.
+    /// \return Serialized key bytes.
+    std::vector<std::uint8_t> to_bytes() const {
+        std::vector<std::uint8_t> out;
+        detail::CompositeKeyCodec<0u, sizeof...(Parts)>::append(parts, out);
+        return out;
+    }
+
+    /// \brief Restores a composite key from `to_bytes()` output.
+    /// \param data Serialized bytes.
+    /// \param size Number of serialized bytes.
+    /// \return Decoded composite key.
+    /// \throws std::runtime_error When bytes are truncated, malformed, or trailing.
+    static CompositeKey from_bytes(const void* data, std::size_t size) {
+        if (data == nullptr) {
+            throw std::runtime_error("CompositeKey::from_bytes: null input");
+        }
+        const std::uint8_t* current = static_cast<const std::uint8_t*>(data);
+        const std::uint8_t* const end = current + size;
+        CompositeKey out;
+        detail::CompositeKeyCodec<0u, sizeof...(Parts)>::read(
+            out.parts, current, end);
+        if (current != end) {
+            throw std::runtime_error("CompositeKey::from_bytes: trailing bytes");
+        }
+        return out;
+    }
+
+    bool operator==(const CompositeKey& other) const { return parts == other.parts; }
+    bool operator!=(const CompositeKey& other) const { return !(*this == other); }
+    bool operator<(const CompositeKey& other) const {
+        return to_bytes() < other.to_bytes();
+    }
+};
+
+/// \brief Constructs a composite key with decayed component types.
+/// \tparam Parts Component argument types.
+/// \param parts Component values in ordering priority.
+/// \return Composite key containing the supplied components.
+template<typename... Parts>
+CompositeKey<typename std::decay<Parts>::type...>
+make_composite_key(Parts&&... parts) {
+    typedef CompositeKey<typename std::decay<Parts>::type...> KeyT;
+    return KeyT(std::forward<Parts>(parts)...);
+}
+
+/// \brief Serializes components as one canonical composite key.
+/// \tparam Parts Component argument types.
+/// \param parts Component values in ordering priority.
+/// \return Canonical composite key bytes.
+template<typename... Parts>
+std::vector<std::uint8_t> composite_key_to_bytes(Parts&&... parts) {
+    return make_composite_key(std::forward<Parts>(parts)...).to_bytes();
+}
+
+/// \brief Decodes canonical composite key bytes.
+/// \tparam Parts Target component types.
+/// \param data Serialized bytes.
+/// \param size Number of serialized bytes.
+/// \return Decoded composite key.
+template<typename... Parts>
+CompositeKey<Parts...> composite_key_from_bytes(const void* data,
+                                                std::size_t size) {
+    return CompositeKey<Parts...>::from_bytes(data, size);
+}
+
+} // namespace mdbxc
+
+#endif // MDBX_CONTAINERS_HEADER_COMPOSITE_KEY_HPP_INCLUDED

--- a/include/mdbx_containers/CompositeKey.hpp
+++ b/include/mdbx_containers/CompositeKey.hpp
@@ -112,45 +112,73 @@ namespace detail {
 
     template<typename T>
     struct CompositeKeyPartCodec<T, typename std::enable_if<
-            std::is_integral<T>::value && !std::is_same<T, bool>::value>::type> {
-        typedef typename std::make_unsigned<T>::type UnsignedT;
+            std::is_integral<T>::value &&
+            !std::is_same<T, bool>::value &&
+            !is_key_character_code_unit<T>::value>::type> {
+        static_assert(sizeof(T) <= sizeof(std::uint64_t),
+                      "CompositeKey integral components must be at most 64 bits");
 
         static void append(T value, std::vector<std::uint8_t>& out) {
-            static_assert(sizeof(T) <= sizeof(std::uint64_t),
-                          "CompositeKey integral components must be at most 64 bits");
-            UnsignedT sortable = static_cast<UnsignedT>(value);
-            if (std::is_signed<T>::value) {
-                sortable = static_cast<UnsignedT>(
-                    sortable ^ (UnsignedT(1) << (sizeof(T) * CHAR_BIT - 1u)));
+            if (mdbx_integer_key_storage_size<T>::value ==
+                    sizeof(std::uint32_t)) {
+                const std::uint32_t sortable =
+                    is_signed_mdbx_integer_key<T>::value
+                        ? sortable_key_from_signed_int32(
+                            static_cast<std::int32_t>(value))
+                        : static_cast<std::uint32_t>(value);
+                composite_key_append_big_endian(sortable, out);
+                return;
             }
+
+            const std::uint64_t sortable =
+                is_signed_mdbx_integer_key<T>::value
+                    ? sortable_key_from_signed_int64(
+                        static_cast<std::int64_t>(value))
+                    : static_cast<std::uint64_t>(value);
             composite_key_append_big_endian(sortable, out);
         }
 
         static T read(const std::uint8_t*& current, const std::uint8_t* end) {
-            static_assert(sizeof(T) <= sizeof(std::uint64_t),
-                          "CompositeKey integral components must be at most 64 bits");
-            UnsignedT raw = composite_key_read_big_endian<UnsignedT>(current, end);
-            if (std::is_signed<T>::value) {
-                raw = static_cast<UnsignedT>(
-                    raw ^ (UnsignedT(1) << (sizeof(T) * CHAR_BIT - 1u)));
-                T value;
-                std::memcpy(&value, &raw, sizeof(value));
-                return value;
+            if (mdbx_integer_key_storage_size<T>::value ==
+                    sizeof(std::uint32_t)) {
+                const std::uint32_t raw =
+                    composite_key_read_big_endian<std::uint32_t>(current, end);
+                return is_signed_mdbx_integer_key<T>::value
+                    ? static_cast<T>(signed_int32_from_sortable_key(raw))
+                    : static_cast<T>(raw);
             }
-            return static_cast<T>(raw);
+
+            const std::uint64_t raw =
+                composite_key_read_big_endian<std::uint64_t>(current, end);
+            return is_signed_mdbx_integer_key<T>::value
+                ? static_cast<T>(signed_int64_from_sortable_key(raw))
+                : static_cast<T>(raw);
+        }
+    };
+
+    template<typename T>
+    struct CompositeKeyPartCodec<T, typename std::enable_if<
+            is_key_character_code_unit<T>::value>::type> {
+        static void append(T value, std::vector<std::uint8_t>& out) {
+            composite_key_append_big_endian(code_unit_key_bits(value), out);
+        }
+
+        static T read(const std::uint8_t*& current, const std::uint8_t* end) {
+            return code_unit_key_from_bits<T>(
+                composite_key_read_big_endian<std::uint32_t>(current, end));
         }
     };
 
     template<>
     struct CompositeKeyPartCodec<bool, void> {
         static void append(bool value, std::vector<std::uint8_t>& out) {
-            out.push_back(value ? 1u : 0u);
+            composite_key_append_big_endian<std::uint32_t>(
+                value ? 1u : 0u, out);
         }
 
         static bool read(const std::uint8_t*& current, const std::uint8_t* end) {
-            composite_key_require_bytes(current, end, 1u);
-            const std::uint8_t value = *current;
-            ++current;
+            const std::uint32_t value =
+                composite_key_read_big_endian<std::uint32_t>(current, end);
             if (value > 1u) {
                 throw std::runtime_error(
                     "CompositeKey::from_bytes: invalid bool component");
@@ -264,9 +292,10 @@ namespace detail {
 
 /// \brief Typed composite key with a canonical bytewise-sortable encoding.
 /// \tparam Parts Two to five supported component types.
-/// \details Integral components use big-endian sortable encodings; strings and
-///          byte vectors use a prefix-safe escaped terminator. The resulting
-///          bytes preserve lexicographic component ordering under MDBX's normal
+/// \details Integral components use the library's platform-neutral 32- or
+///          64-bit sortable rank before big-endian encoding; strings and byte
+///          vectors use a prefix-safe escaped terminator. The resulting bytes
+///          preserve lexicographic component ordering under MDBX's normal
 ///          bytewise key comparator.
 template<typename... Parts>
 struct CompositeKey {
@@ -314,6 +343,9 @@ struct CompositeKey {
         return to_bytes() < other.to_bytes();
     }
 };
+
+template<typename... Parts>
+struct is_canonical_bytewise_key<CompositeKey<Parts...> > : std::true_type {};
 
 /// \brief Constructs a composite key with decayed component types.
 /// \tparam Parts Component argument types.

--- a/include/mdbx_containers/detail/utils.hpp
+++ b/include/mdbx_containers/detail/utils.hpp
@@ -176,6 +176,15 @@ namespace mdbxc {
         static const bool value = decltype(check<T>(0))::value;
     };
 
+    /// \brief Marks key types with a library-defined bytewise key codec.
+    /// \details Application-provided `to_bytes()` and `from_bytes()` methods do
+    ///          not opt a type into key serialization. A specialization denotes
+    ///          a documented, canonical key layout whose bytes use MDBX's normal
+    ///          bytewise comparator.
+    /// \tparam T Key type under inspection.
+    template<typename T>
+    struct is_canonical_bytewise_key : std::false_type {};
+
     // --- Traits ---
 
     template <typename T>
@@ -426,18 +435,18 @@ namespace mdbxc {
         !is_key_integral<T>::value &&
         !std::is_same<T, float>::value &&
         !std::is_same<T, double>::value &&
-        !(has_to_bytes<T>::value && has_from_bytes<T>::value), size_t>::type
+        !is_canonical_bytewise_key<T>::value, size_t>::type
     get_key_size(const T&) {
         return sizeof(T);
     }
 
-    /// \brief Returns the serialized size of a custom byte-serializable key.
-    /// \tparam T Key type providing `to_bytes()`.
+    /// \brief Returns the serialized size of a canonical bytewise key.
+    /// \tparam T Key type with a library-defined canonical codec.
     /// \param key Key value.
     /// \return Number of serialized bytes.
     template<typename T>
     typename std::enable_if<
-        has_to_bytes<T>::value && has_from_bytes<T>::value, size_t>::type
+        is_canonical_bytewise_key<T>::value, size_t>::type
     get_key_size(const T& key) {
         return key.to_bytes().size();
     }
@@ -565,7 +574,10 @@ namespace mdbxc {
     /// \param key The key to convert.
     /// \return MDBX_val representing the key.
     template <bool SafeIntegerKey = true, typename T>
-    typename std::enable_if<!has_to_bytes<T>::value && !std::is_same<T, std::string>::value && !std::is_trivially_copyable<T>::value, MDBX_val>::type
+    typename std::enable_if<
+        !std::is_same<T, std::string>::value &&
+        !std::is_trivially_copyable<T>::value &&
+        !is_canonical_bytewise_key<T>::value, MDBX_val>::type
     serialize_key(const T& key, SerializeScratch& sc) {
         (void)SafeIntegerKey;
         (void)key; 
@@ -577,14 +589,14 @@ namespace mdbxc {
         return val;
     }
 
-    /// \brief Serializes a key using its canonical `to_bytes()` representation.
-    /// \tparam T Key type providing `to_bytes()`.
+    /// \brief Serializes a key using its library-defined canonical representation.
+    /// \tparam T Key type with a library-defined canonical codec.
     /// \param key Key to serialize.
     /// \param sc Scratch storage owning the serialized bytes.
     /// \return MDBX value view over the scratch storage.
     template <bool SafeIntegerKey = true, typename T>
     typename std::enable_if<
-        has_to_bytes<T>::value && has_from_bytes<T>::value, MDBX_val>::type
+        is_canonical_bytewise_key<T>::value, MDBX_val>::type
     serialize_key(const T& key, SerializeScratch& sc) {
         (void)SafeIntegerKey;
         sc.bytes = key.to_bytes();
@@ -1106,8 +1118,7 @@ namespace mdbxc {
     /// \brief Deserializes a value using its `from_bytes()` method.
     /// \tparam T Type providing `from_bytes`.
     template<typename T>
-    typename std::enable_if<
-        has_to_bytes<T>::value && has_from_bytes<T>::value, T>::type
+    typename std::enable_if<has_from_bytes<T>::value, T>::type
     deserialize_value(const MDBX_val& val) {
         return T::from_bytes(val.iov_base, val.iov_len);
     }
@@ -1180,12 +1191,12 @@ namespace mdbxc {
         return deserialize_value<T>(val);
     }
 
-    /// \brief Deserializes a key using its canonical `from_bytes()` representation.
-    /// \tparam T Key type providing static `from_bytes(const void*, size_t)`.
+    /// \brief Deserializes a key using its library-defined canonical representation.
+    /// \tparam T Key type with a library-defined canonical codec.
     /// \param val Serialized key bytes.
     /// \return Deserialized key.
     template<typename T>
-    typename std::enable_if<has_from_bytes<T>::value, T>::type
+    typename std::enable_if<is_canonical_bytewise_key<T>::value, T>::type
     deserialize_key(const MDBX_val& val) {
         return T::from_bytes(val.iov_base, val.iov_len);
     }
@@ -1343,7 +1354,7 @@ namespace mdbxc {
         !is_key_integral<T>::value &&
         !std::is_same<T, float>::value &&
         !std::is_same<T, double>::value &&
-        !(has_to_bytes<T>::value && has_from_bytes<T>::value), T>::type
+        !is_canonical_bytewise_key<T>::value, T>::type
     deserialize_key(const MDBX_val& val) {
         return deserialize_value<T>(val);
     }

--- a/include/mdbx_containers/detail/utils.hpp
+++ b/include/mdbx_containers/detail/utils.hpp
@@ -137,8 +137,6 @@ namespace mdbxc {
         return out;
     }
     
-    // --- Traits --- 
-
     /// \brief Trait to check if a type provides a `to_bytes()` member.
     /// \tparam T Type under inspection.
     template <typename T>
@@ -177,6 +175,8 @@ namespace mdbxc {
     public:
         static const bool value = decltype(check<T>(0))::value;
     };
+
+    // --- Traits ---
 
     template <typename T>
     struct is_string_sequence_container {
@@ -425,9 +425,21 @@ namespace mdbxc {
         !is_key_bitset<T>::value &&
         !is_key_integral<T>::value &&
         !std::is_same<T, float>::value &&
-        !std::is_same<T, double>::value, size_t>::type
+        !std::is_same<T, double>::value &&
+        !(has_to_bytes<T>::value && has_from_bytes<T>::value), size_t>::type
     get_key_size(const T&) {
         return sizeof(T);
+    }
+
+    /// \brief Returns the serialized size of a custom byte-serializable key.
+    /// \tparam T Key type providing `to_bytes()`.
+    /// \param key Key value.
+    /// \return Number of serialized bytes.
+    template<typename T>
+    typename std::enable_if<
+        has_to_bytes<T>::value && has_from_bytes<T>::value, size_t>::type
+    get_key_size(const T& key) {
+        return key.to_bytes().size();
     }
     
     /// \class SerializeScratch
@@ -563,6 +575,20 @@ namespace mdbxc {
         val.iov_base = nullptr;
         val.iov_len  = 0;
         return val;
+    }
+
+    /// \brief Serializes a key using its canonical `to_bytes()` representation.
+    /// \tparam T Key type providing `to_bytes()`.
+    /// \param key Key to serialize.
+    /// \param sc Scratch storage owning the serialized bytes.
+    /// \return MDBX value view over the scratch storage.
+    template <bool SafeIntegerKey = true, typename T>
+    typename std::enable_if<
+        has_to_bytes<T>::value && has_from_bytes<T>::value, MDBX_val>::type
+    serialize_key(const T& key, SerializeScratch& sc) {
+        (void)SafeIntegerKey;
+        sc.bytes = key.to_bytes();
+        return sc.view_bytes();
     }
 
     /// \brief Serializes a key of type std::string.
@@ -1080,7 +1106,8 @@ namespace mdbxc {
     /// \brief Deserializes a value using its `from_bytes()` method.
     /// \tparam T Type providing `from_bytes`.
     template<typename T>
-    typename std::enable_if<has_from_bytes<T>::value, T>::type
+    typename std::enable_if<
+        has_to_bytes<T>::value && has_from_bytes<T>::value, T>::type
     deserialize_value(const MDBX_val& val) {
         return T::from_bytes(val.iov_base, val.iov_len);
     }
@@ -1151,6 +1178,16 @@ namespace mdbxc {
     typename std::enable_if<std::is_same<T, std::string>::value, T>::type
     deserialize_key(const MDBX_val& val) {
         return deserialize_value<T>(val);
+    }
+
+    /// \brief Deserializes a key using its canonical `from_bytes()` representation.
+    /// \tparam T Key type providing static `from_bytes(const void*, size_t)`.
+    /// \param val Serialized key bytes.
+    /// \return Deserialized key.
+    template<typename T>
+    typename std::enable_if<has_from_bytes<T>::value, T>::type
+    deserialize_key(const MDBX_val& val) {
+        return T::from_bytes(val.iov_base, val.iov_len);
     }
 
     template<typename T>
@@ -1305,7 +1342,8 @@ namespace mdbxc {
         !std::is_same<T, std::string>::value &&
         !is_key_integral<T>::value &&
         !std::is_same<T, float>::value &&
-        !std::is_same<T, double>::value, T>::type
+        !std::is_same<T, double>::value &&
+        !(has_to_bytes<T>::value && has_from_bytes<T>::value), T>::type
     deserialize_key(const MDBX_val& val) {
         return deserialize_value<T>(val);
     }

--- a/include/mdbx_containers/sync/logical/adapters/KeyOrderedMultiValueTableLogicalAdapter.hpp
+++ b/include/mdbx_containers/sync/logical/adapters/KeyOrderedMultiValueTableLogicalAdapter.hpp
@@ -18,10 +18,6 @@
 #include <vector>
 
 #include "KeyValueTableLogicalAdapter.hpp"
-#include "../../capture/ILogicalDbiCapture.hpp"
-#include "../../stores/MetaStore.hpp"
-#include "../stores/LogicalJournalStore.hpp"
-#include "../stores/LogicalOutboxStore.hpp"
 
 namespace mdbxc {
 namespace sync {

--- a/include/mdbx_containers/tables.hpp
+++ b/include/mdbx_containers/tables.hpp
@@ -12,6 +12,7 @@
 /// table API.
 
 #include "common.hpp"
+#include "mdbx_containers/CompositeKey.hpp"
 #include "mdbx_containers/AnyValueTable.hpp"
 #include "mdbx_containers/HashedKeyValueStore.hpp"
 #include "mdbx_containers/KeyMultiValueTable.hpp"

--- a/tests/composite_key_test.cpp
+++ b/tests/composite_key_test.cpp
@@ -5,11 +5,44 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include <mdbx_containers/tables.hpp>
 
 namespace {
+
+struct TrivialCustomId {
+    std::uint64_t value;
+
+    std::vector<std::uint8_t> to_bytes() const {
+        std::vector<std::uint8_t> bytes(sizeof(value));
+        std::memcpy(bytes.data(), &value, sizeof(value));
+        return bytes;
+    }
+
+    static TrivialCustomId from_bytes(const void* data, std::size_t size) {
+        if (size != sizeof(std::uint64_t)) {
+            throw std::runtime_error("TrivialCustomId: size mismatch");
+        }
+        TrivialCustomId out;
+        std::memcpy(&out.value, data, sizeof(out.value));
+        return out;
+    }
+};
+
+struct TrivialFromOnlyId {
+    std::uint64_t value;
+
+    static TrivialFromOnlyId from_bytes(const void* data, std::size_t size) {
+        if (size != sizeof(std::uint64_t)) {
+            throw std::runtime_error("TrivialFromOnlyId: size mismatch");
+        }
+        TrivialFromOnlyId out;
+        std::memcpy(&out.value, data, sizeof(out.value));
+        return out;
+    }
+};
 
 int compare_bytes(const std::vector<std::uint8_t>& lhs,
                   const std::vector<std::uint8_t>& rhs) {
@@ -40,6 +73,40 @@ void assert_throws_runtime_error(Fn fn) {
         thrown = true;
     }
     MDBXC_TEST_ASSERT(thrown);
+}
+
+template<typename T>
+void assert_integral_golden_bytes(
+        T value, const std::vector<std::uint8_t>& expected) {
+    const mdbxc::CompositeKey<T, bool> key(value, false);
+    MDBXC_TEST_ASSERT(key.to_bytes() == expected);
+    const mdbxc::CompositeKey<T, bool> restored =
+        mdbxc::CompositeKey<T, bool>::from_bytes(
+            expected.data(), expected.size());
+    MDBXC_TEST_ASSERT(restored == key);
+}
+
+void assert_trivial_custom_key_compatibility() {
+    static_assert(std::is_trivially_copyable<TrivialCustomId>::value,
+                  "Regression type must be trivially copyable");
+    static_assert(std::is_trivially_copyable<TrivialFromOnlyId>::value,
+                  "Regression type must be trivially copyable");
+
+    const TrivialCustomId id = {42u};
+    mdbxc::SerializeScratch scratch;
+    const MDBX_val serialized = mdbxc::serialize_key(id, scratch);
+    MDBXC_TEST_ASSERT(serialized.iov_len == sizeof(id));
+
+    const TrivialCustomId restored =
+        mdbxc::deserialize_key<TrivialCustomId>(serialized);
+    MDBXC_TEST_ASSERT(restored.value == id.value);
+
+    const TrivialFromOnlyId from_only_id = {7u};
+    const MDBX_val from_only_serialized =
+        mdbxc::SerializeScratch::view(&from_only_id, sizeof(from_only_id));
+    const TrivialFromOnlyId from_only_restored =
+        mdbxc::deserialize_key<TrivialFromOnlyId>(from_only_serialized);
+    MDBXC_TEST_ASSERT(from_only_restored.value == from_only_id.value);
 }
 
 } // namespace
@@ -87,6 +154,45 @@ int main() {
     MDBXC_TEST_ASSERT(
         FivePartKeyT::from_bytes(five_part_bytes.data(), five_part_bytes.size()) ==
         five_part_key);
+
+    assert_integral_golden_bytes<short>(
+        static_cast<short>(-1),
+        std::vector<std::uint8_t>{
+            0x7fu, 0xffu, 0xffu, 0xffu, 0u, 0u, 0u, 0u
+        });
+    assert_integral_golden_bytes<long>(
+        static_cast<long>(-1),
+        std::vector<std::uint8_t>{
+            0x7fu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu,
+            0u, 0u, 0u, 0u
+        });
+    assert_integral_golden_bytes<unsigned long>(
+        static_cast<unsigned long>(42u),
+        std::vector<std::uint8_t>{
+            0u, 0u, 0u, 0u, 0u, 0u, 0u, 42u, 0u, 0u, 0u, 0u
+        });
+    assert_integral_golden_bytes<char>(
+        static_cast<char>(static_cast<unsigned char>(0xffu)),
+        std::vector<std::uint8_t>{
+            0u, 0u, 0u, 0xffu, 0u, 0u, 0u, 0u
+        });
+    assert_integral_golden_bytes<wchar_t>(
+        static_cast<wchar_t>(42),
+        std::vector<std::uint8_t>{
+            0u, 0u, 0u, 42u, 0u, 0u, 0u, 0u
+        });
+    assert_integral_golden_bytes<std::int32_t>(
+        static_cast<std::int32_t>(-1),
+        std::vector<std::uint8_t>{
+            0x7fu, 0xffu, 0xffu, 0xffu, 0u, 0u, 0u, 0u
+        });
+    assert_integral_golden_bytes<std::int64_t>(
+        static_cast<std::int64_t>(-1),
+        std::vector<std::uint8_t>{
+            0x7fu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu, 0xffu,
+            0u, 0u, 0u, 0u
+        });
+    assert_trivial_custom_key_compatibility();
 
     std::vector<std::uint8_t> truncated(bytes.begin(), bytes.end() - 1u);
     assert_throws_runtime_error([&truncated]() {

--- a/tests/composite_key_test.cpp
+++ b/tests/composite_key_test.cpp
@@ -1,0 +1,135 @@
+#include "test_assert.hpp"
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <mdbx_containers/tables.hpp>
+
+namespace {
+
+int compare_bytes(const std::vector<std::uint8_t>& lhs,
+                  const std::vector<std::uint8_t>& rhs) {
+    const std::size_t common = lhs.size() < rhs.size() ? lhs.size() : rhs.size();
+    const int comparison = common == 0u ? 0 :
+        std::memcmp(lhs.data(), rhs.data(), common);
+    if (comparison != 0) {
+        return comparison;
+    }
+    if (lhs.size() == rhs.size()) {
+        return 0;
+    }
+    return lhs.size() < rhs.size() ? -1 : 1;
+}
+
+template<typename KeyT>
+void assert_key_bytes_less(const KeyT& lhs, const KeyT& rhs) {
+    MDBXC_TEST_ASSERT(lhs < rhs);
+    MDBXC_TEST_ASSERT(compare_bytes(lhs.to_bytes(), rhs.to_bytes()) < 0);
+}
+
+template<typename Fn>
+void assert_throws_runtime_error(Fn fn) {
+    bool thrown = false;
+    try {
+        fn();
+    } catch (const std::runtime_error&) {
+        thrown = true;
+    }
+    MDBXC_TEST_ASSERT(thrown);
+}
+
+} // namespace
+
+int main() {
+    typedef mdbxc::CompositeKey<std::int64_t, std::string, std::uint32_t> KeyT;
+    const std::string binary_text("north\0star", 10u);
+    const KeyT original(-7, binary_text, 42u);
+    const std::vector<std::uint8_t> bytes = original.to_bytes();
+
+    MDBXC_TEST_ASSERT(KeyT::from_bytes(bytes.data(), bytes.size()) == original);
+    const KeyT decoded =
+        mdbxc::composite_key_from_bytes<std::int64_t, std::string, std::uint32_t>(
+            bytes.data(), bytes.size());
+    MDBXC_TEST_ASSERT(decoded == original);
+    MDBXC_TEST_ASSERT(
+        mdbxc::composite_key_to_bytes(std::int64_t(-7), binary_text, std::uint32_t(42)) ==
+        bytes);
+
+    assert_key_bytes_less(KeyT(-8, "z", 1u), KeyT(-7, "", 0u));
+    assert_key_bytes_less(
+        KeyT(std::numeric_limits<std::int64_t>::min(), "", 0u),
+        KeyT(std::numeric_limits<std::int64_t>::max(), "", 0u));
+    assert_key_bytes_less(KeyT(-7, "alpha", 99u), KeyT(-7, "beta", 0u));
+    assert_key_bytes_less(KeyT(-7, std::string("a", 1u), 1u),
+                          KeyT(-7, std::string("a\0", 2u), 0u));
+    assert_key_bytes_less(KeyT(-7, std::string("a\0", 2u), 1u),
+                          KeyT(-7, std::string("a\1", 2u), 0u));
+    assert_key_bytes_less(KeyT(-7, "same", 1u), KeyT(-7, "same", 2u));
+
+    typedef mdbxc::CompositeKey<float, std::vector<std::uint8_t> > FloatKeyT;
+    const std::vector<std::uint8_t> binary_bytes = {0u, 0xffu, 1u};
+    const FloatKeyT float_key(-1.5f, binary_bytes);
+    const std::vector<std::uint8_t> float_key_bytes = float_key.to_bytes();
+    MDBXC_TEST_ASSERT(
+        FloatKeyT::from_bytes(float_key_bytes.data(), float_key_bytes.size()) ==
+        float_key);
+    assert_key_bytes_less(FloatKeyT(-1.0f, binary_bytes),
+                          FloatKeyT(0.0f, binary_bytes));
+
+    typedef mdbxc::CompositeKey<std::uint8_t, std::uint16_t, std::uint32_t,
+                                std::uint64_t, bool> FivePartKeyT;
+    const FivePartKeyT five_part_key(1u, 2u, 3u, 4u, true);
+    const std::vector<std::uint8_t> five_part_bytes = five_part_key.to_bytes();
+    MDBXC_TEST_ASSERT(
+        FivePartKeyT::from_bytes(five_part_bytes.data(), five_part_bytes.size()) ==
+        five_part_key);
+
+    std::vector<std::uint8_t> truncated(bytes.begin(), bytes.end() - 1u);
+    assert_throws_runtime_error([&truncated]() {
+        (void)KeyT::from_bytes(truncated.data(), truncated.size());
+    });
+    const std::uint8_t invalid_escape[] = {0u, 1u};
+    assert_throws_runtime_error([&invalid_escape]() {
+        (void)mdbxc::CompositeKey<std::string, std::string>::from_bytes(
+            invalid_escape, sizeof(invalid_escape));
+    });
+    const std::uint8_t invalid_float[] = {
+        0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u
+    };
+    assert_throws_runtime_error([&invalid_float]() {
+        (void)mdbxc::CompositeKey<float, std::uint32_t>::from_bytes(
+            invalid_float, sizeof(invalid_float));
+    });
+    const std::uint8_t noncanonical_negative_zero[] = {
+        0x7fu, 0xffu, 0xffu, 0xffu, 0u, 0u, 0u, 0u
+    };
+    assert_throws_runtime_error([&noncanonical_negative_zero]() {
+        (void)mdbxc::CompositeKey<float, std::uint32_t>::from_bytes(
+            noncanonical_negative_zero, sizeof(noncanonical_negative_zero));
+    });
+
+    mdbxc::Config cfg;
+    cfg.pathname = "data/composite_key_test.mdbx";
+    cfg.max_dbs = 8;
+    cfg.no_subdir = true;
+    cfg.relative_to_exe = false;
+    const std::shared_ptr<mdbxc::Connection> connection = mdbxc::Connection::create(cfg);
+
+    mdbxc::KeyValueTable<KeyT, std::string> table(connection, "composite_keys");
+    table.clear();
+    table.insert_or_assign(KeyT(-1, "beta", 2u), "second");
+    table.insert_or_assign(KeyT(-1, "alpha", 1u), "first");
+    table.insert_or_assign(KeyT(0, "alpha", 1u), "third");
+
+    const std::vector<std::pair<KeyT, std::string> > range = table.range<std::vector>(
+        KeyT(-1, "", 0u), KeyT(0, "", 0u));
+    MDBXC_TEST_ASSERT(range.size() == 2u);
+    MDBXC_TEST_ASSERT(range[0].first == KeyT(-1, "alpha", 1u));
+    MDBXC_TEST_ASSERT(range[1].first == KeyT(-1, "beta", 2u));
+
+    return 0;
+}


### PR DESCRIPTION
## What changed

- Added `CompositeKey<P1, ..., PN>` for two to five typed, bytewise-sortable key parts.
- Added canonical key serialization/deserialization support, public umbrella exposure, and C++11/C++17 regressions.
- Removed cross-subdomain includes from the ordered logical adapter; `sync/adapters.hpp` owns its prerequisites.

## Why

Composite-key layouts need a stable, binary-safe physical order before range and secondary-index storage primitives can build on them.

## Validation

- C++11 and C++17: `composite_key_test`, `utils_test`, standalone `CompositeKey.hpp`, and `sync/adapters.hpp`.
- C++11 and C++17: `kv_container_all_types_test`, table umbrella, and full umbrella build targets.
- `git diff --check`.
